### PR TITLE
Fix/issue #207 Count skipped files as analyzed

### DIFF
--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -161,7 +161,7 @@ func (s *CloneService) DetectClonesInFiles(ctx context.Context, filePaths []stri
 	s.sortResults(domainClones, domainClonePairs, domainCloneGroups, req)
 
 	// Create statistics
-	statistics := s.createStatistics(domainClones, domainClonePairs, domainCloneGroups, len(filePaths), linesAnalyzed)
+	statistics := s.createStatistics(domainClones, domainClonePairs, domainCloneGroups, filesAnalyzed, linesAnalyzed)
 
 	duration := time.Since(startTime).Milliseconds()
 	// s.progress.Complete(fmt.Sprintf("Clone detection completed in %dms. Found %d clone pairs in %d groups.",


### PR DESCRIPTION
## Summary
Fix incorrect clone-detection stats where skipped or unreadable files were counted as analyzed.
Now only successfully processed files contribute to FilesAnalyzed, and tests were added to ensure correctness.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Fixes #207

## Changes
- service/clone_service.go: Count FilesAnalyzed only for files that are read and parsed successfully.
- service/clone_service_test.go: Add tests ensuring FilesAnalyzed excludes missing or parse-failed files.

## Testing
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (if needed)

## Additional Context

