### PR TITLE
refactor: improve code duplication calculation to use function-based metrics

### DIFF
--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -17,9 +17,9 @@ const (
 	ComplexityPenaltyLow      = 6
 
 	// Code duplication thresholds and penalties
-	// Strict thresholds: 0% = perfect, 5% = max penalty
-	DuplicationThresholdHigh   = 5.0
-	DuplicationThresholdMedium = 2.5
+	// 0% = perfect, 20% = max penalty
+	DuplicationThresholdHigh   = 20.0
+	DuplicationThresholdMedium = 10.0
 	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -167,7 +167,7 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			name: "typical 74 score case",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity:         7.0,  // Continuous: (7-2)/13*20 = 7.69 → 8
-				CodeDuplication:           15.0, // Continuous: 15/10*20 = 30 → 20 (capped, 0-10% scale)
+				CodeDuplication:           15.0, // Continuous: 15/20*20 = 15 (0-20% scale)
 				CBOClasses:                10,
 				HighCouplingClasses:       2, // 20% ratio: 0.20/0.12*20 = 33.33 → 20 (capped)
 				DepsEnabled:               true,
@@ -175,12 +175,12 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				ArchEnabled:               true,
 				ArchCompliance:            0.125, // (1-0.125)*12 = 10.5 → 11 (new max arch)
 			},
-			expectedScore:             38,  // Updated: 100-8-20-20-3-11 = 38 (0-10% duplication scale, capped)
-			expectedGrade:             "F", // 38 < 45 = F
+			expectedScore:             43,  // Updated: 100-8-15-20-3-11 = 43 (0-20% duplication scale)
+			expectedGrade:             "F", // 43 < 45 = F
 			expectError:               false,
 			expectedComplexityScore:   60,  // 100 - (8/20)*100 = 60
 			expectedDeadCodeScore:     100, // No dead code
-			expectedDuplicationScore:  0,   // 100 - (20/20)*100 = 0 (0-10% scale: 20 penalty capped)
+			expectedDuplicationScore:  25,  // 100 - (15/20)*100 = 25 (0-20% scale: 15 penalty)
 			expectedCouplingScore:     0,   // 100 - (20/20)*100 = 0
 			expectedDependencyScore:   80,  // Normalized: (3/16)*20 = 3.75 → 4, Score: 100 - (4/20)*100 = 80
 			expectedArchitectureScore: 13,  // Compliance 0.125 * 100 = 12.5 → 13
@@ -201,10 +201,10 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			name: "high complexity",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity: 25.0, // Continuous: (25-2)/13*20 = 35.38 → 20 (capped)
-				CodeDuplication:   5.0,  // 5/5*20 = 20 penalty (0-5% scale, capped)
+				CodeDuplication:   5.0,  // 5/20*20 = 5 penalty (0-20% scale)
 			},
-			expectedScore: 60,  // Updated: 100-20-20 = 60 (0-5% duplication scale)
-			expectedGrade: "C", // 60 ≤ 60 < 75 = C
+			expectedScore: 75,  // Updated: 100-20-5 = 75 (0-20% duplication scale)
+			expectedGrade: "B", // 75 ≤ 75 < 90 = B
 			expectError:   false,
 		},
 		{
@@ -248,7 +248,7 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			name: "grade A threshold",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity:   4.0, // Continuous: (4-2)/13*20 = 3.08 → 3
-				CodeDuplication:     2.0, // 2/5*20 = 8 penalty (0-5% scale)
+				CodeDuplication:     2.0, // 2/20*20 = 2 penalty (0-20% scale)
 				CBOClasses:          20,
 				HighCouplingClasses: 2, // 10% ratio: 0.10/0.12*20 = 16.67 → 17
 				DepsEnabled:         true,
@@ -257,8 +257,8 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				ArchEnabled:         true,
 				ArchCompliance:      0.9, // (1-0.9)*12 = 1.2 → 1
 			},
-			expectedScore: 71,  // Updated: 100-3-8-17-0-1 = 71 (0-5% duplication scale)
-			expectedGrade: "C", // 60 ≤ 71 < 75 = C
+			expectedScore: 77,  // Updated: 100-3-2-17-0-1 = 77 (0-20% duplication scale)
+			expectedGrade: "B", // 75 ≤ 77 < 90 = B
 			expectError:   false,
 		},
 		{
@@ -301,12 +301,12 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 		{
 			name: "edge case - duplication at 1.0%",
 			summary: domain.AnalyzeSummary{
-				CodeDuplication: 1.0, // 1% duplication = 4 penalty (0-5% scale: 1/5*20=4)
+				CodeDuplication: 1.0, // 1% duplication = 1 penalty (0-20% scale: 1/20*20=1)
 			},
-			expectedScore:            96,
+			expectedScore:            99,
 			expectedGrade:            "A",
 			expectError:              false,
-			expectedDuplicationScore: 80, // penalty=4, score=100-(4/20)*100=80
+			expectedDuplicationScore: 95, // penalty=1, score=100-(1/20)*100=95
 		},
 		{
 			name: "edge case - small weighted dead code",

--- a/domain/clone.go
+++ b/domain/clone.go
@@ -117,12 +117,14 @@ func (cg *CloneGroup) AddClone(clone *Clone) {
 
 // CloneStatistics provides statistics about clone detection results
 type CloneStatistics struct {
-	TotalClones       int            `json:"total_clones" yaml:"total_clones" csv:"total_clones"`
+	TotalFragments    int            `json:"total_fragments" yaml:"total_fragments" csv:"total_fragments"` // All extracted fragments (functions, classes, etc.)
+	TotalClones       int            `json:"total_clones" yaml:"total_clones" csv:"total_clones"`          // Fragments detected as clones
 	TotalClonePairs   int            `json:"total_clone_pairs" yaml:"total_clone_pairs" csv:"total_clone_pairs"`
 	TotalCloneGroups  int            `json:"total_clone_groups" yaml:"total_clone_groups" csv:"total_clone_groups"`
 	ClonesByType      map[string]int `json:"clones_by_type" yaml:"clones_by_type" csv:"clones_by_type"`
 	AverageSimilarity float64        `json:"average_similarity" yaml:"average_similarity" csv:"average_similarity"`
 	LinesAnalyzed     int            `json:"lines_analyzed" yaml:"lines_analyzed" csv:"lines_analyzed"`
+	NodesAnalyzed     int            `json:"nodes_analyzed" yaml:"nodes_analyzed" csv:"nodes_analyzed"`
 	FilesAnalyzed     int            `json:"files_analyzed" yaml:"files_analyzed" csv:"files_analyzed"`
 }
 

--- a/service/basic_service_test.go
+++ b/service/basic_service_test.go
@@ -148,13 +148,15 @@ func TestCloneService_Basic(t *testing.T) {
 		var pairs []*domain.ClonePair
 		var groups []*domain.CloneGroup
 
-		stats := service.createStatistics(clones, pairs, groups, 0, 0)
+		stats := service.createStatistics(clones, pairs, groups, 0, 0, 0, 0)
 
+		assert.Equal(t, 0, stats.TotalFragments)
 		assert.Equal(t, 0, stats.TotalClones)
 		assert.Equal(t, 0, stats.TotalClonePairs)
 		assert.Equal(t, 0, stats.TotalCloneGroups)
 		assert.Equal(t, 0, stats.FilesAnalyzed)
 		assert.Equal(t, 0, stats.LinesAnalyzed)
+		assert.Equal(t, 0, stats.NodesAnalyzed)
 	})
 
 	// Test basic validation

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -531,17 +531,21 @@ func TestCloneService_CreateStatistics(t *testing.T) {
 		{ID: 2},
 	}
 
+	totalFragments := 10
 	filesAnalyzed := 5
 	linesAnalyzed := 1000
+	nodesAnalyzed := 500
 
-	stats := service.createStatistics(clones, pairs, groups, filesAnalyzed, linesAnalyzed)
+	stats := service.createStatistics(clones, pairs, groups, totalFragments, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
 
 	assert.NotNil(t, stats)
+	assert.Equal(t, 10, stats.TotalFragments)
 	assert.Equal(t, 3, stats.TotalClones)
 	assert.Equal(t, 3, stats.TotalClonePairs)
 	assert.Equal(t, 2, stats.TotalCloneGroups)
 	assert.Equal(t, 5, stats.FilesAnalyzed)
 	assert.Equal(t, 1000, stats.LinesAnalyzed)
+	assert.Equal(t, 500, stats.NodesAnalyzed)
 	assert.InDelta(t, 0.8, stats.AverageSimilarity, 0.01) // (0.8 + 0.9 + 0.7) / 3
 
 	// Check clone type counts


### PR DESCRIPTION
## Summary

- Change duplication rate calculation from line-based to function-based
- Add `NodesAnalyzed` field to `CloneStatistics` for AST node tracking
- Exclude "original" in clone groups, count only copies
- Adjust threshold from 0-10% to 0-20%

## Motivation

The previous line-based calculation had issues where duplication rates varied significantly based on project size:
- Small projects: smaller denominator leads to higher duplication rates
- Large projects: larger denominator dilutes the duplication rate

Function-based calculation provides consistent measurements regardless of project scale.

## Changes

| Item | Before | After |
|------|--------|-------|
| Denominator | LinesAnalyzed | TotalClones (total fragments) |
| Numerator | Duplicated lines | Duplicated fragments (copies only) |
| Threshold | 0-10% | 0-20% |