### PR TITLE
perf: CFG Performance Optimization (#25)

### DIFF
--- a/internal/analyzer/cfg_benchmark_test.go
+++ b/internal/analyzer/cfg_benchmark_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/pyqol/pyqol/internal/parser"
 )
 
+// Performance Baselines (as of August 2025)
+// ==========================================
+// These benchmarks establish performance baselines for CFG operations.
+// Current performance EXCEEDS all project targets:
+//
+// Target: >10,000 lines/second CFG construction
+// Actual: ~73,000 lines/second (7x better)
+//
+// Target: >100,000 blocks/second reachability analysis  
+// Actual: ~4.8M blocks/second (48x better)
+//
+// Target: <10x file size memory usage
+// Actual: ~21KB per operation (well within target)
+//
+// Key Benchmarks:
+// - RealWorldCFGBuild: ~13,626 ns/op, 21,594 B/op, 606 allocs/op
+// - SimpleReachability: ~202 ns/op, 360 B/op, 5 allocs/op  
+// - CFG Construction: 845-9,702 ns/op depending on complexity
+//
+// These baselines should be maintained to prevent performance regressions.
+
 // BenchmarkCFGConstruction benchmarks CFG construction speed
 func BenchmarkCFGConstruction(b *testing.B) {
 	testCases := []struct {

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/pyqol/pyqol/internal/parser"
 	"log"
+	"strconv"
 	"strings"
 )
 
@@ -764,10 +765,10 @@ func (b *CFGBuilder) processTryStatement(stmt *parser.Node) {
 	}
 
 	// Create handler blocks for each except clause
-	var handlers []*BasicBlock
+	handlers := make([]*BasicBlock, len(stmt.Handlers))
 	for i := range stmt.Handlers {
-		handlerBlock := b.createBlock(fmt.Sprintf("%s_%d", LabelExceptBlock, i+1))
-		handlers = append(handlers, handlerBlock)
+		handlerBlock := b.createBlock(LabelExceptBlock + "_" + strconv.Itoa(i+1))
+		handlers[i] = handlerBlock
 	}
 
 	// Create exception context
@@ -965,7 +966,7 @@ func (b *CFGBuilder) processMatchStatement(stmt *parser.Node) {
 	if len(stmt.Body) > 0 {
 		for i, caseNode := range stmt.Body {
 			// Create case block
-			caseBlock := b.createBlock(fmt.Sprintf("%s_%d", LabelMatchCase, i+1))
+			caseBlock := b.createBlock(LabelMatchCase + "_" + strconv.Itoa(i+1))
 
 			// Connect match evaluation to this case (conditional edge)
 			b.cfg.ConnectBlocks(matchBlock, caseBlock, EdgeCondTrue)
@@ -1001,7 +1002,7 @@ func (b *CFGBuilder) processMatchStatement(stmt *parser.Node) {
 // createBlock creates a new basic block
 func (b *CFGBuilder) createBlock(label string) *BasicBlock {
 	b.blockCounter++
-	blockLabel := fmt.Sprintf("%s_%d", label, b.blockCounter)
+	blockLabel := label + "_" + strconv.FormatUint(uint64(b.blockCounter), 10)
 	return b.cfg.CreateBlock(blockLabel)
 }
 


### PR DESCRIPTION
## Summary
- Optimize CFG construction performance with string concatenation and pre-allocation
- Add comprehensive performance baseline documentation
- Achieve 14% faster CFG construction and 10% fewer allocations

## Performance Improvements
- **14% faster** CFG construction (13,626 → 11,117 ns/op)
- **4.6% less memory** usage (21,594 → 20,601 B/op)  
- **10% fewer allocations** (606 → 544 allocs/op)

## Changes Made
1. **String optimization**: Replace `fmt.Sprintf` with direct concatenation
2. **Memory pre-allocation**: Pre-allocate exception handler slices vs repeated `append()`
3. **Performance documentation**: Add baseline performance comments for regression detection

## Performance Status
✅ **Already exceeding all targets:**
- Target: >10,000 lines/second → **Actual: 73,000+ lines/second (7x better)**
- Target: >100,000 blocks/second → **Actual: 4.8M blocks/second (48x better)**
- Target: <10x file size memory → **Actual: Well within target**

## Test Results
```bash
# Before optimizations
BenchmarkRealWorldCFG/RealWorldCFGBuild-10    87607   13626 ns/op   21594 B/op   606 allocs/op

# After optimizations  
BenchmarkRealWorldCFG/RealWorldCFGBuild-10   102319   11117 ns/op   20601 B/op   544 allocs/op
```

## Test plan
- [x] All existing tests pass with race detection
- [x] Benchmarks show measurable performance improvement
- [x] No functionality regressions
- [x] Performance targets maintained (exceeded)

🤖 Generated with [Claude Code](https://claude.ai/code)