### PR TITLE
fix: exclude Type-3 from default enabled clone types

### DIFF
--- a/domain/clone.go
+++ b/domain/clone.go
@@ -38,13 +38,12 @@ func (ct CloneType) String() string {
 }
 
 // DefaultEnabledCloneTypes defines the clone types enabled by default.
-// All four types are enabled: the multi-metric classifier assigns Type-3
-// (APTED structural comparison) to most detected clones, so excluding it
-// would discard the majority of valid detections and leave groups empty.
-var DefaultEnabledCloneTypes = []CloneType{Type1Clone, Type2Clone, Type3Clone, Type4Clone}
+// Type-3 is excluded by default to reduce near-miss false positives in
+// day-to-day analysis. Users can opt in when they want broader detection.
+var DefaultEnabledCloneTypes = []CloneType{Type1Clone, Type2Clone, Type4Clone}
 
 // DefaultEnabledCloneTypeStrings provides string representations for config files.
-var DefaultEnabledCloneTypeStrings = []string{"type1", "type2", "type3", "type4"}
+var DefaultEnabledCloneTypeStrings = []string{"type1", "type2", "type4"}
 
 // CloneLocation represents a location of a clone in source code
 type CloneLocation struct {

--- a/domain/clone_test.go
+++ b/domain/clone_test.go
@@ -363,11 +363,11 @@ func TestDefaultCloneRequest(t *testing.T) {
 	assert.True(t, request.GroupClones, "Default group clones should be true")
 	assert.Equal(t, 0.0, request.MinSimilarity, "Default min similarity should be 0.0")
 	assert.Equal(t, 1.0, request.MaxSimilarity, "Default max similarity should be 1.0")
-	assert.Len(t, request.CloneTypes, 4, "Default clone types should include all four types")
+	assert.Len(t, request.CloneTypes, 3, "Default clone types should include Type-1/2/4 only")
 	assert.Contains(t, request.CloneTypes, Type1Clone, "Default should include Type-1")
 	assert.Contains(t, request.CloneTypes, Type2Clone, "Default should include Type-2 (Jaccard algorithm, PR #301)")
-	assert.Contains(t, request.CloneTypes, Type3Clone, "Default should include Type-3 (multi-metric classifier primary output)")
 	assert.Contains(t, request.CloneTypes, Type4Clone, "Default should include Type-4")
+	assert.NotContains(t, request.CloneTypes, Type3Clone, "Default should exclude Type-3 to reduce near-miss noise")
 
 	// Validate that the default request passes validation
 	err := request.Validate()

--- a/internal/config/default_config.toml
+++ b/internal/config/default_config.toml
@@ -69,7 +69,7 @@ enable_dfa = true                # Enable Data Flow Analysis for enhanced Type-4
 # Filtering settings
 min_similarity = 0.0             # Minimum similarity to report
 max_similarity = 1.0             # Maximum similarity to report
-# enabled_clone_types = ["type1", "type2", "type3", "type4"]  # Default: uses domain.DefaultEnabledCloneTypes
+# enabled_clone_types = ["type1", "type2", "type4"]  # Default: uses domain.DefaultEnabledCloneTypes
 max_results = 10000              # Maximum results (0 = no limit)
 
 # Grouping settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ group_clones = true
 # Filtering settings
 min_similarity = 0.0
 max_similarity = 1.0
-enabled_clone_types = ["type1", "type2", "type3", "type4"]
+enabled_clone_types = ["type1", "type2", "type4"]
 max_results = 10000
 
 # Grouping settings


### PR DESCRIPTION
## Summary
- change default enabled clone types to type1/type2/type4 (exclude Type-3)
- update default clone request test expectations accordingly
- align repository default clone config to the new default in pyproject.toml
- update default config template comment to reflect the new default

## Validation
- GOCACHE=/tmp/go-build go test ./domain
- GOCACHE=/tmp/go-build go test ./internal/config
- GOCACHE=/tmp/go-build go test ./service
