### PR TITLE
Prioritize .pyscn.toml over pyproject.toml for configuration

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -411,8 +411,8 @@ func LoadConfigWithTarget(configPath string, targetPath string) (*Config, error)
 ```
 
 **Configuration File Priority:**
-1. `pyproject.toml` (with `[tool.pyscn]` section)
-2. `.pyscn.toml`
+1. `.pyscn.toml` (dedicated config file)
+2. `pyproject.toml` (with `[tool.pyscn]` section)
 
 **Search Strategy:**
 - **Target Directory & Parents**: Starting from the analysis target, search upward to filesystem root

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -106,17 +106,19 @@ gh pr create --title "feat: Add tree-sitter integration" \
 
 ### Configuration Files
 
-pyscn uses a TOML-only configuration system similar to Ruff. Configuration files are searched in the following order:
+pyscn uses a TOML-only configuration system similar to Ruff. Configuration files are searched in the following priority order:
 
-1. **pyproject.toml** with `[tool.pyscn]` section (recommended)
-2. **.pyscn.toml** (dedicated config file)  
+1. **.pyscn.toml** (dedicated config file - takes precedence)
+2. **pyproject.toml** with `[tool.pyscn]` section (fallback)
 3. **Parent Directories**: Searching upward to filesystem root
+
+When both `.pyscn.toml` and `pyproject.toml` exist in the same directory, `.pyscn.toml` is used and `pyproject.toml` is ignored.
 
 ### Configuration File Names
 
-Supported configuration file names:
+Supported configuration file names (in priority order):
+- `.pyscn.toml` (dedicated config file)
 - `pyproject.toml` (with `[tool.pyscn]` section)
-- `.pyscn.toml`
 
 ### Configuration Example
 

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -59,17 +59,17 @@ func NewTomlConfigLoader() *TomlConfigLoader {
 }
 
 // LoadConfig loads configuration from TOML files with ruff-like priority:
-// 1. pyproject.toml (with [tool.pyscn] section)
-// 2. .pyscn.toml (dedicated config file)
+// 1. .pyscn.toml (dedicated config file)
+// 2. pyproject.toml (with [tool.pyscn] section)
 // 3. defaults
 func (l *TomlConfigLoader) LoadConfig(startDir string) (*CloneConfig, error) {
-	// Try pyproject.toml first
-	if config, err := l.loadFromPyprojectToml(startDir); err == nil {
+	// Try .pyscn.toml first (highest priority)
+	if config, err := l.loadFromPyscnToml(startDir); err == nil {
 		return config, nil
 	}
 
-	// Try .pyscn.toml as fallback
-	if config, err := l.loadFromPyscnToml(startDir); err == nil {
+	// Try pyproject.toml as fallback
+	if config, err := l.loadFromPyprojectToml(startDir); err == nil {
 		return config, nil
 	}
 
@@ -261,7 +261,7 @@ func (l *TomlConfigLoader) mergePyscnTomlConfigs(defaults *CloneConfig, pyscnTom
 // in order of precedence
 func (l *TomlConfigLoader) GetSupportedConfigFiles() []string {
 	return []string{
+		".pyscn.toml",    // dedicated config file (highest priority)
 		"pyproject.toml", // with [tool.pyscn] section
-		".pyscn.toml",    // dedicated config file
 	}
 }


### PR DESCRIPTION
## Summary
- Align configuration file priority with Ruff's behavior
- `.pyscn.toml` now takes precedence over `pyproject.toml`
- Update documentation to reflect new priority order

## Motivation

Currently, pyscn prioritizes `pyproject.toml` over `.pyscn.toml`, which is opposite to how Ruff handles configuration files. Ruff prioritizes dedicated config files (`.ruff.toml`) over `pyproject.toml`, which is more intuitive:

- When users explicitly create a dedicated config file, it should take precedence
- Allows project-specific overrides of team-wide `pyproject.toml` settings
- Aligns with common Python tooling patterns (Ruff, mypy)

## Changes

### Code Changes
- **internal/config/toml_loader.go**
  - `LoadConfig()`: Check `.pyscn.toml` first, then `pyproject.toml`
  - `GetSupportedConfigFiles()`: Return files in new priority order

### Documentation Updates
- **docs/ARCHITECTURE.md**: Updated configuration file priority section
- **CLAUDE.md**: Updated configuration hierarchy description (gitignored)

## Breaking Changes

⚠️ **This is a breaking change** for projects that have both `.pyscn.toml` and `pyproject.toml` with different settings. After this change:
- Settings in `.pyscn.toml` will override those in `pyproject.toml`
- Projects relying on `pyproject.toml` taking precedence will need to update their configuration

## Test Plan
- [ ] Verify `.pyscn.toml` is loaded when both files exist
- [ ] Verify `pyproject.toml` is used when `.pyscn.toml` doesn't exist
- [ ] Verify defaults are used when neither file exists
- [ ] Check documentation is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)