### PR TITLE
refactor: consolidate default CBO thresholds to single source of truth

### DIFF
--- a/service/cbo_config_loader.go
+++ b/service/cbo_config_loader.go
@@ -138,8 +138,8 @@ func (cl *CBOConfigurationLoaderImpl) MergeConfig(base *domain.CBORequest, overr
 func (cl *CBOConfigurationLoaderImpl) configToRequest(pyscnCfg *config.PyscnConfig) *domain.CBORequest {
 	if pyscnCfg == nil {
 		return &domain.CBORequest{
-			LowThreshold:    3,
-			MediumThreshold: 7,
+			LowThreshold:    domain.DefaultCBOLowThreshold,
+			MediumThreshold: domain.DefaultCBOMediumThreshold,
 			MinCBO:          0,
 			MaxCBO:          0,
 			ShowZeros:       domain.BoolPtr(false),


### PR DESCRIPTION
## Summary
- Replace hardcoded CBO threshold values in `cbo_config_loader.go` with `domain.DefaultCBOLowThreshold` and `domain.DefaultCBOMediumThreshold`
- Eliminates DRY violation identified in #271

## Test plan
- [x] All existing CBO tests pass
- [x] Build succeeds

Fixes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)