### PR TITLE
fix: remove license file reference from pyscn-mcp pyproject.toml

### DIFF
--- a/python/pyproject-mcp.toml
+++ b/python/pyproject-mcp.toml
@@ -7,7 +7,6 @@ name = "pyscn-mcp"
 dynamic = ["version"]
 description = "MCP (Model Context Protocol) server for pyscn Python code analyzer"
 readme = "README-mcp.md"
-license = {file = "../LICENSE"}
 authors = [
     {name = "DaisukeYoda", email = "daisukeyoda@users.noreply.github.com"}
 ]


### PR DESCRIPTION
Remove license file reference to avoid build error when building from python/ directory.

## Solution
Remove `license = {file = "../LICENSE"}` field from pyproject-mcp.toml.

License information is already declared in classifiers:
```toml
classifiers = [
    "License :: OSI Approved :: MIT License",
    ...
]
```

This is the standard approach and avoids file path issues.