### PR TITLE
docs: simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,38 +1,32 @@
-## Description
-Brief description of what this PR does.
+## Summary
+<!-- Brief description of what this PR does and why -->
 
 ## Type of Change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change
 - [ ] Documentation update
 - [ ] Performance improvement
-- [ ] Code refactoring
+- [ ] Refactoring
 
 ## Related Issues
-Closes #(issue number)
+<!-- Use "Fixes #123" for bug fixes or "Closes #123" for features -->
+Closes #
 
-## Changes Made
-- Change 1
-- Change 2
-- Change 3
+## Changes
+<!-- List the main changes made in this PR -->
+-
+-
 
 ## Testing
-- [ ] Unit tests pass locally
-- [ ] Integration tests pass locally
-- [ ] Manual testing completed
+- [ ] `make test` passes locally
+- [ ] `make lint` passes locally
+- [ ] Added tests for new functionality (if applicable)
+- [ ] Manual testing completed (if applicable)
 
-## Checklist
-- [ ] My code follows the project's style guidelines
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
+## Documentation
+- [ ] Updated godoc comments
+- [ ] Updated README or other docs (if needed)
 
-## Screenshots (if applicable)
-Add screenshots to help explain your changes.
-
-## Additional Notes
-Any additional information that reviewers should know.
+## Additional Context
+<!-- Optional: Add screenshots, performance metrics, or other relevant info -->


### PR DESCRIPTION
## Summary
Streamlined the PR template to be more concise and actionable, following best practices for Go projects.

## Type of Change
- [x] Documentation update

## Changes
- Reduced template length by ~15% (38 → 32 lines)
- Replaced verbose checklist with Go-specific items (`make test`, `make lint`, godoc)
- Added HTML comment hints for better guidance
- Consolidated optional sections into "Additional Context"
- Removed redundant self-review items

## Testing
- [x] Verified template format

## Documentation
- [x] Updated PR template