### PR TITLE
docs: add mcp integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ https://github.com/user-attachments/assets/07f48070-c0dd-437b-9621-cb3963f863ff
 
 **100,000+ lines/sec** • Built with Go + tree-sitter
 
+## MCP Integration
+
+Run pyscn analyses straight from AI coding assistants via the Model Context Protocol (MCP). The bundled `pyscn-mcp` server exposes the same tools used in the CLI to Claude Code, Cursor, ChatGPT, and other MCP clients.
+
+```json
+{
+  "mcpServers": {
+    "pyscn-mcp": {
+      "command": "uvx",
+      "args": ["pyscn-mcp"],
+      "env": {
+        "PYSCN_CONFIG": "/path/to/.pyscn.toml"
+      }
+    }
+  }
+}
+```
+
+The instructions like "Analyze the code quality" trigger pyscn via MCP.
+
+Dive deeper in `mcp/README.md` for setup walkthroughs and `docs/MCP_INTEGRATION.md` for architecture details.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- add an MCP Integration section to README so users can discover pyscn's MCP server quickly

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Closes #188

## Changes
- add a top-level MCP Integration section with an example MCP client configuration
- document how pyscn-mcp tools are invoked from AI assistants and link to deeper docs

## Testing
- [ ] `make test` passes locally
- [ ] `make lint` passes locally
- [ ] Added tests for new functionality (if applicable)
- [ ] Manual testing completed (if applicable)

## Documentation
- [ ] Updated godoc comments
- [x] Updated README or other docs (if needed)

## Additional Context
<!-- Optional: Add screenshots, performance metrics, or other relevant info -->
