### PR TITLE
fix: disable Type2 clone detection by default

### DIFF
--- a/app/clone_usecase.go
+++ b/app/clone_usecase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -297,9 +298,17 @@ func (uc *CloneUseCase) mergeConfiguration(configReq, requestReq domain.CloneReq
 		merged.ExcludePatterns = requestReq.ExcludePatterns
 	}
 
-	// Override clone types if provided
-	if len(requestReq.CloneTypes) > 0 && len(requestReq.CloneTypes) != len(defaultReq.CloneTypes) {
+	// Override clone types if different from defaults (i.e., explicitly set via CLI)
+	if len(requestReq.CloneTypes) > 0 && !slices.Equal(requestReq.CloneTypes, defaultReq.CloneTypes) {
 		merged.CloneTypes = requestReq.CloneTypes
+	}
+
+	// Override grouping settings if config has empty/zero values
+	if merged.GroupMode == "" && requestReq.GroupMode != "" {
+		merged.GroupMode = requestReq.GroupMode
+	}
+	if merged.GroupThreshold == 0 && requestReq.GroupThreshold > 0 {
+		merged.GroupThreshold = requestReq.GroupThreshold
 	}
 
 	return merged

--- a/cmd/pyscn/check.go
+++ b/cmd/pyscn/check.go
@@ -447,7 +447,7 @@ func (c *CheckCommand) checkClones(cmd *cobra.Command, args []string) (int, erro
 		GroupClones:         true,
 		MinSimilarity:       0.0,
 		MaxSimilarity:       1.0,
-		CloneTypes:          []domain.CloneType{domain.Type1Clone, domain.Type2Clone, domain.Type3Clone, domain.Type4Clone},
+		CloneTypes:          []domain.CloneType{domain.Type1Clone, domain.Type3Clone, domain.Type4Clone}, // Type2 disabled by default
 		Recursive:           true,
 		IncludePatterns:     []string{"**/*.py"},
 		ExcludePatterns:     []string{"__pycache__/*", "*.pyc"},

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -17,10 +17,10 @@ const (
 	ComplexityPenaltyLow      = 6
 
 	// Code duplication thresholds and penalties
-	// Industry standard: < 5% excellent, 5-15% good, 15-25% acceptable, > 25% needs attention
-	DuplicationThresholdHigh   = 30.0
-	DuplicationThresholdMedium = 15.0
-	DuplicationThresholdLow    = 5.0
+	// Strict thresholds: 0% = perfect, 5% = max penalty
+	DuplicationThresholdHigh   = 5.0
+	DuplicationThresholdMedium = 2.5
+	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12
 	DuplicationPenaltyLow      = 6
@@ -226,14 +226,13 @@ func (s *AnalyzeSummary) calculateDeadCodePenalty(normalizationFactor float64) i
 // calculateDuplicationPenalty calculates the penalty for code duplication (max 20)
 // Uses continuous linear function based on defined thresholds
 func (s *AnalyzeSummary) calculateDuplicationPenalty() int {
-	// Linear penalty: starts at DuplicationThresholdLow (5%), reaches max (20) at DuplicationThresholdHigh (30%)
-	// Industry standard: < 5% excellent, 5-15% good, 15-25% acceptable, > 25% needs attention
+	// Linear penalty: 0% = 0 penalty, 5% = max penalty (20)
 	if s.CodeDuplication <= DuplicationThresholdLow {
 		return 0
 	}
 
 	// Formula: penalty = (duplication - low) / (high - low) * 20
-	penaltyRange := DuplicationThresholdHigh - DuplicationThresholdLow // 25%
+	penaltyRange := DuplicationThresholdHigh - DuplicationThresholdLow // 5%
 	penalty := (s.CodeDuplication - DuplicationThresholdLow) / penaltyRange * 20.0
 	if penalty > 20.0 {
 		penalty = 20.0

--- a/domain/clone.go
+++ b/domain/clone.go
@@ -346,7 +346,7 @@ func DefaultCloneRequest() *CloneRequest {
 		KCoreK:              2,
 		MinSimilarity:       0.0,
 		MaxSimilarity:       1.0,
-		CloneTypes:          []CloneType{Type1Clone, Type2Clone, Type3Clone, Type4Clone},
+		CloneTypes:          []CloneType{Type1Clone, Type3Clone, Type4Clone}, // Type2 disabled by default due to high false positive rate
 		// LSH defaults (auto-enable based on fragment count)
 		LSHEnabled:             "auto",
 		LSHAutoThreshold:       500,

--- a/domain/clone_test.go
+++ b/domain/clone_test.go
@@ -363,9 +363,9 @@ func TestDefaultCloneRequest(t *testing.T) {
 	assert.True(t, request.GroupClones, "Default group clones should be true")
 	assert.Equal(t, 0.0, request.MinSimilarity, "Default min similarity should be 0.0")
 	assert.Equal(t, 1.0, request.MaxSimilarity, "Default max similarity should be 1.0")
-	assert.Len(t, request.CloneTypes, 4, "Default clone types should include all 4 types")
+	assert.Len(t, request.CloneTypes, 3, "Default clone types should include Type-1, Type-3, Type-4 (Type-2 disabled by default)")
 	assert.Contains(t, request.CloneTypes, Type1Clone, "Default should include Type-1")
-	assert.Contains(t, request.CloneTypes, Type2Clone, "Default should include Type-2")
+	assert.NotContains(t, request.CloneTypes, Type2Clone, "Default should NOT include Type-2 (high false positive rate)")
 	assert.Contains(t, request.CloneTypes, Type3Clone, "Default should include Type-3")
 	assert.Contains(t, request.CloneTypes, Type4Clone, "Default should include Type-4")
 

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -281,7 +281,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 		Filtering: FilteringConfig{
 			MinSimilarity:     0.0,
 			MaxSimilarity:     1.0,
-			EnabledCloneTypes: []string{"type1", "type2", "type3", "type4"},
+			EnabledCloneTypes: []string{"type1", "type3", "type4"}, // type2 disabled by default
 			MaxResults:        10000,
 		},
 		Input: InputConfig{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ group_clones = true
 # Filtering settings
 min_similarity = 0.0
 max_similarity = 1.0
-enabled_clone_types = ["type1", "type2", "type3", "type4"]
+enabled_clone_types = ["type1", "type3", "type4"]
 max_results = 10000
 
 # Grouping settings


### PR DESCRIPTION
## Summary

- Disable Type2 clone detection by default due to high false positive rate
- Fix clone grouping not working in analyze command
- Change duplication score calculation from pair-based to group-based
- Tighten duplication scoring thresholds (0-5% scale)

## Changes

| File | Change |
|------|--------|
| `domain/clone.go` | Remove Type2 from default CloneTypes |
| `internal/config/pyscn_config.go` | Remove type2 from default config |
| `cmd/pyscn/check.go` | Remove Type2 from default CloneTypes |
| `app/clone_usecase.go` | Use `slices.Equal` for accurate comparison; add GroupMode/GroupThreshold merge |
| `app/analyze_usecase.go` | Pass GroupMode/GroupThreshold to CloneRequest; change duplication calculation to group-based |
| `domain/analyze.go` | Change duplication thresholds from 5-30% to 0-5% |
| `domain/clone_test.go` | Update tests |
| `domain/analyze_test.go` | Update health score test expectations |
| `pyproject.toml` | Remove type2 from `enabled_clone_types` |

## Background

### Type2 False Positives
Type2 clone detection normalizes identifiers and literals, which causes it to incorrectly detect completely different functions as clones when they have similar structure.

### Clone Grouping Fix
GroupMode and GroupThreshold were not being passed to the clone detection service, causing "0 groups" even when clone pairs were detected.

### Duplication Scoring
- Changed from clone-pair-based to clone-group-based calculation for more accurate results
- Tightened thresholds: 0% = perfect (100 score), 5% = max penalty (0 score)
- Example: 0.5% duplication now scores 90 instead of 95

## How to re-enable Type2

Users can explicitly enable Type2 via configuration:

```toml
# pyproject.toml
[tool.pyscn.clones]
enabled_clone_types = ["type1", "type2", "type3", "type4"]

# .pyscn.toml
[clones]
enabled_clone_types = ["type1", "type2", "type3", "type4"]
```

## Test plan

- [x] All tests pass
- [x] Verify Type2 is not detected by default
- [x] Verify clone grouping works correctly
- [x] Verify duplication scoring is stricter

🤖 Generated with [Claude Code](https://claude.com/claude-code)