### PR TITLE
fix: prevent Type-3 clone false positives for different class/function names

### DIFF
--- a/internal/analyzer/apted_cost.go
+++ b/internal/analyzer/apted_cost.go
@@ -312,8 +312,10 @@ func (c *PythonCostModel) extractBaseNodeType(label string) string {
 
 // isTopLevelDefinition checks if a node type represents a top-level definition
 // where the name is semantically significant for clone detection.
+// Note: AsyncFunctionDef is included for consistency with isStructuralNode,
+// though the tree converter normalizes async functions to FunctionDef labels.
 func (c *PythonCostModel) isTopLevelDefinition(baseType string) bool {
-	return baseType == "ClassDef" || baseType == "FunctionDef"
+	return baseType == "ClassDef" || baseType == "FunctionDef" || baseType == "AsyncFunctionDef"
 }
 
 // extractNameFromLabel extracts the name from a label like "ClassDef(MyClass)" -> "MyClass"

--- a/internal/analyzer/apted_test.go
+++ b/internal/analyzer/apted_test.go
@@ -393,6 +393,10 @@ func TestCalculateLabelSimilarity_TopLevelDefinitions(t *testing.T) {
 	sim = costModel.calculateLabelSimilarity("FunctionDef(foo)", "FunctionDef(bar)")
 	assert.Equal(t, 0.0, sim, "Different function names should have zero similarity")
 
+	// Different async function names should have zero similarity
+	sim = costModel.calculateLabelSimilarity("AsyncFunctionDef(async_foo)", "AsyncFunctionDef(async_bar)")
+	assert.Equal(t, 0.0, sim, "Different async function names should have zero similarity")
+
 	// Same class names should have 0.3 similarity
 	sim = costModel.calculateLabelSimilarity("ClassDef(UserProfile)", "ClassDef(UserProfile)")
 	assert.Equal(t, 0.3, sim, "Same class names should have 0.3 similarity")
@@ -439,10 +443,10 @@ func TestIsTopLevelDefinition(t *testing.T) {
 
 	assert.True(t, costModel.isTopLevelDefinition("ClassDef"), "ClassDef should be top-level definition")
 	assert.True(t, costModel.isTopLevelDefinition("FunctionDef"), "FunctionDef should be top-level definition")
+	assert.True(t, costModel.isTopLevelDefinition("AsyncFunctionDef"), "AsyncFunctionDef should be top-level definition for consistency with isStructuralNode")
 	assert.False(t, costModel.isTopLevelDefinition("Name"), "Name should not be top-level definition")
 	assert.False(t, costModel.isTopLevelDefinition("Constant"), "Constant should not be top-level definition")
 	assert.False(t, costModel.isTopLevelDefinition("If"), "If should not be top-level definition")
-	assert.False(t, costModel.isTopLevelDefinition("AsyncFunctionDef"), "AsyncFunctionDef should not be top-level definition")
 }
 
 func TestOptimizedAPTEDAnalyzer(t *testing.T) {


### PR DESCRIPTION
## Summary

- Return zero similarity (full rename cost) for `ClassDef` and `FunctionDef` nodes when their names differ
- Add helper functions `isTopLevelDefinition` and `extractNameFromLabel` for name-aware comparison
- Add comprehensive unit tests for the new behavior

## Problem

`calculateLabelSimilarity` returned 0.3 similarity for all identical base types, causing:
- `ClassDef(A)` vs `ClassDef(B)` → rename cost = 0.7 (too similar)
- Unrelated classes/functions detected as clones when their internal structure was similar

## Solution

For top-level definitions (`ClassDef`, `FunctionDef`), compare names explicitly:
- Different names → 0.0 similarity → 1.0 rename cost (full cost)
- Same names → 0.3 similarity → 0.7 rename cost (unchanged behavior)

Other node types (e.g., `Name(x)` vs `Name(y)`) retain the original 0.3 similarity.

## Test plan

- [x] `make test` - All tests pass
- [x] `make lint` - No lint errors
- [x] New unit tests for `calculateLabelSimilarity`, `extractNameFromLabel`, and `isTopLevelDefinition`