### PR TITLE
ci: remove macOS Intel build

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -26,14 +26,7 @@ jobs:
             goos: windows
             goarch: amd64
             wheel_platform: win_amd64
-          
-          # macOS Intel
-          - os: macos-13
-            platform: darwin-amd64
-            goos: darwin
-            goarch: amd64
-            wheel_platform: macosx_10_9_x86_64
-            
+
           # macOS Apple Silicon
           - os: macos-14
             platform: darwin-arm64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Improved
 - Consolidate default configuration values in `domain/defaults.go` (#254)
 
+### Removed
+- macOS Intel (x86_64) build support (#259)
+
 ## [1.5.0] - 2025-12-08
 
 ### Added


### PR DESCRIPTION
macos-13 runner is deprecated. Remove Intel x86_64 build target.