### PR TITLE
Add line number output to check command

### DIFF
--- a/domain/complexity.go
+++ b/domain/complexity.go
@@ -91,8 +91,11 @@ type ComplexityMetrics struct {
 // FunctionComplexity represents complexity analysis result for a single function
 type FunctionComplexity struct {
 	// Function identification
-	Name     string
-	FilePath string
+	Name        string
+	FilePath    string
+	StartLine   int
+	StartColumn int
+	EndLine     int
 
 	// Complexity metrics
 	Metrics ComplexityMetrics

--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -19,6 +19,7 @@ type ComplexityResult struct {
 	// Function/method information
 	FunctionName string
 	StartLine    int
+	StartCol     int
 	EndLine      int
 
 	// Nesting depth
@@ -154,9 +155,15 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 
 	// Calculate nesting depth if function node is available
 	nestingDepth := 0
+	startLine := 0
+	startCol := 0
+	endLine := 0
 	if cfg.FunctionNode != nil {
 		nestingResult := CalculateMaxNestingDepth(cfg.FunctionNode)
 		nestingDepth = nestingResult.MaxDepth
+		startLine = cfg.FunctionNode.Location.StartLine
+		startCol = cfg.FunctionNode.Location.StartCol
+		endLine = cfg.FunctionNode.Location.EndLine
 	}
 
 	result := &ComplexityResult{
@@ -165,6 +172,9 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		Nodes:               visitor.nodeCount,
 		ConnectedComponents: 1,
 		FunctionName:        cfg.Name,
+		StartLine:           startLine,
+		StartCol:            startCol,
+		EndLine:             endLine,
 		NestingDepth:        nestingDepth,
 		IfStatements:        conditionalDecisions, // Accurate count of decision points
 		LoopStatements:      visitor.loopStatements,

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -134,8 +134,11 @@ func (s *ComplexityServiceImpl) analyzeFile(ctx context.Context, filePath string
 		riskLevel := s.calculateRiskLevel(result.Complexity, req)
 
 		function := domain.FunctionComplexity{
-			Name:     functionName,
-			FilePath: filePath,
+			Name:        functionName,
+			FilePath:    filePath,
+			StartLine:   result.StartLine,
+			StartColumn: result.StartCol,
+			EndLine:     result.EndLine,
 			Metrics: domain.ComplexityMetrics{
 				Complexity:        result.Complexity,
 				Nodes:             result.Nodes,


### PR DESCRIPTION
## Summary

Implements issue #158 - adds `file:line:column` output format to the `check` command for better editor integration and CI/CD compatibility.

## Changes

### Domain Layer
- Add `StartLine`, `StartColumn`, `EndLine` fields to `domain.FunctionComplexity`

### Analyzer Layer
- Populate location information from AST `FunctionNode.Location`
- Add `StartCol` field to `ComplexityResult`

### Service Layer
- Copy location data from analyzer to domain model

### Command Layer
- Update output format for all three analysis types:
  - **Complexity**: `file:line:col: function is too complex (X > Y)`
  - **Dead Code**: `file:line:col: reason (severity)`
  - **Clone Detection**: `file:line:col: clone of file:line:col (similarity: X%)`
- Convert 0-based to 1-based column numbers for editor compatibility

## Output Examples

### Before
```
❌ High complexity in /tmp/test.py:complex_function (complexity: 8 > 5)
❌ Found 1 critical dead code issue(s)
```

### After
```
/tmp/test.py:4:1: complex_function is too complex (8 > 5)
/tmp/test.py:23:9: unreachable code after return (critical)
/tmp/test.py:15:5: clone of /tmp/other.py:20:5 (similarity: 85.0%)
```

## Testing

Tested manually with sample Python files containing complexity issues, dead code, and clones.

## Related

Closes #158