### PR TITLE
fix: remove LSH debug messages to prevent progress bar interruption

### DIFF
--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -139,10 +139,8 @@ func (s *CloneService) DetectClonesInFiles(ctx context.Context, filePaths []stri
 	useLSH := false
 	if req.LSHEnabled == "true" {
 		useLSH = true
-		fmt.Fprintf(os.Stderr, "LSH: Explicitly enabled (lsh_enabled=true)\n")
 	} else if req.LSHEnabled == "false" {
 		useLSH = false
-		fmt.Fprintf(os.Stderr, "LSH: Explicitly disabled (lsh_enabled=false)\n")
 	} else if req.LSHEnabled == "auto" || req.LSHEnabled == "" {
 		// Auto mode: enable LSH if fragment count >= threshold
 		threshold := req.LSHAutoThreshold
@@ -150,8 +148,6 @@ func (s *CloneService) DetectClonesInFiles(ctx context.Context, filePaths []stri
 			threshold = 500 // Default threshold
 		}
 		useLSH = len(allFragments) >= threshold
-		fmt.Fprintf(os.Stderr, "LSH: Auto-detection - %d fragments, threshold=%d, enabled=%v\n",
-			len(allFragments), threshold, useLSH)
 	}
 
 	// Update detector with LSH decision


### PR DESCRIPTION
## Summary

- Remove LSH auto-detection debug messages that interfere with progress bar display in `analyze` command
- LSH functionality continues to work automatically without user-visible messages

## Problem

When running `pyscn analyze` on large codebases (500+ fragments), LSH auto-detection messages were being printed to stderr, interrupting the unified progress bar:

```
Analyzing   0% |                                                | (0/100, 0 it/hr) [0s:0s]LSH: Auto-detection - 920 fragments, threshold=500, enabled=true
Analyzing 100% |██████████████████████████████████████████████| (100/100, 22 it/s)
```

This made it appear as if there were two progress bars.

## Solution

Removed all LSH diagnostic messages from `service/clone_service.go`:
- `LSH: Explicitly enabled (lsh_enabled=true)`
- `LSH: Explicitly disabled (lsh_enabled=false)`  
- `LSH: Auto-detection - %d fragments, threshold=%d, enabled=%v`

## Rationale

- LSH is an internal performance optimization that users don't need to be aware of
- The messages interfere with clean progress bar display
- LSH functionality continues to work automatically based on fragment count threshold (500+)
- Users can still control LSH behavior via config if needed

## After

Clean progress bar display:
```
Analyzing 100% |██████████████████████████████████████████████| (100/100, 22 it/s)
```

## Test plan

- [x] Build and test `pyscn analyze` on large codebase (920 fragments)
- [x] Verify progress bar displays only once
- [x] Verify LSH auto-detection still works (performance is good on large codebases)
- [x] Verify no LSH messages appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)