### PR TITLE
refactor: embed default config and load architecture rules from TOML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,9 +41,10 @@ coverage.txt
 coverage.html
 *.prof
 
-# Environment files
+# Local Environment & config files
 .env
 .env.local
+.pyscn.toml
 
 # Python test files (for testing the analyzer)
 __pycache__/
@@ -82,3 +83,4 @@ python/src/pyscn/bin/
 requirements.md
 AGENTS.md
 CLAUDE.md
+

--- a/cmd/pyscn/init.go
+++ b/cmd/pyscn/init.go
@@ -5,148 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ludo-technologies/pyscn/internal/config"
 	"github.com/spf13/cobra"
 )
-
-const defaultConfigTemplate = `# pyscn configuration file (.pyscn.toml)
-# This file configures all analysis features of pyscn
-# Place this file in your project root to customize analysis behavior
-
-# =============================================================================
-# OUTPUT CONFIGURATION
-# =============================================================================
-[output]
-format = "text"                   # Output format: text, json, yaml, csv, html
-show_details = false              # Show detailed breakdown by default
-sort_by = "complexity"            # Default sort: name, complexity, risk
-min_complexity = 1                # Minimum complexity to report
-directory = ""                    # Output directory for reports (empty = .pyscn/reports/)
-
-# =============================================================================
-# COMPLEXITY ANALYSIS
-# =============================================================================
-[complexity]
-enabled = true                    # Enable complexity analysis
-low_threshold = 9                 # Functions with complexity ≤ 9 are low risk
-medium_threshold = 19             # Functions with complexity 10-19 are medium risk
-                                  # Functions with complexity ≥ 20 are high risk
-max_complexity = 0                # Maximum allowed complexity (0 = no limit)
-report_unchanged = true           # Report functions with complexity = 1
-
-# =============================================================================
-# DEAD CODE DETECTION
-# =============================================================================
-[dead_code]
-enabled = true                    # Enable dead code detection
-min_severity = "warning"          # Minimum severity to report: critical, warning, info
-show_context = false              # Show surrounding code context
-context_lines = 3                 # Number of context lines to show
-sort_by = "severity"              # Sort by: severity, line, file, function
-
-# Detection options - configure what types of dead code to detect
-detect_after_return = true        # Code after return statements
-detect_after_break = true         # Code after break statements
-detect_after_continue = true      # Code after continue statements
-detect_after_raise = true         # Code after raise statements
-detect_unreachable_branches = true # Unreachable conditional branches
-
-# Patterns to ignore (regex patterns)
-ignore_patterns = []
-
-# =============================================================================
-# CLONE DETECTION
-# =============================================================================
-[clones]
-# Analysis settings
-min_lines = 5                     # Minimum lines for clone candidates
-min_nodes = 10                    # Minimum AST nodes for clone candidates
-max_edit_distance = 50.0          # Maximum edit distance allowed
-ignore_literals = false           # Ignore differences in literal values
-ignore_identifiers = false        # Ignore differences in identifier names
-cost_model_type = "python"        # Cost model: default, python, weighted
-
-# Threshold settings for clone type classification (0.0 - 1.0)
-type1_threshold = 0.95            # Type-1: Identical code (except whitespace/comments)
-type2_threshold = 0.85            # Type-2: Syntactically identical (different identifiers)
-type3_threshold = 0.80            # Type-3: Syntactically similar (small modifications)
-type4_threshold = 0.75            # Type-4: Functionally similar (different syntax)
-similarity_threshold = 0.8        # General minimum similarity threshold
-
-# Filtering settings
-min_similarity = 0.0              # Minimum similarity to report
-max_similarity = 1.0              # Maximum similarity to report
-enabled_clone_types = ["type1", "type2", "type3", "type4"] # Clone types to detect
-max_results = 0                   # Maximum results (0 = no limit)
-
-# Grouping settings
-grouping_mode = "connected"       # Grouping mode: connected, star, complete_linkage, k_core
-grouping_threshold = 0.85         # Minimum similarity for group membership
-k_core_k = 2                      # K value for k-core mode (minimum connections per node)
-
-# LSH acceleration settings
-lsh_enabled = "auto"              # LSH acceleration: true, false, auto (based on project size)
-lsh_auto_threshold = 500          # Enable LSH for 500+ fragments
-lsh_similarity_threshold = 0.50   # LSH similarity threshold
-lsh_bands = 32                    # Number of LSH bands
-lsh_rows = 4                      # Rows per LSH band
-lsh_hashes = 128                  # MinHash function count
-
-# Performance settings
-max_memory_mb = 100               # Memory limit in MB
-batch_size = 100                  # Batch size for processing
-enable_batching = true            # Enable batching
-max_goroutines = 4                # Maximum concurrent goroutines
-timeout_seconds = 300             # Timeout in seconds (5 minutes)
-
-# Output settings (clone-specific)
-show_details = false              # Show detailed clone information
-show_content = false              # Include source code content in output
-sort_by = "similarity"            # Sort by: similarity, size, location, type
-group_clones = true               # Group related clones together
-
-# =============================================================================
-# ANALYSIS CONFIGURATION
-# =============================================================================
-[analysis]
-recursive = true                  # Recursively analyze directories
-follow_symlinks = false           # Follow symbolic links
-include_patterns = ["**/*.py"]       # File patterns to include
-exclude_patterns = [              # File patterns to exclude
-    "test_*.py",
-    "*_test.py",
-    "**/__pycache__/",
-    "**/*.pyc",
-    ".pytest_cache/**",
-    ".tox/**",
-    "venv/**",
-    "env/**",
-    ".venv/**",
-    ".env/**"
-]
-
-# =============================================================================
-# EXAMPLE CONFIGURATIONS
-# =============================================================================
-
-# Uncomment and modify these settings for common use cases:
-
-# # Strict mode - high precision
-# [clones]
-# similarity_threshold = 0.95
-# enabled_clone_types = ["type1", "type2"]
-#
-# # Relaxed mode - catch more potential clones
-# [clones]
-# similarity_threshold = 0.7
-# min_lines = 3
-#
-# # Performance optimized for large codebases
-# [clones]
-# lsh_enabled = "true"
-# max_goroutines = 8
-# batch_size = 200
-# max_memory_mb = 1024
-`
 
 // InitCommand represents the init command
 type InitCommand struct {
@@ -219,8 +80,11 @@ func (i *InitCommand) runInit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create directory %s: %w", configDir, err)
 	}
 
+	// Use embedded default config
+	configData := config.DefaultConfigTOML
+
 	// Write the configuration file
-	if err := os.WriteFile(configPath, []byte(defaultConfigTemplate), 0644); err != nil {
+	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
 		return fmt.Errorf("failed to write configuration file: %w", err)
 	}
 

--- a/internal/config/default_config.go
+++ b/internal/config/default_config.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	_ "embed"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// DefaultConfigTOML contains the embedded default configuration file
+//
+//go:embed default_config.toml
+var DefaultConfigTOML string
+
+// LoadDefaultConfig parses the embedded default config and returns the full Config struct
+func LoadDefaultConfig() (*Config, error) {
+	v := viper.New()
+	v.SetConfigType("toml")
+
+	if err := v.ReadConfig(strings.NewReader(DefaultConfigTOML)); err != nil {
+		return nil, err
+	}
+
+	var cfg Config
+	if err := v.Unmarshal(&cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -126,6 +126,47 @@ exclude_patterns = [             # File patterns to exclude
     ".venv/",
     ".env/"
 ]
+# =============================================================================
+# ARCHITECTURE VALIDATION
+# =============================================================================
+# Define architectural layers and validate dependencies
+
+[architecture]
+enabled = true
+validate_layers = true
+
+[[architecture.layers]]
+name = "presentation"
+packages = ["router", "routers", "route", "routes", "endpoint", "endpoints", "handler", "handlers", "controller", "controllers", "view", "views", "api", "apis", "ui", "web", "rest", "graphql"]
+
+[[architecture.layers]]
+name = "application"
+packages = ["service", "services", "usecase", "usecases", "use_case", "use_cases", "workflow", "workflows", "command", "commands", "query", "queries", "manager", "managers", "dependencies", "dependency"]
+
+[[architecture.layers]]
+name = "domain"
+packages = ["model", "models", "entity", "entities", "schema", "schemas", "domain", "domains", "core", "business", "aggregate", "aggregates", "valueobject", "valueobjects"]
+
+[[architecture.layers]]
+name = "infrastructure"
+packages = ["repository", "repositories", "repo", "repos", "db", "database", "adapter", "adapters", "persistence", "storage", "cache", "client", "clients", "external"]
+[[architecture.rules]]
+from = "presentation" 
+allow = ["presentation", "application", "domain", "infrastructure"]
+
+[[architecture.rules]]
+from = "application" 
+allow = ["application", "domain", "infrastructure"]
+
+[[architecture.rules]]
+from = "domain" 
+allow = ["domain", "infrastructure"] 
+deny = ["presentation", "application"]
+
+[[architecture.rules]]
+from = "infrastructure" 
+allow = ["infrastructure", "domain", "application"]
+
 
 # =============================================================================
 # EXAMPLE CONFIGURATIONS


### PR DESCRIPTION
## Summary
Refactors default configuration management to use an embedded TOML file as the single source of truth. This change was motivated by exploring how to configure architecture layers and rules, which revealed that the architecture patterns and rules were hardcoded in multiple places, making them difficult to discover and maintain.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring


## Changes
- **Embedded default config**: Moved default configuration from hardcoded Go string to `internal/config/default_config.toml` embedded at compile time using `//go:embed`
- **Centralized architecture definitions**: Architecture layer patterns and rules are now loaded from the embedded TOML instead of being hardcoded in `system_analysis_service.go`
- **Config validation**: Added validation to catch common configuration errors, specifically detecting when users mistakenly use `source` instead of `from` in architecture rules
- **Fixed field naming**: Corrected architecture rules to use `from` field (not `source`) to match the expected schema
- **Removed duplication**: Eliminated hardcoded fallback architecture patterns in favor of loading from embedded config
- **Local config support**: Added `.pyscn.toml` to `.gitignore` to allow per-project configuration overrides

## Testing
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [ ] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)
  - Verified `pyscn init` generates correct config file from embedded template
  - Tested architecture auto-detection uses patterns from embedded config
  - Confirmed validation catches invalid architecture rules with helpful error messages
  - Tested with user-provided `.pyscn.toml` to ensure config overrides work correctly

## Documentation
- [x] Updated godoc comments
- [ ] Updated README or other docs (if needed)

## Additional Context
This refactoring makes the default architecture configuration discoverable and maintainable in a single location. Users can now:
1. Run `pyscn init` to see the default architecture layer and rule definitions
2. Customize architecture validation by modifying their local `.pyscn.toml`
3. Receive clear validation errors if they misconfigure the architecture section
