### PR TITLE
Fix: Resolve viper race condition in parallel config loading

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,16 +241,18 @@ func loadConfigFromFile(configPath string) (*Config, error) {
 		return DefaultConfig(), nil
 	}
 
+	// Create a new viper instance to avoid race conditions
+	v := viper.New()
 	config := DefaultConfig()
-	viper.SetConfigFile(configPath)
+	v.SetConfigFile(configPath)
 
 	// Read config file
-	if err := viper.ReadInConfig(); err != nil {
+	if err := v.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
 	}
 
 	// Unmarshal into config struct
-	if err := viper.Unmarshal(config); err != nil {
+	if err := v.Unmarshal(config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
@@ -452,16 +454,18 @@ func (c *ComplexityConfig) ExceedsMaxComplexity(complexity int) bool {
 
 // SaveConfig saves configuration to a YAML file
 func SaveConfig(config *Config, path string) error {
-	viper.SetConfigFile(path)
-	viper.SetConfigType("yaml")
+	// Create a new viper instance to avoid race conditions
+	v := viper.New()
+	v.SetConfigFile(path)
+	v.SetConfigType("yaml")
 
 	// Set all config values in viper
-	viper.Set("complexity", config.Complexity)
-	viper.Set("dead_code", config.DeadCode)
-	viper.Set("output", config.Output)
-	viper.Set("analysis", config.Analysis)
+	v.Set("complexity", config.Complexity)
+	v.Set("dead_code", config.DeadCode)
+	v.Set("output", config.Output)
+	v.Set("analysis", config.Analysis)
 
-	return viper.WriteConfig()
+	return v.WriteConfig()
 }
 
 // validateDeadCodeConfig validates the dead code configuration


### PR DESCRIPTION
## Summary
- Fixed race condition when running `analyze` command with parallel goroutines
- Replaced global viper instance with new instances for thread-safe config operations
- Tests now pass with `-race` flag enabled

## Problem
A race condition occurred when the `analyze` command ran multiple analyses (complexity, dead code, clone) in parallel. Each goroutine called `LoadConfig()` which used the global viper instance, causing concurrent read/write conflicts.

## Solution
Created new viper instances in both `loadConfigFromFile()` and `SaveConfig()` functions instead of using the global viper instance. This ensures each configuration operation gets its own isolated viper instance, eliminating race conditions.

## Changes
- `internal/config/config.go`:
  - Modified `loadConfigFromFile()` to use `v := viper.New()`
  - Modified `SaveConfig()` to use `v := viper.New()`
  - All viper method calls updated to use the instance instead of global

## Test Results
✅ Race detector test passes: `go test -race ./cmd/pyqol -run TestAnalyzeCommandValidation`
✅ Full test suite passes with race detection: `go test -race ./...`

Fixes #62

🤖 Generated with [Claude Code](https://claude.ai/code)