### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.5.1] - 2025-12-12
+
+### Fixed
+- Enable architecture strict mode by default (#255)
+
+### Improved
+- Consolidate default configuration values in `domain/defaults.go` (#254)
+
 ## [1.5.0] - 2025-12-08
 
 ### Added


### PR DESCRIPTION
## Summary
- Update CHANGELOG for v1.5.1

## Changes in v1.5.1
- Enable architecture strict mode by default (#255)
- Consolidate default configuration values in `domain/defaults.go` (#254)