### PR TITLE
fix: change default sort order to complexity for HTML reports

### DIFF
--- a/.pyscn.toml
+++ b/.pyscn.toml
@@ -8,7 +8,7 @@
 [output]
 format = "text"                 # Default output format: text, json, yaml, csv, html
 show_details = false             # Show detailed breakdown by default
-sort_by = "name"                 # Default sort: name, complexity, risk
+sort_by = "complexity"           # Default sort: name, complexity, risk
 min_complexity = 1               # Minimum complexity to report
 directory = ""                   # Output directory for reports (empty = current directory)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,7 +235,7 @@ func DefaultConfig() *Config {
 		Output: OutputConfig{
 			Format:        "text",
 			ShowDetails:   false,
-			SortBy:        "name",
+			SortBy:        "complexity",
 			MinComplexity: DefaultMinComplexityFilter,
 		},
 		Analysis: AnalysisConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -35,8 +35,8 @@ func TestDefaultConfig(t *testing.T) {
 	if config.Output.ShowDetails {
 		t.Error("Expected show_details to be false by default")
 	}
-	if config.Output.SortBy != "name" {
-		t.Errorf("Expected sort_by 'name', got %s", config.Output.SortBy)
+	if config.Output.SortBy != "complexity" {
+		t.Errorf("Expected sort_by 'complexity', got %s", config.Output.SortBy)
 	}
 	if config.Output.MinComplexity != 1 {
 		t.Errorf("Expected min complexity 1, got %d", config.Output.MinComplexity)

--- a/internal/reporter/complexity_reporter_test.go
+++ b/internal/reporter/complexity_reporter_test.go
@@ -462,16 +462,16 @@ func TestOutputCSV(t *testing.T) {
 		}
 	}
 
-	// Verify first data row (should be sorted by name)
+	// Verify first data row (should be sorted by complexity descending)
 	firstRow := records[1]
-	if firstRow[0] != "complex_function" { // Sorted by name
-		t.Errorf("Expected first function to be complex_function, got %s", firstRow[0])
+	if firstRow[0] != "very_complex_function" { // Sorted by complexity (highest first)
+		t.Errorf("Expected first function to be very_complex_function, got %s", firstRow[0])
 	}
-	if firstRow[1] != "15" {
-		t.Errorf("Expected complexity 15, got %s", firstRow[1])
+	if firstRow[1] != "25" {
+		t.Errorf("Expected complexity 25, got %s", firstRow[1])
 	}
-	if firstRow[2] != "medium" {
-		t.Errorf("Expected risk medium, got %s", firstRow[2])
+	if firstRow[2] != "high" {
+		t.Errorf("Expected risk high, got %s", firstRow[2])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Changed default `Output.SortBy` from `"name"` to `"complexity"`
- Functions in HTML reports now sorted by complexity (descending) by default
- Makes high-complexity functions immediately visible at the top

## Problem
Issue #130 reported that HTML reports were not properly sorting:
1. **Complexity Functions** - Not sorted by complexity
2. **Longest Dependency Chains** - Not sorted by depth

## Root Cause
The default configuration had `Output.SortBy: "name"`, causing functions to be sorted alphabetically instead of by complexity. The backend sorting logic was already correct, but was overridden by the default config.

## Changes
### Configuration
- `internal/config/config.go:238` - Changed default from `"name"` to `"complexity"`
- `.pyscn.toml:11` - Updated project config to match

### Tests
- `internal/config/config_test.go` - Updated expected default value
- `internal/reporter/complexity_reporter_test.go` - Updated test expectations for complexity-based sorting

## Verification
### Before
```
__main__           (Complexity: 1)  ← alphabetical
complex_func       (Complexity: 7)
medium_func        (Complexity: 5)
simple_func        (Complexity: 1)
very_complex_func  (Complexity: 10)
```

### After
```
very_complex_func  (Complexity: 10) ← highest first
complex_func       (Complexity: 7)
medium_func        (Complexity: 5)
__main__           (Complexity: 1)
simple_func        (Complexity: 1)
```

## Test Results
✅ All tests pass  
✅ Linters pass  
✅ HTML reports correctly sorted

## Note
Longest Dependency Chains were already correctly sorted by depth in `service/system_analysis_service.go:824-827`. No changes needed for that feature.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)