### PR TITLE
fix(analyzer): correct APTED key-root DP ordering

### DIFF
--- a/internal/analyzer/apted.go
+++ b/internal/analyzer/apted.go
@@ -46,9 +46,9 @@ func (a *APTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64 {
 	keyRoots1 := PrepareTreeForAPTED(tree1)
 	keyRoots2 := PrepareTreeForAPTED(tree2)
 
-	// Sort key roots in descending order
-	sort.Sort(sort.Reverse(sort.IntSlice(keyRoots1)))
-	sort.Sort(sort.Reverse(sort.IntSlice(keyRoots2)))
+	// Sort key roots in ascending order (leaves before parents)
+	sort.Ints(keyRoots1)
+	sort.Ints(keyRoots2)
 
 	// Compute distance using APTED algorithm
 	return a.apted(tree1, tree2, keyRoots1, keyRoots2)
@@ -86,9 +86,9 @@ func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode) float64
 		keyRoots2 = keyRoots2[:100]
 	}
 
-	// Sort key roots in descending order
-	sort.Sort(sort.Reverse(sort.IntSlice(keyRoots1)))
-	sort.Sort(sort.Reverse(sort.IntSlice(keyRoots2)))
+	// Sort key roots in ascending order (leaves before parents)
+	sort.Ints(keyRoots1)
+	sort.Ints(keyRoots2)
 
 	// Compute distance using optimized APTED algorithm
 	return a.aptedOptimized(tree1, tree2, keyRoots1, keyRoots2, maxDistance*0.5)
@@ -243,18 +243,10 @@ func (a *APTEDAnalyzer) computeForestDistanceOptimized(nodes1, nodes2 []*TreeNod
 				deleteCost := fd[x][y+1] + a.costModel.Delete(nodes1[x])
 				insertCost := fd[x+1][y] + a.costModel.Insert(nodes2[y])
 
-				var subtreeCost float64
-				if lml_x == lml_i {
-					subtreeCost = fd[lml_i][y] + td[x+1][lml_y]
-				} else if lml_y == lml_j {
-					subtreeCost = fd[x][lml_j] + td[lml_x][y+1]
-				} else {
-					subtreeCost = fd[lml_i][lml_j] + td[lml_x][lml_y]
-				}
+				// td[x+1][y+1] was already computed during a previous key root iteration
+				subtreeCost := fd[lml_x][lml_y] + td[x+1][y+1]
 
 				fd[x+1][y+1] = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
-				// Fix: Update td matrix in both branches
-				td[x+1][y+1] = fd[x+1][y+1]
 			}
 
 			// Early termination check
@@ -326,18 +318,10 @@ func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j i
 				deleteCost := fd[x][y+1] + a.costModel.Delete(nodes1[x])
 				insertCost := fd[x+1][y] + a.costModel.Insert(nodes2[y])
 
-				var subtreeCost float64
-				if lml_x == lml_i {
-					subtreeCost = fd[lml_i][y] + td[x+1][lml_y]
-				} else if lml_y == lml_j {
-					subtreeCost = fd[x][lml_j] + td[lml_x][y+1]
-				} else {
-					subtreeCost = fd[lml_i][lml_j] + td[lml_x][lml_y]
-				}
+				// td[x+1][y+1] was already computed during a previous key root iteration
+				subtreeCost := fd[lml_x][lml_y] + td[x+1][y+1]
 
 				fd[x+1][y+1] = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
-				// Fix: Update td matrix in both branches
-				td[x+1][y+1] = fd[x+1][y+1]
 			}
 		}
 	}

--- a/internal/analyzer/apted_test.go
+++ b/internal/analyzer/apted_test.go
@@ -139,15 +139,14 @@ func TestAPTEDAnalyzer_ComputeDistance_ComplexTrees(t *testing.T) {
 	tree2.AddChild(childE2)
 
 	distance := analyzer.ComputeDistance(tree1, tree2)
-	// Note: APTED algorithm finds an optimal distance of 1.0 for this case
-	// This might be due to structural alignment optimizations in the algorithm
-	assert.Equal(t, 1.0, distance, "APTED algorithm computes optimal distance")
+	// Optimal distance: rename B→D and C→E = 2.0 (root A matches)
+	assert.Equal(t, 2.0, distance, "APTED algorithm computes optimal distance")
 
 	similarity := analyzer.ComputeSimilarity(tree1, tree2)
 	// With max-based normalization: similarity = 1.0 - (distance / max(size1, size2))
-	// distance = 1.0, size1 = 3, size2 = 3
-	// similarity = 1.0 - (1.0 / 3.0) = 0.6667...
-	expectedSimilarity := 1.0 - (1.0 / 3.0) // 1.0 distance, max size = 3
+	// distance = 2.0, size1 = 3, size2 = 3
+	// similarity = 1.0 - (2.0 / 3.0) = 0.3333...
+	expectedSimilarity := 1.0 - (2.0 / 3.0)
 	assert.InDelta(t, expectedSimilarity, similarity, 0.001, "Similarity should be calculated correctly")
 }
 
@@ -243,7 +242,7 @@ func TestAPTEDAnalyzer_ComputeSimilarity(t *testing.T) {
 				root.AddChild(NewTreeNode(3, "Z"))
 				return root
 			}(),
-			expectedSimilarity: 0.3333, // APTED finds optimal distance of 2, max size = 3, 1-2/3=0.333
+			expectedSimilarity: 0.0, // All 3 nodes renamed: distance = 3, max size = 3, 1-3/3=0.0
 			delta:              0.001,
 		},
 		{


### PR DESCRIPTION
## Summary
- sort APTED key roots in ascending postorder so leaf subproblems are solved before parent subproblems
- use precomputed td[x+1][y+1] in forest distance transitions instead of recomputing with branch-specific fallbacks
- update complex-tree and similarity test expectations to match the corrected DP ordering/results

## Testing
- go test ./internal/analyzer