### PR TITLE
test(version): add unit tests for version package functions

### DIFF
--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -77,12 +77,16 @@ func TestInfoIncludesBuildMetadata(t *testing.T) {
 	}
 
 	for name, val := range metadataFields {
-
 		if val == "" {
 			t.Fatalf("%s should not be empty", name)
 		}
 
-		expected := fmt.Sprintf("%s: %s", name, val)
+		var expected string
+		if name == "pyscn" {
+			expected = fmt.Sprintf("%s %s", name, val)
+		} else {
+			expected = fmt.Sprintf("%s: %s", name, val)
+		}
 
 		if !strings.Contains(info, expected) {
 			t.Errorf("Info() output missing %q", expected)


### PR DESCRIPTION
## Summary
This PR adds a complete test suite for the `internal/version` package, improving code quality and test coverage.

## Changes
- Added `version_test.go` with 4 test functions covering all exported functions
- Tests verify version information formatting, content, and metadata inclusion
- All tests use table-driven and assertion-based approaches for maintainability

## Test Coverage
The test suite includes:

1. **`TestShort()`** - Verifies `Short()` returns a non-empty version string
2. **`TestInfo()`** - Validates that `Info()` includes:
   - Package name (`pyscn`)
   - Go runtime version
   - OS/Architecture information
   - All required metadata fields (Commit, Built, Go, OS/Arch)
3. **`TestInfoFormat()`** - Ensures `Info()` output follows the expected multi-line format with correct prefixes
4. **`TestInfoIncludesBuildMetadata()`** - Confirms all build metadata values (version, commit, date) are present in the output

## Testing
All tests pass successfully

**Coverage:** (coverage: 100.0% of statements)

## Motivation
This contribution adds previously missing test coverage for the version package, making it easier to:
- Catch regressions in version information formatting
- Verify build metadata is correctly included
- Ensure consistent output across different platforms

---

**Test Results:**

<img width="1144" height="424" alt="image" src="https://github.com/user-attachments/assets/bfa65b71-d1fe-4b1a-a61e-c4282f050e91" />