### PR TITLE
chore: improve build system and MCP documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ build-python: build-mcp-all
 	@cp dist/$(MCP_BINARY_NAME)-* python/src/pyscn/bin/ 2>/dev/null || true
 	@printf "$(GREEN)Binaries copied to python/src/pyscn/bin/$(NC)\n"
 	@ls -lh python/src/pyscn/bin/
-	python3 -m build
+	uv build
 	@printf "$(GREEN)Python wheel built: $(NC)\n"
 	@ls -lh dist/*.whl
 
@@ -173,14 +173,14 @@ python-wheel:
 	@mkdir -p python/src/pyscn/bin dist
 	go build $(LDFLAGS) -o python/src/pyscn/bin/pyscn-$$(go env GOOS)-$$(go env GOARCH)$$(if [ "$$(go env GOOS)" = "windows" ]; then echo ".exe"; fi) ./cmd/pyscn
 	go build $(LDFLAGS) -o python/src/pyscn/bin/$(MCP_BINARY_NAME)-$$(go env GOOS)-$$(go env GOARCH)$$(if [ "$$(go env GOOS)" = "windows" ]; then echo ".exe"; fi) ./cmd/pyscn-mcp
-	python3 -m build
+	uv build
 
 ## python-dev-install: Install development version with uv
 python-dev-install: python-wheel
 	@printf "$(GREEN)Uninstalling old version...$(NC)\n"
 	-uv tool uninstall pyscn 2>/dev/null || pip uninstall -y pyscn 2>/dev/null || true
 	@printf "$(GREEN)Installing development version with uv...$(NC)\n"
-	uv tool install --force --editable python/
+	uv tool install --force --editable .
 	@printf "$(GREEN)Testing installation...$(NC)\n"
 	pyscn --version
 	@printf "$(GREEN)Testing uvx pyscn-mcp...$(NC)\n"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ https://github.com/user-attachments/assets/07f48070-c0dd-437b-9621-cb3963f863ff
 
 Run pyscn analyses straight from AI coding assistants via the Model Context Protocol (MCP). The bundled `pyscn-mcp` server exposes the same tools used in the CLI to Claude Code, Cursor, ChatGPT, and other MCP clients.
 
+### Claude Code Setup
+
+```bash
+# Add pyscn MCP server with one command
+claude mcp add pyscn-mcp uvx -- pyscn-mcp
+```
+
+### Cursor / Claude Desktop Setup
+
+Add to your MCP settings (`~/.config/claude-desktop/config.json` or Cursor settings):
+
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary
- Replace `python3 -m build` with `uv build` for consistency
- Fix `python-dev-install` target to use project root
- Add simple MCP setup instructions

## Changes
- **Makefile**: Use `uv build` instead of `python3 -m build`
- **Makefile**: Fix editable install path in `python-dev-install`
- **README**: Add one-line setup command for MCP integration

## Test plan
- [x] Tested `make python-dev-install` successfully
- [x] Verified MCP server runs with `pyscn-mcp --help`
- [x] Confirmed README documentation is clear