### PR TITLE
docs: update demo video and gitignore promo directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ requirements.md
 AGENTS.md
 CLAUDE.md
 
+# Promo video (Remotion)
+promo/
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pipx run pyscn analyze .
 
 ## Demo
 
-https://github.com/user-attachments/assets/07f48070-c0dd-437b-9621-cb3963f863ff
+https://github.com/user-attachments/assets/10c747b3-e566-4c30-b873-6755750170a0
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Updated README demo video URL to the new 15-second promo
- Added `promo/` directory to `.gitignore`
