### PR TITLE
fix: use GitHub Actions Python on Windows instead of MSYS2 Python

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -57,7 +57,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config zip unzip mingw-w64-x86_64-go mingw-w64-x86_64-python mingw-w64-x86_64-python-pip
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config zip unzip mingw-w64-x86_64-go
     
     - name: Install wheel verification tools
       run: |
@@ -82,11 +82,15 @@ jobs:
     - name: Build platform-specific wheel (Windows)
       if: matrix.os == 'windows-latest'
       run: |
+        # Inherit Windows PATH to access GitHub Actions Python
+        export MSYS2_PATH_TYPE=inherit
+
         echo "=== Environment Check ==="
         which go && go version
         which gcc && gcc --version | head -1
         which zip && zip --version | head -1
-        
+        which python && python --version
+
         echo "=== Starting Build ==="
         python/scripts/build_platform_wheel.sh "${{ matrix.platform }}" "${{ matrix.wheel_platform }}"
       shell: msys2 {0}

--- a/python/scripts/build_platform_wheel.sh
+++ b/python/scripts/build_platform_wheel.sh
@@ -227,9 +227,10 @@ main() {
     ln -sf pyproject-mcp.toml pyproject.toml
 
     # Build wheel
-    pip install --user build >/dev/null 2>&1 || true
-    # Use python3 for better cross-platform compatibility (especially Windows MSYS2)
-    SETUPTOOLS_SCM_PRETEND_VERSION="$version" python3 -m build --wheel 2>/dev/null || \
+    # Install build tool if not available
+    python -m pip install --quiet build 2>/dev/null || pip install --user --quiet build || true
+
+    # Build with setuptools_scm version override
     SETUPTOOLS_SCM_PRETEND_VERSION="$version" python -m build --wheel
 
     # Remove symlink


### PR DESCRIPTION
Fix Windows build error by using GitHub Actions Python instead of MSYS2 Python.

## Problem
MSYS2 Python had compatibility issues with python -m build:
```
subprocess.CalledProcessError: Command '['D:/a/_temp/msys64/mingw64/bin/python.exe', ...
```

## Solution
- Remove MSYS2 Python packages
- Set `MSYS2_PATH_TYPE=inherit` to access GitHub Actions Python from MSYS2 shell
- Simplify pip install build command

Benefits:
- Uses existing GitHub Actions Python (no additional downloads)
- Better compatibility with build tools
- Simpler setup