### PR TITLE
docs: add algorithm documentation for all analysis engines

### DIFF
--- a/docs/algorithms/cbo.md
+++ b/docs/algorithms/cbo.md
@@ -1,0 +1,347 @@
+# CBO (Coupling Between Objects) Algorithm
+
+This document describes the design and implementation of the CBO analysis algorithm in pyscn. The core implementation resides in `internal/analyzer/cbo.go`, domain definitions in `domain/cbo.go`, and the service layer in `service/cbo_service.go`.
+
+## Overview
+
+### What is CBO?
+
+CBO (Coupling Between Objects) is one of the object-oriented design metrics proposed by Chidamber & Kemerer (1994). It measures the number of distinct classes a given class depends on, providing a quantitative assessment of inter-class coupling.
+
+A higher CBO value indicates greater dependency on external classes, which increases the following risks:
+
+- **Change propagation**: Changes to dependent classes may ripple into this class
+- **Testing difficulty**: More mocks and stubs are required for unit testing
+- **Reduced reusability**: The class becomes harder to reuse in different contexts
+- **Comprehension overhead**: Understanding the class requires knowledge of many other classes
+
+### Academic Background
+
+Reference: Chidamber, S.R. & Kemerer, C.F. (1994). "A Metrics Suite for Object Oriented Design", IEEE Transactions on Software Engineering, 20(6), 476-493.
+
+CBO was originally defined as the count of other classes to which a given class is coupled. pyscn adapts this definition for Python code structures, detecting the dependency types described below.
+
+## Analysis Architecture
+
+```mermaid
+graph TD
+    A[Python Source File] --> B[tree-sitter Parser]
+    B --> C[AST]
+    C --> D[CBOAnalyzer]
+    D --> E1[Collect Classes]
+    D --> E2[Collect Imports]
+    E1 --> F[Per-class Dependency Analysis]
+    E2 --> F
+    F --> G1[Inheritance Analysis]
+    F --> G2[Type Hint Analysis]
+    F --> G3[Instantiation & Attribute Access Analysis]
+    G1 --> H[Dependency Set]
+    G2 --> H
+    G3 --> H
+    H --> I[CBO = Size of Dependency Set]
+    I --> J[Risk Level Assessment]
+```
+
+The analysis executes in two passes:
+
+1. **Pass 1**: Walk the AST to collect all class definitions and import statements
+2. **Pass 2**: For each class, analyze dependencies and compute the CBO value
+
+## Dependency Detection
+
+pyscn detects five types of dependencies. Each dependency is tracked as a unique class name in a set, so multiple references to the same class are counted only once.
+
+### 1. Inheritance Dependencies
+
+Base class declarations are detected as dependencies.
+
+```python
+from abc import ABC
+
+class Animal(ABC):          # Dependency on ABC
+    pass
+
+class Dog(Animal):          # Dependency on Animal
+    pass
+
+class GuideDog(Dog, Serializable):  # Dependencies on Dog and Serializable
+    pass
+```
+
+The implementation iterates over the `classNode.Bases` field and extracts each base class name (`internal/analyzer/cbo.go:172-188`).
+
+### 2. Type Hint Dependencies
+
+Class names appearing in type annotations are detected as dependencies.
+
+```python
+class OrderService:
+    repository: OrderRepository        # Dependency on OrderRepository
+    logger: Logger                      # Dependency on Logger
+
+    def process(self, order: Order) -> Result:  # Dependencies on Order, Result
+        pass
+
+    def find_all(self) -> list[Order]:  # Dependency on Order (generic type)
+        pass
+```
+
+The following type annotation structures are recursively parsed:
+
+| AST Node Type | Python Code Example | Processing |
+|---|---|---|
+| `Name` | `User` | Extracted directly as a class name |
+| `Subscript` | `List[User]`, `Dict[str, User]` | Type parameter portion recursively parsed |
+| `Attribute` | `mymodule.MyClass` | Extracted as a module-qualified class name |
+| `BinOp` (op=`\|`) | `Context \| None` | Both sides of the union recursively parsed |
+| `GenericType` | Generic types | TypeParameter children recursively parsed |
+| `TypeNode` | tree-sitter type node | Children recursively parsed |
+
+### 3. Instantiation Dependencies
+
+Class instantiation is detected as a dependency.
+
+```python
+class UserService:
+    def __init__(self):
+        self.repo = UserRepository()   # Dependency on UserRepository
+        self.cache = RedisCache()      # Dependency on RedisCache
+```
+
+Detection logic (`internal/analyzer/cbo.go:319-385`):
+
+1. Walk `NodeCall` and `NodeAssign` nodes
+2. Extract the callee name from the AST structure
+3. Add as a dependency under these conditions:
+   - Matches an imported name -> counted as `ImportDependencies`
+   - Matches a known local class in the same file -> counted as `InstantiationDependencies`
+   - Matches a built-in type when `IncludeBuiltins` is enabled -> counted as `InstantiationDependencies`
+4. Function calls (non-class callables) are **not** added as dependencies
+
+### 4. Attribute Access Dependencies
+
+Method calls and attribute references on objects are detected as dependencies.
+
+```python
+class ReportGenerator:
+    def generate(self, data):
+        formatted = self.formatter.format(data)  # Dependency on formatter's type
+        self.logger.info("Report generated")      # Dependency on logger's type
+```
+
+The type of the object is inferred from the `Left` field of `NodeAttribute` nodes. If the name exists in the import name mapping, the fully-qualified name is used.
+
+### 5. Import Dependencies
+
+When any of the above dependencies originates from an imported name, it is counted as `ImportDependencies`.
+
+```python
+from services.auth import AuthService
+from models import User
+
+class ProfileService:
+    auth: AuthService    # AuthService is import-derived -> ImportDependencies
+    user: User           # User is import-derived -> ImportDependencies
+```
+
+Import name resolution (`internal/analyzer/cbo.go:404-443`):
+
+| Import Form | Alias | Mapping |
+|---|---|---|
+| `import json` | `json` | `json` |
+| `import json as j` | `j` | `json` |
+| `from models import User` | `User` | `models.User` |
+| `from models import User as U` | `U` | `models.User` |
+
+## Union Type Support (Python 3.10+)
+
+The `X | Y` union type syntax introduced in Python 3.10 is fully supported.
+
+```python
+class Handler:
+    context: Context | None         # Dependency on Context (None is a builtin, excluded)
+    input: Request | Response       # Dependencies on Request and Response
+    data: str | int | CustomType    # Dependency on CustomType (str, int are builtins, excluded)
+```
+
+In the AST this is represented as a `BinOp` node with operator `|`. Both the `Left` and `Right` subtrees are recursively parsed (`internal/analyzer/cbo.go:279-290`). Nested unions (`A | B | C`) are correctly handled through the recursive structure.
+
+## Filtering
+
+### Built-in Type Exclusion
+
+By default, Python built-in types are not counted as dependencies (`IncludeBuiltins=false`).
+
+**Excluded built-in types** (`internal/analyzer/cbo.go:732-738`):
+`bool`, `int`, `float`, `complex`, `str`, `bytes`, `bytearray`, `list`, `tuple`, `range`, `dict`, `set`, `frozenset`, `object`, `type`, `super`, `property`, `classmethod`, `staticmethod`, `Exception`, `BaseException`, various exception classes, `memoryview`, `slice`
+
+**Always excluded built-in functions** (`internal/analyzer/cbo.go:742-749`):
+`print`, `len`, `max`, `min`, `sum`, `abs`, `sorted`, `isinstance`, `getattr`, `setattr`, etc. -- these are functions, not class dependencies, and are always excluded regardless of the `IncludeBuiltins` setting.
+
+### Standard Library Exclusion
+
+When `IncludeImports=true` (the default), imported modules are included as dependencies. Setting `IncludeImports=false` excludes standard library modules.
+
+Excluded standard library modules (`internal/analyzer/cbo.go:762-766`):
+`os`, `sys`, `re`, `json`, `datetime`, `collections`, `itertools`, `functools`, `operator`, `math`, `random`, `string`, `io`, `pathlib`, `unittest`, `logging`, `argparse`, `configparser`, `urllib`, `http`
+
+### Class Exclusion Patterns
+
+Default exclusion patterns: `test_*`, `*_test`, `__*__`
+
+Setting `PublicClassesOnly=true` also excludes private classes prefixed with an underscore (`_PrivateClass`).
+
+## CBO Value Calculation
+
+The CBO value is computed as the size of the dependency set:
+
+```
+CBO = |dependency set|
+```
+
+Multiple dependency types referencing the same class (e.g., both inheritance and type hint) are counted only once. The implementation uses a `map[string]bool` to guarantee uniqueness (`internal/analyzer/cbo.go:148-162`).
+
+### Worked Example
+
+```python
+from models import User, Order
+
+class OrderService(BaseService):          # Building the dependency set:
+    repository: OrderRepository           #   {BaseService, OrderRepository,
+    cache: CacheManager                   #    CacheManager, User, Order,
+                                          #    NotificationService}
+    def create_order(self, user: User) -> Order:
+        notification = NotificationService()
+        return Order()                    # Order is already in the set, no duplicate
+```
+
+CBO = 6 (BaseService, OrderRepository, CacheManager, User, Order, NotificationService)
+
+## Risk Thresholds
+
+Risk levels are determined based on the CBO value. Thresholds are based on industry standards from the Chidamber & Kemerer metrics suite (`domain/defaults.go:114-121`).
+
+| Risk Level | CBO Range | Condition | Meaning |
+|---|---|---|---|
+| **Low** | CBO <= 3 | `cbo <= LowThreshold` | Well-encapsulated class |
+| **Medium** | 4 <= CBO <= 7 | `cbo <= MediumThreshold` | Refactoring should be considered |
+| **High** | CBO > 7 | `cbo > MediumThreshold` | Highly coupled; splitting or refactoring recommended |
+
+Default thresholds:
+- `DefaultCBOLowThreshold = 3`
+- `DefaultCBOMediumThreshold = 7`
+
+Thresholds are customizable via command-line flags or the configuration file (`.pyscn.toml`).
+
+## Health Score Integration
+
+In the `pyscn analyze` command's overall health score calculation, CBO contributes as the **Coupling (CBO)** category with a maximum penalty of 20 points (`domain/analyze.go:258-278`).
+
+### Penalty Calculation
+
+```
+weightedRatio = (HighRiskClasses * 1.0 + MediumRiskClasses * 0.5) / TotalAnalyzedClasses
+
+penalty = min(20, weightedRatio / 0.25 * 20)
+```
+
+- High Risk classes (CBO > 7) have a weight of 1.0
+- Medium Risk classes (4 <= CBO <= 7) have a weight of 0.5
+- Low Risk classes (CBO <= 3) contribute no penalty
+
+The penalty is computed as a continuous linear function: 0 points at a weighted ratio of 0%, reaching the maximum of 20 points at 25%.
+
+### Category Score
+
+```
+CouplingScore = 100 - (penalty / 20 * 100)
+```
+
+This is normalized to a 0-100 scale and displayed as part of the health score breakdown.
+
+### Worked Examples
+
+A project with 20 classes where 3 are High Risk and 4 are Medium Risk:
+
+```
+weightedRatio = (3 * 1.0 + 4 * 0.5) / 20 = 5.0 / 20 = 0.25
+penalty = min(20, 0.25 / 0.25 * 20) = min(20, 20) = 20
+CouplingScore = 100 - (20 / 20 * 100) = 0
+```
+
+A project with 20 classes where 1 is High Risk and 2 are Medium Risk:
+
+```
+weightedRatio = (1 * 1.0 + 2 * 0.5) / 20 = 2.0 / 20 = 0.10
+penalty = min(20, 0.10 / 0.25 * 20) = min(20, 8) = 8
+CouplingScore = 100 - (8 / 20 * 100) = 60
+```
+
+## Output Formats
+
+CBO analysis results can be output in the following formats:
+
+| Format | Use Case |
+|---|---|
+| `text` | Human-readable CLI output (default) |
+| `json` | Programmatic consumption |
+| `yaml` | Configuration file compatibility |
+| `csv` | Spreadsheet analysis |
+| `html` | Interactive report (auto-opens in browser) |
+
+For each class, the following information is included:
+
+- Class name, file path, line range
+- CBO value and risk level
+- Dependency breakdown by type (inheritance, type hints, instantiation, attribute access, imports)
+- List of dependent classes
+- Whether the class is abstract
+- List of base classes
+
+## Configuration
+
+### Command-line Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--low-threshold` | 3 | Upper bound CBO value for Low risk |
+| `--medium-threshold` | 7 | Upper bound CBO value for Medium risk |
+| `--include-builtins` | false | Include built-in types as dependencies |
+| `--include-imports` | true | Include imported modules as dependencies |
+| `--min-cbo` | 0 | Minimum CBO value to display |
+| `--max-cbo` | 0 (no limit) | Maximum CBO value to display |
+| `--show-zeros` | false | Include classes with CBO = 0 |
+| `--sort-by` | coupling | Sort criteria (coupling, name, risk, location) |
+
+### Configuration File (.pyscn.toml)
+
+```toml
+[cbo]
+low_threshold = 3
+medium_threshold = 7
+include_builtins = false
+include_imports = true
+min_cbo = 0
+max_cbo = 0
+show_zeros = false
+```
+
+Configuration priority: Command-line flags > Configuration file > Default values
+
+## Implementation Notes
+
+### AST Walker
+
+The `walkNode` method (`internal/analyzer/cbo.go:636-659`) recursively traverses the AST, visiting the `Children`, `Body`, `Args`, and `Value` fields of each node. It uses a visitor pattern where returning `false` short-circuits traversal of the subtree.
+
+### Regex Cache
+
+Exclusion pattern matching caches compiled regular expressions for reuse (`internal/analyzer/cbo.go:696-718`). Patterns containing wildcards (`*`) are converted to regular expressions; patterns without wildcards use exact string matching.
+
+### Abstract Class Detection
+
+A class is identified as abstract if it contains at least one method decorated with `@abstractmethod` (`internal/analyzer/cbo.go:676-692`). Abstract classes are explicitly labeled in the output but are not excluded from CBO calculation.
+
+## Related Documentation
+
+- [Analyze Scoring Reference](../ANALYZE_SCORING.md) -- Position of the CBO penalty within the overall health score

--- a/docs/algorithms/clone-detection.md
+++ b/docs/algorithms/clone-detection.md
@@ -1,0 +1,523 @@
+# Clone Detection Algorithm Reference
+
+This document describes the clone detection algorithms implemented in pyscn. The implementation lives primarily in `internal/analyzer/` with domain types and thresholds defined in `domain/clone.go` and `domain/defaults.go`.
+
+## Overview
+
+Code clones are segments of source code that are similar or identical. They arise from copy-paste programming, framework boilerplate, and design patterns. While not always harmful, excessive duplication increases maintenance cost: a bug fix in one copy must be replicated across all others, and divergent evolution can introduce subtle inconsistencies.
+
+pyscn's clone detector parses Python source code into ASTs via tree-sitter, converts those ASTs into ordered labeled trees, and then applies a cascade of algorithms -- from cheap textual hashing to expensive tree edit distance and control flow analysis -- to classify clone pairs into four standard types.
+
+## Clone Type Classification
+
+The taxonomy follows the standard four-type classification from clone detection research (Roy & Cordy, 2007; Bellon et al., 2007):
+
+| Type | Name | Description | Default Threshold |
+|------|------|-------------|-------------------|
+| Type-1 | Identical | Identical code except whitespace, layout, and comments | >= 0.85 |
+| Type-2 | Renamed | Syntactically identical except for identifier names, literal values, and types | >= 0.75 |
+| Type-3 | Near-Miss | Copied fragments with further modifications (added, changed, or removed statements) | >= 0.70 |
+| Type-4 | Semantic | Syntactically different but functionally similar (same computation, different syntax) | >= 0.65 |
+
+Thresholds are strictly ordered: Type-1 > Type-2 > Type-3 > Type-4. The classifier checks from highest to lowest, assigning the first type whose threshold is met. This ordering is enforced by the request validator (`domain/clone.go:Validate()`).
+
+## Detection Pipeline
+
+The detection pipeline processes code in several stages:
+
+```mermaid
+flowchart TD
+    A[Python Source Files] --> B[Tree-sitter Parser]
+    B --> C[AST Fragment Extraction]
+    C --> D{Fragment Count >= LSH Threshold?}
+    D -->|Yes| E[LSH Candidate Generation]
+    D -->|No| F[Exhaustive Pairwise Comparison]
+    E --> G[MinHash Pre-filter]
+    G --> H[APTED Verification]
+    F --> H
+    H --> I{Multi-dimensional Classification Enabled?}
+    I -->|Yes| J[Cascading Classifier]
+    I -->|No| K[Single-metric Classification]
+    J --> L[Significance Filtering]
+    K --> L
+    L --> M[Grouping Strategy]
+    M --> N[Clone Groups + Clone Pairs]
+```
+
+### Stage 1: Fragment Extraction
+
+The detector extracts candidate code fragments from the AST. A fragment is a compound statement node of one of these types:
+
+- `FunctionDef`, `AsyncFunctionDef`
+- `ClassDef`
+- `For`, `AsyncFor`, `While`
+- `If`, `Try`
+- `With`, `AsyncWith`
+
+Each fragment must meet minimum size requirements to be included:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `MinLines` | 5 | Minimum source lines |
+| `MinNodes` | 10 | Minimum AST node count |
+
+Fragments that fail either threshold are discarded before any comparison.
+
+### Stage 2: Tree Conversion
+
+AST nodes from the parser are converted into ordered labeled trees (`TreeNode`) suitable for the APTED algorithm. The conversion:
+
+1. Creates a `TreeNode` for each AST node with a label encoding the node type and, for some node types, the associated value (e.g., `FunctionDef(my_func)`, `Name(x)`, `Constant(42)`).
+2. Recursively converts children, body, orelse, finalbody, and handler nodes.
+3. Optionally skips docstrings (enabled by default) -- the first `Constant(str)` in a function, class, or module body is omitted from the tree.
+4. Prepares the tree for APTED by computing post-order IDs, left-most leaf descendants, and key roots.
+
+### Stage 3: Pairwise Comparison
+
+For each candidate pair of fragments, the detector applies early filtering and then computes similarity.
+
+**Early filtering** rejects pairs where:
+- Both fragments overlap in the same file (same or overlapping line ranges).
+- Size difference exceeds 50% of the average size.
+- Line count difference exceeds 50% of either fragment's line count.
+
+**Comparison** then proceeds via one of two paths depending on configuration.
+
+### Stage 4: Grouping
+
+Detected clone pairs are assembled into clone groups using a configurable strategy (see [Grouping Algorithms](#grouping-algorithms)).
+
+## Detection Algorithms by Type
+
+### Type-1: Textual Comparison with FNV Hash
+
+**Implementation:** `textual_similarity.go` (`TextualSimilarityAnalyzer`)
+
+Type-1 detection identifies code fragments that are textually identical after normalization. The algorithm:
+
+1. **Normalize content**: Remove Python comments (single-line `#` and multi-line `'''`/`"""`) and collapse whitespace to single spaces using a precompiled regex.
+2. **FNV-64a hash comparison**: Compute a 64-bit FNV hash of each normalized string. If the hashes match, the fragments are identical (similarity = 1.0).
+3. **Levenshtein fallback**: If hashes differ, compute Levenshtein edit distance between the normalized strings and convert to similarity: `1.0 - distance / max(len(s1), len(s2))`. This uses a space-optimized O(min(m,n)) dynamic programming implementation.
+
+Type-1 analysis is opt-in (`EnableTextualAnalysis`) because it requires storing raw source content in each fragment, increasing memory usage.
+
+### Type-2: Normalized AST Hash with Jaccard Coefficient
+
+**Implementation:** `syntactic_similarity.go` (`SyntacticSimilarityAnalyzer`)
+
+Type-2 detection identifies fragments that share the same syntactic structure but differ in identifier names and literal values. Instead of tree edit distance, it compares **sets of normalized AST features** using the Jaccard coefficient.
+
+The algorithm:
+
+1. **Feature extraction** via `ASTFeatureExtractor` with `includeLiterals=false`:
+   - **Subtree hashes**: Bottom-up FNV hashes of subtrees up to height 3. The canonical label strips content after `(` so `Name(foo)` and `Name(bar)` both become `Name`.
+   - **k-grams**: Sliding window of size 4 over the pre-order traversal of canonical labels.
+   - **Node type distribution**: Presence markers and binned frequency counts for each base node type.
+   - **Structural patterns**: Presence of common constructs (`If`, `For`, `While`, `Try`, `Return`, `Call`, etc.).
+2. **Jaccard similarity**: `|A intersection B| / |A union B|` over the two feature sets.
+
+This approach eliminates false positives from the APTED-based approach, since only nodes with identical normalized structure contribute to similarity.
+
+### Type-3: APTED Tree Edit Distance
+
+**Implementation:** `structural_similarity.go` (`StructuralSimilarityAnalyzer`), `apted.go` (`APTEDAnalyzer`), `apted_tree.go`, `apted_cost.go`
+
+Type-3 detection is the core algorithm, using APTED (All Path Tree Edit Distance) based on Pawlik & Augsten's O(n^2 log n) algorithm to compute the minimum-cost sequence of edit operations that transforms one tree into another.
+
+#### Edit Operations and Cost Models
+
+The algorithm supports three edit operations, each with a configurable cost:
+
+| Operation | Description |
+|-----------|-------------|
+| **Insert** | Add a node to the tree |
+| **Delete** | Remove a node from the tree |
+| **Rename** | Change a node's label |
+
+Three cost models are available:
+
+**DefaultCostModel**: Uniform cost of 1.0 for all operations.
+
+**PythonCostModel** (default): Python-aware cost model with type-dependent multipliers:
+
+| Node Category | Insert/Delete Multiplier | Examples |
+|---------------|-------------------------|----------|
+| Structural | 1.5x | `FunctionDef`, `ClassDef`, `Arguments` |
+| Control flow | 1.3x | `If`, `For`, `While`, `Try`, `Return`, `Raise` |
+| Expression | 0.8x | `BinOp`, `Call`, `Attribute`, `List`, `Dict` |
+| Literal (ignored) | 0.1x | `Constant(...)` when `IgnoreLiterals=true` |
+| Identifier (ignored) | 0.2x | `Name(...)` when `IgnoreIdentifiers=true` |
+| Boilerplate | 0.1x | Type annotations, decorators, Field() calls |
+| Default | 1.0x | All other nodes |
+
+Rename cost is scaled by label similarity: identical labels cost 0, same base type costs 0.7 (similarity 0.3), related types (`For`/`AsyncFor`) cost 0.8, same category cost 0.9, and unrelated types cost 1.0. Top-level definition names (`ClassDef`, `FunctionDef`) with different names pay full cost (similarity 0.0).
+
+**WeightedCostModel**: Wraps any base cost model and applies global weights to insert, delete, and rename operations.
+
+#### Boilerplate Handling
+
+To reduce false positives for framework patterns (dataclasses, Pydantic, attrs), nodes identified as boilerplate receive a cost multiplier of 0.1 by default. Boilerplate labels include:
+
+- `AnnAssign` (type annotations)
+- `Decorator` nodes
+- Type hint patterns (`generic_type`, `type_parameter`)
+- Field factory calls (`Field(`, `field(`, `Factory(`, `attrib(`, `attr.ib(`)
+
+#### APTED Algorithm Details
+
+```mermaid
+flowchart TD
+    A[Input: Tree1, Tree2] --> B[Post-order Traversal]
+    B --> C[Compute Left-most Leaves]
+    C --> D[Identify Key Roots]
+    D --> E[Forest Distance DP]
+    E --> F[Tree Distance Matrix]
+    F --> G[Normalize to Similarity]
+```
+
+1. **Preparation**: Assign post-order IDs to every node, compute left-most leaf descendants, and identify key roots (nodes whose left-most leaf has not yet been visited during traversal).
+2. **Forest distance**: For each pair of key roots, compute the forest distance using dynamic programming. The recurrence considers three operations (insert, delete, rename) and selects the minimum cost.
+3. **Optimization**: Trees larger than 500 nodes use an optimized path with early termination. Trees larger than 2000 nodes use an approximate distance based on structural properties (height difference and size difference).
+4. **Normalization**: Distance is converted to similarity: `similarity = 1.0 - min(distance, maxSize) / maxSize`, where `maxSize = max(size1, size2)`. This normalization is stricter than the common `(size1 + size2)` divisor and reduces false positives.
+
+#### Batch Processing
+
+For large codebases, pairwise comparison uses batch processing to limit memory:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `BatchSizeThreshold` | 50 | Minimum fragments to trigger batching |
+| `BatchSizeLarge` | 100 | Batch size for normal projects |
+| `BatchSizeSmall` | 50 | Batch size for large projects (>500 fragments) |
+| `MaxClonePairs` | 10,000 | Maximum pairs retained, sorted by similarity descending |
+
+### Type-4: CFG-based Semantic Analysis
+
+**Implementation:** `semantic_similarity.go` (`SemanticSimilarityAnalyzer`), `dfa.go`, `dfa_builder.go`
+
+Type-4 detection identifies functionally similar code that uses different syntax. It builds Control Flow Graphs (CFGs) and optionally performs Data Flow Analysis (DFA) for each fragment.
+
+#### CFG Feature Comparison
+
+The analyzer extracts the following features from each CFG:
+
+| Feature | Weight | Description |
+|---------|--------|-------------|
+| Cyclomatic complexity | 0.25 | `V(G) = E - N + 2P` -- primary indicator of control flow complexity |
+| Edge type distribution | 0.25 | Cosine similarity of edge type vectors (conditional, loop, exception, etc.) |
+| Block count | 0.20 | Number of basic blocks |
+| Edge count | 0.15 | Number of edges between blocks |
+| Branching factor | 0.10 | Average successors per block |
+| Loop/conditional structure | 0.05 | Loop back-edge count and conditional branch count |
+
+The final CFG similarity is a weighted average of these components.
+
+#### DFA Feature Comparison (Optional)
+
+When DFA analysis is enabled (`EnableDFAAnalysis`), the analyzer additionally builds reaching-definition analysis and compares data flow features:
+
+| Feature | Weight | Description |
+|---------|--------|-------------|
+| Def-use pair count | 0.25 | Total definitions-to-uses pairs indicates data flow complexity |
+| Average chain length | 0.20 | Uses per definition shows variable reuse patterns |
+| Cross-block pair ratio | 0.20 | Data dependencies across control flow structure |
+| Definition kind distribution | 0.20 | Cosine similarity of definition kinds (assign, param, loop) |
+| Use kind distribution | 0.15 | Cosine similarity of use kinds (read, call, attribute) |
+
+The overall Type-4 similarity combines CFG and DFA components with configurable weights:
+
+```
+similarity = 0.60 * cfgSimilarity + 0.40 * dfaSimilarity
+```
+
+Type-4 analysis is opt-in (`EnableSemanticAnalysis`) due to its higher CPU cost.
+
+## Multi-dimensional Classification
+
+**Implementation:** `similarity_analyzer.go` (`CloneClassifier`)
+
+When `EnableMultiDimensionalAnalysis` is set, the classifier uses a cascading approach that applies progressively more expensive analyzers. Classification stops at the first match:
+
+```mermaid
+flowchart TD
+    A[Fragment Pair] --> B{Type-1: Textual?}
+    B -->|similarity >= 0.85| C[Type-1 Clone, confidence=1.00]
+    B -->|No| D{Type-2: Syntactic?}
+    D -->|similarity >= 0.75| E[Type-2 Clone, confidence=0.95]
+    D -->|No| F{Type-3: Structural?}
+    F -->|similarity >= 0.70| G[Type-3 Clone, confidence=0.90]
+    F -->|No| H{Type-4: Semantic?}
+    H -->|similarity >= 0.65| I[Type-4 Clone, confidence=0.85]
+    H -->|No| J{Structural fallback >= 0.65?}
+    J -->|Yes| K[Type-4 Clone, confidence=0.80]
+    J -->|No| L[Not a Clone]
+```
+
+Each step uses a dedicated `SimilarityAnalyzer`:
+
+| Step | Analyzer | Algorithm | Confidence |
+|------|----------|-----------|------------|
+| 1 | `TextualSimilarityAnalyzer` | FNV hash + Levenshtein | 1.00 |
+| 2 | `SyntacticSimilarityAnalyzer` | Normalized AST Jaccard | 0.95 |
+| 3 | `StructuralSimilarityAnalyzer` | APTED tree edit distance | 0.90 |
+| 4 | `SemanticSimilarityAnalyzer` | CFG/DFA comparison | 0.85 |
+| fallback | `StructuralSimilarityAnalyzer` | APTED (reuse cached result) | 0.80 |
+
+When multi-dimensional analysis is disabled (the default), only the APTED structural similarity is computed and thresholds are applied via a simple else-if chain.
+
+**Important**: Even when multi-dimensional classification is used, the final `Similarity` and `Distance` values reported in clone pairs always come from the APTED analyzer. The classifier result is used only for type assignment. This ensures consistent, continuous similarity scores across all clone types.
+
+## LSH Acceleration
+
+**Implementation:** `lsh_index.go` (`LSHIndex`), `minhash.go` (`MinHasher`), `ast_features.go` (`ASTFeatureExtractor`)
+
+For large codebases, exhaustive O(n^2) pairwise comparison becomes prohibitive. LSH (Locality-Sensitive Hashing) reduces the number of pairs that need expensive APTED verification.
+
+```mermaid
+flowchart TD
+    A[All Fragments] --> B[Feature Extraction]
+    B --> C[MinHash Signatures]
+    C --> D[LSH Banding]
+    D --> E[Candidate Pairs]
+    E --> F[MinHash Pre-filter]
+    F --> G[APTED Verification]
+    G --> H[Confirmed Clone Pairs]
+```
+
+### Stage 1: Feature Extraction
+
+The `ASTFeatureExtractor` extracts a set of string features from each tree node:
+- Subtree hashes (height <= `LSHRows`, default 4)
+- k-gram sequences (k=4) from pre-order traversal of canonical labels
+- Node type presence and binned distribution markers
+- Structural pattern tokens
+
+### Stage 2: MinHash Signatures
+
+The `MinHasher` computes compact fixed-size signatures that approximate Jaccard similarity:
+
+1. 128 universal hash functions are generated deterministically: `h_i(x) = (a_i * x) ^ b_i + a_i + b_i` with odd `a_i` values.
+2. Each feature string is hashed to a 64-bit base via FNV-64a.
+3. For each hash function, the minimum value across all features is kept.
+4. The resulting signature vector has 128 elements.
+
+Jaccard similarity is estimated as the fraction of positions where two signatures agree: `match_count / total_positions`.
+
+### Stage 3: LSH Banding
+
+The `LSHIndex` partitions each signature into bands and hashes each band to a bucket:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `LSHBands` | 32 | Number of bands |
+| `LSHRows` | 4 | Rows per band |
+| `LSHMinHashCount` | 128 | Total hash functions (= bands * rows) |
+
+For each band, the corresponding rows of the signature are hashed together (FNV-64a) to produce a bucket key. Two fragments are candidates if they share at least one bucket.
+
+The probability that two fragments with true Jaccard similarity `s` become candidates is:
+
+```
+P(candidate) = 1 - (1 - s^r)^b
+```
+
+where `r` = rows per band and `b` = number of bands. With the defaults (r=4, b=32), fragments with Jaccard similarity 0.5 have approximately 99.8% chance of being candidates, while those with similarity 0.1 have only 0.1% chance.
+
+### Stage 4: Verification
+
+Candidate pairs are filtered by estimated MinHash similarity (`LSHSimilarityThreshold`, default 0.50) before expensive APTED verification.
+
+### Automatic Activation
+
+LSH activation is controlled by the `LSHEnabled` setting:
+
+| Value | Behavior |
+|-------|----------|
+| `"true"` | Always use LSH |
+| `"false"` | Never use LSH |
+| `"auto"` (default) | Enable LSH when fragment count >= `LSHAutoThreshold` (default: 500) |
+
+## Grouping Algorithms
+
+After detecting clone pairs, the detector groups related fragments into clone groups. Five strategies are available:
+
+### Connected Components (default)
+
+**Implementation:** `connected_grouping.go` (`ConnectedGrouping`)
+
+Uses Union-Find to build connected components from all pairs whose similarity meets the grouping threshold. This has the highest recall -- any transitive chain of similarities connects fragments into the same group.
+
+- **Strengths**: Fast, finds all related clones.
+- **Weakness**: May create large groups with loosely similar members due to transitivity (A similar to B, B similar to C, but A dissimilar to C).
+
+### Star/Medoid
+
+**Implementation:** `star_medoid_grouping.go` (`StarMedoidGrouping`)
+
+Iteratively selects medoids (the member with highest average similarity to others) and reassigns fragments to their most similar medoid. Runs up to 10 iterations with early stopping after 3 consecutive no-change iterations.
+
+1. Initialize each fragment in its own cluster.
+2. Compute medoid for each cluster.
+3. Connect non-medoid fragments to most similar medoid via Union-Find.
+4. Rebuild clusters and repeat.
+5. Filter members below threshold relative to the cluster medoid.
+
+- **Strengths**: Balanced precision and recall, avoids extreme transitivity.
+- **Weakness**: More expensive than connected components.
+
+### Complete Linkage
+
+**Implementation:** `complete_linkage_grouping.go` (`CompleteLinkageGrouping`)
+
+Agglomerative hierarchical clustering that only merges two clusters when the *minimum* pairwise similarity between any member of cluster A and any member of cluster B meets the threshold.
+
+- **Strengths**: Highest precision -- every pair within a group is guaranteed to meet the threshold.
+- **Weakness**: Can miss related clones that are only transitively similar. O(n^3) merging cost.
+
+### k-Core
+
+**Implementation:** `k_core_grouping.go` (`KCoreGrouping`)
+
+Builds a similarity graph where edges connect pairs meeting the threshold, then iteratively removes vertices with fewer than k neighbors (default k=2). The remaining vertices form the k-core subgraph. Connected components within the k-core become groups.
+
+- **Strengths**: Scalable, filters out weakly connected outliers.
+- **Weakness**: May aggressively prune valid but sparsely connected clones.
+
+### Centroid
+
+**Implementation:** `centroid_grouping.go` (`CentroidGrouping`)
+
+BFS-based grouping that grows groups from a seed fragment by adding neighbors that meet the similarity threshold. Avoids the transitivity problem by directly comparing candidates to existing members.
+
+- **Strengths**: Avoids transitivity issues.
+- **Weakness**: Non-deterministic seed selection, group composition depends on traversal order.
+
+## Scoring and Thresholds
+
+### Default Thresholds
+
+All thresholds are defined in `domain/defaults.go`:
+
+| Constant | Value | Usage |
+|----------|-------|-------|
+| `DefaultType1CloneThreshold` | 0.85 | Type-1 (identical) minimum similarity |
+| `DefaultType2CloneThreshold` | 0.75 | Type-2 (renamed) minimum similarity |
+| `DefaultType3CloneThreshold` | 0.70 | Type-3 (near-miss) minimum similarity |
+| `DefaultType4CloneThreshold` | 0.65 | Type-4 (semantic) minimum similarity |
+| `DefaultCloneSimilarityThreshold` | 0.65 | General minimum for reporting (aligned with Type-4) |
+| `DefaultCloneGroupingThreshold` | 0.65 | Minimum for group membership (= Type-4 threshold) |
+| `DefaultLSHSimilarityThreshold` | 0.50 | MinHash pre-filter for LSH candidates |
+
+### Similarity Calculation
+
+The primary similarity metric is APTED-based:
+
+```
+distance = APTED(tree1, tree2)
+maxSize = max(tree1.Size(), tree2.Size())
+similarity = 1.0 - min(distance, maxSize) / maxSize
+```
+
+The `maxSize` normalization (rather than `size1 + size2`) is intentionally stricter to reduce false positives. A fragment pair where one tree can be fully transformed into the other with at most `max(size1, size2)` operations receives similarity 0.0.
+
+### Confidence Scoring
+
+When using single-metric classification, confidence is computed as:
+
+```
+confidence = similarity
+           + min(avgSize / 100, 0.20)                    // up to 20% bonus for large fragments
+           + complexityRatio * 0.10                       // up to 10% for similar complexity
+confidence = min(confidence, 1.0)
+```
+
+When using multi-dimensional classification, confidence is assigned based on which analyzer matched (see the [classification table](#multi-dimensional-classification)).
+
+### Significance Filtering
+
+A clone pair is reported only if all of these conditions are met:
+
+1. Similarity >= `SimilarityThreshold` (or `Type4Threshold` if unset)
+2. Distance <= `MaxEditDistance` (default: 50.0; 0 means no limit)
+3. Minimum fragment size >= `MinNodes`
+
+### Impact on Health Score
+
+In the unified `analyze` command, clone duplication contributes up to 20 penalty points to the overall health score. The penalty formula is:
+
+```
+penalty = min(20, max(0, (duplicationPercentage - 1) / 7 * 20))
+```
+
+This means duplication starts penalizing at 1% and reaches the maximum penalty at 8%.
+
+## Configuration Reference
+
+All clone detection parameters can be set via CLI flags, config files (`.pyscn.toml` or `pyproject.toml [tool.pyscn]`), or programmatic defaults.
+
+### Core Parameters
+
+| Parameter | CLI Flag | Default | Description |
+|-----------|----------|---------|-------------|
+| MinLines | `--min-lines` | 5 | Minimum source lines for a fragment |
+| MinNodes | `--min-nodes` | 10 | Minimum AST nodes for a fragment |
+| SimilarityThreshold | `--clone-threshold` | 0.65 | Minimum similarity for reporting |
+| MaxEditDistance | `--max-edit-distance` | 50.0 | Maximum tree edit distance |
+| SkipDocstrings | `--skip-docstrings` | true | Omit docstrings from AST comparison |
+| CostModelType | -- | `"python"` | Cost model: `"default"`, `"python"`, `"weighted"` |
+
+### Type Thresholds
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Type1Threshold | 0.85 | Minimum similarity for Type-1 |
+| Type2Threshold | 0.75 | Minimum similarity for Type-2 |
+| Type3Threshold | 0.70 | Minimum similarity for Type-3 |
+| Type4Threshold | 0.65 | Minimum similarity for Type-4 |
+
+### Advanced Analysis Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `EnableMultiDimensionalAnalysis` | false | Use cascading classifier with per-type analyzers |
+| `EnableTextualAnalysis` | false | Enable Type-1 textual comparison (increases memory) |
+| `EnableSemanticAnalysis` | false | Enable Type-4 CFG-based analysis (increases CPU) |
+| `EnableDFAAnalysis` | false | Enable Data Flow Analysis for enhanced Type-4 (implies semantic) |
+
+### LSH Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| LSHEnabled | `"auto"` | LSH mode: `"auto"`, `"true"`, `"false"` |
+| LSHAutoThreshold | 500 | Fragment count to auto-enable LSH |
+| LSHSimilarityThreshold | 0.50 | MinHash pre-filter threshold |
+| LSHBands | 32 | Number of LSH bands |
+| LSHRows | 4 | Rows per band |
+| LSHMinHashCount | 128 | Total MinHash functions |
+
+### Grouping Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| GroupingMode | `"connected"` | Strategy: `connected`, `star`, `complete_linkage`, `k_core`, `centroid` |
+| GroupingThreshold | 0.65 | Minimum similarity for group membership |
+| KCoreK | 2 | k value for k-core grouping |
+
+### Performance Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| MaxClonePairs | 10,000 | Maximum pairs kept in memory |
+| BatchSizeThreshold | 50 | Fragment count to trigger batch processing |
+| BatchSizeLarge | 100 | Batch size for normal projects |
+| BatchSizeSmall | 50 | Batch size for projects > 500 fragments |
+| ReduceBoilerplateSimilarity | true | Apply lower weight to boilerplate nodes |
+| BoilerplateMultiplier | 0.1 | Cost multiplier for boilerplate nodes |
+
+## References
+
+- Pawlik, M. & Augsten, N. (2015). Efficient computation of the tree edit distance. *ACM Transactions on Database Systems*.
+- Roy, C. K. & Cordy, J. R. (2007). A survey on software clone detection research. *Queen's University Technical Report*.
+- Bellon, S. et al. (2007). Comparison and evaluation of clone detection tools. *IEEE Transactions on Software Engineering*.
+- McCabe, T. J. (1976). A complexity measure. *IEEE Transactions on Software Engineering*.
+- Broder, A. Z. (1997). On the resemblance and containment of documents. *Proceedings of Compression and Complexity of Sequences*.

--- a/docs/algorithms/complexity.md
+++ b/docs/algorithms/complexity.md
@@ -1,0 +1,344 @@
+# Cyclomatic Complexity Analysis
+
+This document describes how pyscn computes McCabe cyclomatic complexity for Python functions. The implementation spans three main phases: parsing, control-flow graph construction, and metric calculation.
+
+## Overview
+
+Cyclomatic complexity, introduced by Thomas J. McCabe in 1976, quantifies the number of linearly independent paths through a program's source code. A function with complexity 1 has a single straight-line path; each decision point (branch, loop, exception handler) adds one to the count.
+
+High cyclomatic complexity correlates with code that is harder to understand, test, and maintain. pyscn uses this metric to flag functions that may benefit from refactoring.
+
+## End-to-End Pipeline
+
+```mermaid
+flowchart LR
+    A["Python Source"] --> B["tree-sitter Parse"]
+    B --> C["AST Builder"]
+    C --> D["Internal AST"]
+    D --> E["CFG Builder"]
+    E --> F["Control Flow Graph"]
+    F --> G["Complexity Visitor"]
+    G --> H["ComplexityResult"]
+```
+
+1. **Parse** -- tree-sitter produces a concrete syntax tree (CST) from raw Python source.
+2. **AST Build** -- `ASTBuilder` converts the CST into an internal `parser.Node` tree.
+3. **CFG Build** -- `CFGBuilder` walks the AST and emits a per-function control flow graph.
+4. **Calculate** -- `CalculateComplexity` traverses the CFG, counts decision points, and derives the final metric.
+
+## Phase 1: Tree-sitter Python Parsing
+
+### Parser Setup
+
+pyscn uses the [go-tree-sitter](https://github.com/smacker/go-tree-sitter) binding with the Python grammar (`internal/parser/parser.go`):
+
+```go
+parser := sitter.NewParser()
+parser.SetLanguage(python.GetLanguage())
+```
+
+Parsing is invoked via `Parser.Parse(ctx, source)`, which returns a `ParseResult` containing the tree-sitter tree, root node, source bytes, and the converted internal AST.
+
+### AST Conversion
+
+The `ASTBuilder` (`internal/parser/ast_builder.go`) recursively maps tree-sitter node types to internal `parser.Node` types. Each tree-sitter node type has a dedicated builder method:
+
+| tree-sitter type | Internal NodeType | Builder method |
+|---|---|---|
+| `function_definition` | `FunctionDef` / `AsyncFunctionDef` | `buildFunctionDef` |
+| `if_statement` | `If` | `buildIfStatement` |
+| `for_statement` | `For` / `AsyncFor` | `buildForStatement` |
+| `while_statement` | `While` | `buildWhileStatement` |
+| `try_statement` | `Try` | `buildTryStatement` |
+| `with_statement` | `With` / `AsyncWith` | `buildWithStatement` |
+| `match_statement` | `Match` | `buildMatchStatement` |
+| `boolean_operator` | `BoolOp` | `buildBoolOp` |
+| `except_clause` | `ExceptHandler` | `buildExceptHandler` |
+
+The internal `Node` structure (`internal/parser/ast.go`) stores typed fields for body statements, else branches, exception handlers, test conditions, and iterator expressions, making downstream CFG construction straightforward.
+
+### Location Tracking
+
+Every node records its source position (`Location` struct with `StartLine`, `StartCol`, `EndLine`, `EndCol`), which the complexity results carry forward to map functions back to their source locations.
+
+## Phase 2: Control Flow Graph Construction
+
+### Core Data Structures
+
+The CFG (`internal/analyzer/cfg.go`) consists of:
+
+- **BasicBlock** -- A sequence of statements with no internal branching. Each block has a unique ID, a list of `parser.Node` statements, and predecessor/successor edge lists.
+- **Edge** -- A directed connection between two blocks. Each edge carries a type that describes the kind of control transfer.
+- **CFG** -- Holds a map of all blocks, plus distinguished `Entry` and `Exit` blocks. Also stores the `FunctionNode` pointer for nesting depth calculation.
+
+### Edge Types
+
+```go
+const (
+    EdgeNormal    // Sequential flow
+    EdgeCondTrue  // True branch of a conditional
+    EdgeCondFalse // False branch of a conditional
+    EdgeException // Exception flow to handler
+    EdgeLoop      // Back-edge to loop header
+    EdgeBreak     // Break out of loop
+    EdgeContinue  // Continue to loop header
+    EdgeReturn    // Return to function exit
+)
+```
+
+### CFG Builder Algorithm
+
+The `CFGBuilder` (`internal/analyzer/cfg_builder.go`) maintains:
+
+- `currentBlock` -- the block being populated with statements
+- `loopStack` -- tracks nested loops for break/continue resolution
+- `exceptionStack` -- tracks nested try blocks for exception routing
+- `scopeStack` -- tracks nested scopes for fully qualified naming
+- `functionCFGs` -- stores separately built CFGs for nested functions and methods
+
+#### Building Process
+
+```mermaid
+flowchart TD
+    Start["Build(funcNode)"] --> Init["Create ENTRY block"]
+    Init --> Body["Create func_body block"]
+    Body --> Walk["Walk function body statements"]
+    Walk --> Stmt{"Statement type?"}
+    Stmt -->|if/elif/else| IfHandler["processIfStatement"]
+    Stmt -->|for/async for| ForHandler["processForStatement"]
+    Stmt -->|while| WhileHandler["processWhileStatement"]
+    Stmt -->|try/except/finally| TryHandler["processTryStatement"]
+    Stmt -->|with| WithHandler["processWithStatement"]
+    Stmt -->|match| MatchHandler["processMatchStatement"]
+    Stmt -->|return| RetHandler["Connect to EXIT via EdgeReturn"]
+    Stmt -->|break| BreakHandler["Connect to loop exit via EdgeBreak"]
+    Stmt -->|continue| ContHandler["Connect to loop header via EdgeContinue"]
+    Stmt -->|raise| RaiseHandler["Connect to handlers via EdgeException"]
+    Stmt -->|other| SimpleHandler["Add to currentBlock"]
+    IfHandler --> Walk
+    ForHandler --> Walk
+    WhileHandler --> Walk
+    TryHandler --> Walk
+    WithHandler --> Walk
+    MatchHandler --> Walk
+    RetHandler --> Walk
+    BreakHandler --> Walk
+    ContHandler --> Walk
+    RaiseHandler --> Walk
+    SimpleHandler --> Walk
+    Walk --> Done["Connect last block to EXIT"]
+```
+
+#### If/Elif/Else Handling
+
+For an `if` statement, the builder:
+
+1. Uses the current block as the condition block.
+2. Creates a `then` block connected via `EdgeCondTrue`.
+3. If there is an `elif`, creates a new condition block connected via `EdgeCondFalse`, then recurses.
+4. If there is an `else`, creates an else block connected via `EdgeCondFalse`.
+5. Creates a `merge` block where all branches converge.
+
+Each condition test produces one decision point (one `EdgeCondTrue` + one `EdgeCondFalse` pair from the same block).
+
+#### Loop Handling (for/while)
+
+Loops produce a four-block pattern:
+
+```mermaid
+flowchart TD
+    Pre["Previous block"] --> H["Loop Header"]
+    H -->|"EdgeCondTrue (has items)"| B["Loop Body"]
+    H -->|"EdgeCondFalse (exhausted)"| X["Loop Exit"]
+    B --> H2["Loop Header (EdgeLoop)"]
+    H2 -.-> H
+```
+
+- `for` loops: the header evaluates the iterator; `EdgeCondTrue` enters the body, `EdgeCondFalse` exits.
+- `while` loops: the header evaluates the condition similarly.
+- Both support optional `else` clauses (executed when the loop completes normally without `break`).
+- `break` connects to the loop exit block; `continue` connects to the loop header.
+
+#### Exception Handling (try/except/finally)
+
+The try handler creates:
+
+1. A `try_block` connected from the current block.
+2. Handler blocks for each `except` clause, connected from the try block via `EdgeException`.
+3. An optional `else` block (executed if no exception occurred).
+4. An optional `finally` block (always executed).
+5. A `try_exit` merge block.
+
+The `exceptionStack` tracks nesting so that `raise`, `break`, `continue`, and `return` inside try blocks properly route through `finally` blocks before reaching their destination.
+
+#### Match Statement Handling (Python 3.10+)
+
+Each `case` clause creates a separate block connected from the match evaluation block via `EdgeCondTrue`. A fallback `EdgeCondFalse` connects to the merge block for the no-match scenario.
+
+#### Nested Functions and Classes
+
+When the builder encounters a nested function or class definition, it creates a separate `CFGBuilder` instance, builds an independent CFG for that scope, and stores it in `functionCFGs`. The outer CFG simply records the definition as a statement in the current block.
+
+`BuildAll(moduleNode)` returns all CFGs (module-level plus per-function) as a map keyed by fully qualified name.
+
+## Phase 3: Complexity Calculation
+
+### McCabe Formula
+
+pyscn uses the **decision point** method:
+
+```
+Complexity = (number of decision points) + 1
+```
+
+A decision point is any CFG node that produces a branching choice. This is equivalent to the classic graph-theoretic formula `E - N + 2P` for a single connected component, but is more robust for CFGs with synthetic entry/exit nodes.
+
+### Complexity Visitor
+
+`CalculateComplexity` (`internal/analyzer/complexity.go`) traverses the CFG using a depth-first walk and counts:
+
+| Counter | What it tracks |
+|---|---|
+| `decisionPoints` map | Unique blocks with `EdgeCondTrue`/`EdgeCondFalse` outgoing edges |
+| `loopStatements` | Edges of type `EdgeLoop` |
+| `exceptionHandlers` | Edges of type `EdgeException` |
+| `switchCases` | Match/switch case edges |
+
+The total decision points are computed by `countDecisionPoints`:
+
+```go
+func countDecisionPoints(visitor *complexityVisitor) int {
+    conditionalDecisions := len(visitor.decisionPoints)
+    return conditionalDecisions + visitor.exceptionHandlers + visitor.switchCases
+}
+```
+
+The final complexity is then:
+
+```go
+complexity := decisionPoints + 1
+```
+
+The minimum complexity for any function is 1 (a function with no branching has one linear path).
+
+### Python Syntax Elements and Their Contribution
+
+The following table maps Python syntax to how it affects the complexity count:
+
+| Python Construct | CFG Edges Created | Decision Points Added |
+|---|---|---|
+| `if` / `elif` | `EdgeCondTrue` + `EdgeCondFalse` | +1 per condition |
+| `for` / `async for` | `EdgeCondTrue` + `EdgeCondFalse` + `EdgeLoop` | +1 (loop condition) |
+| `while` | `EdgeCondTrue` + `EdgeCondFalse` + `EdgeLoop` | +1 (loop condition) |
+| `except` clause | `EdgeException` from try block | +1 per handler |
+| `match` / `case` | `EdgeCondTrue` per case | +1 per case (via switchCases counter) |
+| `and` / `or` | Not directly modeled in CFG | Not counted (short-circuit not modeled) |
+| `try` / `finally` | Normal + exception flow edges | 0 (structural, not a decision) |
+| `with` | Normal + exception flow | 0 (structural) |
+| `break` | `EdgeBreak` to loop exit | 0 (terminates path, not a decision) |
+| `continue` | `EdgeContinue` to loop header | 0 (terminates path, not a decision) |
+| `return` | `EdgeReturn` to function exit | 0 (terminates path) |
+| `raise` | `EdgeException` to handlers/exit | 0 (terminates path) |
+| Comprehension (`[x for ...]`) | Implicit loop in CFG with `EdgeCondTrue`/`EdgeCondFalse` | +1 per `for` clause; +1 per `if` filter |
+
+**Note**: Boolean operators (`and`/`or`) introduce short-circuit evaluation in Python, but the current implementation does not model them as separate CFG branches. This is a deliberate simplification; the complexity impact of short-circuit operators is typically modest and adding CFG branches for them would inflate scores beyond standard McCabe values.
+
+### Nesting Depth
+
+In addition to cyclomatic complexity, pyscn calculates the maximum nesting depth for each function via `CalculateMaxNestingDepth` (`internal/analyzer/nesting_depth.go`). This traverses the AST (not the CFG) and increments depth for each nesting construct:
+
+- `if`, `elif`, `for`, `async for`, `while`, `with`, `async with`
+- `try`, `except` handler, `match`, `case`
+- `lambda`, list/dict/set comprehensions, generator expressions
+
+The `else` clause does not add nesting depth (it is at the same level as the corresponding `if`/`for`/`while`).
+
+## Risk Level Classification
+
+Each function receives a risk level based on configurable thresholds (`internal/config/config.go`):
+
+| Risk Level | Complexity Range (default) | Interpretation |
+|---|---|---|
+| **Low** | 1 -- 9 | Simple, well-structured function. Easy to understand and test. |
+| **Medium** | 10 -- 19 | Moderately complex. Consider simplification but acceptable. |
+| **High** | 20+ | Highly complex. Strong candidate for refactoring. |
+
+These thresholds are derived from McCabe's original 1976 paper and align with widely accepted industry standards.
+
+### Configuration
+
+Thresholds are configurable via `.pyscn.toml` or `pyproject.toml`:
+
+```toml
+[complexity]
+low_threshold = 9       # Upper bound for "low" risk (inclusive)
+medium_threshold = 19   # Upper bound for "medium" risk (inclusive)
+enabled = true          # Enable/disable complexity analysis
+report_unchanged = true # Report functions with complexity 1
+max_complexity = 0      # Maximum allowed complexity (0 = no limit)
+```
+
+The `AssessRiskLevel` method determines the category:
+
+```go
+func (c *ComplexityConfig) AssessRiskLevel(complexity int) string {
+    if complexity <= c.LowThreshold {
+        return "low"
+    } else if complexity <= c.MediumThreshold {
+        return "medium"
+    }
+    return "high"
+}
+```
+
+When `max_complexity` is set to a positive value, `ExceedsMaxComplexity` can be used as a quality gate to fail CI checks for functions exceeding the limit.
+
+## Output
+
+### ComplexityResult
+
+Each analyzed function produces a `ComplexityResult` (`internal/analyzer/complexity.go`) with:
+
+| Field | Description |
+|---|---|
+| `Complexity` | McCabe cyclomatic complexity value |
+| `Edges` | Number of edges in the CFG |
+| `Nodes` | Number of non-entry/exit blocks in the CFG |
+| `ConnectedComponents` | Always 1 (single function) |
+| `FunctionName` | Fully qualified function name |
+| `StartLine`, `StartCol`, `EndLine` | Source location |
+| `NestingDepth` | Maximum nesting depth |
+| `IfStatements` | Count of conditional decision points |
+| `LoopStatements` | Count of loop back-edges |
+| `ExceptionHandlers` | Count of exception handler edges |
+| `SwitchCases` | Count of match/case edges |
+| `RiskLevel` | `"low"`, `"medium"`, or `"high"` |
+
+### Aggregate Metrics
+
+`CalculateAggregateComplexity` computes summary statistics across all functions in a file or project:
+
+- Total function count
+- Average, minimum, and maximum complexity
+- Count of high/medium/low risk functions
+
+### Report Formats
+
+The `ComplexityAnalyzer` (`internal/analyzer/complexity_analyzer.go`) coordinates analysis and delegates formatting to `reporter.ComplexityReporter`, which supports JSON, YAML, CSV, and HTML output. HTML reports include interactive visualizations.
+
+## Performance Considerations
+
+- **Per-function CFGs**: Each function gets its own CFG built by an independent `CFGBuilder`. Nested functions are built with separate builder instances, avoiding interference with the parent scope.
+- **Depth-first walk**: The CFG traversal uses a visited-set to prevent infinite loops on back-edges while counting all edges exactly once.
+- **Parallel file analysis**: Multiple files are analyzed concurrently (default: 4 goroutines), with each file independently parsed, CFG-built, and scored.
+- **Filtering**: `ShouldReport` filters out trivial functions (complexity = 1) when `report_unchanged` is false, reducing noise in reports for large codebases.
+
+## Integration with Health Score
+
+The overall project health score (`docs/ANALYZE_SCORING.md`) uses average cyclomatic complexity as one of its penalty categories. The complexity penalty is a continuous linear function:
+
+```
+penalty = min(20, max(0, (avg_complexity - 2) / 13 * 20))
+```
+
+This starts penalizing at an average complexity of 2 and reaches the maximum 20-point penalty at an average of 15.

--- a/docs/algorithms/dead-code.md
+++ b/docs/algorithms/dead-code.md
@@ -1,0 +1,509 @@
+# Dead Code Detection Algorithm
+
+This document describes the design and implementation of the dead code detection algorithm in pyscn. The core implementation resides in `internal/analyzer/dead_code.go` and `internal/analyzer/reachability.go`, with domain definitions in `domain/dead_code.go` and the service layer in `service/dead_code_service.go`.
+
+## Overview
+
+### What is Dead Code?
+
+Dead code is source code that can never be executed during any possible run of a program. Common examples include statements placed after `return`, `break`, `continue`, or `raise`, and branches that can never be reached due to exhaustive control flow in preceding branches.
+
+### Why Detection Matters
+
+- **Code clarity**: Dead code creates confusion for developers who may try to understand or modify it, not realising it has no effect.
+- **Maintenance burden**: Dead code must still be read, reviewed, and maintained alongside live code.
+- **Hidden bugs**: Dead code may indicate a logic error where the developer intended the code to execute but introduced a premature terminator.
+- **Code coverage noise**: Dead code inflates line counts and distorts coverage metrics, making it harder to assess true test quality.
+
+## Analysis Architecture
+
+```mermaid
+graph TD
+    A[Python Source File] --> B[tree-sitter Parser]
+    B --> C[AST]
+    C --> D[CFGBuilder]
+    D --> E[CFG per Function]
+    E --> F[ReachabilityAnalyzer]
+    F --> G1[Standard DFS Reachability]
+    F --> G2[All-Paths-Return Detection]
+    G1 --> H[Reachable / Unreachable Block Sets]
+    G2 --> H
+    H --> I[DeadCodeDetector]
+    I --> J[Reason & Severity Classification]
+    J --> K[DeadCodeFinding Results]
+```
+
+The analysis executes in four stages:
+
+1. **Parsing**: The Python source file is parsed into an AST using tree-sitter (`internal/parser`).
+2. **CFG Construction**: `CFGBuilder` (`internal/analyzer/cfg_builder.go`) converts each function's AST into a Control Flow Graph (CFG) composed of `BasicBlock` nodes connected by typed edges.
+3. **Reachability Analysis**: `ReachabilityAnalyzer` (`internal/analyzer/reachability.go`) determines which blocks are reachable from the entry point using DFS traversal, augmented by all-paths-return detection.
+4. **Dead Code Classification**: `DeadCodeDetector` (`internal/analyzer/dead_code.go`) examines each unreachable block, determines the reason it is dead, and assigns a severity level.
+
+## Control Flow Graph Construction
+
+The CFG is the foundation of dead code detection. Each function is represented as a graph of `BasicBlock` nodes connected by directed `Edge` objects.
+
+### Basic Block Structure
+
+A `BasicBlock` (`internal/analyzer/cfg.go:63-84`) contains:
+- A unique ID
+- A list of AST statement nodes
+- Predecessor and successor edge lists
+- Entry/exit flags
+
+### Edge Types
+
+The CFG uses typed edges to model different control flow paths (`internal/analyzer/cfg.go:10-29`):
+
+| Edge Type | Meaning |
+|---|---|
+| `EdgeNormal` | Sequential flow to the next statement |
+| `EdgeCondTrue` | True branch of a conditional |
+| `EdgeCondFalse` | False branch of a conditional |
+| `EdgeException` | Exception handling flow |
+| `EdgeLoop` | Loop back-edge |
+| `EdgeBreak` | Break statement flow to loop exit |
+| `EdgeContinue` | Continue statement flow to loop header |
+| `EdgeReturn` | Return statement flow to function exit |
+
+### Terminator Handling in the CFG Builder
+
+When the CFG builder encounters a terminator statement (`return`, `break`, `continue`, `raise`), it performs two actions:
+
+1. **Connects the current block** to the appropriate target (exit block, loop exit, loop header, or exception handler) via a typed edge.
+2. **Creates a new "unreachable" block** and sets it as the current block. Any subsequent statements in the same scope are added to this disconnected block.
+
+This design ensures that code after a terminator is structurally isolated in the CFG, making it detectable by reachability analysis.
+
+For example, when processing a `return` statement (`internal/analyzer/cfg_builder.go:323-367`):
+
+```
+currentBlock --[EdgeReturn]--> CFG.Exit
+currentBlock = new unreachable block (disconnected)
+```
+
+## Detection Patterns
+
+### Pattern 1: Unreachable Code After Return
+
+Code placed after a `return` statement within the same block or scope.
+
+```python
+def calculate(x):
+    result = x * 2
+    return result
+    print("This never executes")   # CRITICAL: unreachable_after_return
+    cleanup()                       # CRITICAL: unreachable_after_return
+```
+
+**Detection mechanism**: The CFG builder connects the block containing `return` directly to the exit block via an `EdgeReturn` edge. It then creates a new "unreachable" block for any following statements. Since this block has no incoming edges from reachable blocks, the reachability analyzer marks it as unreachable.
+
+### Pattern 2: Unreachable Code After Break
+
+Code placed after a `break` statement inside a loop.
+
+```python
+def search(items):
+    for item in items:
+        if item.matches():
+            break
+            log("found")            # CRITICAL: unreachable_after_break
+        process(item)               # Reachable (only when condition is false)
+    return items
+```
+
+**Detection mechanism**: The CFG builder connects the block containing `break` to the loop's exit block via an `EdgeBreak` edge, then creates an unreachable block for subsequent statements (`internal/analyzer/cfg_builder.go:817-858`).
+
+### Pattern 3: Unreachable Code After Continue
+
+Code placed after a `continue` statement inside a loop.
+
+```python
+def filter_items(items):
+    for i in range(10):
+        if i > 5:
+            continue
+            x = 1                   # CRITICAL: unreachable_after_continue
+        process(i)                  # Reachable (only when condition is false)
+```
+
+**Detection mechanism**: The CFG builder connects the block containing `continue` to the loop's header block via an `EdgeContinue` edge, then creates an unreachable block (`internal/analyzer/cfg_builder.go:860-901`).
+
+### Pattern 4: Unreachable Code After Raise
+
+Code placed after a `raise` statement.
+
+```python
+def validate(x):
+    if x < 0:
+        raise ValueError("negative")
+        log("error raised")        # CRITICAL: unreachable_after_raise
+    return x
+```
+
+**Detection mechanism**: The CFG builder connects the block containing `raise` to exception handlers (if inside a `try` block) or to the exit block, then creates an unreachable block (`internal/analyzer/cfg_builder.go:1120-1163`).
+
+### Pattern 5: Unreachable Code After Exhaustive Branches
+
+When all branches of an `if/elif/else` chain contain terminators (return, raise, break, continue), any code after the entire conditional is unreachable.
+
+```python
+def classify(x):
+    if x > 0:
+        return "positive"
+    elif x < 0:
+        return "negative"
+    else:
+        return "zero"
+    print("unreachable")            # WARNING: unreachable_branch
+```
+
+**Detection mechanism**: The CFG builder's `allBranchesTerminate()` method (`internal/analyzer/cfg_builder.go:1466-1475`) checks whether both the then-branch and else-branch end with terminator statements. If they do, the merge block is replaced with an unreachable block, and subsequent code flows into it without any reachable predecessor.
+
+This also works with nested exhaustive returns:
+
+```python
+def nested(x, y):
+    if x > 0:
+        if y > 0:
+            return "both positive"
+        else:
+            return "x positive, y not"
+    else:
+        return "x not positive"
+    print("unreachable")            # WARNING: unreachable_branch
+```
+
+### Pattern 6: Unreachable Code in Exception Handling
+
+Dead code within `try/except/finally` blocks.
+
+```python
+def risky():
+    try:
+        x = 1
+        return x
+        raise ValueError()         # CRITICAL: unreachable_after_return
+    except ValueError:
+        y = 2                       # Reachable (conservative analysis)
+    finally:
+        cleanup()                   # Always reachable
+```
+
+**Detection mechanism**: Exception handlers are conservatively considered reachable because an exception could be raised at any point before the return statement. The `finally` block is always treated as reachable. However, code after a `return` or `raise` within the same `try` body is correctly detected as dead.
+
+## Reachability Analysis
+
+The `ReachabilityAnalyzer` (`internal/analyzer/reachability.go`) determines which blocks in the CFG are reachable from the entry point.
+
+### Algorithm
+
+The analysis uses a two-phase approach (`internal/analyzer/reachability.go:188-205`):
+
+```mermaid
+graph TD
+    A[Start] --> B[Phase 1: Standard DFS from Entry]
+    B --> C[Mark all DFS-reachable blocks]
+    C --> D[Phase 2: All-Paths-Return Detection]
+    D --> E[Find blocks where ALL successors lead to return]
+    E --> F[Remove fall-through successors of those blocks from reachable set]
+    F --> G[Compute unreachable = all blocks - reachable blocks]
+    G --> H[Filter to blocks with statements]
+```
+
+#### Phase 1: Standard DFS Reachability
+
+A depth-first traversal starting from the CFG entry block. Each visited block is marked as reachable. The traversal follows all successor edges.
+
+```go
+// Walk performs a depth-first traversal of the CFG (cfg.go:268-276)
+func (cfg *CFG) Walk(visitor CFGVisitor) {
+    visited := make(map[string]bool)
+    cfg.walkBlock(cfg.Entry, visitor, visited)
+}
+```
+
+#### Phase 2: All-Paths-Return Detection
+
+This phase handles a subtle case: when all branches of a conditional return, the code after the conditional is unreachable even though the CFG may have structural edges connecting it.
+
+The `allSuccessorsReturn()` method (`internal/analyzer/reachability.go:228-283`) recursively checks whether every execution path from a given block leads to a `return` statement. It uses:
+- **Memoization** (`allPathsReturnCache`): Caches results to avoid redundant computation.
+- **Cycle detection** (`visited` map): Prevents infinite recursion on loops.
+
+```go
+func (ra *ReachabilityAnalyzer) allSuccessorsReturn(block *BasicBlock, visited map[string]bool) bool {
+    // Base cases: contains return -> true; exit block -> false; no successors -> false
+    // Recursive: ALL successors must lead to returns
+}
+```
+
+When a block is identified as an all-paths-return block, its normal-edge successors are removed from the reachable set (`internal/analyzer/reachability.go:286-305`).
+
+### Unreachable Block Filtering
+
+After reachability analysis, only unreachable blocks that contain statements are reported (`internal/analyzer/reachability.go:140-150`). Empty blocks (structural nodes like merge points) are excluded to avoid false positives.
+
+## Dead Code Reason Classification
+
+The `DeadCodeDetector.determineDeadCodeReason()` method (`internal/analyzer/dead_code.go:219-231`) determines why a block is dead by examining its context in the CFG.
+
+### Classification Logic
+
+The detector uses a two-step approach (`internal/analyzer/dead_code.go:234-298`):
+
+1. **Source proximity check**: For each unreachable block, scan all other blocks in the CFG. If a block ending within 5 lines before the unreachable block contains a terminator statement, classify accordingly.
+
+2. **CFG edge check**: Examine the predecessor edges of the unreachable block. If a predecessor contains a terminator and is sequentially before the unreachable block (verified by line numbers and edge types), classify accordingly.
+
+The classification priority is:
+1. `unreachable_after_return` -- predecessor contains `return`
+2. `unreachable_after_break` -- predecessor contains `break`
+3. `unreachable_after_continue` -- predecessor contains `continue`
+4. `unreachable_after_raise` -- predecessor contains `raise`
+5. `unreachable_branch` -- default for blocks unreachable due to exhaustive branching
+6. `unreachable_after_infinite_loop` -- code after an infinite loop
+
+| Reason | Description |
+|---|---|
+| `unreachable_after_return` | Code appears after a `return` statement |
+| `unreachable_after_break` | Code appears after a `break` statement |
+| `unreachable_after_continue` | Code appears after a `continue` statement |
+| `unreachable_after_raise` | Code appears after a `raise` statement |
+| `unreachable_branch` | Code in a branch unreachable under normal execution flow |
+| `unreachable_after_infinite_loop` | Code appears after an infinite loop |
+
+## Severity Classification
+
+Each finding is assigned a severity level based on the confidence of the detection.
+
+| Severity | Numeric Level | Criteria | Meaning |
+|---|---|---|---|
+| **Critical** | 3 | Code directly after a terminator (`return`, `break`, `continue`, `raise`) in the same scope | Definitely unreachable; almost certainly a bug or leftover code |
+| **Warning** | 2 | Unreachable branches due to exhaustive control flow (default severity) | Likely unreachable; may indicate a logic issue |
+| **Info** | 1 | Potential optimization opportunities | May be intentional or context-dependent |
+
+### Severity Assignment Rules
+
+From `internal/analyzer/dead_code.go:219-231`:
+
+- If a terminator (`return`, `break`, `continue`, `raise`) is found in a preceding block: **Critical**
+- If no specific terminator is identified (e.g., unreachable due to exhaustive branching): **Warning** (default)
+
+### Severity Filtering
+
+Results can be filtered by minimum severity (`domain/dead_code.go:41`). The default minimum severity is `Warning`, which excludes `Info`-level findings.
+
+```go
+// Default configuration (domain/dead_code.go:226)
+MinSeverity: DeadCodeSeverityWarning,
+```
+
+The `FilterFindingsBySeverity()` function (`internal/analyzer/dead_code.go:511-528`) uses a numeric ordering to filter:
+- Info = 1, Warning = 2, Critical = 3
+
+## False Positive Avoidance
+
+### Conservative Exception Handling
+
+Exception handlers (`except` blocks) are always treated as reachable, even if the `try` body contains a `return` before any potentially-raising statement. This is because in Python, exceptions can be raised at almost any point:
+
+```python
+def foo():
+    try:
+        return 1
+    except ValueError:
+        x = 2   # Conservatively considered reachable
+```
+
+This conservative approach is implemented by the CFG builder connecting the `try` block to all exception handlers via `EdgeException` edges (`internal/analyzer/cfg_builder.go:974-977`).
+
+### Finally Block Always Reachable
+
+`finally` blocks are always treated as reachable because Python guarantees their execution regardless of how the `try` block exits (`internal/analyzer/cfg_builder.go:1026-1038`).
+
+### No Constant Folding
+
+The analyzer does not perform constant folding or value tracking. An `if False:` branch is not detected as dead code because the analyzer does not evaluate conditions:
+
+```python
+def foo():
+    if False:
+        x = 1   # NOT flagged (no constant evaluation)
+    else:
+        y = 2   # Reachable
+```
+
+This is intentional: constant-based dead branches are better handled by linters that perform value analysis. pyscn focuses on structural unreachability from the control flow graph.
+
+### Module-Level Code Skipped
+
+The `__main__` module-level CFG is excluded from dead code analysis (`internal/analyzer/dead_code.go:169`). Only function-level CFGs are analysed, which avoids false positives from module-level code patterns like guard clauses.
+
+### Empty Blocks Excluded
+
+Unreachable blocks with no statements are excluded from results (`internal/analyzer/reachability.go:140-150`). These are structural artifacts of the CFG (merge nodes, empty exit blocks) and do not correspond to actual dead code.
+
+### Sequential Proximity Heuristic
+
+The `isSequentiallyAfter()` method (`internal/analyzer/dead_code.go:343-373`) uses a line-number gap threshold of 10 lines to determine whether an unreachable block is "directly after" a terminator block. This avoids misclassifying structurally distant blocks that happen to be unreachable for other reasons.
+
+## Concrete Examples
+
+### Example 1: Multiple Returns with Dead Code
+
+```python
+def classify(x):
+    if x > 0:
+        return 1
+        dead1 = True    # CRITICAL: unreachable_after_return (line 4)
+    if x < 0:
+        return -1
+        dead2 = True    # CRITICAL: unreachable_after_return (line 7)
+    return 0
+    dead3 = True        # CRITICAL: unreachable_after_return (line 9)
+```
+
+This produces 3 findings, all at Critical severity.
+
+### Example 2: Complex Loop with Mixed Terminators
+
+```python
+def complex():
+    try:
+        for i in range(10):
+            if i > 5:
+                break
+                x = 1           # CRITICAL: unreachable_after_break
+            elif i < 0:
+                return -1
+                y = 2           # CRITICAL: unreachable_after_return
+            else:
+                continue
+                z = 3           # CRITICAL: unreachable_after_continue
+        return 0
+        unreachable = True      # CRITICAL: unreachable_after_return
+    except:
+        pass
+    finally:
+        cleanup = True          # Reachable (finally always executes)
+```
+
+This produces 4 findings, all at Critical severity.
+
+### Example 3: Exhaustive If/Elif/Else
+
+```python
+def sign(x):
+    if x > 0:
+        return "positive"
+    elif x < 0:
+        raise ValueError("negative")
+    else:
+        return "zero"
+    print("unreachable")        # WARNING: unreachable_branch
+```
+
+The print statement receives Warning severity because the unreachability is inferred from exhaustive branch analysis rather than a direct terminator predecessor.
+
+## Health Score Integration
+
+In the `pyscn analyze` command's overall health score calculation, dead code contributes as the **Dead Code** category with a maximum penalty of 20 points.
+
+### Penalty Calculation
+
+```
+weightedDeadCode = (CriticalFindings * 1.0) + (WarningFindings * 0.5) + (InfoFindings * 0.2)
+normalizationFactor = log10(max(1, totalFiles / 10))
+penalty = min(20, weightedDeadCode / normalizationFactor)
+```
+
+- Critical findings have a weight of 1.0
+- Warning findings have a weight of 0.5
+- Info findings have a weight of 0.2
+- The normalization factor scales with project size to avoid penalising large projects unfairly
+
+See [Analyze Scoring Reference](../ANALYZE_SCORING.md) for the complete scoring breakdown.
+
+## Configuration
+
+### Detection Toggles
+
+Each detection pattern can be individually enabled or disabled (`domain/dead_code.go:54-58`):
+
+| Option | Default | Description |
+|---|---|---|
+| `detect_after_return` | true | Detect unreachable code after `return` |
+| `detect_after_break` | true | Detect unreachable code after `break` |
+| `detect_after_continue` | true | Detect unreachable code after `continue` |
+| `detect_after_raise` | true | Detect unreachable code after `raise` |
+| `detect_unreachable_branches` | true | Detect unreachable branches in conditionals |
+
+### Output Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--min-severity` | warning | Minimum severity to report (info, warning, critical) |
+| `--sort-by` | severity | Sort criteria (severity, line, file, function) |
+| `--show-context` | false | Show surrounding code context |
+| `--context-lines` | 3 | Number of context lines to display |
+| `--format` | text | Output format (text, json, yaml, csv, html) |
+
+### Configuration File (.pyscn.toml)
+
+```toml
+[deadcode]
+min_severity = "warning"
+sort_by = "severity"
+detect_after_return = true
+detect_after_break = true
+detect_after_continue = true
+detect_after_raise = true
+detect_unreachable_branches = true
+```
+
+Configuration priority: Command-line flags > Configuration file > Default values
+
+## Output Formats
+
+| Format | Use Case |
+|---|---|
+| `text` | Human-readable CLI output (default) |
+| `json` | Programmatic consumption |
+| `yaml` | Configuration file compatibility |
+| `csv` | Spreadsheet analysis |
+| `html` | Interactive report (auto-opens in browser) |
+
+For each finding, the following information is included:
+- File path and line range
+- Function name
+- Dead code snippet
+- Reason and severity
+- Human-readable description
+
+## Implementation Notes
+
+### Performance Characteristics
+
+- CFG construction is linear in the number of AST nodes.
+- DFS reachability is O(V + E) where V = blocks and E = edges.
+- All-paths-return detection uses memoization to avoid exponential traversal of branching structures.
+- The `findTerminatorInPredecessors` method has O(B) complexity per unreachable block, where B is the total number of blocks in the CFG.
+
+### Parallel File Processing
+
+The service layer processes multiple files independently. Each file undergoes parsing, CFG construction, and dead code analysis. Errors in one file do not stop processing of others (`service/dead_code_service.go:35-60`).
+
+### Summary Metrics
+
+The analysis produces aggregate metrics at file and project levels:
+- `TotalBlocks` / `DeadBlocks`: Raw block counts
+- `ReachableRatio`: Proportion of reachable blocks
+- `DeadCodeRatio`: Proportion of dead blocks per file
+- `FindingsByReason`: Distribution of findings by reason category
+
+## Related Documentation
+
+- [Analyze Scoring Reference](../ANALYZE_SCORING.md) -- Position of the dead code penalty within the overall health score
+- [CBO Algorithm](cbo.md) -- Companion algorithm documentation

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -1,0 +1,430 @@
+# Dependency Analysis
+
+This document describes the algorithms and data structures behind pyscn's module dependency analysis. The implementation lives primarily in `internal/analyzer/dependency_graph.go`, `internal/analyzer/module_analyzer.go`, `internal/analyzer/circular_detector.go`, and `internal/analyzer/coupling_metrics.go`, with domain types defined in `domain/system_analysis.go`.
+
+## Overview
+
+Dependency analysis examines the `import` relationships between Python modules in a project. It answers questions such as:
+
+- Which modules depend on which other modules?
+- Are there circular dependency chains that make the code hard to maintain?
+- How deep is the dependency tree?
+- Are modules well-positioned on Robert C. Martin's Main Sequence?
+
+Understanding these relationships is critical for maintaining a healthy codebase. Excessive coupling, deep dependency chains, and circular imports all increase the cost of change and the risk of introducing bugs.
+
+## Module Dependency Graph Construction
+
+### Data Model
+
+The dependency graph is a directed graph where:
+
+- **Nodes** are Python modules (each `.py` file maps to one node).
+- **Edges** are import relationships between modules.
+
+Each `ModuleNode` tracks:
+
+| Field | Description |
+|---|---|
+| `Name` | Dotted module name, e.g. `mypackage.submodule` |
+| `FilePath` | Absolute path to the `.py` file |
+| `Package` | Top-level package extracted from the module name |
+| `IsPackage` | `true` if the file is `__init__.py` |
+| `InDegree` | Number of modules that import this module (fan-in) |
+| `OutDegree` | Number of modules this module imports (fan-out) |
+| `Dependencies` | Set of outgoing module names |
+| `Dependents` | Set of incoming module names |
+
+Edges carry a `DependencyEdgeType`:
+
+| Type | Python syntax | Example |
+|---|---|---|
+| `import` | `import module` | `import os` |
+| `from_import` | `from module import name` | `from utils import helper` |
+| `relative` | `from .module import name` | `from .models import User` |
+| `implicit` | Indirect dependency | -- |
+
+### Two-Pass Construction
+
+Graph construction proceeds in two passes (see `ModuleAnalyzer.AnalyzeProject`):
+
+```
+Pass 1 -- Register all modules
+  For each .py file matching include patterns and not matching exclude patterns:
+    Convert file path to dotted module name
+    Add a ModuleNode to the graph
+
+Pass 2 -- Resolve imports and add edges
+  For each .py file:
+    Parse file with tree-sitter
+    Extract import statements from the AST
+    Resolve each import to a target module name
+    Add a DependencyEdge to the graph
+```
+
+```mermaid
+flowchart TD
+    A[Collect .py files] --> B[Pass 1: Register modules as nodes]
+    B --> C[Pass 2: Parse each file with tree-sitter]
+    C --> D[Extract import statements from AST]
+    D --> E{Relative import?}
+    E -- Yes --> F[Resolve relative to current package]
+    E -- No --> G[Resolve absolute import]
+    F --> H[Add DependencyEdge to graph]
+    G --> H
+    H --> I[Detect cycles, calculate metrics]
+```
+
+### Import Resolution
+
+#### Absolute Imports
+
+For `import foo.bar` or `from foo.bar import Baz`, the analyzer searches in priority order:
+
+1. **Current file directory** -- check for `foo/bar.py` or `foo/bar/__init__.py`
+2. **Project root** -- same check relative to the project root
+3. **Parent directory** -- one level up
+4. **Python path entries** -- additional search paths provided in configuration
+5. **Standard library check** -- matches against a known set of stdlib module names (e.g. `os`, `sys`, `typing`)
+6. **Third-party fallback** -- if `includeThirdParty` is enabled, unresolved names are included as-is
+
+Results are cached in `resolvedModules` to avoid repeated filesystem lookups.
+
+#### Relative Imports
+
+For `from .models import User` or `from ..utils import helper`:
+
+1. The **level** (number of leading dots) determines how many directory levels to ascend from the current file.
+2. The remaining module name (after the dots) is appended to the resolved parent directory.
+3. The result is converted back to a dotted module name.
+
+```python
+# In mypackage/sub/views.py:
+from .models import User       # Level 1 -> mypackage.sub.models
+from ..utils import helper     # Level 2 -> mypackage.utils
+```
+
+#### Re-Export Resolution
+
+Python packages commonly re-export names in `__init__.py`:
+
+```python
+# mypackage/__init__.py
+from .module_a import ClassA
+from .module_b import ClassB
+```
+
+When another module does `from mypackage import ClassA`, a naive analysis would record a dependency on `mypackage` rather than `mypackage.module_a`. The `ReExportResolver` fixes this by:
+
+1. Parsing the target package's `__init__.py` with tree-sitter
+2. Building a map of exported name to actual source module
+3. Respecting `__all__` declarations when present (filtering to only declared exports)
+4. Caching results per package to avoid repeated parsing
+5. Resolving each imported name independently -- different names may come from different source modules
+
+#### TYPE_CHECKING Exclusion
+
+Imports guarded by `if TYPE_CHECKING:` blocks are excluded from dependency edges. These imports exist only for static type checkers and do not create runtime dependencies, so including them would produce false circular dependency reports. The analyzer walks up the AST parent chain to detect this pattern, handling both `TYPE_CHECKING` and `typing.TYPE_CHECKING` forms.
+
+#### __init__.py Self-Import Filtering
+
+When an `__init__.py` file imports from its own submodules (a standard Python re-export pattern), those edges are filtered out. Without this, every package would appear to have a dependency on all of its own submodules, inflating coupling numbers.
+
+## Cycle Detection Algorithm
+
+### Tarjan's Strongly Connected Components
+
+Circular dependency detection uses **Tarjan's algorithm** to find all strongly connected components (SCCs) in the dependency graph. An SCC with more than one node represents a circular dependency.
+
+The algorithm runs in O(V + E) time where V is the number of modules and E is the number of edges.
+
+```
+function strongConnect(module):
+    index[module] = lowLink[module] = currentIndex++
+    push module onto stack
+    inStack[module] = true
+
+    for each dependency of module:
+        if dependency not visited:
+            strongConnect(dependency)
+            lowLink[module] = min(lowLink[module], lowLink[dependency])
+        else if dependency in stack:
+            lowLink[module] = min(lowLink[module], index[dependency])
+
+    if lowLink[module] == index[module]:
+        // module is root of an SCC
+        pop all nodes from stack until module is popped
+        if component has more than 1 node:
+            record as circular dependency
+```
+
+```mermaid
+graph LR
+    A((A)) --> B((B))
+    B --> C((C))
+    C --> A
+    C --> D((D))
+
+    style A fill:#f99
+    style B fill:#f99
+    style C fill:#f99
+```
+
+In this example, {A, B, C} form a strongly connected component (cycle), while D does not participate.
+
+### Cycle Severity Assessment
+
+Each detected cycle is assigned a severity based on its size and the importance of involved modules:
+
+| Severity | Condition |
+|---|---|
+| **Critical** | 10+ modules in the cycle, OR any module has fan-in > 10 (core infrastructure) |
+| **High** | 6--9 modules |
+| **Medium** | 3--5 modules |
+| **Low** | 2 modules (simple mutual dependency) |
+
+### Dependency Chain Analysis within Cycles
+
+For each SCC, the analyzer finds the actual dependency chains between modules using BFS. This produces human-readable paths like `A -> B -> C -> A` that explain exactly how the cycle forms.
+
+### Cycle-Breaking Suggestions
+
+The system generates actionable refactoring suggestions:
+
+- **Largest cycle**: Extract common functionality into a separate module
+- **Core infrastructure modules** (appearing in multiple cycles): Refactor to reduce coupling
+- **Critical cycles**: Apply Dependency Inversion Principle
+- **Simple two-module cycles**: Introduce a third module or use dependency injection
+
+## Dependency Depth Analysis
+
+Dependency depth measures the length of the longest chain of transitive dependencies starting from any module.
+
+### Calculation
+
+The algorithm performs a recursive DFS from each root module (modules with `OutDegree == 0`), tracking the maximum depth reached. Cycles are handled by maintaining a visited set to prevent infinite recursion.
+
+```
+function findMaxDepthFrom(module, visited):
+    if module in visited: return 0
+    visited.add(module)
+
+    maxChildDepth = 0
+    for each dependency of module:
+        childDepth = findMaxDepthFrom(dependency, visited)
+        maxChildDepth = max(maxChildDepth, childDepth)
+
+    visited.remove(module)
+    return maxChildDepth + 1
+```
+
+### Expected Depth
+
+The expected maximum depth for a well-structured project of N modules is approximately:
+
+```
+expected = max(3, ceil(log2(N + 1)) + 1)
+```
+
+Exceeding this threshold suggests that the dependency chain is deeper than necessary, which can indicate poor layering or excessive transitive coupling.
+
+## Robert C. Martin's Package Metrics
+
+The coupling metrics calculator (`CouplingMetricsCalculator`) computes metrics from Robert C. Martin's package design principles for each module.
+
+### Afferent Coupling (Ca)
+
+**Ca** = number of modules that depend on this module (i.e., `InDegree`).
+
+High Ca means many other modules will break if this module changes. Such modules should be stable and well-tested.
+
+### Efferent Coupling (Ce)
+
+**Ce** = number of modules this module depends on (i.e., `OutDegree`).
+
+High Ce means this module is sensitive to changes in many other modules.
+
+### Instability (I)
+
+```
+I = Ce / (Ca + Ce)
+```
+
+| Value | Meaning |
+|---|---|
+| I = 0 | Maximally stable -- only depended upon, depends on nothing |
+| I = 1 | Maximally unstable -- depends on others, nobody depends on it |
+
+If `Ca + Ce = 0` (isolated module), instability defaults to 0.
+
+### Abstractness (A)
+
+Abstractness measures the ratio of "abstract" public names to total public names in a module. A name is considered abstract if it matches one of these heuristics:
+
+- Ends with `Interface`, `Abstract`, `Base`, or `ABC`
+- Starts with `I` followed by an uppercase letter (e.g., `IRepository`)
+
+```
+A = abstract_public_names / total_public_names
+```
+
+A value of 0 means entirely concrete; 1 means entirely abstract.
+
+### Distance from Main Sequence (D)
+
+The **Main Sequence** is the ideal line where `A + I = 1`. Modules on this line have the right balance of abstractness and stability.
+
+```
+D = |A + I - 1|
+```
+
+```mermaid
+quadrantChart
+    title Main Sequence Diagram
+    x-axis "Concrete (A=0)" --> "Abstract (A=1)"
+    y-axis "Stable (I=0)" --> "Unstable (I=1)"
+    quadrant-1 Zone of Uselessness
+    quadrant-2 Good Position
+    quadrant-3 Zone of Pain
+    quadrant-4 Good Position
+```
+
+| Zone | Position | Problem |
+|---|---|---|
+| **Zone of Pain** | Low A, Low I (concrete + stable) | Hard to change because many modules depend on concrete implementations |
+| **Zone of Uselessness** | High A, High I (abstract + unstable) | Abstract modules that nobody uses |
+| **Main Sequence** | D close to 0 | Well-balanced -- abstractness matches stability |
+
+### Risk Level Assignment
+
+Based on the Distance metric, each module is assigned a risk level:
+
+| Distance (D) | Risk Level |
+|---|---|
+| D > 0.7 | High |
+| D > 0.4 | Medium |
+| D <= 0.4 | Low |
+
+## System-Wide Metrics
+
+The `SystemMetrics` struct aggregates module-level metrics into project-wide indicators:
+
+| Metric | Formula | Description |
+|---|---|---|
+| Average Fan-In | sum(Ca) / N | Average number of incoming dependencies |
+| Average Fan-Out | sum(Ce) / N | Average number of outgoing dependencies |
+| Dependency Ratio | Total Edges / N | Average dependencies per module |
+| Average Instability | sum(I) / N | System-wide average instability |
+| Average Abstractness | sum(A) / N | System-wide average abstractness |
+| Main Sequence Deviation | sum(D) / N | Average distance from main sequence |
+| Cyclic Dependencies | count of modules in SCCs | Number of modules involved in cycles |
+| Max Dependency Depth | longest chain length | Maximum transitive dependency depth |
+
+### Modularity Index
+
+The modularity index measures how well the system is decomposed into packages:
+
+```
+cohesionRatio = intra_package_edges / total_edges
+cyclePenalty  = 1.0 - (cyclic_modules / total_modules * 0.5)
+
+ModularityIndex = cohesionRatio * cyclePenalty
+```
+
+A modularity index close to 1.0 indicates high intra-package cohesion with low inter-package coupling and few cycles. A single-package system defaults to 0.5.
+
+### System Complexity
+
+System complexity is a composite score combining:
+
+```
+structural = 0.4 * log2(1 + edges/modules)
+size       = 0.3 * log2(1 + modules)
+coupling   = 0.3 * sqrt(variance(instability)) * 10
+
+SystemComplexity = structural + size + coupling
+```
+
+### Refactoring Priorities
+
+Modules are ranked for refactoring priority based on:
+
+| Factor | Weight |
+|---|---|
+| Distance from Main Sequence > 0.5 | D * 50 points |
+| Module is in a dependency cycle | +30 points |
+| Cyclomatic complexity > 20 | (complexity - 20) * 2 points |
+
+Only modules scoring above 10 points are included. The top 10 are reported.
+
+## Health Score Integration
+
+Dependency analysis contributes up to **16 points** of penalty to the overall health score (out of 100). The penalty is split into three components:
+
+| Component | Max Penalty | Formula |
+|---|---|---|
+| Circular dependencies | 10 | `10 * (modules_in_cycles / total_modules)` |
+| Excessive depth | 3 | `min(3, max_depth - expected_depth)` where `expected = max(3, ceil(log2(N+1)) + 1)` |
+| Main Sequence Deviation | 3 | `round(avg_MSD * 3)` where MSD is clamped to [0, 1] |
+
+When dependency analysis is disabled (`--skip-deps`), the penalty is zero and does not affect the health score.
+
+## Concrete Example
+
+Consider a small project with four modules:
+
+```
+myapp/
+  __init__.py
+  models.py      # defines User, Order
+  services.py    # from .models import User; from .repository import UserRepo
+  repository.py  # from .models import User
+  views.py       # from .services import UserService; from .models import Order
+```
+
+### Dependency Graph
+
+```mermaid
+graph TD
+    views --> services
+    views --> models
+    services --> models
+    services --> repository
+    repository --> models
+```
+
+### Computed Metrics
+
+| Module | Ca | Ce | I | A | D | Risk |
+|---|---|---|---|---|---|---|
+| models | 3 | 0 | 0.00 | 0.0 | 1.00 | High |
+| repository | 1 | 1 | 0.50 | 0.0 | 0.50 | Medium |
+| services | 1 | 2 | 0.67 | 0.0 | 0.33 | Low |
+| views | 0 | 2 | 1.00 | 0.0 | 0.00 | Low |
+
+- **models** sits in the Zone of Pain (D=1.0): it is maximally stable (everything depends on it) but entirely concrete. Introducing abstract base classes or protocols would improve this.
+- **views** is maximally unstable (I=1.0) with D=0.0 -- perfectly positioned as a top-level consumer.
+- **No cycles** exist, so the cycle penalty is 0.
+- **Max depth** is 3 (views -> services -> repository -> models).
+
+### Health Score Impact
+
+With 4 modules and no cycles:
+
+- Cycle penalty: `10 * 0/4 = 0`
+- Expected depth: `max(3, ceil(log2(5)) + 1) = max(3, 4) = 4`; actual depth = 3, so excess = 0
+- MSD penalty: `round(avg(1.0, 0.5, 0.33, 0.0) * 3) = round(0.46 * 3) = round(1.37) = 1`
+- **Total dependency penalty: 1 out of 16**
+
+## Key Source Files
+
+| File | Purpose |
+|---|---|
+| `internal/analyzer/dependency_graph.go` | Graph data structures (`DependencyGraph`, `ModuleNode`, `DependencyEdge`) |
+| `internal/analyzer/module_analyzer.go` | Import parsing, resolution, and graph construction |
+| `internal/analyzer/circular_detector.go` | Tarjan's SCC algorithm and cycle analysis |
+| `internal/analyzer/coupling_metrics.go` | Robert C. Martin's metrics and system-wide calculations |
+| `internal/analyzer/reexport_resolver.go` | Re-export resolution for `__init__.py` files |
+| `domain/system_analysis.go` | Domain types for analysis results |
+| `domain/analyze.go` | Health score dependency penalty calculation |
+| `service/system_analysis_service.go` | Service orchestration -- builds graph, runs detectors, assembles results |


### PR DESCRIPTION
## Summary

- Add comprehensive technical documentation for all 5 core analysis algorithms under `docs/algorithms/`
- Each document is based on actual implementation code with mermaid diagrams and concrete examples
- Total: 2,153 lines of documentation across 5 files

### New files

| File | Lines | Coverage |
|---|---|---|
| `clone-detection.md` | 523 | Type 1-4 classification, FNV hash, Jaccard, APTED, CFG comparison, LSH acceleration, 5 grouping algorithms |
| `dead-code.md` | 509 | CFG-based reachability, 6 detection patterns, severity classification, false positive avoidance |
| `dependency.md` | 430 | Tarjan's SCC, dependency depth, Abstractness/Instability/Main Sequence Deviation |
| `cbo.md` | 347 | 5 dependency types, Union type support, risk thresholds, penalty calculation |
| `complexity.md` | 344 | tree-sitter AST, CFG construction, McCabe calculation, nesting depth |
