### PR TITLE
refactor: consolidate default CloneTypes to single source of truth

### DIFF
--- a/cmd/pyscn/check.go
+++ b/cmd/pyscn/check.go
@@ -447,7 +447,7 @@ func (c *CheckCommand) checkClones(cmd *cobra.Command, args []string) (int, erro
 		GroupClones:         true,
 		MinSimilarity:       0.0,
 		MaxSimilarity:       1.0,
-		CloneTypes:          []domain.CloneType{domain.Type1Clone, domain.Type3Clone, domain.Type4Clone}, // Type2 disabled by default
+		CloneTypes:          domain.DefaultEnabledCloneTypes,
 		Recursive:           true,
 		IncludePatterns:     []string{"**/*.py"},
 		ExcludePatterns:     []string{"__pycache__/*", "*.pyc"},

--- a/domain/clone.go
+++ b/domain/clone.go
@@ -37,6 +37,13 @@ func (ct CloneType) String() string {
 	}
 }
 
+// DefaultEnabledCloneTypes defines the clone types enabled by default.
+// Type2Clone is excluded due to high false positive rate.
+var DefaultEnabledCloneTypes = []CloneType{Type1Clone, Type3Clone, Type4Clone}
+
+// DefaultEnabledCloneTypeStrings provides string representations for config files.
+var DefaultEnabledCloneTypeStrings = []string{"type1", "type3", "type4"}
+
 // CloneLocation represents a location of a clone in source code
 type CloneLocation struct {
 	FilePath  string `json:"file_path" yaml:"file_path" csv:"file_path"`
@@ -348,7 +355,7 @@ func DefaultCloneRequest() *CloneRequest {
 		KCoreK:              2,
 		MinSimilarity:       0.0,
 		MaxSimilarity:       1.0,
-		CloneTypes:          []CloneType{Type1Clone, Type3Clone, Type4Clone}, // Type2 disabled by default due to high false positive rate
+		CloneTypes:          DefaultEnabledCloneTypes,
 		// LSH defaults (auto-enable based on fragment count)
 		LSHEnabled:             "auto",
 		LSHAutoThreshold:       500,

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -281,7 +281,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 		Filtering: FilteringConfig{
 			MinSimilarity:     0.0,
 			MaxSimilarity:     1.0,
-			EnabledCloneTypes: []string{"type1", "type3", "type4"}, // type2 disabled by default
+			EnabledCloneTypes: domain.DefaultEnabledCloneTypeStrings,
 			MaxResults:        10000,
 		},
 		Input: InputConfig{


### PR DESCRIPTION
## Summary
- Define `DefaultEnabledCloneTypes` and `DefaultEnabledCloneTypeStrings` in `domain/clone.go`
- Reference these constants from 3 locations that previously had duplicated values
- Eliminates DRY violation identified in #261

## Changes
| File | Change |
|------|--------|
| `domain/clone.go` | Add `DefaultEnabledCloneTypes` and `DefaultEnabledCloneTypeStrings` |
| `domain/clone.go` | Update `DefaultCloneRequest()` to use new constant |
| `internal/config/pyscn_config.go` | Update `DefaultPyscnConfig()` to use new constant |
| `cmd/pyscn/check.go` | Update `checkClones()` to use new constant |

Closes #261
