### PR TITLE
feat: improve output format flags and file generation

### DIFF
--- a/app/clone_usecase_test.go
+++ b/app/clone_usecase_test.go
@@ -342,7 +342,7 @@ func TestCloneUseCase_Execute(t *testing.T) {
 				return req
 			}(),
 			expectError: true,
-			errorMsg:    "no valid output writer specified",
+			errorMsg:    "no valid output writer or output path specified",
 		},
 		{
 			name: "output formatting error",
@@ -617,7 +617,7 @@ func TestCloneUseCase_ExecuteWithFiles(t *testing.T) {
 					Return(createMockCloneResponse(), nil)
 			},
 			expectError: true,
-			errorMsg:    "no valid output writer specified",
+			errorMsg:    "no valid output writer or output path specified",
 		},
 	}
 

--- a/app/complexity_usecase.go
+++ b/app/complexity_usecase.go
@@ -3,9 +3,13 @@ package app
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pyqol/pyqol/domain"
+	"github.com/pyqol/pyqol/service"
 )
 
 // ComplexityUseCase orchestrates the complexity analysis workflow
@@ -77,9 +81,50 @@ func (uc *ComplexityUseCase) Execute(ctx context.Context, req domain.ComplexityR
 		return domain.NewAnalysisError("complexity analysis failed", err)
 	}
 
-	// Format and output results
-	if err := uc.formatter.Write(response, finalReq.OutputFormat, finalReq.OutputWriter); err != nil {
-		return domain.NewOutputError("failed to write output", err)
+	// Handle file output if specified
+	if finalReq.OutputPath != "" {
+		// Create or open the file
+		file, err := os.Create(finalReq.OutputPath)
+		if err != nil {
+			return domain.NewOutputError(fmt.Sprintf("failed to create output file: %s", finalReq.OutputPath), err)
+		}
+		defer file.Close()
+
+		// Write content to file
+		if err := uc.formatter.Write(response, finalReq.OutputFormat, file); err != nil {
+			return domain.NewOutputError("failed to write output", err)
+		}
+
+		// Get absolute path for display
+		absPath, err := filepath.Abs(finalReq.OutputPath)
+		if err != nil {
+			absPath = finalReq.OutputPath
+		}
+
+		// Handle browser opening for HTML files
+		if finalReq.OutputFormat == domain.OutputFormatHTML {
+			// Open in browser unless NoOpen flag is set
+			if !finalReq.NoOpen {
+				fileURL := "file://" + absPath
+				if err := service.OpenBrowser(fileURL); err != nil {
+					// Log error but don't fail the operation
+					fmt.Fprintf(os.Stderr, "Warning: Could not open browser: %v\n", err)
+				} else {
+					fmt.Fprintf(os.Stderr, "HTML report generated and opened: %s\n", absPath)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "HTML report generated: %s\n", absPath)
+			}
+		} else {
+			// For other formats, just confirm file creation
+			formatName := strings.ToUpper(string(finalReq.OutputFormat))
+			fmt.Fprintf(os.Stderr, "%s report generated: %s\n", formatName, absPath)
+		}
+	} else {
+		// Normal output to writer (stdout for text format)
+		if err := uc.formatter.Write(response, finalReq.OutputFormat, finalReq.OutputWriter); err != nil {
+			return domain.NewOutputError("failed to write output", err)
+		}
 	}
 
 	return nil
@@ -159,9 +204,50 @@ func (uc *ComplexityUseCase) AnalyzeFile(ctx context.Context, filePath string, r
 		return domain.NewAnalysisError("file analysis failed", err)
 	}
 
-	// Format and output results
-	if err := uc.formatter.Write(response, finalReq.OutputFormat, finalReq.OutputWriter); err != nil {
-		return domain.NewOutputError("failed to write output", err)
+	// Handle file output if specified
+	if finalReq.OutputPath != "" {
+		// Create or open the file
+		file, err := os.Create(finalReq.OutputPath)
+		if err != nil {
+			return domain.NewOutputError(fmt.Sprintf("failed to create output file: %s", finalReq.OutputPath), err)
+		}
+		defer file.Close()
+
+		// Write content to file
+		if err := uc.formatter.Write(response, finalReq.OutputFormat, file); err != nil {
+			return domain.NewOutputError("failed to write output", err)
+		}
+
+		// Get absolute path for display
+		absPath, err := filepath.Abs(finalReq.OutputPath)
+		if err != nil {
+			absPath = finalReq.OutputPath
+		}
+
+		// Handle browser opening for HTML files
+		if finalReq.OutputFormat == domain.OutputFormatHTML {
+			// Open in browser unless NoOpen flag is set
+			if !finalReq.NoOpen {
+				fileURL := "file://" + absPath
+				if err := service.OpenBrowser(fileURL); err != nil {
+					// Log error but don't fail the operation
+					fmt.Fprintf(os.Stderr, "Warning: Could not open browser: %v\n", err)
+				} else {
+					fmt.Fprintf(os.Stderr, "HTML report generated and opened: %s\n", absPath)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "HTML report generated: %s\n", absPath)
+			}
+		} else {
+			// For other formats, just confirm file creation
+			formatName := strings.ToUpper(string(finalReq.OutputFormat))
+			fmt.Fprintf(os.Stderr, "%s report generated: %s\n", formatName, absPath)
+		}
+	} else {
+		// Normal output to writer (stdout for text format)
+		if err := uc.formatter.Write(response, finalReq.OutputFormat, finalReq.OutputWriter); err != nil {
+			return domain.NewOutputError("failed to write output", err)
+		}
 	}
 
 	return nil
@@ -173,8 +259,8 @@ func (uc *ComplexityUseCase) validateRequest(req domain.ComplexityRequest) error
 		return fmt.Errorf("no input paths specified")
 	}
 
-	if req.OutputWriter == nil {
-		return fmt.Errorf("output writer is required")
+	if req.OutputWriter == nil && req.OutputPath == "" {
+		return fmt.Errorf("output writer or output path is required")
 	}
 
 	if req.MinComplexity < 0 {
@@ -199,7 +285,7 @@ func (uc *ComplexityUseCase) validateRequest(req domain.ComplexityRequest) error
 
 	// Validate output format
 	switch req.OutputFormat {
-	case domain.OutputFormatText, domain.OutputFormatJSON, domain.OutputFormatYAML, domain.OutputFormatCSV:
+	case domain.OutputFormatText, domain.OutputFormatJSON, domain.OutputFormatYAML, domain.OutputFormatCSV, domain.OutputFormatHTML:
 		// Valid formats
 	default:
 		return fmt.Errorf("unsupported output format: %s", req.OutputFormat)

--- a/app/complexity_usecase_test.go
+++ b/app/complexity_usecase_test.go
@@ -181,7 +181,7 @@ func TestComplexityUseCase_Execute(t *testing.T) {
 			},
 			expectError: true,
 			errorType:   "*domain.DomainError",
-			errorMsg:    "output writer is required",
+			errorMsg:    "output writer or output path is required",
 		},
 		{
 			name: "validation error - negative min complexity",
@@ -495,7 +495,7 @@ func TestComplexityUseCase_validateRequest(t *testing.T) {
 			request: domain.ComplexityRequest{
 				Paths: []string{"/test/file.py"},
 			},
-			wantErr: "output writer is required",
+			wantErr: "output writer or output path is required",
 		},
 		{
 			name: "negative min complexity",

--- a/app/dead_code_usecase_test.go
+++ b/app/dead_code_usecase_test.go
@@ -236,7 +236,7 @@ func TestDeadCodeUseCase_Execute(t *testing.T) {
 			},
 			expectError: true,
 			errorType:   "*domain.DomainError",
-			errorMsg:    "output writer is required",
+			errorMsg:    "output writer or output path is required",
 		},
 		{
 			name: "validation error - negative context lines",
@@ -579,7 +579,7 @@ func TestDeadCodeUseCase_validateRequest(t *testing.T) {
 			request: domain.DeadCodeRequest{
 				Paths: []string{"/test/file.py"},
 			},
-			wantErr: "output writer is required",
+			wantErr: "output writer or output path is required",
 		},
 		{
 			name: "negative context lines",

--- a/cmd/pyqol/.pyqol.yaml
+++ b/cmd/pyqol/.pyqol.yaml
@@ -73,7 +73,7 @@ clones:
       - "*_test.py"
   
   output:
-    format: "text"                 # Output format: text, json, yaml, csv
+    format: "text"                 # Output format: text, json, yaml, csv, html
     show_details: false            # Show detailed clone information
     show_content: false            # Include source code content in output
     sort_by: "similarity"          # Sort by: similarity, size, location, type
@@ -88,7 +88,7 @@ clones:
 # OUTPUT CONFIGURATION
 # =============================================================================
 output:
-  format: "text"                   # Default output format: text, json, yaml, csv
+  format: "text"                   # Default output format: text, json, yaml, csv, html
   show_details: false              # Show detailed breakdown by default
   sort_by: "name"                  # Default sort: name, complexity, risk
   min_complexity: 1                # Minimum complexity to report

--- a/cmd/pyqol/check.go
+++ b/cmd/pyqol/check.go
@@ -150,7 +150,7 @@ func (c *CheckCommand) checkComplexity(cmd *cobra.Command, args []string) (int, 
 	complexityCmd := NewComplexityCommand()
 
 	// Configure with stricter defaults for checking
-	complexityCmd.outputFormat = "text"
+	// Default to text output for check command
 	complexityCmd.minComplexity = 1   // Analyze all functions
 	complexityCmd.maxComplexity = 0   // No filter - we want to see ALL functions
 	complexityCmd.lowThreshold = 5    // Low: 1-5
@@ -204,7 +204,7 @@ func (c *CheckCommand) checkDeadCode(cmd *cobra.Command, args []string) (int, er
 	deadCodeCmd := NewDeadCodeCommand()
 
 	// Configure for critical issues only
-	deadCodeCmd.outputFormat = "text"
+	// Default to text output for check command
 	deadCodeCmd.minSeverity = "critical"
 	deadCodeCmd.configFile = c.configFile
 	deadCodeCmd.verbose = false
@@ -249,7 +249,7 @@ func (c *CheckCommand) checkClones(cmd *cobra.Command, args []string) (int, erro
 	cloneCmd := NewCloneCommand()
 
 	// Configure for informational reporting
-	cloneCmd.outputFormat = "text"
+	// Default to text output for check command
 	cloneCmd.similarityThreshold = 0.8
 	cloneCmd.configFile = c.configFile
 	cloneCmd.verbose = false

--- a/cmd/pyqol/complexity_test.go
+++ b/cmd/pyqol/complexity_test.go
@@ -33,7 +33,7 @@ func TestComplexityCommandInterface(t *testing.T) {
 	// Test that flags are properly configured
 	flags := cobraCmd.Flags()
 
-	expectedFlags := []string{"format", "min", "max", "sort", "details", "config", "low-threshold", "medium-threshold"}
+	expectedFlags := []string{"html", "json", "csv", "yaml", "min", "max", "sort", "details", "config", "low-threshold", "medium-threshold"}
 	for _, flagName := range expectedFlags {
 		if !flags.HasFlags() {
 			t.Error("Command should have flags defined")
@@ -109,14 +109,14 @@ func TestComplexityCommandFlags(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Valid format flag",
-			args:    []string{"--format", "json", tempDir},
+			name:    "Valid json flag",
+			args:    []string{"--json", tempDir},
 			wantErr: false, // May still fail due to file discovery, but flag should parse
 		},
 		{
-			name:    "Invalid format flag",
-			args:    []string{"--format", "invalid", tempDir},
-			wantErr: true,
+			name:    "Valid html flag",
+			args:    []string{"--html", tempDir},
+			wantErr: false, // May still fail due to file discovery, but flag should parse
 		},
 		{
 			name:    "Valid min complexity",
@@ -177,8 +177,9 @@ func TestComplexityCommandFlags(t *testing.T) {
 func TestComplexityCommandDefaults(t *testing.T) {
 	cmd := NewComplexityCommand()
 
-	if cmd.outputFormat != "text" {
-		t.Errorf("Expected default outputFormat to be 'text', got '%s'", cmd.outputFormat)
+	// Default is no format flags set (text output)
+	if cmd.html || cmd.json || cmd.csv || cmd.yaml {
+		t.Errorf("Expected default format flags to be false")
 	}
 
 	if cmd.minComplexity != 1 {

--- a/cmd/pyqol/init.go
+++ b/cmd/pyqol/init.go
@@ -83,7 +83,7 @@ clones:
       - "*_test.py"
   
   output:
-    format: "text"                 # Output format: text, json, yaml, csv
+    format: "text"                 # Output format: text, json, yaml, csv, html
     show_details: false            # Show detailed clone information
     show_content: false            # Include source code content in output
     sort_by: "similarity"          # Sort by: similarity, size, location, type
@@ -98,7 +98,7 @@ clones:
 # OUTPUT CONFIGURATION
 # =============================================================================
 output:
-  format: "text"                   # Default output format: text, json, yaml, csv
+  format: "text"                   # Default output format: text, json, yaml, csv, html
   show_details: false              # Show detailed breakdown by default
   sort_by: "name"                  # Default sort: name, complexity, risk
   min_complexity: 1                # Minimum complexity to report

--- a/cmd/pyqol/new_commands_test.go
+++ b/cmd/pyqol/new_commands_test.go
@@ -33,7 +33,7 @@ func TestAnalyzeCommandInterface(t *testing.T) {
 
 	// Test that essential flags are present
 	flags := cobraCmd.Flags()
-	expectedFlags := []string{"format", "config", "skip-complexity", "skip-deadcode", "skip-clones"}
+	expectedFlags := []string{"html", "json", "csv", "yaml", "config", "skip-complexity", "skip-deadcode", "skip-clones"}
 	for _, flagName := range expectedFlags {
 		flag := flags.Lookup(flagName)
 		if flag == nil {

--- a/cmd/pyqol/utils.go
+++ b/cmd/pyqol/utils.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// generateFileName generates an automatic filename for the output
+func generateFileName(command, extension string) string {
+	timestamp := time.Now().Format("20060102_150405")
+	return fmt.Sprintf("%s_%s.%s", command, timestamp, extension)
+}

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -1,0 +1,116 @@
+package domain
+
+import (
+	"time"
+)
+
+// AnalyzeResponse represents the combined results of all analyses
+type AnalyzeResponse struct {
+	// Analysis results
+	Complexity *ComplexityResponse `json:"complexity,omitempty" yaml:"complexity,omitempty"`
+	DeadCode   *DeadCodeResponse   `json:"dead_code,omitempty" yaml:"dead_code,omitempty"`
+	Clone      *CloneResponse      `json:"clone,omitempty" yaml:"clone,omitempty"`
+
+	// Overall summary
+	Summary AnalyzeSummary `json:"summary" yaml:"summary"`
+
+	// Metadata
+	GeneratedAt time.Time `json:"generated_at" yaml:"generated_at"`
+	Duration    int64     `json:"duration_ms" yaml:"duration_ms"`
+	Version     string    `json:"version" yaml:"version"`
+}
+
+// AnalyzeSummary provides an overall summary of all analyses
+type AnalyzeSummary struct {
+	// File statistics
+	TotalFiles     int `json:"total_files" yaml:"total_files"`
+	AnalyzedFiles  int `json:"analyzed_files" yaml:"analyzed_files"`
+	SkippedFiles   int `json:"skipped_files" yaml:"skipped_files"`
+
+	// Analysis status
+	ComplexityEnabled bool `json:"complexity_enabled" yaml:"complexity_enabled"`
+	DeadCodeEnabled   bool `json:"dead_code_enabled" yaml:"dead_code_enabled"`
+	CloneEnabled      bool `json:"clone_enabled" yaml:"clone_enabled"`
+
+	// Key metrics
+	TotalFunctions      int     `json:"total_functions" yaml:"total_functions"`
+	AverageComplexity   float64 `json:"average_complexity" yaml:"average_complexity"`
+	HighComplexityCount int     `json:"high_complexity_count" yaml:"high_complexity_count"`
+	
+	DeadCodeCount       int     `json:"dead_code_count" yaml:"dead_code_count"`
+	CriticalDeadCode    int     `json:"critical_dead_code" yaml:"critical_dead_code"`
+	
+	ClonePairs          int     `json:"clone_pairs" yaml:"clone_pairs"`
+	CloneGroups         int     `json:"clone_groups" yaml:"clone_groups"`
+	CodeDuplication     float64 `json:"code_duplication_percentage" yaml:"code_duplication_percentage"`
+
+	// Overall health score (0-100)
+	HealthScore int    `json:"health_score" yaml:"health_score"`
+	Grade       string `json:"grade" yaml:"grade"` // A, B, C, D, F
+}
+
+// CalculateHealthScore calculates an overall health score based on analysis results
+func (s *AnalyzeSummary) CalculateHealthScore() {
+	score := 100
+
+	// Deduct points for high complexity
+	if s.AverageComplexity > 20 {
+		score -= 30
+	} else if s.AverageComplexity > 10 {
+		score -= 20
+	} else if s.AverageComplexity > 5 {
+		score -= 10
+	}
+
+	// Deduct points for dead code
+	if s.DeadCodeCount > 0 {
+		deduction := (s.DeadCodeCount * 2)
+		if deduction > 20 {
+			deduction = 20
+		}
+		score -= deduction
+	}
+
+	// Deduct points for critical dead code
+	score -= s.CriticalDeadCode * 5
+
+	// Deduct points for code duplication
+	if s.CodeDuplication > 30 {
+		score -= 25
+	} else if s.CodeDuplication > 20 {
+		score -= 15
+	} else if s.CodeDuplication > 10 {
+		score -= 10
+	}
+
+	// Ensure score is within bounds
+	if score < 0 {
+		score = 0
+	}
+
+	s.HealthScore = score
+
+	// Assign grade based on score
+	switch {
+	case score >= 90:
+		s.Grade = "A"
+	case score >= 80:
+		s.Grade = "B"
+	case score >= 70:
+		s.Grade = "C"
+	case score >= 60:
+		s.Grade = "D"
+	default:
+		s.Grade = "F"
+	}
+}
+
+// IsHealthy returns true if the codebase is considered healthy
+func (s *AnalyzeSummary) IsHealthy() bool {
+	return s.HealthScore >= 70
+}
+
+// HasIssues returns true if any issues were found
+func (s *AnalyzeSummary) HasIssues() bool {
+	return s.HighComplexityCount > 0 || s.DeadCodeCount > 0 || s.ClonePairs > 0
+}

--- a/domain/complexity.go
+++ b/domain/complexity.go
@@ -13,6 +13,7 @@ const (
 	OutputFormatJSON OutputFormat = "json"
 	OutputFormatYAML OutputFormat = "yaml"
 	OutputFormatCSV  OutputFormat = "csv"
+	OutputFormatHTML OutputFormat = "html"
 )
 
 // SortCriteria represents the criteria for sorting results
@@ -44,6 +45,8 @@ type ComplexityRequest struct {
 	// Output configuration
 	OutputFormat OutputFormat
 	OutputWriter io.Writer
+	OutputPath   string // Path to save output file (for HTML format)
+	NoOpen       bool   // Don't auto-open HTML in browser
 	ShowDetails  bool
 
 	// Filtering and sorting

--- a/domain/complexity_test.go
+++ b/domain/complexity_test.go
@@ -14,6 +14,7 @@ func TestOutputFormat(t *testing.T) {
 		{"JSON format", OutputFormatJSON, true},
 		{"YAML format", OutputFormatYAML, true},
 		{"CSV format", OutputFormatCSV, true},
+		{"HTML format", OutputFormatHTML, true},
 		{"Invalid format", OutputFormat("invalid"), false},
 	}
 
@@ -22,6 +23,7 @@ func TestOutputFormat(t *testing.T) {
 		OutputFormatJSON: true,
 		OutputFormatYAML: true,
 		OutputFormatCSV:  true,
+		OutputFormatHTML: true,
 	}
 
 	for _, tt := range tests {

--- a/domain/dead_code.go
+++ b/domain/dead_code.go
@@ -32,6 +32,8 @@ type DeadCodeRequest struct {
 	// Output configuration
 	OutputFormat OutputFormat
 	OutputWriter io.Writer
+	OutputPath   string // Path to save output file (for HTML format)
+	NoOpen       bool   // Don't auto-open HTML in browser
 	ShowContext  bool
 	ContextLines int // Number of lines to show around dead code
 
@@ -236,6 +238,7 @@ func (req *DeadCodeRequest) Validate() error {
 		OutputFormatJSON: true,
 		OutputFormatYAML: true,
 		OutputFormatCSV:  true,
+		OutputFormatHTML: true,
 	}
 
 	if !validFormats[req.OutputFormat] {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -312,10 +312,11 @@ func (c *Config) Validate() error {
 		"json": true,
 		"yaml": true,
 		"csv":  true,
+		"html": true,
 	}
 
 	if !validFormats[c.Output.Format] {
-		return fmt.Errorf("invalid output.format '%s', must be one of: text, json, yaml, csv", c.Output.Format)
+		return fmt.Errorf("invalid output.format '%s', must be one of: text, json, yaml, csv, html", c.Output.Format)
 	}
 
 	// Validate sort options

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -1,0 +1,435 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"time"
+
+	"github.com/pyqol/pyqol/domain"
+	"gopkg.in/yaml.v3"
+)
+
+// AnalyzeFormatter handles formatting of unified analysis reports
+type AnalyzeFormatter struct {
+	complexityFormatter *OutputFormatterImpl
+	deadCodeFormatter   *DeadCodeFormatterImpl
+	cloneFormatter      *CloneOutputFormatter
+}
+
+// NewAnalyzeFormatter creates a new analyze formatter
+func NewAnalyzeFormatter() *AnalyzeFormatter {
+	return &AnalyzeFormatter{
+		complexityFormatter: NewOutputFormatter(),
+		deadCodeFormatter:   NewDeadCodeFormatter(),
+		cloneFormatter:      NewCloneOutputFormatter(),
+	}
+}
+
+// Write formats and writes the unified analysis response
+func (f *AnalyzeFormatter) Write(response *domain.AnalyzeResponse, format domain.OutputFormat, writer io.Writer) error {
+	switch format {
+	case domain.OutputFormatText:
+		return f.writeText(response, writer)
+	case domain.OutputFormatJSON:
+		return f.writeJSON(response, writer)
+	case domain.OutputFormatYAML:
+		return f.writeYAML(response, writer)
+	case domain.OutputFormatCSV:
+		return f.writeCSV(response, writer)
+	case domain.OutputFormatHTML:
+		return f.writeHTML(response, writer)
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+// writeText formats the response as plain text
+func (f *AnalyzeFormatter) writeText(response *domain.AnalyzeResponse, writer io.Writer) error {
+	fmt.Fprintf(writer, "PyQOL Comprehensive Analysis Report\n")
+	fmt.Fprintf(writer, "====================================\n\n")
+	fmt.Fprintf(writer, "Generated: %s\n\n", response.GeneratedAt.Format(time.RFC3339))
+
+	// Summary section
+	fmt.Fprintf(writer, "Overall Health Score: %d/100 (Grade: %s)\n", 
+		response.Summary.HealthScore, response.Summary.Grade)
+	fmt.Fprintf(writer, "Analysis Duration: %.2fs\n\n", float64(response.Duration)/1000.0)
+
+	// File statistics
+	fmt.Fprintf(writer, "File Statistics:\n")
+	fmt.Fprintf(writer, "  Total Files: %d\n", response.Summary.TotalFiles)
+	fmt.Fprintf(writer, "  Analyzed: %d\n", response.Summary.AnalyzedFiles)
+	fmt.Fprintf(writer, "  Skipped: %d\n\n", response.Summary.SkippedFiles)
+
+	// Complexity analysis results
+	if response.Complexity != nil && response.Summary.ComplexityEnabled {
+		fmt.Fprintf(writer, "Complexity Analysis:\n")
+		fmt.Fprintf(writer, "--------------------\n")
+		fmt.Fprintf(writer, "  Total Functions: %d\n", response.Summary.TotalFunctions)
+		fmt.Fprintf(writer, "  Average Complexity: %.2f\n", response.Summary.AverageComplexity)
+		fmt.Fprintf(writer, "  High Complexity Count: %d\n\n", response.Summary.HighComplexityCount)
+	}
+
+	// Dead code analysis results
+	if response.DeadCode != nil && response.Summary.DeadCodeEnabled {
+		fmt.Fprintf(writer, "Dead Code Detection:\n")
+		fmt.Fprintf(writer, "-------------------\n")
+		fmt.Fprintf(writer, "  Total Issues: %d\n", response.Summary.DeadCodeCount)
+		fmt.Fprintf(writer, "  Critical Issues: %d\n\n", response.Summary.CriticalDeadCode)
+	}
+
+	// Clone detection results
+	if response.Clone != nil && response.Summary.CloneEnabled {
+		fmt.Fprintf(writer, "Clone Detection:\n")
+		fmt.Fprintf(writer, "---------------\n")
+		fmt.Fprintf(writer, "  Clone Pairs: %d\n", response.Summary.ClonePairs)
+		fmt.Fprintf(writer, "  Clone Groups: %d\n", response.Summary.CloneGroups)
+		fmt.Fprintf(writer, "  Code Duplication: %.2f%%\n\n", response.Summary.CodeDuplication)
+	}
+
+	// Recommendations
+	fmt.Fprintf(writer, "Recommendations:\n")
+	fmt.Fprintf(writer, "---------------\n")
+	if response.Summary.HighComplexityCount > 0 {
+		fmt.Fprintf(writer, "  • Refactor %d high-complexity functions\n", response.Summary.HighComplexityCount)
+	}
+	if response.Summary.DeadCodeCount > 0 {
+		fmt.Fprintf(writer, "  • Remove %d dead code segments\n", response.Summary.DeadCodeCount)
+	}
+	if response.Summary.CodeDuplication > 10 {
+		fmt.Fprintf(writer, "  • Reduce code duplication (currently %.1f%%)\n", response.Summary.CodeDuplication)
+	}
+
+	return nil
+}
+
+// writeJSON formats the response as JSON
+func (f *AnalyzeFormatter) writeJSON(response *domain.AnalyzeResponse, writer io.Writer) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(response)
+}
+
+// writeYAML formats the response as YAML
+func (f *AnalyzeFormatter) writeYAML(response *domain.AnalyzeResponse, writer io.Writer) error {
+	encoder := yaml.NewEncoder(writer)
+	return encoder.Encode(response)
+}
+
+// writeCSV formats the response as CSV (summary only)
+func (f *AnalyzeFormatter) writeCSV(response *domain.AnalyzeResponse, writer io.Writer) error {
+	// Write header
+	fmt.Fprintf(writer, "Metric,Value\n")
+	
+	// Write summary metrics
+	fmt.Fprintf(writer, "Health Score,%d\n", response.Summary.HealthScore)
+	fmt.Fprintf(writer, "Grade,%s\n", response.Summary.Grade)
+	fmt.Fprintf(writer, "Total Files,%d\n", response.Summary.TotalFiles)
+	fmt.Fprintf(writer, "Analyzed Files,%d\n", response.Summary.AnalyzedFiles)
+	fmt.Fprintf(writer, "Average Complexity,%.2f\n", response.Summary.AverageComplexity)
+	fmt.Fprintf(writer, "High Complexity Count,%d\n", response.Summary.HighComplexityCount)
+	fmt.Fprintf(writer, "Dead Code Count,%d\n", response.Summary.DeadCodeCount)
+	fmt.Fprintf(writer, "Critical Dead Code,%d\n", response.Summary.CriticalDeadCode)
+	fmt.Fprintf(writer, "Clone Pairs,%d\n", response.Summary.ClonePairs)
+	fmt.Fprintf(writer, "Clone Groups,%d\n", response.Summary.CloneGroups)
+	fmt.Fprintf(writer, "Code Duplication,%.2f\n", response.Summary.CodeDuplication)
+	
+	return nil
+}
+
+// writeHTML formats the response as HTML
+func (f *AnalyzeFormatter) writeHTML(response *domain.AnalyzeResponse, writer io.Writer) error {
+	tmpl := template.Must(template.New("analyze").Parse(analyzeHTMLTemplate))
+	return tmpl.Execute(writer, response)
+}
+
+// HTML template for unified report
+const analyzeHTMLTemplate = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PyQOL Analysis Report</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            background: white;
+            border-radius: 10px;
+            padding: 30px;
+            margin-bottom: 20px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        }
+        .header h1 {
+            color: #667eea;
+            margin-bottom: 10px;
+        }
+        .score-badge {
+            display: inline-block;
+            padding: 10px 20px;
+            border-radius: 50px;
+            font-size: 24px;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .grade-a { background: #4caf50; color: white; }
+        .grade-b { background: #8bc34a; color: white; }
+        .grade-c { background: #ff9800; color: white; }
+        .grade-d { background: #ff5722; color: white; }
+        .grade-f { background: #f44336; color: white; }
+        
+        .tabs {
+            background: white;
+            border-radius: 10px;
+            overflow: hidden;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+        }
+        .tab-buttons {
+            display: flex;
+            background: #f5f5f5;
+        }
+        .tab-button {
+            flex: 1;
+            padding: 15px;
+            border: none;
+            background: transparent;
+            cursor: pointer;
+            font-size: 16px;
+            transition: all 0.3s;
+        }
+        .tab-button.active {
+            background: white;
+            color: #667eea;
+            font-weight: bold;
+        }
+        .tab-content {
+            display: none;
+            padding: 30px;
+        }
+        .tab-content.active {
+            display: block;
+        }
+        
+        .metric-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin: 20px 0;
+        }
+        .metric-card {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+        }
+        .metric-value {
+            font-size: 32px;
+            font-weight: bold;
+            color: #667eea;
+        }
+        .metric-label {
+            color: #666;
+            margin-top: 5px;
+        }
+        
+        .table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 20px 0;
+        }
+        .table th, .table td {
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #ddd;
+        }
+        .table th {
+            background: #f8f9fa;
+            font-weight: 600;
+        }
+        
+        .risk-low { color: #4caf50; }
+        .risk-medium { color: #ff9800; }
+        .risk-high { color: #f44336; }
+        
+        .severity-critical { color: #f44336; }
+        .severity-warning { color: #ff9800; }
+        .severity-info { color: #2196f3; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>PyQOL Analysis Report</h1>
+            <p>Generated: {{.GeneratedAt.Format "2006-01-02 15:04:05"}}</p>
+            <div class="score-badge grade-{{if eq .Summary.Grade "A"}}a{{else if eq .Summary.Grade "B"}}b{{else if eq .Summary.Grade "C"}}c{{else if eq .Summary.Grade "D"}}d{{else}}f{{end}}">
+                Health Score: {{.Summary.HealthScore}}/100 (Grade: {{.Summary.Grade}})
+            </div>
+        </div>
+
+        <div class="tabs">
+            <div class="tab-buttons">
+                <button class="tab-button active" onclick="showTab('summary')">Summary</button>
+                {{if .Summary.ComplexityEnabled}}
+                <button class="tab-button" onclick="showTab('complexity')">Complexity</button>
+                {{end}}
+                {{if .Summary.DeadCodeEnabled}}
+                <button class="tab-button" onclick="showTab('deadcode')">Dead Code</button>
+                {{end}}
+                {{if .Summary.CloneEnabled}}
+                <button class="tab-button" onclick="showTab('clone')">Clone Detection</button>
+                {{end}}
+            </div>
+
+            <div id="summary" class="tab-content active">
+                <h2>Analysis Summary</h2>
+                <div class="metric-grid">
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Summary.TotalFiles}}</div>
+                        <div class="metric-label">Total Files</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Summary.AnalyzedFiles}}</div>
+                        <div class="metric-label">Analyzed Files</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.2f" .Summary.AverageComplexity}}</div>
+                        <div class="metric-label">Avg Complexity</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Summary.DeadCodeCount}}</div>
+                        <div class="metric-label">Dead Code Issues</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Summary.ClonePairs}}</div>
+                        <div class="metric-label">Clone Pairs</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.1f%%" .Summary.CodeDuplication}}</div>
+                        <div class="metric-label">Code Duplication</div>
+                    </div>
+                </div>
+            </div>
+
+            {{if .Summary.ComplexityEnabled}}
+            <div id="complexity" class="tab-content">
+                <h2>Complexity Analysis</h2>
+                {{if .Complexity}}
+                <div class="metric-grid">
+                    <div class="metric-card">
+                        <div class="metric-value">{{len .Complexity.Functions}}</div>
+                        <div class="metric-label">Total Functions</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.2f" .Complexity.Summary.AverageComplexity}}</div>
+                        <div class="metric-label">Average</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Complexity.Summary.MaxComplexity}}</div>
+                        <div class="metric-label">Maximum</div>
+                    </div>
+                </div>
+                
+                <h3>Top Complex Functions</h3>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Function</th>
+                            <th>File</th>
+                            <th>Complexity</th>
+                            <th>Risk</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{range $i, $f := .Complexity.Functions}}
+                        {{if lt $i 10}}
+                        <tr>
+                            <td>{{$f.Name}}</td>
+                            <td>{{$f.FilePath}}</td>
+                            <td>{{$f.Metrics.Complexity}}</td>
+                            <td class="risk-{{$f.RiskLevel}}">{{$f.RiskLevel}}</td>
+                        </tr>
+                        {{end}}
+                        {{end}}
+                    </tbody>
+                </table>
+                {{end}}
+            </div>
+            {{end}}
+
+            {{if .Summary.DeadCodeEnabled}}
+            <div id="deadcode" class="tab-content">
+                <h2>Dead Code Detection</h2>
+                {{if .DeadCode}}
+                <div class="metric-grid">
+                    <div class="metric-card">
+                        <div class="metric-value">{{.DeadCode.Summary.TotalFindings}}</div>
+                        <div class="metric-label">Total Issues</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.DeadCode.Summary.CriticalFindings}}</div>
+                        <div class="metric-label">Critical</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.DeadCode.Summary.WarningFindings}}</div>
+                        <div class="metric-label">Warnings</div>
+                    </div>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+
+            {{if .Summary.CloneEnabled}}
+            <div id="clone" class="tab-content">
+                <h2>Clone Detection</h2>
+                {{if .Clone}}
+                <div class="metric-grid">
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Clone.Statistics.TotalClonePairs}}</div>
+                        <div class="metric-label">Clone Pairs</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Clone.Statistics.TotalCloneGroups}}</div>
+                        <div class="metric-label">Clone Groups</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.2f" .Clone.Statistics.AverageSimilarity}}</div>
+                        <div class="metric-label">Avg Similarity</div>
+                    </div>
+                </div>
+                {{end}}
+            </div>
+            {{end}}
+        </div>
+    </div>
+
+    <script>
+        function showTab(tabName) {
+            // Hide all tabs
+            const tabs = document.querySelectorAll('.tab-content');
+            tabs.forEach(tab => tab.classList.remove('active'));
+            
+            // Remove active from all buttons
+            const buttons = document.querySelectorAll('.tab-button');
+            buttons.forEach(btn => btn.classList.remove('active'));
+            
+            // Show selected tab
+            document.getElementById(tabName).classList.add('active');
+            
+            // Mark button as active
+            event.target.classList.add('active');
+        }
+    </script>
+</body>
+</html>`

--- a/service/browser.go
+++ b/service/browser.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// OpenBrowser opens the specified URL in the default browser
+func OpenBrowser(url string) error {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "darwin": // macOS
+		cmd = "open"
+		args = []string{url}
+	case "linux":
+		// Try different commands in order of preference
+		for _, openCmd := range []string{"xdg-open", "gnome-open", "kde-open"} {
+			if _, err := exec.LookPath(openCmd); err == nil {
+				cmd = openCmd
+				args = []string{url}
+				break
+			}
+		}
+		if cmd == "" {
+			return fmt.Errorf("no suitable browser opener found for Linux")
+		}
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start", url}
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	// Use Start() instead of Run() to avoid waiting for the browser to close
+	if err := exec.Command(cmd, args...).Start(); err != nil {
+		return fmt.Errorf("failed to open browser: %w", err)
+	}
+
+	return nil
+}

--- a/service/config_loader.go
+++ b/service/config_loader.go
@@ -119,6 +119,8 @@ func (c *ConfigurationLoaderImpl) convertToComplexityRequest(cfg *config.Config)
 		outputFormat = domain.OutputFormatYAML
 	case "csv":
 		outputFormat = domain.OutputFormatCSV
+	case "html":
+		outputFormat = domain.OutputFormatHTML
 	default:
 		outputFormat = domain.OutputFormatText
 	}

--- a/service/dead_code_config_loader.go
+++ b/service/dead_code_config_loader.go
@@ -121,6 +121,8 @@ func (cl *DeadCodeConfigurationLoaderImpl) configToRequest(cfg *config.Config) *
 		outputFormat = domain.OutputFormatYAML
 	case "csv":
 		outputFormat = domain.OutputFormatCSV
+	case "html":
+		outputFormat = domain.OutputFormatHTML
 	default:
 		outputFormat = domain.OutputFormatText
 	}

--- a/service/dead_code_formatter.go
+++ b/service/dead_code_formatter.go
@@ -30,6 +30,8 @@ func (f *DeadCodeFormatterImpl) Format(response *domain.DeadCodeResponse, format
 		return f.formatYAML(response)
 	case domain.OutputFormatCSV:
 		return f.formatCSV(response)
+	case domain.OutputFormatHTML:
+		return f.formatHTML(response)
 	default:
 		return "", domain.NewUnsupportedFormatError(string(format))
 	}
@@ -61,6 +63,10 @@ func (f *DeadCodeFormatterImpl) FormatFinding(finding domain.DeadCodeFinding, fo
 	case domain.OutputFormatYAML:
 		data, err := yaml.Marshal(finding)
 		return string(data), err
+	case domain.OutputFormatHTML:
+		// HTML formatting for individual findings is not typically needed
+		// Fall back to text format for individual findings
+		return f.formatFindingText(finding), nil
 	default:
 		return "", domain.NewUnsupportedFormatError(string(format))
 	}
@@ -186,4 +192,11 @@ func (f *DeadCodeFormatterImpl) formatCSV(response *domain.DeadCodeResponse) (st
 	}
 
 	return output.String(), nil
+}
+
+// formatHTML formats the response as Lighthouse-style HTML
+func (f *DeadCodeFormatterImpl) formatHTML(response *domain.DeadCodeResponse) (string, error) {
+	htmlFormatter := NewHTMLFormatter()
+	projectName := "Python Project" // Default project name, could be configurable
+	return htmlFormatter.FormatDeadCodeAsHTML(response, projectName)
 }

--- a/service/output_formatter.go
+++ b/service/output_formatter.go
@@ -32,6 +32,8 @@ func (f *OutputFormatterImpl) Format(response *domain.ComplexityResponse, format
 		return f.formatYAML(response)
 	case domain.OutputFormatCSV:
 		return f.formatCSV(response)
+	case domain.OutputFormatHTML:
+		return f.formatHTML(response)
 	default:
 		return "", domain.NewUnsupportedFormatError(string(format))
 	}
@@ -316,4 +318,11 @@ func (f *OutputFormatterImpl) formatSummaryText(response *domain.ComplexityRespo
 	}
 
 	return builder.String()
+}
+
+// formatHTML formats the response as Lighthouse-style HTML
+func (f *OutputFormatterImpl) formatHTML(response *domain.ComplexityResponse) (string, error) {
+	htmlFormatter := NewHTMLFormatter()
+	projectName := "Python Project" // Default project name, could be configurable
+	return htmlFormatter.FormatComplexityAsHTML(response, projectName)
 }

--- a/service/output_formatter_test.go
+++ b/service/output_formatter_test.go
@@ -248,6 +248,25 @@ func TestOutputFormatter_Format(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:     "format as HTML",
+			response: createTestComplexityResponse(),
+			format:   domain.OutputFormatHTML,
+			validateOutput: func(t *testing.T, output string) {
+				// Verify HTML structure
+				assert.Contains(t, output, "<!DOCTYPE html>", "Should contain HTML doctype")
+				assert.Contains(t, output, "<title>", "Should contain title tag")
+				assert.Contains(t, output, "PyQol Code Quality Report", "Should contain report title")
+				assert.Contains(t, output, "Overall Score", "Should contain overall score")
+				assert.Contains(t, output, "<style>", "Should contain embedded CSS")
+				assert.Contains(t, output, "Complexity Score", "Should contain complexity score")
+				
+				// Check for Lighthouse-style elements
+				assert.Contains(t, output, "score-circle", "Should have score circle element")
+				assert.Contains(t, output, "score-gauge", "Should have score gauge element")
+			},
+			expectError: false,
+		},
+		{
 			name:        "unsupported format error",
 			response:    createTestComplexityResponse(),
 			format:      domain.OutputFormat("invalid"),


### PR DESCRIPTION
## Summary
- Replace `--format` flag with individual format flags (`--html`, `--json`, `--csv`, `--yaml`)
- Add automatic file generation for non-text formats with timestamps
- Add HTML report auto-opening with `--no-open` flag to disable
- Add unified analyze command with comprehensive reporting

## Key Changes

### Command Interface Improvements
- **Individual format flags**: `--html`, `--json`, `--csv`, `--yaml` instead of `--format`
- **Automatic file naming**: `clone_20250828_143021.html` format with timestamps
- **Browser integration**: HTML reports auto-open in default browser
- **No-open flag**: `--no-open` to disable automatic browser opening

### New Features
- **Unified analyze command**: Comprehensive reporting across all analysis types
- **Cross-platform browser support**: Works on macOS, Linux, and Windows
- **File output handling**: Automatic file creation and path resolution
- **HTML format support**: Added to all analysis commands

### Technical Updates
- Added `OutputPath` and `NoOpen` fields to domain models
- Updated configuration loaders to handle new flag system
- Enhanced formatters with HTML support
- Updated tests for new flag expectations

## User Experience
Before:
```bash
pyqol clone --format html src/
# Creates output on stdout, user needs to redirect to file
```

After:
```bash
pyqol clone --html src/
# Automatically creates clone_20250828_143021.html and opens in browser
```

## Backwards Compatibility
- Text output remains the default behavior (no flags needed)
- All existing flags and functionality preserved
- Only `--format` flag removed in favor of individual format flags

🤖 Generated with [Claude Code](https://claude.ai/code)