### PR TITLE
feat: Star/Medoid clone grouping (Issue #80)

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -202,12 +202,12 @@ func DefaultCloneDetectorConfig() *CloneDetectorConfig {
 
 // CloneDetector detects code clones using APTED algorithm
 type CloneDetector struct {
-	config         *CloneDetectorConfig
-	analyzer       *APTEDAnalyzer
-	converter      *TreeConverter
-	fragments      []*CodeFragment
-	clonePairs     []*ClonePair
-	cloneGroups    []*CloneGroup
+	config      *CloneDetectorConfig
+	analyzer    *APTEDAnalyzer
+	converter   *TreeConverter
+	fragments   []*CodeFragment
+	clonePairs  []*ClonePair
+	cloneGroups []*CloneGroup
 }
 
 // NewCloneDetectorFromConfig creates a new clone detector from unified config
@@ -360,7 +360,6 @@ func (cd *CloneDetector) DetectClones(fragments []*CodeFragment) ([]*ClonePair, 
 	return cd.DetectClonesWithContext(context.Background(), fragments)
 }
 
-
 // DetectClonesWithContext detects clones with context support for cancellation
 func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments []*CodeFragment) ([]*ClonePair, []*CloneGroup) {
 	cd.fragments = fragments
@@ -406,7 +405,6 @@ func (cd *CloneDetector) prepareFragments() {
 	}
 }
 
-
 // calculateBatchSize determines the optimal batch size based on fragment count
 func (cd *CloneDetector) calculateBatchSize(fragmentCount int) int {
 	if fragmentCount < cd.config.BatchSizeThreshold {
@@ -442,7 +440,6 @@ func (cd *CloneDetector) detectClonePairsWithContext(ctx context.Context) {
 	cd.limitAndSortClonePairs(cd.config.MaxClonePairs)
 }
 
-
 // detectClonePairsStandardWithContext uses standard approach with context
 func (cd *CloneDetector) detectClonePairsStandardWithContext(ctx context.Context) {
 	n := len(cd.fragments)
@@ -471,7 +468,6 @@ func (cd *CloneDetector) detectClonePairsStandardWithContext(ctx context.Context
 		}
 	}
 }
-
 
 // detectClonePairsWithBatchingContext processes batches with context support
 func (cd *CloneDetector) detectClonePairsWithBatchingContext(ctx context.Context, maxPairs, batchSize int) {
@@ -541,7 +537,7 @@ func (cd *CloneDetector) detectClonePairsWithBatchingContext(ctx context.Context
 func (cd *CloneDetector) shouldCompareFragments(fragment1, fragment2 *CodeFragment) bool {
 	// Early filtering: Skip if size difference is too large (>50%)
 	sizeDiff := math.Abs(float64(fragment1.Size - fragment2.Size))
-	avgSize := float64(fragment1.Size + fragment2.Size) / 2.0
+	avgSize := float64(fragment1.Size+fragment2.Size) / 2.0
 	if avgSize > 0 && sizeDiff/avgSize > 0.5 {
 		return false // Too different in size to be clones
 	}
@@ -735,12 +731,13 @@ func (cd *CloneDetector) calculateGroupSimilarity(group *CloneGroup) {
 
 // groupClonesWithStrategy groups clone pairs using a pluggable strategy.
 // This keeps backward compatibility with the existing groupClones method.
+//nolint:unused // Hook for pluggable grouping; used when strategy is wired via config.
 func (cd *CloneDetector) groupClonesWithStrategy(strategy GroupingStrategy) {
     if strategy == nil {
         cd.groupClones()
         return
     }
-    cd.cloneGroups = strategy.GroupClones(cd.clonePairs)
+	cd.cloneGroups = strategy.GroupClones(cd.clonePairs)
 }
 
 // isSameLocation checks if two locations refer to the same code

--- a/internal/analyzer/grouping_strategy.go
+++ b/internal/analyzer/grouping_strategy.go
@@ -3,9 +3,8 @@ package analyzer
 // GroupingStrategy defines a strategy for grouping clone pairs into clone groups.
 // Implementations should avoid recomputing similarities and work with provided pairs.
 type GroupingStrategy interface {
-    // GroupClones groups the given clone pairs into clone groups.
-    GroupClones(pairs []*ClonePair) []*CloneGroup
-    // GetName returns the strategy name.
-    GetName() string
+	// GroupClones groups the given clone pairs into clone groups.
+	GroupClones(pairs []*ClonePair) []*CloneGroup
+	// GetName returns the strategy name.
+	GetName() string
 }
-

--- a/internal/analyzer/star_medoid_grouping.go
+++ b/internal/analyzer/star_medoid_grouping.go
@@ -1,362 +1,358 @@
 package analyzer
 
 import (
-    "fmt"
-    "sort"
+	"fmt"
+	"sort"
 )
 
 // StarMedoidGrouping groups fragments by iteratively selecting medoids and reassigning members.
 // It uses provided pair similarities only and does not recompute.
 type StarMedoidGrouping struct {
-    threshold      float64
-    maxIterations  int
-    noChangeLimit  int
+	threshold     float64
+	maxIterations int
+	noChangeLimit int
 }
 
 // NewStarMedoidGrouping creates a new Star/Medoid grouping with a similarity threshold.
 // Default: maxIterations=10, early-stop after 3 consecutive no-change iterations.
 func NewStarMedoidGrouping(threshold float64) *StarMedoidGrouping {
-    return &StarMedoidGrouping{
-        threshold:     threshold,
-        maxIterations:  10,
-        noChangeLimit:  3,
-    }
+	return &StarMedoidGrouping{
+		threshold:     threshold,
+		maxIterations: 10,
+		noChangeLimit: 3,
+	}
 }
 
 func (s *StarMedoidGrouping) GetName() string { return "Star/Medoid" }
 
 // GroupClones groups clone pairs using a star/medoid strategy.
 func (s *StarMedoidGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
-    if len(pairs) == 0 {
-        return []*CloneGroup{}
-    }
+	if len(pairs) == 0 {
+		return []*CloneGroup{}
+	}
 
-    // 1. Collect unique fragments and cache similarities
-    fragments := s.collectFragments(pairs)
-    if len(fragments) == 0 {
-        return []*CloneGroup{}
-    }
-    simMap := s.buildSimilarityMap(pairs)
+	// 1. Collect unique fragments and cache similarities
+	fragments := s.collectFragments(pairs)
+	if len(fragments) == 0 {
+		return []*CloneGroup{}
+	}
+	simMap := s.buildSimilarityMap(pairs)
 
-    // 2. Initialize clusters: each fragment alone, with union-find to merge via medoids
-    type ufNode struct {
-        parent *CodeFragment
-        rank   int
-    }
-    parent := make(map[*CodeFragment]*CodeFragment, len(fragments))
-    rank := make(map[*CodeFragment]int, len(fragments))
-    var ufFind func(*CodeFragment) *CodeFragment
-    ufFind = func(x *CodeFragment) *CodeFragment {
-        if parent[x] != x {
-            parent[x] = ufFind(parent[x])
-        }
-        return parent[x]
-    }
-    ufUnion := func(a, b *CodeFragment) bool {
-        ra := ufFind(a)
-        rb := ufFind(b)
-        if ra == rb {
-            return false
-        }
-        if rank[ra] < rank[rb] {
-            parent[ra] = rb
-        } else if rank[ra] > rank[rb] {
-            parent[rb] = ra
-        } else {
-            parent[rb] = ra
-            rank[ra]++
-        }
-        return true
-    }
-    for _, f := range fragments {
-        parent[f] = f
-        rank[f] = 0
-    }
+	// 2. Initialize clusters: each fragment alone, with union-find to merge via medoids
+	parent := make(map[*CodeFragment]*CodeFragment, len(fragments))
+	rank := make(map[*CodeFragment]int, len(fragments))
+	var ufFind func(*CodeFragment) *CodeFragment
+	ufFind = func(x *CodeFragment) *CodeFragment {
+		if parent[x] != x {
+			parent[x] = ufFind(parent[x])
+		}
+		return parent[x]
+	}
+	ufUnion := func(a, b *CodeFragment) bool {
+		ra := ufFind(a)
+		rb := ufFind(b)
+		if ra == rb {
+			return false
+		}
+		if rank[ra] < rank[rb] {
+			parent[ra] = rb
+		} else if rank[ra] > rank[rb] {
+			parent[rb] = ra
+		} else {
+			parent[rb] = ra
+			rank[ra]++
+		}
+		return true
+	}
+	for _, f := range fragments {
+		parent[f] = f
+		rank[f] = 0
+	}
 
-    // helper to rebuild clusters from union-find parents
-    buildClusters := func() [][]*CodeFragment {
-        groups := make(map[*CodeFragment][]*CodeFragment)
-        for _, f := range fragments {
-            r := ufFind(f)
-            groups[r] = append(groups[r], f)
-        }
-        out := make([][]*CodeFragment, 0, len(groups))
-        for _, members := range groups {
-            out = append(out, members)
-        }
-        return out
-    }
+	// helper to rebuild clusters from union-find parents
+	buildClusters := func() [][]*CodeFragment {
+		groups := make(map[*CodeFragment][]*CodeFragment)
+		for _, f := range fragments {
+			r := ufFind(f)
+			groups[r] = append(groups[r], f)
+		}
+		out := make([][]*CodeFragment, 0, len(groups))
+		for _, members := range groups {
+			out = append(out, members)
+		}
+		return out
+	}
 
-    clusters := buildClusters()
+	clusters := buildClusters()
 
-    // 3. Iteratively improve: medoid selection and reassignment
-    noChangeStreak := 0
-    for iter := 0; iter < s.maxIterations; iter++ {
-        // a) compute medoids for each cluster
-        medoids := make([]*CodeFragment, len(clusters))
-        for i, members := range clusters {
-            medoids[i] = s.findMedoid(members, simMap)
-        }
+	// 3. Iteratively improve: medoid selection and reassignment
+	noChangeStreak := 0
+	for iter := 0; iter < s.maxIterations; iter++ {
+		// a) compute medoids for each cluster
+		medoids := make([]*CodeFragment, len(clusters))
+		for i, members := range clusters {
+			medoids[i] = s.findMedoid(members, simMap)
+		}
 
-        // b) connect each non-medoid fragment to the most similar medoid (union-find)
-        isMedoid := make(map[*CodeFragment]bool, len(medoids))
-        for _, m := range medoids {
-            if m != nil {
-                isMedoid[m] = true
-            }
-        }
-        changed := false
-        for _, f := range fragments {
-            // Keep medoids anchored after the first iteration to avoid oscillation
-            if iter > 0 && isMedoid[f] {
-                continue
-            }
-            bestMedoid := (*CodeFragment)(nil)
-            bestSim := -1.0
-            for _, m := range medoids {
-                if m == nil || m == f { // skip self-medoid
-                    continue
-                }
-                sim := similarity(simMap, f, m)
-                if sim > bestSim || (almostEqual(sim, bestSim) && bestMedoid != nil && fragmentLess(m, bestMedoid)) {
-                    bestSim = sim
-                    bestMedoid = m
-                }
-            }
-            if bestMedoid != nil && bestSim > 0.0 {
-                if ufUnion(f, bestMedoid) {
-                    changed = true
-                }
-            }
-        }
+		// b) connect each non-medoid fragment to the most similar medoid (union-find)
+		isMedoid := make(map[*CodeFragment]bool, len(medoids))
+		for _, m := range medoids {
+			if m != nil {
+				isMedoid[m] = true
+			}
+		}
+		changed := false
+		for _, f := range fragments {
+			// Keep medoids anchored after the first iteration to avoid oscillation
+			if iter > 0 && isMedoid[f] {
+				continue
+			}
+			bestMedoid := (*CodeFragment)(nil)
+			bestSim := -1.0
+			for _, m := range medoids {
+				if m == nil || m == f { // skip self-medoid
+					continue
+				}
+				sim := similarity(simMap, f, m)
+				if sim > bestSim || (almostEqual(sim, bestSim) && bestMedoid != nil && fragmentLess(m, bestMedoid)) {
+					bestSim = sim
+					bestMedoid = m
+				}
+			}
+			if bestMedoid != nil && bestSim > 0.0 {
+				if ufUnion(f, bestMedoid) {
+					changed = true
+				}
+			}
+		}
 
-        // c) rebuild clusters and check convergence
-        if !changed {
-            noChangeStreak++
-        } else {
-            noChangeStreak = 0
-        }
-        clusters = buildClusters()
-        if noChangeStreak >= s.noChangeLimit {
-            break
-        }
-    }
+		// c) rebuild clusters and check convergence
+		if !changed {
+			noChangeStreak++
+		} else {
+			noChangeStreak = 0
+		}
+		clusters = buildClusters()
+		if noChangeStreak >= s.noChangeLimit {
+			break
+		}
+	}
 
-    // 4. Filter members below threshold relative to cluster medoid
-    // and 5. Build CloneGroup objects (exclude size-1 groups)
-    result := make([]*CloneGroup, 0)
-    groupID := 0
-    for _, members := range clusters {
-        if len(members) < 2 {
-            continue // skip singletons
-        }
-        medoid := s.findMedoid(members, simMap)
-        filtered := make([]*CodeFragment, 0, len(members))
-        for _, f := range members {
-            if f == medoid {
-                filtered = append(filtered, f)
-                continue
-            }
-            if similarity(simMap, f, medoid) >= s.threshold {
-                filtered = append(filtered, f)
-            }
-        }
-        if len(filtered) < 2 {
-            continue
-        }
+	// 4. Filter members below threshold relative to cluster medoid
+	// and 5. Build CloneGroup objects (exclude size-1 groups)
+	result := make([]*CloneGroup, 0)
+	groupID := 0
+	for _, members := range clusters {
+		if len(members) < 2 {
+			continue // skip singletons
+		}
+		medoid := s.findMedoid(members, simMap)
+		filtered := make([]*CodeFragment, 0, len(members))
+		for _, f := range members {
+			if f == medoid {
+				filtered = append(filtered, f)
+				continue
+			}
+			if similarity(simMap, f, medoid) >= s.threshold {
+				filtered = append(filtered, f)
+			}
+		}
+		if len(filtered) < 2 {
+			continue
+		}
 
-        // Sort fragments deterministically for stable output
-        sort.Slice(filtered, func(i, j int) bool { return fragmentLess(filtered[i], filtered[j]) })
+		// Sort fragments deterministically for stable output
+		sort.Slice(filtered, func(i, j int) bool { return fragmentLess(filtered[i], filtered[j]) })
 
-        group := NewCloneGroup(groupID)
-        groupID++
-        for _, f := range filtered {
-            group.AddFragment(f)
-        }
-        // Compute average similarity from cache among group members
-        group.Similarity = averageGroupSimilarity(simMap, filtered)
-        result = append(result, group)
-    }
+		group := NewCloneGroup(groupID)
+		groupID++
+		for _, f := range filtered {
+			group.AddFragment(f)
+		}
+		// Compute average similarity from cache among group members
+		group.Similarity = averageGroupSimilarity(simMap, filtered)
+		result = append(result, group)
+	}
 
-    // Stable sort groups by decreasing similarity, then size, then first fragment location
-    sort.Slice(result, func(i, j int) bool {
-        if !almostEqual(result[i].Similarity, result[j].Similarity) {
-            return result[i].Similarity > result[j].Similarity
-        }
-        if result[i].Size != result[j].Size {
-            return result[i].Size > result[j].Size
-        }
-        // tie-breaker by first fragment location
-        if len(result[i].Fragments) == 0 || len(result[j].Fragments) == 0 {
-            return false
-        }
-        return fragmentLess(result[i].Fragments[0], result[j].Fragments[0])
-    })
+	// Stable sort groups by decreasing similarity, then size, then first fragment location
+	sort.Slice(result, func(i, j int) bool {
+		if !almostEqual(result[i].Similarity, result[j].Similarity) {
+			return result[i].Similarity > result[j].Similarity
+		}
+		if result[i].Size != result[j].Size {
+			return result[i].Size > result[j].Size
+		}
+		// tie-breaker by first fragment location
+		if len(result[i].Fragments) == 0 || len(result[j].Fragments) == 0 {
+			return false
+		}
+		return fragmentLess(result[i].Fragments[0], result[j].Fragments[0])
+	})
 
-    return result
+	return result
 }
 
 // findMedoid selects the member with the maximum average similarity to others.
 // Ties are broken by smaller location order.
 func (s *StarMedoidGrouping) findMedoid(fragments []*CodeFragment, sims map[string]float64) *CodeFragment {
-    if len(fragments) == 0 {
-        return nil
-    }
-    if len(fragments) == 1 {
-        return fragments[0]
-    }
+	if len(fragments) == 0 {
+		return nil
+	}
+	if len(fragments) == 1 {
+		return fragments[0]
+	}
 
-    var best *CodeFragment
-    bestAvg := -1.0
-    for _, cand := range fragments {
-        sum := 0.0
-        for _, other := range fragments {
-            if cand == other {
-                continue
-            }
-            sum += similarity(sims, cand, other)
-        }
-        avg := sum / float64(len(fragments)-1)
-        if avg > bestAvg || (almostEqual(avg, bestAvg) && best != nil && fragmentLess(cand, best)) {
-            bestAvg = avg
-            best = cand
-        } else if best == nil { // initialize
-            best = cand
-            bestAvg = avg
-        }
-    }
-    return best
+	var best *CodeFragment
+	bestAvg := -1.0
+	for _, cand := range fragments {
+		sum := 0.0
+		for _, other := range fragments {
+			if cand == other {
+				continue
+			}
+			sum += similarity(sims, cand, other)
+		}
+		avg := sum / float64(len(fragments)-1)
+		if avg > bestAvg || (almostEqual(avg, bestAvg) && best != nil && fragmentLess(cand, best)) {
+			bestAvg = avg
+			best = cand
+		} else if best == nil { // initialize
+			best = cand
+			bestAvg = avg
+		}
+	}
+	return best
 }
 
 // Helper: collect unique fragments from pairs
 func (s *StarMedoidGrouping) collectFragments(pairs []*ClonePair) []*CodeFragment {
-    seen := make(map[*CodeFragment]struct{})
-    order := make([]*CodeFragment, 0)
-    for _, p := range pairs {
-        if p.Fragment1 != nil {
-            if _, ok := seen[p.Fragment1]; !ok {
-                seen[p.Fragment1] = struct{}{}
-                order = append(order, p.Fragment1)
-            }
-        }
-        if p.Fragment2 != nil {
-            if _, ok := seen[p.Fragment2]; !ok {
-                seen[p.Fragment2] = struct{}{}
-                order = append(order, p.Fragment2)
-            }
-        }
-    }
-    return order
+	seen := make(map[*CodeFragment]struct{})
+	order := make([]*CodeFragment, 0)
+	for _, p := range pairs {
+		if p.Fragment1 != nil {
+			if _, ok := seen[p.Fragment1]; !ok {
+				seen[p.Fragment1] = struct{}{}
+				order = append(order, p.Fragment1)
+			}
+		}
+		if p.Fragment2 != nil {
+			if _, ok := seen[p.Fragment2]; !ok {
+				seen[p.Fragment2] = struct{}{}
+				order = append(order, p.Fragment2)
+			}
+		}
+	}
+	return order
 }
 
 // Helper: build similarity cache from given pairs
 func (s *StarMedoidGrouping) buildSimilarityMap(pairs []*ClonePair) map[string]float64 {
-    sims := make(map[string]float64, len(pairs)*2)
-    for _, p := range pairs {
-        if p.Fragment1 == nil || p.Fragment2 == nil {
-            continue
-        }
-        k := pairKey(p.Fragment1, p.Fragment2)
-        if old, ok := sims[k]; !ok || p.Similarity > old {
-            sims[k] = p.Similarity // keep the highest if duplicates exist
-        }
-    }
-    return sims
+	sims := make(map[string]float64, len(pairs)*2)
+	for _, p := range pairs {
+		if p.Fragment1 == nil || p.Fragment2 == nil {
+			continue
+		}
+		k := pairKey(p.Fragment1, p.Fragment2)
+		if old, ok := sims[k]; !ok || p.Similarity > old {
+			sims[k] = p.Similarity // keep the highest if duplicates exist
+		}
+	}
+	return sims
 }
 
 // similarity returns cached similarity, or 0 if not present.
 func similarity(sims map[string]float64, a, b *CodeFragment) float64 {
-    if a == nil || b == nil {
-        return 0.0
-    }
-    if a == b {
-        return 1.0
-    }
-    if v, ok := sims[pairKey(a, b)]; ok {
-        return v
-    }
-    return 0.0
+	if a == nil || b == nil {
+		return 0.0
+	}
+	if a == b {
+		return 1.0
+	}
+	if v, ok := sims[pairKey(a, b)]; ok {
+		return v
+	}
+	return 0.0
 }
 
 // averageGroupSimilarity computes average pairwise similarity among members using cache.
 func averageGroupSimilarity(sims map[string]float64, members []*CodeFragment) float64 {
-    if len(members) < 2 {
-        return 1.0
-    }
-    sum := 0.0
-    cnt := 0
-    for i := 0; i < len(members); i++ {
-        for j := i + 1; j < len(members); j++ {
-            sum += similarity(sims, members[i], members[j])
-            cnt++
-        }
-    }
-    if cnt == 0 {
-        return 0.0
-    }
-    return sum / float64(cnt)
+	if len(members) < 2 {
+		return 1.0
+	}
+	sum := 0.0
+	cnt := 0
+	for i := 0; i < len(members); i++ {
+		for j := i + 1; j < len(members); j++ {
+			sum += similarity(sims, members[i], members[j])
+			cnt++
+		}
+	}
+	if cnt == 0 {
+		return 0.0
+	}
+	return sum / float64(cnt)
 }
 
 // pairKey creates a canonical key for a pair of fragments based on stable location ordering.
 func pairKey(a, b *CodeFragment) string {
-    ka := fragmentID(a)
-    kb := fragmentID(b)
-    if ka <= kb {
-        return ka + "||" + kb
-    }
-    return kb + "||" + ka
+	ka := fragmentID(a)
+	kb := fragmentID(b)
+	if ka <= kb {
+		return ka + "||" + kb
+	}
+	return kb + "||" + ka
 }
 
 // fragmentID returns a stable identifier for a fragment based on its location.
 func fragmentID(f *CodeFragment) string {
-    if f == nil || f.Location == nil {
-        return fmt.Sprintf("%p", f)
-    }
-    loc := f.Location
-    return fmt.Sprintf("%s|%d|%d|%d|%d", loc.FilePath, loc.StartLine, loc.EndLine, loc.StartCol, loc.EndCol)
+	if f == nil || f.Location == nil {
+		return fmt.Sprintf("%p", f)
+	}
+	loc := f.Location
+	return fmt.Sprintf("%s|%d|%d|%d|%d", loc.FilePath, loc.StartLine, loc.EndLine, loc.StartCol, loc.EndCol)
 }
 
 // fragmentLess provides deterministic ordering between two fragments by location.
 func fragmentLess(a, b *CodeFragment) bool {
-    if a == b {
-        return false
-    }
-    if a == nil {
-        return true
-    }
-    if b == nil {
-        return false
-    }
-    al, bl := a.Location, b.Location
-    if al == nil && bl == nil {
-        return fmt.Sprintf("%p", a) < fmt.Sprintf("%p", b)
-    }
-    if al == nil {
-        return true
-    }
-    if bl == nil {
-        return false
-    }
-    if al.FilePath != bl.FilePath {
-        return al.FilePath < bl.FilePath
-    }
-    if al.StartLine != bl.StartLine {
-        return al.StartLine < bl.StartLine
-    }
-    if al.StartCol != bl.StartCol {
-        return al.StartCol < bl.StartCol
-    }
-    if al.EndLine != bl.EndLine {
-        return al.EndLine < bl.EndLine
-    }
-    return al.EndCol < bl.EndCol
+	if a == b {
+		return false
+	}
+	if a == nil {
+		return true
+	}
+	if b == nil {
+		return false
+	}
+	al, bl := a.Location, b.Location
+	if al == nil && bl == nil {
+		return fmt.Sprintf("%p", a) < fmt.Sprintf("%p", b)
+	}
+	if al == nil {
+		return true
+	}
+	if bl == nil {
+		return false
+	}
+	if al.FilePath != bl.FilePath {
+		return al.FilePath < bl.FilePath
+	}
+	if al.StartLine != bl.StartLine {
+		return al.StartLine < bl.StartLine
+	}
+	if al.StartCol != bl.StartCol {
+		return al.StartCol < bl.StartCol
+	}
+	if al.EndLine != bl.EndLine {
+		return al.EndLine < bl.EndLine
+	}
+	return al.EndCol < bl.EndCol
 }
 
 func almostEqual(a, b float64) bool {
-    const eps = 1e-9
-    d := a - b
-    if d < 0 {
-        d = -d
-    }
-    return d <= eps
+	const eps = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d <= eps
 }

--- a/internal/analyzer/star_medoid_grouping_test.go
+++ b/internal/analyzer/star_medoid_grouping_test.go
@@ -1,157 +1,156 @@
 package analyzer
 
 import (
-    "fmt"
-    "testing"
-    "time"
+	"fmt"
+	"testing"
+	"time"
 
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func newFrag(path string, sl, el int) *CodeFragment {
-    return &CodeFragment{Location: &CodeLocation{FilePath: path, StartLine: sl, EndLine: el}}
+	return &CodeFragment{Location: &CodeLocation{FilePath: path, StartLine: sl, EndLine: el}}
 }
 
 func newPair(a, b *CodeFragment, sim float64) *ClonePair {
-    return &ClonePair{Fragment1: a, Fragment2: b, Similarity: sim}
+	return &ClonePair{Fragment1: a, Fragment2: b, Similarity: sim}
 }
 
 func TestStarMedoidGrouping_SimpleCase(t *testing.T) {
-    // A-B: 0.9, B-C: 0.8, A-C: 0.3
-    // threshold = 0.85 -> expect only {A,B}
-    A := newFrag("A.py", 1, 5)
-    B := newFrag("B.py", 1, 5)
-    C := newFrag("C.py", 1, 5)
+	// A-B: 0.9, B-C: 0.8, A-C: 0.3
+	// threshold = 0.85 -> expect only {A,B}
+	A := newFrag("A.py", 1, 5)
+	B := newFrag("B.py", 1, 5)
+	C := newFrag("C.py", 1, 5)
 
-    pairs := []*ClonePair{
-        newPair(A, B, 0.90),
-        newPair(B, C, 0.80),
-        newPair(A, C, 0.30),
-    }
+	pairs := []*ClonePair{
+		newPair(A, B, 0.90),
+		newPair(B, C, 0.80),
+		newPair(A, C, 0.30),
+	}
 
-    g := NewStarMedoidGrouping(0.85)
-    groups := g.GroupClones(pairs)
+	g := NewStarMedoidGrouping(0.85)
+	groups := g.GroupClones(pairs)
 
-    if !assert.Len(t, groups, 1, "Should form exactly one group") {
-        t.Fatalf("unexpected groups: %+v", groups)
-    }
-    grp := groups[0]
-    assert.Equal(t, 2, grp.Size)
-    // Check that A and B are members, C excluded
-    hasA := false
-    hasB := false
-    for _, f := range grp.Fragments {
-        if f == A {
-            hasA = true
-        }
-        if f == B {
-            hasB = true
-        }
-        if f == C {
-            t.Fatalf("C should be excluded from the group")
-        }
-    }
-    assert.True(t, hasA && hasB, "Group should contain A and B")
+	if !assert.Len(t, groups, 1, "Should form exactly one group") {
+		t.Fatalf("unexpected groups: %+v", groups)
+	}
+	grp := groups[0]
+	assert.Equal(t, 2, grp.Size)
+	// Check that A and B are members, C excluded
+	hasA := false
+	hasB := false
+	for _, f := range grp.Fragments {
+		if f == A {
+			hasA = true
+		}
+		if f == B {
+			hasB = true
+		}
+		if f == C {
+			t.Fatalf("C should be excluded from the group")
+		}
+	}
+	assert.True(t, hasA && hasB, "Group should contain A and B")
 }
 
 func TestStarMedoidGrouping_MultipleGroups(t *testing.T) {
-    // Two independent groups and a singleton (excluded)
-    A1 := newFrag("g1_a1.py", 1, 3)
-    A2 := newFrag("g1_a2.py", 1, 3)
-    A3 := newFrag("g1_a3.py", 1, 3)
-    B1 := newFrag("g2_b1.py", 1, 3)
-    B2 := newFrag("g2_b2.py", 1, 3)
-    Z := newFrag("z.py", 1, 3)
+	// Two independent groups and a singleton (excluded)
+	A1 := newFrag("g1_a1.py", 1, 3)
+	A2 := newFrag("g1_a2.py", 1, 3)
+	A3 := newFrag("g1_a3.py", 1, 3)
+	B1 := newFrag("g2_b1.py", 1, 3)
+	B2 := newFrag("g2_b2.py", 1, 3)
+	Z := newFrag("z.py", 1, 3)
 
-    pairs := []*ClonePair{
-        // Group A
-        newPair(A1, A2, 0.90),
-        newPair(A1, A3, 0.88),
-        newPair(A2, A3, 0.86),
-        // Group B
-        newPair(B1, B2, 0.92),
-        // Cross-group noise (below threshold)
-        newPair(A1, B1, 0.20),
-        newPair(A2, B2, 0.25),
-        // Z has no high-similarity links
-        newPair(Z, A1, 0.10),
-    }
+	pairs := []*ClonePair{
+		// Group A
+		newPair(A1, A2, 0.90),
+		newPair(A1, A3, 0.88),
+		newPair(A2, A3, 0.86),
+		// Group B
+		newPair(B1, B2, 0.92),
+		// Cross-group noise (below threshold)
+		newPair(A1, B1, 0.20),
+		newPair(A2, B2, 0.25),
+		// Z has no high-similarity links
+		newPair(Z, A1, 0.10),
+	}
 
-    g := NewStarMedoidGrouping(0.85)
-    groups := g.GroupClones(pairs)
+	g := NewStarMedoidGrouping(0.85)
+	groups := g.GroupClones(pairs)
 
-    // Expect two groups: sizes 3 and 2
-    if !assert.Len(t, groups, 2, "Should form two groups") {
-        t.Fatalf("unexpected groups len: %d", len(groups))
-    }
-    sizes := []int{groups[0].Size, groups[1].Size}
-    if sizes[0] > sizes[1] {
-        // ok
-    } else {
-        sizes[0], sizes[1] = sizes[1], sizes[0]
-    }
-    assert.Equal(t, []int{3, 2}, sizes)
+	// Expect two groups: sizes 3 and 2
+	if !assert.Len(t, groups, 2, "Should form two groups") {
+		t.Fatalf("unexpected groups len: %d", len(groups))
+	}
+	sizes := []int{groups[0].Size, groups[1].Size}
+	if sizes[0] > sizes[1] {
+		// ok
+	} else {
+		sizes[0], sizes[1] = sizes[1], sizes[0]
+	}
+	assert.Equal(t, []int{3, 2}, sizes)
 
-    // Ensure Z not included in any group
-    for _, grp := range groups {
-        for _, f := range grp.Fragments {
-            if f == Z {
-                t.Fatalf("singleton Z should be excluded")
-            }
-        }
-    }
+	// Ensure Z not included in any group
+	for _, grp := range groups {
+		for _, f := range grp.Fragments {
+			if f == Z {
+				t.Fatalf("singleton Z should be excluded")
+			}
+		}
+	}
 }
 
 func TestStarMedoidGrouping_NoGroups(t *testing.T) {
-    A := newFrag("a.py", 1, 2)
-    B := newFrag("b.py", 1, 2)
-    C := newFrag("c.py", 1, 2)
+	A := newFrag("a.py", 1, 2)
+	B := newFrag("b.py", 1, 2)
+	C := newFrag("c.py", 1, 2)
 
-    pairs := []*ClonePair{
-        newPair(A, B, 0.60),
-        newPair(B, C, 0.65),
-        newPair(A, C, 0.55),
-    }
+	pairs := []*ClonePair{
+		newPair(A, B, 0.60),
+		newPair(B, C, 0.65),
+		newPair(A, C, 0.55),
+	}
 
-    g := NewStarMedoidGrouping(0.80)
-    groups := g.GroupClones(pairs)
-    assert.Len(t, groups, 0, "All similarities below threshold; no groups expected")
+	g := NewStarMedoidGrouping(0.80)
+	groups := g.GroupClones(pairs)
+	assert.Len(t, groups, 0, "All similarities below threshold; no groups expected")
 }
 
 func TestStarMedoidGrouping_LargeScale(t *testing.T) {
-    // Build 10 clusters of 12 fragments (total 120+)
-    clusterCount := 10
-    perCluster := 12
-    total := clusterCount * perCluster
-    frags := make([]*CodeFragment, 0, total)
-    for i := 0; i < total; i++ {
-        frags = append(frags, newFrag(fmt.Sprintf("file_%03d.py", i), 1, 3))
-    }
+	// Build 10 clusters of 12 fragments (total 120+)
+	clusterCount := 10
+	perCluster := 12
+	total := clusterCount * perCluster
+	frags := make([]*CodeFragment, 0, total)
+	for i := 0; i < total; i++ {
+		frags = append(frags, newFrag(fmt.Sprintf("file_%03d.py", i), 1, 3))
+	}
 
-    // Build star-like pairs within each cluster: center is index base
-    basePairs := make([]*ClonePair, 0)
-    for c := 0; c < clusterCount; c++ {
-        base := c * perCluster
-        center := frags[base]
-        for j := 1; j < perCluster; j++ {
-            basePairs = append(basePairs, newPair(center, frags[base+j], 0.90))
-        }
-    }
+	// Build star-like pairs within each cluster: center is index base
+	basePairs := make([]*ClonePair, 0)
+	for c := 0; c < clusterCount; c++ {
+		base := c * perCluster
+		center := frags[base]
+		for j := 1; j < perCluster; j++ {
+			basePairs = append(basePairs, newPair(center, frags[base+j], 0.90))
+		}
+	}
 
-    g := NewStarMedoidGrouping(0.85)
-    start := time.Now()
-    groups := g.GroupClones(basePairs)
-    elapsed := time.Since(start)
+	g := NewStarMedoidGrouping(0.85)
+	start := time.Now()
+	groups := g.GroupClones(basePairs)
+	elapsed := time.Since(start)
 
-    // Expect clusterCount groups
-    assert.Len(t, groups, clusterCount, "Should form one group per cluster")
-    // Each should have perCluster members
-    for _, grp := range groups {
-        assert.Equal(t, perCluster, grp.Size)
-    }
-    // Sanity runtime guard (should be fast on 120 frags)
-    if elapsed > 2*time.Second {
-        t.Fatalf("Large-scale grouping took too long: %s", elapsed)
-    }
+	// Expect clusterCount groups
+	assert.Len(t, groups, clusterCount, "Should form one group per cluster")
+	// Each should have perCluster members
+	for _, grp := range groups {
+		assert.Equal(t, perCluster, grp.Size)
+	}
+	// Sanity runtime guard (should be fast on 120 frags)
+	if elapsed > 2*time.Second {
+		t.Fatalf("Large-scale grouping took too long: %s", elapsed)
+	}
 }
-


### PR DESCRIPTION
Implements Star/Medoid grouping strategy for clone groups (Issue #80).

Summary
- Add GroupingStrategy interface to allow pluggable grouping algorithms.
- Implement StarMedoidGrouping with:
  - Similarity cache (no recomputation of pair similarities)
  - Iterative medoid selection + reassignment with early convergence
  - Deterministic tie-breaking by fragment location (smallest ID wins)
  - Exclusion of members below threshold relative to cluster medoid
  - Singleton groups excluded
- Integrate a strategy hook into CloneDetector (`groupClonesWithStrategy`) while keeping existing `groupClones` untouched for backward compatibility.
- Add unit tests covering simple, multiple-groups, no-groups, and large-scale scenarios.

Performance
- Time: O(n×k) per iteration with cached similarities, max 10 iterations, early stop after 3 stable rounds.
- Memory: lightweight map cache for similarities (`pairKey -> score`).

Files
- internal/analyzer/grouping_strategy.go
- internal/analyzer/star_medoid_grouping.go
- internal/analyzer/star_medoid_grouping_test.go
- internal/analyzer/clone_detector.go (adds `groupClonesWithStrategy` helper only)

Notes
- Medoid tie-breaking uses location ordering per spec (smaller ID wins).
- Convergence: stop after 3 consecutive no-change iterations or max 10.
- Ready to be made configurable (threshold, max iterations) via config plumbing.

Testing
- Analyzer tests added and pass locally: `go test ./internal/analyzer -run StarMedoidGrouping -v`.

Closes #80.
