### PR TITLE
PR: Integrate TF-IDF + Cosine Similarity for Precision Type-2 Clone Detection

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -30,6 +30,8 @@ type AnalyzeUseCaseConfig struct {
 	// Clone detection options
 	EnableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
+	UseTFIDF  bool 
+
 	ConfigFile string
 	Verbose    bool
 }

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -30,6 +30,8 @@ type AnalyzeCommand struct {
 	configFile string
 	verbose    bool
 
+	UseTFIDF bool
+
 	// Analysis selection
 	skipComplexity bool
 	skipDeadCode   bool
@@ -74,6 +76,7 @@ func NewAnalyzeCommand() *AnalyzeCommand {
 		enableDFA:       true,
 		detectCycles:    true,
 		validateArch:    true,
+		UseTFIDF:		 false,
 	}
 }
 
@@ -135,7 +138,10 @@ Examples:
 	cmd.Flags().Float64Var(&c.cloneSimilarity, "clone-threshold", 0.9, "Minimum similarity for clone detection (0.0-1.0)")
 	cmd.Flags().IntVar(&c.minCBO, "min-cbo", 0, "Minimum CBO to report")
 
-	return cmd
+	// Use TF-IDF flag
+	cmd.Flags().BoolVar(&c.UseTFIDF, "use-tfidf", false, "Use TF-IDF + Cosine Similarity for Type-2 clone detection")
+
+    return cmd
 }
 
 // runAnalyze executes the comprehensive analysis using the clean architecture
@@ -187,6 +193,7 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 		CloneSimilarity: c.cloneSimilarity,
 		MinCBO:          c.minCBO,
 		EnableDFA:       c.enableDFA,
+		UseTFIDF:        c.UseTFIDF,
 	}
 
 	// Handle analysis selection

--- a/internal/analyzer/apted.go
+++ b/internal/analyzer/apted.go
@@ -20,8 +20,8 @@ func NewAPTEDAnalyzer(costModel CostModel) *APTEDAnalyzer {
 	}
 }
 
-// ComputeDistance computes the tree edit distance between two trees
-func (a *APTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64 {
+// ComputeDistanceTrees computes the tree edit distance between two trees
+func (a *APTEDAnalyzer) ComputeDistanceTrees(tree1, tree2 *TreeNode) float64 {
 	// Handle edge cases
 	if tree1 == nil && tree2 == nil {
 		return 0.0
@@ -418,8 +418,8 @@ func (a *APTEDAnalyzer) computeDeleteCostWithDepthLimit(root *TreeNode, maxDepth
 	return cost
 }
 
-// ComputeSimilarity computes similarity score between two trees (0.0 to 1.0)
-func (a *APTEDAnalyzer) ComputeSimilarity(tree1, tree2 *TreeNode, _ *TFIDFCalculator) float64 {
+// ComputeSimilarityTrees computes similarity score between two trees (0.0 to 1.0)
+func (a *APTEDAnalyzer) ComputeSimilarityTrees(tree1, tree2 *TreeNode, _ *TFIDFCalculator) float64 {
 	// Handle nil cases
 	if tree1 == nil && tree2 == nil {
 		return 1.0 // Identical (both empty)
@@ -428,7 +428,7 @@ func (a *APTEDAnalyzer) ComputeSimilarity(tree1, tree2 *TreeNode, _ *TFIDFCalcul
 		return 0.0 // Completely different (one empty)
 	}
 
-	distance := a.ComputeDistance(tree1, tree2)
+	distance := a.ComputeDistanceTrees(tree1, tree2)
 
 	// Get sizes of both trees
 	size1 := float64(tree1.Size())
@@ -468,8 +468,8 @@ type TreeEditResult struct {
 
 // ComputeDetailedDistance computes detailed tree edit distance information
 func (a *APTEDAnalyzer) ComputeDetailedDistance(tree1, tree2 *TreeNode) *TreeEditResult {
-	distance := a.ComputeDistance(tree1, tree2)
-	similarity := a.ComputeSimilarity(tree1, tree2, nil)
+	distance := a.ComputeDistanceTrees(tree1, tree2)
+	similarity := a.ComputeSimilarityTrees(tree1, tree2, nil)
 
 	var size1, size2 int
 	if tree1 != nil {
@@ -504,8 +504,8 @@ func NewOptimizedAPTEDAnalyzer(costModel CostModel, maxDistance float64) *Optimi
 	}
 }
 
-// ComputeDistance computes tree edit distance with early stopping optimization
-func (a *OptimizedAPTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64 {
+// ComputeDistanceTrees computes tree edit distance with early stopping optimization
+func (a *OptimizedAPTEDAnalyzer) ComputeDistanceTrees(tree1, tree2 *TreeNode) float64 {
 	// Quick size-based early termination
 	if a.enableEarlyStop {
 		sizeDiff := math.Abs(float64(tree1.Size() - tree2.Size()))
@@ -515,7 +515,7 @@ func (a *OptimizedAPTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64
 	}
 
 	// Use parent implementation
-	distance := a.APTEDAnalyzer.ComputeDistance(tree1, tree2)
+	distance := a.APTEDAnalyzer.ComputeDistanceTrees(tree1, tree2)
 
 	// Early termination check
 	if a.enableEarlyStop && distance > a.maxDistance {
@@ -530,7 +530,7 @@ func (a *APTEDAnalyzer) BatchComputeDistances(pairs [][2]*TreeNode) []float64 {
 	distances := make([]float64, len(pairs))
 
 	for i, pair := range pairs {
-		distances[i] = a.ComputeDistance(pair[0], pair[1])
+		distances[i] = a.ComputeDistanceTrees(pair[0], pair[1])
 	}
 
 	return distances
@@ -601,7 +601,7 @@ func (a *APTEDAnalyzer) ClusterSimilarTrees(trees []*TreeNode, similarityThresho
 	for i := 0; i < n; i++ {
 		for j := i + 1; j < n; j++ {
 			if validTrees[i] != nil && validTrees[j] != nil {
-				dist := a.ComputeDistance(validTrees[i], validTrees[j])
+				dist := a.ComputeDistanceTrees(validTrees[i], validTrees[j])
 				distances[i][j] = dist
 				distances[j][i] = dist
 			}

--- a/internal/analyzer/apted.go
+++ b/internal/analyzer/apted.go
@@ -419,7 +419,7 @@ func (a *APTEDAnalyzer) computeDeleteCostWithDepthLimit(root *TreeNode, maxDepth
 }
 
 // ComputeSimilarity computes similarity score between two trees (0.0 to 1.0)
-func (a *APTEDAnalyzer) ComputeSimilarity(tree1, tree2 *TreeNode) float64 {
+func (a *APTEDAnalyzer) ComputeSimilarity(tree1, tree2 *TreeNode, _ *TFIDFCalculator) float64 {
 	// Handle nil cases
 	if tree1 == nil && tree2 == nil {
 		return 1.0 // Identical (both empty)
@@ -469,7 +469,7 @@ type TreeEditResult struct {
 // ComputeDetailedDistance computes detailed tree edit distance information
 func (a *APTEDAnalyzer) ComputeDetailedDistance(tree1, tree2 *TreeNode) *TreeEditResult {
 	distance := a.ComputeDistance(tree1, tree2)
-	similarity := a.ComputeSimilarity(tree1, tree2)
+	similarity := a.ComputeSimilarity(tree1, tree2, nil)
 
 	var size1, size2 int
 	if tree1 != nil {

--- a/internal/analyzer/apted_interface_impl.go
+++ b/internal/analyzer/apted_interface_impl.go
@@ -1,0 +1,22 @@
+package analyzer
+
+// ComputeSimilarity (Interface Implementation)
+func (a *APTEDAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, calc *TFIDFCalculator) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+	return a.ComputeSimilarityTrees(f1.TreeNode, f2.TreeNode, calc)
+}
+
+// ComputeDistance (Interface Implementation)
+func (a *APTEDAnalyzer) ComputeDistance(f1, f2 *CodeFragment) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+	return a.ComputeDistanceTrees(f1.TreeNode, f2.TreeNode)
+}
+
+// GetName returns the name of this analyzer
+func (a *APTEDAnalyzer) GetName() string {
+	return "apted"
+}

--- a/internal/analyzer/apted_validation_test.go
+++ b/internal/analyzer/apted_validation_test.go
@@ -12,7 +12,7 @@ func TestAPTEDAnalyzer_NilChecks(t *testing.T) {
 
 	t.Run("ComputeDistance with nil trees", func(t *testing.T) {
 		// Both nil
-		distance := analyzer.ComputeDistance(nil, nil)
+		distance := analyzer.ComputeDistanceTrees(nil, nil)
 		assert.Equal(t, 0.0, distance, "Distance between two nil trees should be 0")
 
 		// Create a test tree for comparison
@@ -20,17 +20,17 @@ func TestAPTEDAnalyzer_NilChecks(t *testing.T) {
 		tree.AddChild(NewTreeNode(2, "child"))
 
 		// First nil
-		distance = analyzer.ComputeDistance(nil, tree)
+		distance = analyzer.ComputeDistanceTrees(nil, tree)
 		assert.Greater(t, distance, 0.0, "Distance from nil to tree should be > 0")
 
 		// Second nil
-		distance = analyzer.ComputeDistance(tree, nil)
+		distance = analyzer.ComputeDistanceTrees(tree, nil)
 		assert.Greater(t, distance, 0.0, "Distance from tree to nil should be > 0")
 	})
 
 	t.Run("ComputeSimilarity with nil trees", func(t *testing.T) {
 		// Both nil
-		similarity := analyzer.ComputeSimilarity(nil, nil)
+		similarity := analyzer.ComputeSimilarityTrees(nil, nil, nil)
 		assert.Equal(t, 1.0, similarity, "Similarity between two nil trees should be 1.0")
 
 		// Create a test tree for comparison
@@ -38,11 +38,11 @@ func TestAPTEDAnalyzer_NilChecks(t *testing.T) {
 		tree.AddChild(NewTreeNode(2, "child"))
 
 		// First nil
-		similarity = analyzer.ComputeSimilarity(nil, tree)
+		similarity = analyzer.ComputeSimilarityTrees(nil, tree, nil)
 		assert.Equal(t, 0.0, similarity, "Similarity from nil to tree should be 0.0")
 
 		// Second nil
-		similarity = analyzer.ComputeSimilarity(tree, nil)
+		similarity = analyzer.ComputeSimilarityTrees(tree, nil, nil)
 		assert.Equal(t, 0.0, similarity, "Similarity from tree to nil should be 0.0")
 	})
 
@@ -74,10 +74,10 @@ func TestAPTEDAnalyzer_NilChecks(t *testing.T) {
 		tree2.AddChild(NewTreeNode(6, "body"))
 
 		// Should work normally
-		distance := analyzer.ComputeDistance(tree1, tree2)
+		distance := analyzer.ComputeDistanceTrees(tree1, tree2)
 		assert.GreaterOrEqual(t, distance, 0.0, "Distance should be non-negative")
 
-		similarity := analyzer.ComputeSimilarity(tree1, tree2)
+		similarity := analyzer.ComputeSimilarityTrees(tree1, tree2, nil)
 		assert.GreaterOrEqual(t, similarity, 0.0, "Similarity should be >= 0")
 		assert.LessOrEqual(t, similarity, 1.0, "Similarity should be <= 1")
 	})

--- a/internal/analyzer/centroid_grouping.go
+++ b/internal/analyzer/centroid_grouping.go
@@ -187,7 +187,7 @@ func (c *CentroidGrouping) calculateSimilarity(f1, f2 *CodeFragment) float64 {
 	if f1 == nil || f2 == nil || f1.TreeNode == nil || f2.TreeNode == nil {
 		return 0.0
 	}
-	return c.analyzer.ComputeSimilarity(f1.TreeNode, f2.TreeNode)
+	return c.analyzer.ComputeSimilarity(f1.TreeNode, f2.TreeNode, nil)
 }
 
 // calculateGroupSimilarity calculates average similarity within a group

--- a/internal/analyzer/centroid_grouping.go
+++ b/internal/analyzer/centroid_grouping.go
@@ -187,7 +187,7 @@ func (c *CentroidGrouping) calculateSimilarity(f1, f2 *CodeFragment) float64 {
 	if f1 == nil || f2 == nil || f1.TreeNode == nil || f2.TreeNode == nil {
 		return 0.0
 	}
-	return c.analyzer.ComputeSimilarity(f1.TreeNode, f2.TreeNode, nil)
+	return c.analyzer.ComputeSimilarityTrees(f1.TreeNode, f2.TreeNode, nil)
 }
 
 // calculateGroupSimilarity calculates average similarity within a group

--- a/internal/analyzer/clone_classifier_test.go
+++ b/internal/analyzer/clone_classifier_test.go
@@ -40,15 +40,15 @@ func TestCloneClassifier(t *testing.T) {
 		classifier := NewCloneClassifier(config)
 
 		// Both nil
-		result := classifier.ClassifyClone(nil, nil)
+		result := classifier.ClassifyClone(nil, nil, nil)
 		assert.Nil(t, result)
 
 		// One nil
 		fragment := &CodeFragment{Content: "test"}
-		result = classifier.ClassifyClone(fragment, nil)
+		result = classifier.ClassifyClone(fragment, nil, nil)
 		assert.Nil(t, result)
 
-		result = classifier.ClassifyClone(nil, fragment)
+		result = classifier.ClassifyClone(nil, fragment, nil)
 		assert.Nil(t, result)
 	})
 
@@ -83,7 +83,7 @@ func TestTextualSimilarityAnalyzer(t *testing.T) {
 		f1 := &CodeFragment{Content: "def hello():\n    return 'world'"}
 		f2 := &CodeFragment{Content: "def hello():\n    return 'world'"}
 
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		assert.Equal(t, 1.0, similarity)
 	})
 
@@ -94,7 +94,7 @@ func TestTextualSimilarityAnalyzer(t *testing.T) {
 		f2 := &CodeFragment{Content: "def hello():\n        return 'world'"}
 
 		// After normalization, whitespace differences should result in high similarity
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		assert.Greater(t, similarity, 0.9)
 	})
 
@@ -105,7 +105,7 @@ func TestTextualSimilarityAnalyzer(t *testing.T) {
 		f2 := &CodeFragment{Content: "def hello():  # greeting\n    return 'world'"}
 
 		// After comment removal, should be identical
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		assert.Equal(t, 1.0, similarity)
 	})
 
@@ -115,12 +115,12 @@ func TestTextualSimilarityAnalyzer(t *testing.T) {
 		// Both empty
 		f1 := &CodeFragment{Content: ""}
 		f2 := &CodeFragment{Content: ""}
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		assert.Equal(t, 1.0, similarity)
 
 		// One empty
 		f3 := &CodeFragment{Content: "def hello(): pass"}
-		similarity = analyzer.ComputeSimilarity(f1, f3)
+		similarity = analyzer.ComputeSimilarity(f1, f3, nil)
 		assert.Equal(t, 0.0, similarity)
 	})
 
@@ -128,10 +128,10 @@ func TestTextualSimilarityAnalyzer(t *testing.T) {
 		analyzer := NewTextualSimilarityAnalyzer()
 
 		f1 := &CodeFragment{Content: "test"}
-		similarity := analyzer.ComputeSimilarity(f1, nil)
+		similarity := analyzer.ComputeSimilarity(f1, nil, nil)
 		assert.Equal(t, 0.0, similarity)
 
-		similarity = analyzer.ComputeSimilarity(nil, f1)
+		similarity = analyzer.ComputeSimilarity(nil, f1, nil)
 		assert.Equal(t, 0.0, similarity)
 	})
 
@@ -141,7 +141,7 @@ func TestTextualSimilarityAnalyzer(t *testing.T) {
 		f1 := &CodeFragment{Content: "def calculate_sum(a, b):"}
 		f2 := &CodeFragment{Content: "def calculate_total(x, y):"}
 
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		// Should be similar but not identical
 		assert.Greater(t, similarity, 0.5)
 		assert.Less(t, similarity, 1.0)
@@ -164,11 +164,11 @@ func TestSyntacticSimilarityAnalyzer(t *testing.T) {
 	t.Run("NilFragments", func(t *testing.T) {
 		analyzer := NewSyntacticSimilarityAnalyzer()
 
-		similarity := analyzer.ComputeSimilarity(nil, nil)
+		similarity := analyzer.ComputeSimilarity(nil, nil, nil)
 		assert.Equal(t, 0.0, similarity)
 
 		fragment := &CodeFragment{}
-		similarity = analyzer.ComputeSimilarity(fragment, nil)
+		similarity = analyzer.ComputeSimilarity(fragment, nil, nil)
 		assert.Equal(t, 0.0, similarity)
 	})
 
@@ -204,7 +204,7 @@ func TestSyntacticSimilarityAnalyzer(t *testing.T) {
 		PrepareTreeForAPTED(f1.TreeNode)
 		PrepareTreeForAPTED(f2.TreeNode)
 
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		// Type-2 clones should have high similarity (>= 0.80)
 		assert.GreaterOrEqual(t, similarity, 0.80,
 			"Type-2 clones (renamed identifiers/literals) should have high similarity")
@@ -250,7 +250,7 @@ func TestSyntacticSimilarityAnalyzer(t *testing.T) {
 			Type4Threshold: domain.DefaultType4CloneThreshold,
 		})
 
-		result := classifier.ClassifyClone(f1, f2)
+		result := classifier.ClassifyClone(f1, f2, nil)
 
 		// These ARE Type-2 clones and MUST be detected
 		require.NotNil(t, result, "Type-2 clones should be detected")
@@ -285,7 +285,7 @@ func TestSyntacticSimilarityAnalyzer(t *testing.T) {
 		PrepareTreeForAPTED(f1.TreeNode)
 		PrepareTreeForAPTED(f2.TreeNode)
 
-		similarity := analyzer.ComputeSimilarity(f1, f2)
+		similarity := analyzer.ComputeSimilarity(f1, f2, nil)
 		// Different structures should have low similarity (< 0.50)
 		assert.Less(t, similarity, 0.50,
 			"Structurally different code should have low similarity")
@@ -361,7 +361,7 @@ class InMemoryMetrics:
 			Type4Threshold: domain.DefaultType4CloneThreshold,
 		})
 
-		result := classifier.ClassifyClone(f1, f2)
+		result := classifier.ClassifyClone(f1, f2, nil)
 
 		// Issue #292: These were incorrectly reported as 97.6% similar Type-2 clones.
 		// With Jaccard coefficient, they should NOT be classified as Type-2 clones.
@@ -372,7 +372,7 @@ class InMemoryMetrics:
 
 		// Also verify the raw syntactic similarity is well below the threshold
 		syntacticAnalyzer := NewSyntacticSimilarityAnalyzer()
-		similarity := syntacticAnalyzer.ComputeSimilarity(f1, f2)
+		similarity := syntacticAnalyzer.ComputeSimilarity(f1, f2, nil)
 		assert.Less(t, similarity, domain.DefaultType2CloneThreshold,
 			"Syntactic similarity should be below Type-2 threshold (issue #292)")
 	})
@@ -458,7 +458,7 @@ class InMemoryMetrics:
 			Type4Threshold: domain.DefaultType4CloneThreshold,
 		})
 
-		result := classifier.ClassifyClone(f1, f2)
+		result := classifier.ClassifyClone(f1, f2, nil)
 
 		// Issue #292: These were incorrectly reported as 98.9% similar Type-2 clones.
 		// With Jaccard coefficient, they should NOT be classified as Type-2 clones.
@@ -469,7 +469,7 @@ class InMemoryMetrics:
 
 		// Also verify the raw syntactic similarity is well below the threshold
 		syntacticAnalyzer := NewSyntacticSimilarityAnalyzer()
-		similarity := syntacticAnalyzer.ComputeSimilarity(f1, f2)
+		similarity := syntacticAnalyzer.ComputeSimilarity(f1, f2, nil)
 		assert.Less(t, similarity, domain.DefaultType2CloneThreshold,
 			"Syntactic similarity should be below Type-2 threshold (issue #292)")
 	})
@@ -493,7 +493,7 @@ func TestStructuralSimilarityAnalyzer(t *testing.T) {
 	t.Run("NilFragments", func(t *testing.T) {
 		analyzer := NewStructuralSimilarityAnalyzer()
 
-		similarity := analyzer.ComputeSimilarity(nil, nil)
+		similarity := analyzer.ComputeSimilarity(nil, nil, nil)
 		assert.Equal(t, 0.0, similarity)
 	})
 
@@ -516,11 +516,11 @@ func TestSemanticSimilarityAnalyzer(t *testing.T) {
 	t.Run("NilFragments", func(t *testing.T) {
 		analyzer := NewSemanticSimilarityAnalyzer()
 
-		similarity := analyzer.ComputeSimilarity(nil, nil)
+		similarity := analyzer.ComputeSimilarity(nil, nil, nil)
 		assert.Equal(t, 0.0, similarity)
 
 		fragment := &CodeFragment{}
-		similarity = analyzer.ComputeSimilarity(fragment, nil)
+		similarity = analyzer.ComputeSimilarity(fragment, nil, nil)
 		assert.Equal(t, 0.0, similarity)
 	})
 
@@ -602,7 +602,7 @@ def helper():
 		}
 
 		// Compare with classifier
-		result := detector.classifier.ClassifyClone(fragments1[0], fragments2[0])
+		result := detector.classifier.ClassifyClone(fragments1[0], fragments2[0], nil)
 		require.NotNil(t, result)
 		assert.Greater(t, result.Similarity, 0.9)
 	})
@@ -821,7 +821,7 @@ class ProductInventory:
 
 		if class1 != nil && class2 != nil {
 			// Check that similarity is below Type-2 threshold
-			similarity := detector.analyzer.ComputeSimilarity(class1.TreeNode, class2.TreeNode)
+			similarity := detector.analyzer.ComputeSimilarity(class1, class2, nil)
 			assert.Less(t, similarity, domain.DefaultType2CloneThreshold,
 				"Different dataclasses should NOT be detected as Type-2 clones (issue #310)")
 		}
@@ -888,7 +888,7 @@ class ProductInventory:
 		}
 
 		if class1 != nil && class2 != nil {
-			similarity := detector.analyzer.ComputeSimilarity(class1.TreeNode, class2.TreeNode)
+			similarity := detector.analyzer.ComputeSimilarity(class1, class2, nil)
 			assert.Less(t, similarity, domain.DefaultType2CloneThreshold,
 				"Different Pydantic models should NOT be detected as Type-2 clones (issue #310)")
 		}
@@ -965,7 +965,7 @@ class UserMetricsV2:
 		}
 
 		if method1 != nil && method2 != nil {
-			similarity := detector.analyzer.ComputeSimilarity(method1.TreeNode, method2.TreeNode)
+			similarity := detector.analyzer.ComputeSimilarity(method1, method2, nil)
 			// These identical methods SHOULD be detected as clones (Type-2 at minimum)
 			assert.GreaterOrEqual(t, similarity, domain.DefaultType3CloneThreshold,
 				"Identical methods within dataclasses SHOULD be detected as clones")

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -428,8 +428,8 @@ def compute(x, y):
 		analyzerWithDFA := NewSemanticSimilarityAnalyzerWithDFA()
 		analyzerWithoutDFA := NewSemanticSimilarityAnalyzer()
 
-		simWithDFA := analyzerWithDFA.ComputeSimilarity(f1, f2)
-		simWithoutDFA := analyzerWithoutDFA.ComputeSimilarity(f1, f2)
+		simWithDFA := analyzerWithDFA.ComputeSimilarity(f1, f2, nil)
+		simWithoutDFA := analyzerWithoutDFA.ComputeSimilarity(f1, f2, nil)
 
 		// Both should produce valid similarity scores
 		assert.Greater(t, simWithDFA, 0.0)

--- a/internal/analyzer/recursion_test.go
+++ b/internal/analyzer/recursion_test.go
@@ -56,10 +56,10 @@ func TestRecursionDepthLimits(t *testing.T) {
 		// APTED operations should not crash
 		analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
 
-		distance := analyzer.ComputeDistance(root, root2)
+		distance := analyzer.ComputeDistanceTrees(root, root2)
 		assert.GreaterOrEqual(t, distance, 0.0, "Distance should be non-negative")
 
-		similarity := analyzer.ComputeSimilarity(root, root2)
+		similarity := analyzer.ComputeSimilarityTrees(root, root2, nil)
 		assert.GreaterOrEqual(t, similarity, 0.0, "Similarity should be non-negative")
 		assert.LessOrEqual(t, similarity, 1.0, "Similarity should not exceed 1.0")
 	})
@@ -168,7 +168,7 @@ func TestAPTEDRecursionProtection(t *testing.T) {
 
 	t.Run("compute distance with deep trees", func(t *testing.T) {
 		// This should not panic or crash
-		distance := analyzer.ComputeDistance(tree1, tree2)
+		distance := analyzer.ComputeDistanceTrees(tree1, tree2)
 		assert.GreaterOrEqual(t, distance, 0.0, "Distance should be non-negative")
 
 		// Should complete in reasonable time (not hang)
@@ -177,7 +177,7 @@ func TestAPTEDRecursionProtection(t *testing.T) {
 
 	t.Run("compute similarity with deep trees", func(t *testing.T) {
 		// This should not panic or crash
-		similarity := analyzer.ComputeSimilarity(tree1, tree2)
+		similarity := analyzer.ComputeSimilarityTrees(tree1, tree2, nil)
 		assert.GreaterOrEqual(t, similarity, 0.0, "Similarity should be non-negative")
 		assert.LessOrEqual(t, similarity, 1.0, "Similarity should not exceed 1.0")
 	})

--- a/internal/analyzer/semantic_similarity.go
+++ b/internal/analyzer/semantic_similarity.go
@@ -56,6 +56,17 @@ type CFGFeatures struct {
 	ConditionalCount int              // Number of conditional branches
 }
 
+// ComputeDistance computes the semantic distance (1 - similarity) between two code fragments.
+func (s *SemanticSimilarityAnalyzer) ComputeDistance(f1, f2 *CodeFragment) float64 {
+	if f1 == nil && f2 == nil {
+		return 0.0
+	}
+	if f1 == nil || f2 == nil {
+		return 1.0
+	}
+	return 1.0 - s.ComputeSimilarity(f1, f2, nil)
+}
+
 // ComputeSimilarity computes the semantic similarity between two code fragments
 // by comparing their CFG structures and optionally DFA features.
 func (s *SemanticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, _ *TFIDFCalculator) float64 {

--- a/internal/analyzer/semantic_similarity.go
+++ b/internal/analyzer/semantic_similarity.go
@@ -58,7 +58,7 @@ type CFGFeatures struct {
 
 // ComputeSimilarity computes the semantic similarity between two code fragments
 // by comparing their CFG structures and optionally DFA features.
-func (s *SemanticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
+func (s *SemanticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, _ *TFIDFCalculator) float64 {
 	if f1 == nil || f2 == nil {
 		return 0.0
 	}

--- a/internal/analyzer/similarity_analyzer.go
+++ b/internal/analyzer/similarity_analyzer.go
@@ -6,6 +6,9 @@ type SimilarityAnalyzer interface {
 	// ComputeSimilarity returns a similarity score between 0.0 and 1.0
 	ComputeSimilarity(f1, f2 *CodeFragment, calc *TFIDFCalculator) float64
 
+	// ComputeDistance returns a distance score (0.0 for identical, higher for different)
+	ComputeDistance(f1, f2 *CodeFragment) float64
+
 	// GetName returns the name of this analyzer
 	GetName() string
 }

--- a/internal/analyzer/structural_similarity.go
+++ b/internal/analyzer/structural_similarity.go
@@ -42,7 +42,7 @@ func (s *StructuralSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, _
 	}
 
 	// Compute similarity using APTED
-	return s.analyzer.ComputeSimilarity(tree1, tree2, nil)
+	return s.analyzer.ComputeSimilarityTrees(tree1, tree2, nil)
 }
 
 // ComputeDistance computes the edit distance between two code fragments.
@@ -59,7 +59,7 @@ func (s *StructuralSimilarityAnalyzer) ComputeDistance(f1, f2 *CodeFragment) flo
 		return 0.0
 	}
 
-	return s.analyzer.ComputeDistance(tree1, tree2)
+	return s.analyzer.ComputeDistanceTrees(tree1, tree2)
 }
 
 // getTreeNode retrieves or builds the tree node for a code fragment

--- a/internal/analyzer/structural_similarity.go
+++ b/internal/analyzer/structural_similarity.go
@@ -28,7 +28,7 @@ func NewStructuralSimilarityAnalyzerWithCostModel(costModel CostModel) *Structur
 
 // ComputeSimilarity computes the structural similarity between two code fragments
 // using APTED tree edit distance.
-func (s *StructuralSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
+func (s *StructuralSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, _ *TFIDFCalculator) float64 {
 	if f1 == nil || f2 == nil {
 		return 0.0
 	}
@@ -42,7 +42,7 @@ func (s *StructuralSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) f
 	}
 
 	// Compute similarity using APTED
-	return s.analyzer.ComputeSimilarity(tree1, tree2)
+	return s.analyzer.ComputeSimilarity(tree1, tree2, nil)
 }
 
 // ComputeDistance computes the edit distance between two code fragments.

--- a/internal/analyzer/syntactic_similarity.go
+++ b/internal/analyzer/syntactic_similarity.go
@@ -67,16 +67,16 @@ func (s *SyntacticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, ca
 
 	// Extract normalized feature sets
 	features1, _ := s.extractor.ExtractFeatures(tree1)
-    features2, _ := s.extractor.ExtractFeatures(tree2)
+	features2, _ := s.extractor.ExtractFeatures(tree2)
 
-    // Use TF-IDF + Cosine if calculator is provided and feature is enabled
-    if calc != nil {
-        v1 := calc.ToWeightedVector(features1)
-        v2 := calc.ToWeightedVector(features2)
-        return CosineSimilarity(v1, v2)
-    }
+	// Use TF-IDF + Cosine if calculator is provided and feature is enabled
+	if calc != nil {
+		v1 := calc.ToWeightedVector(features1)
+		v2 := calc.ToWeightedVector(features2)
+		return CosineSimilarity(v1, v2)
+	}
 
-    return jaccardSimilarity(features1, features2)
+	return jaccardSimilarity(features1, features2)
 }
 
 // ComputeDistance computes the syntactic distance between two code fragments.

--- a/internal/analyzer/textual_similarity.go
+++ b/internal/analyzer/textual_similarity.go
@@ -45,7 +45,7 @@ func NewTextualSimilarityAnalyzerWithConfig(config *TextualSimilarityConfig) *Te
 // ComputeSimilarity computes the textual similarity between two code fragments.
 // Returns 1.0 for identical content (after normalization), or a Levenshtein-based
 // similarity score for near-matches.
-func (t *TextualSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
+func (t *TextualSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment, _ *TFIDFCalculator) float64 {
 	if f1 == nil || f2 == nil {
 		return 0.0
 	}

--- a/internal/analyzer/textual_similarity.go
+++ b/internal/analyzer/textual_similarity.go
@@ -42,6 +42,17 @@ func NewTextualSimilarityAnalyzerWithConfig(config *TextualSimilarityConfig) *Te
 	}
 }
 
+// ComputeDistance computes the textual distance (1 - similarity) between two code fragments.
+func (t *TextualSimilarityAnalyzer) ComputeDistance(f1, f2 *CodeFragment) float64 {
+	if f1 == nil && f2 == nil {
+		return 0.0
+	}
+	if f1 == nil || f2 == nil {
+		return 1.0
+	}
+	return 1.0 - t.ComputeSimilarity(f1, f2, nil)
+}
+
 // ComputeSimilarity computes the textual similarity between two code fragments.
 // Returns 1.0 for identical content (after normalization), or a Levenshtein-based
 // similarity score for near-matches.

--- a/internal/analyzer/tfidf.go
+++ b/internal/analyzer/tfidf.go
@@ -1,0 +1,44 @@
+package analyzer
+
+import "math"
+
+// handles the weight calculations for code features
+type TFIDFCalculator struct {
+    DocumentFrequency map[string]int  // feature → how many code blocks contain it
+    TotalDocuments    int             // total number of code blocks scanned
+}
+
+// calculates the Inverse Document Frequency
+func (c *TFIDFCalculator) IDF(feature string) float64 {
+    df := c.DocumentFrequency[feature]
+    if df == 0 {
+        return 0
+    }
+    // log(N/df) dampens the weight of very common terms
+    return math.Log(float64(c.TotalDocuments) / float64(df))
+}
+
+// converts features into TF-IDF weighted values
+func (c *TFIDFCalculator) ToWeightedVector(features []string) map[string]float64 {
+    tf := make(map[string]int)
+    for _, f := range features {
+        tf[f]++
+    }
+    
+    vector := make(map[string]float64)
+    for f, count := range tf {
+        vector[f] = float64(count) * c.IDF(f)
+    }
+    return vector
+}
+
+func CosineSimilarity(v1, v2 map[string]float64) float64 {
+    var dotProduct, norm1, norm2 float64
+    for k, val1 := range v1 {
+        if val2, ok := v2[k]; ok { dotProduct += val1 * val2 }
+        norm1 += val1 * val1
+    }
+    for _, val2 := range v2 { norm2 += val2 * val2 }
+    if norm1 == 0 || norm2 == 0 { return 0 }
+    return dotProduct / (math.Sqrt(norm1) * math.Sqrt(norm2))
+}

--- a/internal/analyzer/tfidf.go
+++ b/internal/analyzer/tfidf.go
@@ -4,41 +4,76 @@ import "math"
 
 // handles the weight calculations for code features
 type TFIDFCalculator struct {
-    DocumentFrequency map[string]int  // feature → how many code blocks contain it
-    TotalDocuments    int             // total number of code blocks scanned
+	DocumentFrequency map[string]int // feature → how many code blocks contain it
+	TotalDocuments    int            // total number of code blocks scanned
+}
+
+// NewTFIDFCalculator creates a new TF-IDF calculator
+func NewTFIDFCalculator() *TFIDFCalculator {
+	return &TFIDFCalculator{
+		DocumentFrequency: make(map[string]int),
+	}
+}
+
+// ComputeIDF pre-calculates the counts for IDF from a set of code fragments
+func (c *TFIDFCalculator) ComputeIDF(fragments []*CodeFragment) {
+	if len(fragments) == 0 {
+		return
+	}
+	c.TotalDocuments = len(fragments)
+	extractor := NewASTFeatureExtractor() // Use default options
+	for _, f := range fragments {
+		if f.TreeNode != nil {
+			features, _ := extractor.ExtractFeatures(f.TreeNode)
+			// Deduplicate features per "document" for DF calculation
+			uniqueFeatures := make(map[string]struct{})
+			for _, feat := range features {
+				uniqueFeatures[feat] = struct{}{}
+			}
+			for feat := range uniqueFeatures {
+				c.DocumentFrequency[feat]++
+			}
+		}
+	}
 }
 
 // calculates the Inverse Document Frequency
 func (c *TFIDFCalculator) IDF(feature string) float64 {
-    df := c.DocumentFrequency[feature]
-    if df == 0 {
-        return 0
-    }
-    // log(N/df) dampens the weight of very common terms
-    return math.Log(float64(c.TotalDocuments) / float64(df))
+	df := c.DocumentFrequency[feature]
+	if df == 0 {
+		return 0
+	}
+	// log(N/df) dampens the weight of very common terms
+	return math.Log(float64(c.TotalDocuments) / float64(df))
 }
 
 // converts features into TF-IDF weighted values
 func (c *TFIDFCalculator) ToWeightedVector(features []string) map[string]float64 {
-    tf := make(map[string]int)
-    for _, f := range features {
-        tf[f]++
-    }
-    
-    vector := make(map[string]float64)
-    for f, count := range tf {
-        vector[f] = float64(count) * c.IDF(f)
-    }
-    return vector
+	tf := make(map[string]int)
+	for _, f := range features {
+		tf[f]++
+	}
+
+	vector := make(map[string]float64)
+	for f, count := range tf {
+		vector[f] = float64(count) * c.IDF(f)
+	}
+	return vector
 }
 
 func CosineSimilarity(v1, v2 map[string]float64) float64 {
-    var dotProduct, norm1, norm2 float64
-    for k, val1 := range v1 {
-        if val2, ok := v2[k]; ok { dotProduct += val1 * val2 }
-        norm1 += val1 * val1
-    }
-    for _, val2 := range v2 { norm2 += val2 * val2 }
-    if norm1 == 0 || norm2 == 0 { return 0 }
-    return dotProduct / (math.Sqrt(norm1) * math.Sqrt(norm2))
+	var dotProduct, norm1, norm2 float64
+	for k, val1 := range v1 {
+		if val2, ok := v2[k]; ok {
+			dotProduct += val1 * val2
+		}
+		norm1 += val1 * val1
+	}
+	for _, val2 := range v2 {
+		norm2 += val2 * val2
+	}
+	if norm1 == 0 || norm2 == 0 {
+		return 0
+	}
+	return dotProduct / (math.Sqrt(norm1) * math.Sqrt(norm2))
 }

--- a/internal/analyzer/tfidf_integration_test.go
+++ b/internal/analyzer/tfidf_integration_test.go
@@ -1,0 +1,280 @@
+package analyzer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTFIDFIntegration(t *testing.T) {
+	p := parser.New()
+	ctx := context.Background()
+
+	// Boilerplate code (will appear frequent and get lower weights with TF-IDF)
+	code1 := `@dataclass
+class UserProfile:
+    username: str
+    email: str
+    created_at: int = 0`
+
+	code2 := `@dataclass
+class ProductEntry:
+    product_id: str
+    sku: str
+    price_cents: int = 0`
+
+	// This code has identical boilerplate structure but different "domain" labels
+	// Jaccard similarity (default) often gives high similarity because of shared structure labels.
+	// TF-IDF should give lower similarity if those common labels are frequent.
+
+	res1, err := p.Parse(ctx, []byte(code1))
+	require.NoError(t, err)
+	res2, err := p.Parse(ctx, []byte(code2))
+	require.NoError(t, err)
+
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 1
+	config.MinNodes = 1
+	config.UseTFIDF = true // Enable TF-IDF
+
+	detector := NewCloneDetector(config)
+
+	// Simulate IDF computation by giving it a set of files
+	// In a real run, DetectClones does this. We'll manually trigger the pre-computation phase
+	// by providing some fragments.
+	fragments1 := detector.ExtractFragments([]*parser.Node{res1.AST}, "test1.py")
+	fragments2 := detector.ExtractFragments([]*parser.Node{res2.AST}, "test2.py")
+
+	// Prepare trees (this is usually done in DetectClones)
+	converter := NewTreeConverter()
+	for _, f := range fragments1 {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+	for _, f := range fragments2 {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+
+	// Manually initialize TF-IDF calculator with these fragments
+	allFragments := append(fragments1, fragments2...)
+	detector.tfidfCalculator = NewTFIDFCalculator()
+	detector.tfidfCalculator.ComputeIDF(allFragments)
+
+	require.NotNil(t, detector.tfidfCalculator)
+
+	// Now compare with TF-IDF enabled
+	similarity := detector.analyzer.ComputeSimilarity(fragments1[0], fragments2[0], detector.tfidfCalculator)
+
+	t.Logf("TF-IDF Similarity: %f", similarity)
+
+	// Compare with no TF-IDF (effectively Jaccard)
+	similarityNoTFIDF := detector.analyzer.ComputeSimilarity(fragments1[0], fragments2[0], nil)
+	t.Logf("Jaccard Similarity: %f", similarityNoTFIDF)
+
+	// TF-IDF should generally be different than Jaccard
+	// In this specific case, if @dataclass and other nodes are common, similarity should go DOWN
+	assert.NotEqual(t, similarityNoTFIDF, similarity, "TF-IDF similarity should differ from Jaccard")
+}
+
+func TestTFIDF_TrueClones(t *testing.T) {
+	p := parser.New()
+	ctx := context.Background()
+
+	// Identical code but with different variable names (Type-2)
+	code1 := `def calculate_total(prices):
+    total = 0
+    for price in prices:
+        total += price
+    return total`
+
+	code2 := `def sum_all_items(values):
+    s = 0
+    for v in values:
+        s += v
+    return s`
+
+	res1, err := p.Parse(ctx, []byte(code1))
+	require.NoError(t, err)
+	res2, err := p.Parse(ctx, []byte(code2))
+	require.NoError(t, err)
+
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 1
+	config.MinNodes = 1
+	config.UseTFIDF = true
+	detector := NewCloneDetector(config)
+
+	fragments1 := detector.ExtractFragments([]*parser.Node{res1.AST}, "test1.py")
+	fragments2 := detector.ExtractFragments([]*parser.Node{res2.AST}, "test2.py")
+
+	converter := NewTreeConverter()
+	for _, f := range fragments1 {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+	for _, f := range fragments2 {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+
+	// Manually initialize TF-IDF calculator
+	allFragments := append(fragments1, fragments2...)
+	detector.tfidfCalculator = NewTFIDFCalculator()
+	detector.tfidfCalculator.ComputeIDF(allFragments)
+
+	// Now compare
+	similarity := detector.analyzer.ComputeSimilarity(fragments1[0], fragments2[0], detector.tfidfCalculator)
+
+	t.Logf("True Clone TF-IDF Similarity: %f", similarity)
+
+	// Since these are structurally identical and only variable names changed,
+	// similarity should be very high (1.0 or very close to it depending on normalization)
+	assert.Greater(t, similarity, 0.9, "Highly similar files should have high similarity")
+}
+
+func TestTFIDF_PartialSimilarity(t *testing.T) {
+	p := parser.New()
+	ctx := context.Background()
+
+	// Two functions that share some logic (a loop summing things)
+	// but have different surrounds and different details
+	// Two functions that share some logic (a loop summing things)
+	// but have different surrounds and different details
+	code1 := `def sum_positive_numbers(arr):
+    res = 0
+    for x in arr:
+        if x > 0:
+            res += x
+    return res`
+
+	code2 := `def complex_process(data):
+    s = 0
+    for val in data:
+        if val > 0:
+            s += val
+    try:
+        save_to_db(s)
+    except Exception:
+        log_error()
+    return s`
+
+	res1, err := p.Parse(ctx, []byte(code1))
+	require.NoError(t, err)
+	res2, err := p.Parse(ctx, []byte(code2))
+	require.NoError(t, err)
+
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 1
+	config.MinNodes = 1
+	config.UseTFIDF = true
+	detector := NewCloneDetector(config)
+
+	fragments1 := detector.ExtractFragments([]*parser.Node{res1.AST}, "test1.py")
+	fragments2 := detector.ExtractFragments([]*parser.Node{res2.AST}, "test2.py")
+
+	converter := NewTreeConverter()
+	for _, f := range fragments1 {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+	for _, f := range fragments2 {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+
+	// Manually initialize TF-IDF calculator
+	allFragments := append(fragments1, fragments2...)
+	detector.tfidfCalculator = NewTFIDFCalculator()
+	detector.tfidfCalculator.ComputeIDF(allFragments)
+
+	// Now compare
+	similarity := detector.analyzer.ComputeSimilarity(fragments1[0], fragments2[0], detector.tfidfCalculator)
+
+	t.Logf("Partial Clone TF-IDF Similarity: %f", similarity)
+
+	// Should be in (0, 1) range
+	assert.True(t, similarity > 0.0 && similarity < 1.0, "Partial similarity should be between 0 and 1")
+	assert.Greater(t, similarity, 0.4, "These should be fairly similar due to the shared loop/if structure")
+}
+
+func TestTFIDF_RealWorldAmbiguous(t *testing.T) {
+	p := parser.New()
+	ctx := context.Background()
+
+	// Read real test files
+	pathA := filepath.Join("..", "..", "testdata", "python", "clones", "type4", "find_max_a.py")
+	pathB := filepath.Join("..", "..", "testdata", "python", "clones", "type4", "find_max_b.py")
+
+	codeA, err := os.ReadFile(pathA)
+	require.NoError(t, err)
+	codeB, err := os.ReadFile(pathB)
+	require.NoError(t, err)
+
+	resA, err := p.Parse(ctx, codeA)
+	require.NoError(t, err)
+	resB, err := p.Parse(ctx, codeB)
+	require.NoError(t, err)
+
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 3
+	config.MinNodes = 5
+	config.UseTFIDF = true
+	detector := NewCloneDetector(config)
+
+	fragmentsA := detector.ExtractFragments([]*parser.Node{resA.AST}, pathA)
+	fragmentsB := detector.ExtractFragments([]*parser.Node{resB.AST}, pathB)
+
+	require.NotEmpty(t, fragmentsA)
+	require.NotEmpty(t, fragmentsB)
+
+	converter := NewTreeConverter()
+	for _, f := range append(fragmentsA, fragmentsB...) {
+		f.TreeNode = converter.ConvertAST(f.ASTNode)
+		PrepareTreeForAPTED(f.TreeNode)
+	}
+
+	// Manually initialize TF-IDF calculator
+	allFragments := append(fragmentsA, fragmentsB...)
+	detector.tfidfCalculator = NewTFIDFCalculator()
+	detector.tfidfCalculator.ComputeIDF(allFragments)
+
+	foundValidComparison := false
+	for _, fA := range fragmentsA {
+		// Only look at find_maximum or find_min_max
+		nameA := fA.ASTNode.Name
+		for _, fB := range fragmentsB {
+			if fB.ASTNode.Name == nameA {
+				similarity := detector.analyzer.ComputeSimilarity(fA, fB, detector.tfidfCalculator)
+				t.Logf("Function %s Real-World Similarity: %f", nameA, similarity)
+
+				// Ensure it's not exactly 0.5 or 1.0 or 0.0
+				assert.True(t, similarity > 0.0 && similarity < 1.0)
+				assert.NotEqual(t, 0.5, similarity)
+				foundValidComparison = true
+			}
+		}
+	}
+	assert.True(t, foundValidComparison, "Should have found matching function names to compare")
+}
+
+func TestCloneDetector_UseTFIDF_Selection(t *testing.T) {
+	config := DefaultCloneDetectorConfig()
+
+	t.Run("Default_Analyzer_Is_APTED", func(t *testing.T) {
+		config.UseTFIDF = false
+		detector := NewCloneDetector(config)
+		assert.Equal(t, "apted", detector.analyzer.GetName())
+	})
+
+	t.Run("TFIDF_Enabled_Analyzer_Is_Syntactic", func(t *testing.T) {
+		config.UseTFIDF = true
+		detector := NewCloneDetector(config)
+		assert.Equal(t, "syntactic", detector.analyzer.GetName())
+	})
+}

--- a/internal/analyzer/type4_similarity_test.go
+++ b/internal/analyzer/type4_similarity_test.go
@@ -69,7 +69,7 @@ func TestType4SimilarityScores(t *testing.T) {
 			f1 := &CodeFragment{ASTNode: functions[i].ast}
 			f2 := &CodeFragment{ASTNode: functions[j].ast}
 
-			sim := analyzer.ComputeSimilarity(f1, f2)
+			sim := analyzer.ComputeSimilarity(f1, f2, nil)
 			t.Logf("  %s:%s vs %s:%s = %.3f",
 				functions[i].file, functions[i].name,
 				functions[j].file, functions[j].name,
@@ -85,7 +85,7 @@ func TestType4SimilarityScores(t *testing.T) {
 			f1 := &CodeFragment{ASTNode: functions[i].ast}
 			f2 := &CodeFragment{ASTNode: functions[j].ast}
 
-			sim := analyzerNoDFA.ComputeSimilarity(f1, f2)
+			sim := analyzerNoDFA.ComputeSimilarity(f1, f2, nil)
 			t.Logf("  %s:%s vs %s:%s = %.3f",
 				functions[i].file, functions[i].name,
 				functions[j].file, functions[j].name,

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -155,6 +155,9 @@ type CloneAnalysisConfig struct {
 
 	// Advanced analysis
 	EnableDFA *bool `mapstructure:"enable_dfa" yaml:"enable_dfa" json:"enable_dfa"` // Data Flow Analysis for Type-4
+
+	// TF-IDF toggle
+	UseTFIDF bool `mapstructure:"use_tfidf" yaml:"use_tfidf" json:"use_tfidf"`
 }
 
 // ThresholdConfig holds similarity thresholds for different clone types
@@ -264,6 +267,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 			SkipDocstrings:    domain.BoolPtr(true),
 			CostModelType:     "python",
 			EnableDFA:         domain.BoolPtr(true), // Enable Data Flow Analysis by default for multi-dimensional classification
+			UseTFIDF: 		   false, //default to traditional jaccard
 		},
 		Thresholds: ThresholdConfig{
 			Type1Threshold:      domain.DefaultType1CloneThreshold,

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -236,7 +236,7 @@ func (s *CloneService) ComputeSimilarity(ctx context.Context, fragment1, fragmen
 	costModel := analyzer.NewPythonCostModel()
 	aptedAnalyzer := analyzer.NewAPTEDAnalyzer(costModel)
 
-	similarity := aptedAnalyzer.ComputeSimilarity(tree1, tree2, nil)
+	similarity := aptedAnalyzer.ComputeSimilarityTrees(tree1, tree2, nil)
 	return similarity, nil
 }
 

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -236,7 +236,7 @@ func (s *CloneService) ComputeSimilarity(ctx context.Context, fragment1, fragmen
 	costModel := analyzer.NewPythonCostModel()
 	aptedAnalyzer := analyzer.NewAPTEDAnalyzer(costModel)
 
-	similarity := aptedAnalyzer.ComputeSimilarity(tree1, tree2)
+	similarity := aptedAnalyzer.ComputeSimilarity(tree1, tree2, nil)
 	return similarity, nil
 }
 


### PR DESCRIPTION
Key changes : 

1. Architectural Refactoring 
    - SimilarityAnalyzer Interface: Created a new interface in internal/analyzer to decouple CloneDetector from specific mathematical strategies.
    - Switchable Strategies : Refactored NewCloneDetector to support selecting between the structural APTEDAnalyzer (default) and the new SyntacticSimilarityAnalyzer.

2. Core Logic Implementation
    - SyntacticSimilarityAnalyzer: A high-performance analyzer that uses AST feature extraction. It supports traditional Jaccard similarity and the new TF-IDF mode.
    - TFIDFCalculator: New utility to handle IDF pre-computation and convert feature sets into weighted vectors for Cosine Similarity.
    - CloneDetector Integration: Added a pre-computation phase to DetectClones to calculate global inverse document frequencies before performing pairwise comparisons.

3. Verification 
    - Created tfidf_integration_test.go
    - Verified that common Type-1/2/3 tests still pass under the default configuration, ensuring backward compatibility.

The feature is opt-in for this version. To enable it, set the UseTFIDF flag in your CloneDetectorConfig : 

``` go
config := &analyzer.CloneDetectorConfig{
    UseTFIDF: true,
    // ... rest of config
}
detector := analyzer.NewCloneDetector(config)````