### PR TITLE
fix: consolidate default settings to single source of truth

### DIFF
--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -69,7 +69,7 @@ enable_dfa = true                # Enable Data Flow Analysis for enhanced Type-4
 # Filtering settings
 min_similarity = 0.0             # Minimum similarity to report
 max_similarity = 1.0             # Maximum similarity to report
-enabled_clone_types = ["type1", "type2", "type3", "type4"] # Clone types to detect
+enabled_clone_types = ["type1", "type3", "type4"] # Clone types to detect (type2 disabled due to high false positive rate)
 max_results = 10000              # Maximum results (0 = no limit)
 
 # Grouping settings

--- a/service/dead_code_config_loader.go
+++ b/service/dead_code_config_loader.go
@@ -274,7 +274,7 @@ func (cl *DeadCodeConfigurationLoaderImpl) requestToConfig(req *domain.DeadCodeR
 	case domain.DeadCodeSeverityInfo:
 		cfg.DeadCode.MinSeverity = "info"
 	default:
-		cfg.DeadCode.MinSeverity = "warning"
+		cfg.DeadCode.MinSeverity = domain.DefaultDeadCodeMinSeverity
 	}
 
 	// Convert sort criteria
@@ -286,7 +286,7 @@ func (cl *DeadCodeConfigurationLoaderImpl) requestToConfig(req *domain.DeadCodeR
 	case domain.DeadCodeSortByFunction:
 		cfg.DeadCode.SortBy = "function"
 	default:
-		cfg.DeadCode.SortBy = "severity"
+		cfg.DeadCode.SortBy = domain.DefaultDeadCodeSortBy
 	}
 
 	// Set dead code specific config


### PR DESCRIPTION
## Summary
- Remove type2 from `enabled_clone_types` in default_config.toml to match `domain.DefaultEnabledCloneTypes`
- Replace hardcoded strings in dead_code_config_loader.go with domain constants

Closes #272
