### PR TITLE
feat: add Claude Code plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "pyscn-marketplace",
+  "owner": {
+    "name": "Ludo Technologies"
+  },
+  "metadata": {
+    "description": "Python code quality analysis tools"
+  },
+  "plugins": [
+    {
+      "name": "pyscn-mcp",
+      "source": ".",
+      "description": "Python code quality analysis with complexity, dead code, clone detection, and coupling metrics"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "pyscn-mcp",
+  "description": "Python code quality analysis MCP server",
+  "mcpServers": {
+    "pyscn-mcp": {
+      "command": "uvx",
+      "args": ["pyscn-mcp"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ You can interact with pyscn with your AI coding tools:
 
 ### Claude Code Setup
 
+**Option 1: Install via Plugin Marketplace (Recommended)**
+
+```bash
+/plugin marketplace add ludo-technologies/pyscn
+/plugin install pyscn-mcp@pyscn-marketplace
+```
+
+**Option 2: Manual MCP Setup**
+
 ```bash
 claude mcp add pyscn-mcp uvx -- pyscn-mcp
 ```


### PR DESCRIPTION
## Summary

- Add Claude Code plugin marketplace configuration for easy installation
- Users can install pyscn-mcp directly from Claude Code without manual setup

## Changes

- Add `.claude-plugin/marketplace.json` - marketplace definition
- Add `.claude-plugin/plugin.json` - plugin manifest (uses uvx for zero-install)
- Update README with plugin installation instructions

## Installation

After merging, users can install via:

```bash
/plugin marketplace add ludo-technologies/pyscn
/plugin install pyscn-mcp@pyscn-marketplace
```

## Test plan

- [ ] Verify marketplace.json schema is valid
- [ ] Verify plugin.json schema is valid
- [ ] Test installation after merge

Closes #279