### PR TITLE
fix: replace hardcoded version in analyze command with dynamic version

### DIFF
--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ludo-technologies/pyscn/app"
 	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/version"
 	"github.com/ludo-technologies/pyscn/service"
 	"github.com/spf13/cobra"
 )
@@ -962,7 +963,7 @@ func (c *AnalyzeCommand) generateUnifiedReport(cmd *cobra.Command, result *Analy
 		CBO:         result.CBOResponse,
 		GeneratedAt: time.Now(),
 		Duration:    result.Overall.TotalTime.Milliseconds(),
-		Version:     "1.0.0", // TODO: Get from build info
+		Version:     version.Version,
 	}
 	
 	// Calculate summary statistics


### PR DESCRIPTION
## Problem
The `analyze` command was hardcoding the version as `"1.0.0"` instead of using the dynamic version information that's properly injected during build time via ldflags.

## Solution
- Add import for `internal/version` package to `analyze.go`
- Replace hardcoded `"1.0.0"` with `version.Version` 
- Remove TODO comment as version management is now properly implemented

## Before
```json
{
  "version": "1.0.0"  // Always showed 1.0.0 regardless of actual version
}
```

## After  
```json
{
  "version": "v0.1.0-beta.14"  // Shows actual build version
}
```

## Impact
- ✅ Consistent version reporting across all commands
- ✅ Analyze command now shows correct build version
- ✅ No breaking changes to API/CLI interface
- ✅ Resolves the TODO comment in analyze.go:965

## Testing
- [x] All existing tests pass
- [x] Version command works correctly
- [x] Analyze command now reports proper version

This fix ensures all commands (complexity, deadcode, clone, cbo, analyze) report consistent version information.

🤖 Generated with [Claude Code](https://claude.ai/code)