### PR TITLE
fix: remove MaxComplexity filtering from service layer

### DIFF
--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -168,11 +168,8 @@ func (s *ComplexityServiceImpl) filterFunctions(functions []domain.FunctionCompl
 			continue
 		}
 
-		// Apply maximum complexity filter
-		if req.MaxComplexity > 0 && function.Metrics.Complexity > req.MaxComplexity {
-			continue
-		}
-
+		// MaxComplexity is used only as a warning threshold (not for filtering)
+		// See check command for threshold violation detection
 		filtered = append(filtered, function)
 	}
 

--- a/service/complexity_service_test.go
+++ b/service/complexity_service_test.go
@@ -98,20 +98,6 @@ func TestComplexityService_Analyze(t *testing.T) {
 		}
 	})
 
-	t.Run("analyze with max complexity limit", func(t *testing.T) {
-		req := newDefaultComplexityRequest("../testdata/python/simple/control_flow.py")
-		req.MaxComplexity = 3 // Only functions with complexity <= 3
-
-		response, err := service.Analyze(ctx, req)
-
-		assert.NoError(t, err)
-		if response != nil {
-			for _, function := range response.Functions {
-				assert.LessOrEqual(t, function.Metrics.Complexity, 3)
-			}
-		}
-	})
-
 	t.Run("analyze multiple files", func(t *testing.T) {
 		req := newDefaultComplexityRequest(
 			"../testdata/python/simple/functions.py",
@@ -224,30 +210,21 @@ func TestComplexityService_FilterFunctions(t *testing.T) {
 		assert.Equal(t, "func4", filtered[2].Name)
 	})
 
-	t.Run("filter by maximum complexity", func(t *testing.T) {
+	t.Run("MaxComplexity does not filter functions", func(t *testing.T) {
+		// MaxComplexity is used only as a warning threshold, not for filtering
 		req := domain.ComplexityRequest{
 			MinComplexity: 1,
-			MaxComplexity: 8,
+			MaxComplexity: 8, // This should NOT filter out functions
 		}
 
 		filtered := service.filterFunctions(functions, req)
 
-		require.Len(t, filtered, 2)
+		// All 4 functions should be returned (MaxComplexity doesn't filter)
+		require.Len(t, filtered, 4)
 		assert.Equal(t, "func1", filtered[0].Name)
 		assert.Equal(t, "func2", filtered[1].Name)
-	})
-
-	t.Run("filter by both min and max complexity", func(t *testing.T) {
-		req := domain.ComplexityRequest{
-			MinComplexity: 5,
-			MaxComplexity: 10,
-		}
-
-		filtered := service.filterFunctions(functions, req)
-
-		require.Len(t, filtered, 2)
-		assert.Equal(t, "func2", filtered[0].Name)
-		assert.Equal(t, "func3", filtered[1].Name)
+		assert.Equal(t, "func3", filtered[2].Name)
+		assert.Equal(t, "func4", filtered[3].Name)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Remove MaxComplexity filtering from service layer's `filterFunctions`
- Fix `check` command to correctly report functions exceeding the `max_complexity` threshold from config file

## Problem
The `check` command was not respecting the `max_complexity` setting in `.pyscn.toml`.

**Root cause:** `filterFunctions` was filtering out functions that exceeded `MaxComplexity`, so those functions were never passed to the check command for violation reporting.

## Changes
| File | Change |
|------|--------|
| `service/complexity_service.go` | Remove MaxComplexity filtering |
| `service/complexity_service_test.go` | Update related tests |

## Test plan
- [x] `make test` - All tests pass
- [x] Manual test: Verified that a function with complexity 4 is reported when `max_complexity = 3`

```bash
$ cat .pyscn.toml
[complexity]
max_complexity = 3

$ pyscn check .
test.py:1:1: complex_function is too complex (4 > 3)
```

Fixes #297