### PR TITLE
fix: add unzip and python to Windows MSYS2 environment

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -57,7 +57,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config zip mingw-w64-x86_64-go
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config zip unzip mingw-w64-x86_64-go mingw-w64-x86_64-python mingw-w64-x86_64-python-pip
     
     - name: Install wheel verification tools
       run: |

--- a/python/scripts/build_platform_wheel.sh
+++ b/python/scripts/build_platform_wheel.sh
@@ -228,6 +228,8 @@ main() {
 
     # Build wheel
     pip install --user build >/dev/null 2>&1 || true
+    # Use python3 for better cross-platform compatibility (especially Windows MSYS2)
+    SETUPTOOLS_SCM_PRETEND_VERSION="$version" python3 -m build --wheel 2>/dev/null || \
     SETUPTOOLS_SCM_PRETEND_VERSION="$version" python -m build --wheel
 
     # Remove symlink


### PR DESCRIPTION
Fix Windows build failures by adding missing commands to MSYS2.

## Problems
1. `unzip: command not found` when extracting pyscn-mcp wheel
2. `python: command not found` when building pyscn-mcp wheel

## Solution
- Add `unzip` to MSYS2 packages
- Add `mingw-w64-x86_64-python` and `mingw-w64-x86_64-python-pip` to MSYS2
- Fallback to `python3` command for better cross-platform compatibility

These commands are needed for the pyscn-mcp wheel build process.