### PR TITLE
makefile: fixed ANSI escape codes being printed literally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,29 +29,29 @@ all: test build
 
 ## build: Build the binary
 build:
-	@echo -e "$(GREEN)Building $(BINARY_NAME) $(VERSION)...$(NC)"
+	@printf "$(GREEN)Building $(BINARY_NAME) $(VERSION)...$(NC)\n"
 	go build $(LDFLAGS) -o $(BINARY_NAME) ./cmd/pyscn
 
 ## test: Run tests
 test:
-	@echo -e "$(GREEN)Running tests...$(NC)"
+	@printf "$(GREEN)Running tests...$(NC)\n"
 	go test -v ./...
 
 ## bench: Run benchmarks
 bench:
-	@echo -e "$(GREEN)Running benchmarks...$(NC)"
+	@printf "$(GREEN)Running benchmarks...$(NC)\n"
 	go test -bench=. -benchmem ./...
 
 ## coverage: Generate coverage report
 coverage:
-	@echo -e "$(GREEN)Generating coverage report...$(NC)"
+	@printf "$(GREEN)Generating coverage report...$(NC)\n"
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
-	@echo -e "$(GREEN)Coverage report generated: coverage.html$(NC)"
+	@printf "$(GREEN)Coverage report generated: coverage.html$(NC)\n"
 
 ## clean: Clean build artifacts
 clean:
-	@echo -e "$(YELLOW)Cleaning...$(NC)"
+	@printf "$(YELLOW)Cleaning...$(NC)\n"
 	rm -f $(BINARY_NAME)
 	rm -f coverage.out coverage.html
 	rm -rf dist/
@@ -59,7 +59,7 @@ clean:
 
 ## install: Install the binary
 install: build
-	@echo -e "$(GREEN)Installing $(BINARY_NAME)...$(NC)"
+	@printf "$(GREEN)Installing $(BINARY_NAME)...$(NC)\n"
 	go install $(LDFLAGS) ./cmd/pyscn
 
 ## run: Run the application
@@ -74,26 +74,26 @@ version:
 
 ## fmt: Format code
 fmt:
-	@echo -e "$(GREEN)Formatting code...$(NC)"
+	@printf "$(GREEN)Formatting code...$(NC)\n"
 	go fmt ./...
 	gofmt -s -w .
 
 ## lint: Run linters
 lint:
-	@echo -e "$(GREEN)Running linters...$(NC)"
+	@printf "$(GREEN)Running linters...$(NC)\n"
 	go vet ./...
 	golangci-lint run
 
 ## release: Create a new release (use: make release VERSION=v0.1.0)
 release:
 	@if [ -z "$(VERSION)" ]; then \
-		echo -e "$(YELLOW)Please specify VERSION. Usage: make release VERSION=v0.1.0$(NC)"; \
+		printf "$(YELLOW)Please specify VERSION. Usage: make release VERSION=v0.1.0$(NC)\n"; \
 		exit 1; \
 	fi
-	@echo -e "$(GREEN)Creating release $(VERSION)...$(NC)"
+	@printf "$(GREEN)Creating release $(VERSION)...$(NC)\n"
 	git tag -a $(VERSION) -m "Release $(VERSION)"
 	git push origin $(VERSION)
-	@echo -e "$(GREEN)Release $(VERSION) created and pushed!$(NC)"
+	@printf "$(GREEN)Release $(VERSION) created and pushed!$(NC)\n"
 
 ## dev: Development build with hot reload (requires air)
 dev:
@@ -105,43 +105,43 @@ dev:
 build-all: build-linux build-darwin build-windows
 
 build-linux:
-	@echo -e "$(GREEN)Building for Linux...$(NC)"
+	@printf "$(GREEN)Building for Linux...$(NC)\n"
 	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-linux-amd64 ./cmd/pyscn
 	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-linux-arm64 ./cmd/pyscn
 
 build-darwin:
-	@echo -e "$(GREEN)Building for macOS...$(NC)"
+	@printf "$(GREEN)Building for macOS...$(NC)\n"
 	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-darwin-amd64 ./cmd/pyscn
 	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-darwin-arm64 ./cmd/pyscn
 
 build-windows:
-	@echo -e "$(GREEN)Building for Windows...$(NC)"
+	@printf "$(GREEN)Building for Windows...$(NC)\n"
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-windows-amd64.exe ./cmd/pyscn
 	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o dist/$(BINARY_NAME)-windows-arm64.exe ./cmd/pyscn
 
 # Python packaging
 ## build-python: Build Python wheels with embedded binaries
 build-python:
-	@echo -e "$(GREEN)Building Python wheels...$(NC)"
+	@printf "$(GREEN)Building Python wheels...$(NC)\n"
 	python/scripts/build_all_wheels.sh
 
 ## python-wheel: Build Python wheel for current platform only
 python-wheel:
-	@echo -e "$(GREEN)Building Python wheel for current platform...$(NC)"
+	@printf "$(GREEN)Building Python wheel for current platform...$(NC)\n"
 	@mkdir -p python/src/pyscn/bin dist
 	go build $(LDFLAGS) -o python/src/pyscn/bin/pyscn-$$(go env GOOS)-$$(go env GOARCH)$$(if [ "$$(go env GOOS)" = "windows" ]; then echo ".exe"; fi) ./cmd/pyscn
 	python/scripts/create_wheel.sh
 
 ## python-test: Test Python package installation
 python-test: python-wheel
-	@echo -e "$(GREEN)Testing Python package...$(NC)"
+	@printf "$(GREEN)Testing Python package...$(NC)\n"
 	pip install --force-reinstall dist/*.whl
-	@echo -e "$(GREEN)Testing pyscn command...$(NC)"
+	@printf "$(GREEN)Testing pyscn command...$(NC)\n"
 	pyscn --version || pyscn --help
 
 ## python-clean: Clean Python build artifacts
 python-clean:
-	@echo -e "$(YELLOW)Cleaning Python build artifacts...$(NC)"
+	@printf "$(YELLOW)Cleaning Python build artifacts...$(NC)\n"
 	rm -rf python/src/pyscn/bin
 	rm -rf dist
 	rm -rf build


### PR DESCRIPTION
## Description

ANSI escape codes were previously printed verbatim, this adds the `-e` flag to echo commands that use them.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

Before:

<img width="819" height="148" alt="image" src="https://github.com/user-attachments/assets/e96e6ecf-b7f2-4e47-bb93-ca48f6cc5bd3" />

After:

<img width="819" height="148" alt="image" src="https://github.com/user-attachments/assets/05f7f3dd-b69c-42b2-82a3-edf2de91c6cd" />
