### PR TITLE
fix(python): fix binary auto-detection for pyscn_mcp package in create_wheel.sh

### DIFF
--- a/python/scripts/create_wheel.sh
+++ b/python/scripts/create_wheel.sh
@@ -536,11 +536,31 @@ main() {
                 ;;
         esac
         
-        local bin_base="$python_dir/src/pyscn/bin"
-        local expected_binaries=(
-            "$bin_base/pyscn-${os}-${arch}${suffix}"
-            "$bin_base/pyscn-mcp-${os}-${arch}${suffix}"
-        )
+        # Set bin_base based on package type
+        local bin_base
+        if [[ "$PACKAGE_NAME" == "pyscn" ]]; then
+            bin_base="$python_dir/src/pyscn/bin"
+        elif [[ "$PACKAGE_NAME" == "pyscn_mcp" ]]; then
+            bin_base="$python_dir/src/pyscn_mcp/bin"
+        else
+            echo "Error: Unknown package name: $PACKAGE_NAME"
+            exit 1
+        fi
+
+        # Build expected_binaries based on package type
+        local expected_binaries=()
+        if [[ "$PACKAGE_NAME" == "pyscn" ]]; then
+            # pyscn package needs both binaries
+            expected_binaries=(
+                "$bin_base/pyscn-${os}-${arch}${suffix}"
+                "$bin_base/pyscn-mcp-${os}-${arch}${suffix}"
+            )
+        elif [[ "$PACKAGE_NAME" == "pyscn_mcp" ]]; then
+            # pyscn_mcp package only needs the MCP server binary
+            expected_binaries=(
+                "$bin_base/pyscn-mcp-${os}-${arch}${suffix}"
+            )
+        fi
         
         local missing=()
         for candidate in "${expected_binaries[@]}"; do


### PR DESCRIPTION
## Summary

Fixes #201

This PR fixes the binary auto-detection logic in `create_wheel.sh` to properly support the `pyscn_mcp` package.

## Problem

The auto-detection logic (lines 513-561) had two issues when handling the `pyscn_mcp` package:

1. **Hardcoded bin_base path**: The `bin_base` variable was hardcoded to `src/pyscn/bin`, which is incorrect for `pyscn_mcp` that needs binaries from `src/pyscn_mcp/bin`

2. **Always searched for both binaries**: The logic always searched for both `pyscn` and `pyscn-mcp` binaries regardless of package type, but:
   - `pyscn` package needs both binaries
   - `pyscn_mcp` package only needs the `pyscn-mcp` binary

## Solution

Updated the auto-detection logic to:

1. **Conditionally set bin_base** based on `PACKAGE_NAME` variable:
   - `pyscn` → `src/pyscn/bin`
   - `pyscn_mcp` → `src/pyscn_mcp/bin`

2. **Dynamically build expected_binaries** array based on package type:
   - `pyscn` → requires both `pyscn` and `pyscn-mcp` binaries
   - `pyscn_mcp` → requires only `pyscn-mcp` binary

This aligns the auto-detection logic with the existing validation logic (lines 203-217) that already correctly handles both package types.

## Impact

Currently, this has no immediate impact since `build_platform_wheel.sh` always explicitly specifies binaries using the `--binary` flag. However, this fix prevents future issues if someone runs `create_wheel.sh` directly without the `--binary` flag.

## Test Plan

- [x] Bash syntax check passed
- [x] Verified logic consistency with existing validation (lines 203-217)
- [x] Confirmed conditional logic correctly handles both `pyscn` and `pyscn_mcp` packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)