### PR TITLE
refactor: adjust duplication threshold from 0-20% to 0-10%

### DIFF
--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -17,9 +17,9 @@ const (
 	ComplexityPenaltyLow      = 6
 
 	// Code duplication thresholds and penalties
-	// 0% = perfect, 20% = max penalty
-	DuplicationThresholdHigh   = 20.0
-	DuplicationThresholdMedium = 10.0
+	// 0% = perfect, 10% = max penalty
+	DuplicationThresholdHigh   = 10.0
+	DuplicationThresholdMedium = 5.0
 	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12


### PR DESCRIPTION
## Summary

- Adjust duplication threshold from 0-20% to 0-10%
- Update test expectations accordingly

## Motivation

After the clone detection algorithm improvement in PR #266, which significantly reduced false positives, a stricter threshold is now appropriate.

With the improved algorithm, actual code duplication is now accurately detected, making the stricter 0-10% threshold reasonable.