### PR TITLE
feat: enable Type-2 clone detection by default

### DIFF
--- a/domain/clone.go
+++ b/domain/clone.go
@@ -38,11 +38,12 @@ func (ct CloneType) String() string {
 }
 
 // DefaultEnabledCloneTypes defines the clone types enabled by default.
-// Type2Clone is excluded due to high false positive rate.
-var DefaultEnabledCloneTypes = []CloneType{Type1Clone, Type3Clone, Type4Clone}
+// Type-2 detection uses Jaccard coefficient algorithm (PR #301) which resolved
+// the false positive issues reported in #292.
+var DefaultEnabledCloneTypes = []CloneType{Type1Clone, Type2Clone, Type3Clone, Type4Clone}
 
 // DefaultEnabledCloneTypeStrings provides string representations for config files.
-var DefaultEnabledCloneTypeStrings = []string{"type1", "type3", "type4"}
+var DefaultEnabledCloneTypeStrings = []string{"type1", "type2", "type3", "type4"}
 
 // CloneLocation represents a location of a clone in source code
 type CloneLocation struct {

--- a/domain/clone_test.go
+++ b/domain/clone_test.go
@@ -363,9 +363,9 @@ func TestDefaultCloneRequest(t *testing.T) {
 	assert.True(t, request.GroupClones, "Default group clones should be true")
 	assert.Equal(t, 0.0, request.MinSimilarity, "Default min similarity should be 0.0")
 	assert.Equal(t, 1.0, request.MaxSimilarity, "Default max similarity should be 1.0")
-	assert.Len(t, request.CloneTypes, 3, "Default clone types should include Type-1, Type-3, Type-4 (Type-2 disabled by default)")
+	assert.Len(t, request.CloneTypes, 4, "Default clone types should include all types (Type-1 through Type-4)")
 	assert.Contains(t, request.CloneTypes, Type1Clone, "Default should include Type-1")
-	assert.NotContains(t, request.CloneTypes, Type2Clone, "Default should NOT include Type-2 (high false positive rate)")
+	assert.Contains(t, request.CloneTypes, Type2Clone, "Default should include Type-2 (Jaccard algorithm, PR #301)")
 	assert.Contains(t, request.CloneTypes, Type3Clone, "Default should include Type-3")
 	assert.Contains(t, request.CloneTypes, Type4Clone, "Default should include Type-4")
 

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -69,7 +69,7 @@ enable_dfa = true                # Enable Data Flow Analysis for enhanced Type-4
 # Filtering settings
 min_similarity = 0.0             # Minimum similarity to report
 max_similarity = 1.0             # Maximum similarity to report
-enabled_clone_types = ["type1", "type3", "type4"] # Clone types to detect (type2 disabled due to high false positive rate)
+# enabled_clone_types = ["type1", "type2", "type3", "type4"]  # Default: uses domain.DefaultEnabledCloneTypes
 max_results = 10000              # Maximum results (0 = no limit)
 
 # Grouping settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ group_clones = true
 # Filtering settings
 min_similarity = 0.0
 max_similarity = 1.0
-enabled_clone_types = ["type1", "type3", "type4"]
+enabled_clone_types = ["type1", "type2", "type3", "type4"]
 max_results = 10000
 
 # Grouping settings


### PR DESCRIPTION
## Summary

- Enable Type-2 clone detection by default now that PR #301 resolved the false positive issues
- Establish domain package as single source of truth for default `enabled_clone_types`

## Changes

| File | Description |
|------|-------------|
| `domain/clone.go` | Add `Type2Clone` to `DefaultEnabledCloneTypes` |
| `domain/clone_test.go` | Update test to expect Type-2 enabled |
| `internal/config/default_config.toml` | Comment out `enabled_clone_types` to use domain defaults |
| `pyproject.toml` | Add `type2` for this project's analysis |

## Background

Type-2 clone detection was previously disabled due to high false positive rates (issue #292). PR #301 replaced the APTED algorithm with Jaccard coefficient, which resolved this issue. Regression tests confirm:

- True positives: Structurally identical code with different identifiers is correctly detected
- False positives fixed: Different dataclasses/class structures are no longer misclassified as Type-2 clones

## Test plan

- [x] `go test ./...` - All tests pass
- [x] Type-2 regression tests pass (`TestSyntacticSimilarityAnalyzer/Type2Clone_*`)

Closes #292