### PR TITLE
chore: remove unused labels from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,5 @@ updates:
       go-dependencies:
         patterns:
           - "*"
-    # Add labels to PRs
-    labels:
-      - "dependencies"
-      - "go"
     # Set PR limit
     open-pull-requests-limit: 1


### PR DESCRIPTION
Remove unused labels configuration that was causing Dependabot warnings.