### PR TITLE
chore: set release Go version to 1.23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.23'
     
     - name: Run tests
       run: go test -v ./...


### PR DESCRIPTION
Align release workflow with CI's Go version (1.23) to ensure consistent, reproducible release builds.\n\n- Update actions/setup-go in .github/workflows/release.yml to Go 1.23\n- No code changes; workflow-only.\n\nOnce merged, tag pushes (v*) will build with Go 1.23 via GoReleaser.