### PR TITLE
chore: add pyscn-mcp as standalone PyPI package

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -244,25 +244,231 @@ jobs:
         packages-dir: dist/
         verbose: true
 
-  create-github-release:
-    name: Create GitHub Release
-    needs: [build-wheels, test-wheels]
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    
-    permissions:
-      contents: write
-    
+  build-mcp-wheels:
+    name: Build pyscn-mcp wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          # Linux builds
+          - os: ubuntu-latest
+            platform: linux-amd64
+            goos: linux
+            goarch: amd64
+            wheel_platform: manylinux_2_17_x86_64
+
+          # Windows builds
+          - os: windows-latest
+            platform: windows-amd64
+            goos: windows
+            goarch: amd64
+            wheel_platform: win_amd64
+
+          # macOS Intel
+          - os: macos-13
+            platform: darwin-amd64
+            goos: darwin
+            goarch: amd64
+            wheel_platform: macosx_10_9_x86_64
+
+          # macOS Apple Silicon
+          - os: macos-14
+            platform: darwin-arm64
+            goos: darwin
+            goarch: arm64
+            wheel_platform: macosx_11_0_arm64
+
     steps:
     - uses: actions/checkout@v4
-    
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+        cache: true
+
+    - name: Set up MSYS2 (Windows)
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config zip mingw-w64-x86_64-go
+
+    - name: Install build tools
+      run: |
+        pip install --user build twine
+      shell: bash
+
+    - name: Verify Go module
+      run: |
+        go mod download
+        go mod verify
+
+    - name: Build pyscn-mcp wheel (Linux/macOS)
+      if: matrix.os != 'windows-latest'
+      run: |
+        python/scripts/build_mcp_wheel.sh "${{ matrix.platform }}" "${{ matrix.wheel_platform }}"
+      shell: bash
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+        CC: ${{ (matrix.goos == 'darwin' && matrix.goarch == 'arm64') && 'clang -target arm64-apple-macos11' || (matrix.goos == 'darwin' && matrix.goarch == 'amd64') && 'clang -target x86_64-apple-macos10.13' || '' }}
+
+    - name: Build pyscn-mcp wheel (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        python/scripts/build_mcp_wheel.sh "${{ matrix.platform }}" "${{ matrix.wheel_platform }}"
+      shell: msys2 {0}
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+
+    - name: Verify wheels
+      run: |
+        python -m twine check dist/*.whl
+      shell: bash
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: mcp-wheels-${{ matrix.platform }}
+        path: dist/*.whl
+        retention-days: 7
+
+  test-mcp-wheels:
+    name: Test pyscn-mcp wheels
+    needs: build-mcp-wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.8', '3.13']
+
+    steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Download all wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: mcp-wheels-*
+        path: wheels/
+        merge-multiple: true
+
+    - name: Test wheel installation
+      shell: bash
+      run: |
+        wheel_count=$(ls wheels/*.whl 2>/dev/null | wc -l)
+        if [ $wheel_count -eq 0 ]; then
+          echo "No wheels found, skipping test"
+          exit 0
+        fi
+
+        echo "Available wheels:"
+        ls -la wheels/
+
+        if pip install wheels/pyscn_mcp-*.whl; then
+          echo "Testing pyscn-mcp command..."
+          if pyscn-mcp --help >/dev/null 2>&1; then
+            echo "✅ pyscn-mcp installation and execution successful!"
+          else
+            echo "❌ pyscn-mcp command failed"
+            exit 1
+          fi
+        else
+          echo "⚠️  Wheel installation failed - likely unsupported platform combination"
+        fi
+
+  publish-mcp-pypi:
+    name: Publish pyscn-mcp to PyPI
+    needs: [build-mcp-wheels, test-mcp-wheels]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyscn-mcp
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Download all wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: mcp-wheels-*
+        path: dist/
+        merge-multiple: true
+
+    - name: List wheels to publish
+      run: ls -la dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        packages-dir: dist/
+        verbose: true
+
+  publish-mcp-test-pypi:
+    name: Publish pyscn-mcp to Test PyPI
+    needs: [build-mcp-wheels, test-mcp-wheels]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pyscn-mcp
+
+    permissions:
+      contents: read
+
+    steps:
+    - name: Download all wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: mcp-wheels-*
+        path: dist/
+        merge-multiple: true
+
+    - name: List wheels to publish
+      run: ls -la dist/
+
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist/
+        verbose: true
+
+  create-github-release:
+    name: Create GitHub Release
+    needs: [build-wheels, test-wheels, build-mcp-wheels, test-mcp-wheels]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download pyscn wheels
       uses: actions/download-artifact@v4
       with:
         pattern: wheels-*
         path: wheels/
         merge-multiple: true
-    
+
+    - name: Download pyscn-mcp wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: mcp-wheels-*
+        path: wheels/
+        merge-multiple: true
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:

--- a/python/README-mcp.md
+++ b/python/README-mcp.md
@@ -1,0 +1,50 @@
+# pyscn-mcp
+
+MCP (Model Context Protocol) server for pyscn Python code analyzer.
+
+## Installation
+
+```bash
+# Install via pipx (recommended)
+pipx install pyscn-mcp
+
+# Or with uv
+uvx pyscn-mcp
+
+# Or with pip
+pip install pyscn-mcp
+```
+
+## Usage
+
+### As MCP Server
+
+Configure in your MCP client (e.g., Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "pyscn-mcp": {
+      "command": "uvx",
+      "args": ["pyscn-mcp"],
+      "env": {
+        "PYSCN_CONFIG": "/path/to/.pyscn.toml"
+      }
+    }
+  }
+}
+```
+
+### Standalone
+
+```bash
+pyscn-mcp
+```
+
+## Documentation
+
+For full documentation, visit the [pyscn repository](https://github.com/ludo-technologies/pyscn).
+
+## License
+
+MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/python/pyproject-mcp.toml
+++ b/python/pyproject-mcp.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools_scm>=8", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyscn-mcp"
+dynamic = ["version"]
+description = "MCP (Model Context Protocol) server for pyscn Python code analyzer"
+readme = "README-mcp.md"
+license = {file = "../LICENSE"}
+authors = [
+    {name = "DaisukeYoda", email = "daisukeyoda@users.noreply.github.com"}
+]
+maintainers = [
+    {name = "DaisukeYoda", email = "daisukeyoda@users.noreply.github.com"}
+]
+keywords = [
+    "mcp",
+    "model-context-protocol",
+    "pyscn",
+    "python",
+    "static-analysis",
+    "code-quality"
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Quality Assurance",
+    "Typing :: Typed",
+]
+requires-python = ">=3.8"
+dependencies = []
+
+[project.scripts]
+pyscn-mcp = "pyscn_mcp.__main__:main"
+
+[project.urls]
+Homepage = "https://github.com/ludo-technologies/pyscn"
+Documentation = "https://github.com/ludo-technologies/pyscn/tree/main/docs"
+Repository = "https://github.com/ludo-technologies/pyscn"
+Issues = "https://github.com/ludo-technologies/pyscn/issues"
+Changelog = "https://github.com/ludo-technologies/pyscn/blob/main/CHANGELOG.md"
+
+[tool.setuptools]
+packages = ["pyscn_mcp"]
+package-dir = {"" = "src"}
+
+[tool.setuptools.package-data]
+pyscn_mcp = ["bin/*"]
+
+[tool.setuptools.exclude-package-data]
+"*" = ["*.py[co]", "__pycache__", "*.so", "*.pyd"]
+
+[tool.setuptools_scm]
+root = ".."

--- a/python/scripts/build_mcp_wheel.sh
+++ b/python/scripts/build_mcp_wheel.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+
+# build_mcp_wheel.sh - Build pyscn-mcp wheel for a specific platform
+# Usage: build_mcp_wheel.sh <platform> <wheel_platform>
+
+set -e
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+main() {
+    local platform="$1"
+    local wheel_platform="$2"
+
+    if [[ -z "$platform" || -z "$wheel_platform" ]]; then
+        echo -e "${RED}Usage: build_mcp_wheel.sh <platform> <wheel_platform>${NC}"
+        exit 1
+    fi
+
+    local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local python_dir="$(dirname "$script_dir")"
+    local project_dir="$(dirname "$python_dir")"
+
+    # Version detection (same as build_platform_wheel.sh)
+    normalize_version() {
+        local git_describe="$1"
+        git_describe="${git_describe#v}"
+
+        if [[ "$git_describe" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]+)(-dirty)?$ ]]; then
+            local base_version="${BASH_REMATCH[1]}"
+            local commits_ahead="${BASH_REMATCH[2]}"
+            local commit_hash="${BASH_REMATCH[3]}"
+            local is_dirty="${BASH_REMATCH[4]}"
+
+            if [[ -n "$is_dirty" ]]; then
+                echo "${base_version}.post${commits_ahead}.dev0+g${commit_hash}"
+            else
+                echo "${base_version}.post${commits_ahead}+g${commit_hash}"
+            fi
+        elif [[ "$git_describe" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(-dirty)?$ ]]; then
+            local base_version="${BASH_REMATCH[1]}"
+            local is_dirty="${BASH_REMATCH[2]}"
+
+            if [[ -n "$is_dirty" ]]; then
+                echo "${base_version}.dev0"
+            else
+                echo "$base_version"
+            fi
+        else
+            echo "0.0.0.dev0"
+        fi
+    }
+
+    local git_tag="${GITHUB_REF_NAME:-${GITHUB_REF#refs/tags/}}"
+    local version
+
+    if [[ -z "$git_tag" && -n "${GITHUB_REF:-}" ]]; then
+        git_tag="${GITHUB_REF#refs/tags/}"
+    fi
+
+    if [[ -z "$git_tag" || "$git_tag" == "0.0.0.dev0" ]]; then
+        local current_tag=$(git tag --points-at HEAD 2>/dev/null | grep "^v[0-9]" | head -1)
+        if [[ -n "$current_tag" ]]; then
+            git_tag="$current_tag"
+        fi
+    fi
+
+    if [[ -n "$git_tag" && "$git_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        version=$(normalize_version "${git_tag}")
+        echo -e "${GREEN}Using CI tag version: $version${NC}"
+    else
+        version=$(normalize_version "$(git describe --tags --always --dirty 2>/dev/null || echo "0.0.0.dev0")")
+        echo -e "${YELLOW}Using git describe version: $version${NC}"
+    fi
+
+    local go_module=$(go list -m)
+    local commit=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+    local date=$(date +%Y-%m-%d)
+
+    echo -e "${GREEN}Building pyscn-mcp wheel for platform: $platform${NC}"
+    echo "Version: $version"
+    echo "GOOS: ${GOOS:-$(go env GOOS)}"
+    echo "GOARCH: ${GOARCH:-$(go env GOARCH)}"
+
+    local bin_dir="$python_dir/src/pyscn_mcp/bin"
+    local dist_dir="$project_dir/dist"
+
+    mkdir -p "$bin_dir" "$dist_dir"
+
+    local binary_suffix=""
+    if [[ "$platform" == *"windows"* ]]; then
+        binary_suffix=".exe"
+    fi
+
+    local binary_filename="pyscn-mcp-${platform}${binary_suffix}"
+    local binary_path="$bin_dir/$binary_filename"
+    local cmd_path="$project_dir/cmd/pyscn-mcp"
+
+    echo -e "${GREEN}Building pyscn-mcp binary...${NC}"
+
+    local ldflags="-s -w -X '${go_module}/internal/version.Version=${version}' -X '${go_module}/internal/version.Commit=${commit}' -X '${go_module}/internal/version.Date=${date}'"
+
+    case "$platform" in
+        *"windows"*)
+            CGO_ENABLED=1 go build -ldflags="$ldflags" -o "$binary_path" "$cmd_path"
+            ;;
+        *"darwin"*)
+            if [[ -z "${SDKROOT}" && -n "$(command -v xcrun)" ]]; then
+                export SDKROOT="$(xcrun --show-sdk-path)"
+            fi
+            CGO_ENABLED=1 go build -ldflags="$ldflags" -o "$binary_path" "$cmd_path"
+            ;;
+        *"linux"*)
+            CGO_ENABLED=1 go build -ldflags="$ldflags" -o "$binary_path" "$cmd_path"
+            ;;
+    esac
+
+    if [[ ! -f "$binary_path" ]]; then
+        echo -e "${RED}Error: Failed to build pyscn-mcp${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Binary created: $binary_path${NC}"
+    local size=$(du -h "$binary_path" | cut -f1)
+    echo "  Binary size: $size"
+
+    # Build wheel
+    echo -e "${GREEN}Building wheel...${NC}"
+    cd "$python_dir"
+
+    # Use pyproject-mcp.toml via symlink
+    ln -sf pyproject-mcp.toml pyproject.toml
+
+    # Build wheel
+    SETUPTOOLS_SCM_PRETEND_VERSION="$version" python -m build --wheel
+
+    # Remove symlink
+    rm -f pyproject.toml
+
+    # Rename wheel to include correct platform tag
+    local built_wheel=$(ls -t dist/pyscn_mcp-*.whl | head -1)
+    if [[ -f "$built_wheel" ]]; then
+        local wheel_name="pyscn_mcp-${version}-py3-none-${wheel_platform}.whl"
+        local final_wheel="$dist_dir/$wheel_name"
+
+        # Extract wheel, modify WHEEL file, update RECORD, and repack
+        local temp_dir=$(mktemp -d)
+        cd "$temp_dir"
+        unzip -q "$python_dir/$built_wheel"
+
+        # Update platform tag in WHEEL file
+        local wheel_file=$(find . -name "WHEEL" -type f)
+        if [[ -f "$wheel_file" ]]; then
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "s/Tag: py3-none-any/Tag: py3-none-${wheel_platform}/" "$wheel_file"
+            else
+                sed -i "s/Tag: py3-none-any/Tag: py3-none-${wheel_platform}/" "$wheel_file"
+            fi
+        fi
+
+        # Update RECORD file with new hash for WHEEL
+        local record_file=$(find . -name "RECORD" -type f)
+        if [[ -f "$record_file" && -f "$wheel_file" ]]; then
+            local wheel_hash=$(python -c "import hashlib,base64; print('sha256=' + base64.urlsafe_b64encode(hashlib.sha256(open('$wheel_file', 'rb').read()).digest()).decode().rstrip('='))")
+            local wheel_size=$(wc -c < "$wheel_file" | tr -d ' ')
+            local wheel_path="${wheel_file#./}"
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "s|^${wheel_path},.*|${wheel_path},${wheel_hash},${wheel_size}|" "$record_file"
+            else
+                sed -i "s|^${wheel_path},.*|${wheel_path},${wheel_hash},${wheel_size}|" "$record_file"
+            fi
+        fi
+
+        # Repack wheel
+        rm -f "$python_dir/$built_wheel"
+        zip -q -r "$final_wheel" .
+
+        cd "$python_dir"
+        rm -rf "$temp_dir"
+
+        echo -e "${GREEN}Wheel created: $final_wheel${NC}"
+    else
+        echo -e "${RED}Error: Wheel not found${NC}"
+        exit 1
+    fi
+
+    # Cleanup
+    rm -rf "$bin_dir"
+    rm -rf "$python_dir/dist"
+    rm -rf "$python_dir/build"
+    rm -rf "$python_dir/src/pyscn_mcp.egg-info"
+
+    echo -e "${GREEN}pyscn-mcp wheel build completed!${NC}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/python/src/pyscn_mcp/__init__.py
+++ b/python/src/pyscn_mcp/__init__.py
@@ -1,0 +1,7 @@
+"""
+pyscn-mcp: MCP (Model Context Protocol) server for pyscn Python code analyzer.
+
+This package provides an MCP server interface to pyscn's code analysis capabilities.
+"""
+
+__version__ = "0.0.0"  # Will be set by setuptools_scm

--- a/python/src/pyscn_mcp/__main__.py
+++ b/python/src/pyscn_mcp/__main__.py
@@ -1,0 +1,96 @@
+"""
+Entry point for pyscn-mcp MCP server.
+
+This module provides a Python wrapper for the Go-implemented pyscn-mcp binary.
+It automatically detects the platform and executes the appropriate MCP server binary.
+"""
+
+import os
+import sys
+import platform
+from pathlib import Path
+
+
+def get_mcp_binary_path() -> str:
+    """
+    Get the path to the pyscn-mcp binary for the current platform.
+
+    Returns:
+        str: Path to the pyscn-mcp binary.
+
+    Raises:
+        FileNotFoundError: If the binary is not found for the current platform.
+    """
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+
+    # Normalize architecture names
+    if machine in ('x86_64', 'amd64'):
+        machine = 'amd64'
+    elif machine in ('aarch64', 'arm64'):
+        machine = 'arm64'
+    else:
+        raise FileNotFoundError(
+            f"Unsupported architecture: {machine}. "
+            f"Supported architectures: amd64, arm64"
+        )
+
+    # Determine binary name
+    binary_name = f"pyscn-mcp-{system}-{machine}"
+    if system == "windows":
+        binary_name += ".exe"
+
+    # Binary path within the package
+    binary_path = Path(__file__).parent / "bin" / binary_name
+
+    if not binary_path.exists():
+        raise FileNotFoundError(
+            f"pyscn-mcp binary not found for platform {system}-{machine}.\n"
+            f"Expected location: {binary_path}\n"
+            f"Please check that the package was installed correctly."
+        )
+
+    return str(binary_path)
+
+
+def main():
+    """
+    Main entry point for pyscn-mcp MCP server.
+
+    Replaces the current process with the Go-implemented MCP server binary.
+    This ensures proper stdio handling for MCP's JSON-RPC communication.
+    """
+    try:
+        binary_path = get_mcp_binary_path()
+
+        # Prepare arguments
+        args = [binary_path] + sys.argv[1:]
+
+        # Replace the current process with the MCP server binary
+        # This is critical for MCP servers as they need direct stdio access
+        # and proper signal handling without a Python wrapper layer
+        if sys.platform == "win32":
+            # Windows: use os.execv
+            os.execv(binary_path, args)
+        else:
+            # Unix-like: use os.execv
+            os.execv(binary_path, args)
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        print(
+            f"\nPlatform information:\n"
+            f"  System: {platform.system()}\n"
+            f"  Architecture: {platform.machine()}\n"
+            f"  Python: {platform.python_version()}",
+            file=sys.stderr
+        )
+        sys.exit(1)
+
+    except Exception as e:
+        print(f"Unexpected error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Add pyscn-mcp as a separate PyPI package to enable `uvx pyscn-mcp` usage.

## Changes
- Add `python/src/pyscn_mcp` package with MCP server entry point
- Add `python/pyproject-mcp.toml` for pyscn-mcp package configuration
- Add `python/scripts/build_mcp_wheel.sh` for building platform-specific wheels
- Update CI workflow to build, test, and publish pyscn-mcp wheels to PyPI
- Add `python/README-mcp.md` with installation and usage instructions

## Motivation
Currently, `uvx pyscn-mcp` doesn't work because there's no `pyscn-mcp` package on PyPI. This PR adds pyscn-mcp as a standalone package while maintaining backward compatibility with the full pyscn package.

## Package Strategy
- **pyscn** (existing): Full package with both `pyscn` and `pyscn-mcp` commands
- **pyscn-mcp** (new): Lightweight MCP server package for MCP-only usage

Users can choose based on their needs:
- `pipx install pyscn` - Full toolset
- `uvx pyscn-mcp` - MCP server only

## CI Workflow
Added parallel jobs for pyscn-mcp:
- `build-mcp-wheels`: Build wheels for all platforms (Linux, Windows, macOS x64/ARM)
- `test-mcp-wheels`: Test installation on Python 3.8 and 3.13
- `publish-mcp-pypi`: Publish to PyPI on version tags
- `publish-mcp-test-pypi`: Publish to Test PyPI on manual trigger