### PR TITLE
fix: replace hardcoded thresholds with constants in CentroidGrouping

### DIFF
--- a/internal/analyzer/centroid_grouping.go
+++ b/internal/analyzer/centroid_grouping.go
@@ -3,6 +3,8 @@ package analyzer
 import (
 	"fmt"
 	"sort"
+
+	"github.com/ludo-technologies/pyscn/internal/constants"
 )
 
 // CentroidGrouping implements centroid-based grouping that avoids transitive problems
@@ -23,10 +25,10 @@ func NewCentroidGrouping(threshold float64) *CentroidGrouping {
 	return &CentroidGrouping{
 		threshold:      threshold,
 		analyzer:       NewAPTEDAnalyzer(costModel),
-		type1Threshold: 0.95, // Default fallback values
-		type2Threshold: 0.85,
-		type3Threshold: 0.80,
-		type4Threshold: 0.75,
+		type1Threshold: constants.DefaultType1CloneThreshold,
+		type2Threshold: constants.DefaultType2CloneThreshold,
+		type3Threshold: constants.DefaultType3CloneThreshold,
+		type4Threshold: constants.DefaultType4CloneThreshold,
 	}
 }
 

--- a/internal/analyzer/centroid_grouping_test.go
+++ b/internal/analyzer/centroid_grouping_test.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/internal/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -10,10 +11,10 @@ func TestCentroidGroupingThresholds(t *testing.T) {
 	t.Run("Default thresholds are set correctly", func(t *testing.T) {
 		grouping := NewCentroidGrouping(0.7)
 
-		assert.Equal(t, 0.95, grouping.type1Threshold, "Type1 threshold should default to 0.95")
-		assert.Equal(t, 0.85, grouping.type2Threshold, "Type2 threshold should default to 0.85")
-		assert.Equal(t, 0.80, grouping.type3Threshold, "Type3 threshold should default to 0.80")
-		assert.Equal(t, 0.75, grouping.type4Threshold, "Type4 threshold should default to 0.75")
+		assert.Equal(t, constants.DefaultType1CloneThreshold, grouping.type1Threshold, "Type1 threshold should use constants.DefaultType1CloneThreshold")
+		assert.Equal(t, constants.DefaultType2CloneThreshold, grouping.type2Threshold, "Type2 threshold should use constants.DefaultType2CloneThreshold")
+		assert.Equal(t, constants.DefaultType3CloneThreshold, grouping.type3Threshold, "Type3 threshold should use constants.DefaultType3CloneThreshold")
+		assert.Equal(t, constants.DefaultType4CloneThreshold, grouping.type4Threshold, "Type4 threshold should use constants.DefaultType4CloneThreshold")
 	})
 
 	t.Run("SetThresholds updates values correctly", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace hardcoded clone type threshold values in `NewCentroidGrouping()` with constants from `internal/constants/clone_thresholds.go`
- Update tests to verify constants are used correctly

## Changes
- `internal/analyzer/centroid_grouping.go`: Use `constants.DefaultType*CloneThreshold` instead of hardcoded values
- `internal/analyzer/centroid_grouping_test.go`: Update assertions to reference constants

## Related Issues
Closes #244
Parent: #98

## Test plan
- [x] `go test ./internal/analyzer/... -run TestCentroidGrouping -v` passes
- [x] `make lint` passes
- [x] `make build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)