### PR TITLE
chore: Add Python 3.13 support to PyPI package

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -139,7 +139,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.11']
+        python-version: ['3.8', '3.13']
     
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",


### PR DESCRIPTION
## Summary
- Add Python 3.13 classifier to pyproject.toml for PyPI display
- Update CI test matrix to test on Python 3.8 and 3.13 (replacing 3.11)

## Details
This change ensures that the PyPI package page displays Python 3.13 support. The CI/CD workflow now tests against:
- Python 3.8 (minimum supported version)
- Python 3.13 (latest version)

This approach maintains the same CI execution time while providing coverage for both the minimum and latest Python versions. Intermediate versions (3.9-3.12) are expected to work if both extremes pass.