### PR TITLE
docs: Add jscan link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Building with Cursor, Claude, or ChatGPT? pyscn performs structural analysis to keep your codebase maintainable.
 
+> Working with JavaScript/TypeScript? Check out [jscan](https://github.com/ludo-technologies/jscan)
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Add link to jscan (JavaScript/TypeScript code quality analyzer) as a sister project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)