### PR TITLE
docs: add MCP use case examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ https://github.com/user-attachments/assets/07f48070-c0dd-437b-9621-cb3963f863ff
 
 Run pyscn analyses straight from AI coding assistants via the Model Context Protocol (MCP). The bundled `pyscn-mcp` server exposes the same tools used in the CLI to Claude Code, Cursor, ChatGPT, and other MCP clients.
 
+### MCP Use Cases
+
+You can interact with pyscn with your AI coding tools:
+
+1. "Analyze the code quality of the app/ directory"
+
+2. "Find duplicate code and help me refactor it"
+
+3. "Show me complex code and help me simplify it"
+
 ### Claude Code Setup
 
 ```bash


### PR DESCRIPTION
## Summary
- Add MCP use case examples to README
- Shows 3 common prompts for AI coding assistants
