### PR TITLE
fix(html): shorten tab labels to prevent wrapping

### DIFF
--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -417,10 +417,10 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 <button class="tab-button" onclick="showTab('deadcode', this)">Dead Code</button>
                 {{end}}
                 {{if .Summary.CloneEnabled}}
-                <button class="tab-button" onclick="showTab('clone', this)">Clone Detection</button>
+                <button class="tab-button" onclick="showTab('clone', this)">Clone</button>
                 {{end}}
                 {{if .Summary.CBOEnabled}}
-                <button class="tab-button" onclick="showTab('cbo', this)">Class Coupling</button>
+                <button class="tab-button" onclick="showTab('cbo', this)">Coupling</button>
                 {{end}}
                 {{if .Summary.LCOMEnabled}}
                 <button class="tab-button" onclick="showTab('lcom', this)">Cohesion</button>
@@ -761,7 +761,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             {{if .Summary.CloneEnabled}}
             <div id="clone" class="tab-content">
                 <div class="tab-header-with-score">
-                    <h2 style="margin: 0;">Clone Detection</h2>
+                    <h2 style="margin: 0;">Clone</h2>
                     <div class="score-badge-compact score-{{scoreQuality .Summary.DuplicationScore}}">
                         {{.Summary.DuplicationScore}}/100
                     </div>
@@ -862,7 +862,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             {{if .Summary.CBOEnabled}}
             <div id="cbo" class="tab-content">
                 <div class="tab-header-with-score">
-                    <h2 style="margin: 0;">Class Coupling</h2>
+                    <h2 style="margin: 0;">Coupling</h2>
                     <div class="score-badge-compact score-{{scoreQuality .Summary.CouplingScore}}">
                         {{.Summary.CouplingScore}}/100
                     </div>

--- a/service/analyze_formatter_test.go
+++ b/service/analyze_formatter_test.go
@@ -237,8 +237,8 @@ func TestAnalyzeFormatter_Write_HTML(t *testing.T) {
 	// Verify tabs are present for enabled analyses
 	assert.Contains(t, output, "Complexity")
 	assert.Contains(t, output, "Dead Code")
-	assert.Contains(t, output, "Clone Detection")
-	assert.Contains(t, output, "Class Coupling")
+	assert.Contains(t, output, "Clone")
+	assert.Contains(t, output, "Coupling")
 }
 
 func TestAnalyzeFormatter_Write_UnsupportedFormat(t *testing.T) {


### PR DESCRIPTION
## Summary
- Shorten "Clone Detection" → "Clone" and "Class Coupling" → "Coupling" in the unified analyze HTML report
- Prevents tab labels from wrapping to a second line when all tabs are enabled

## Test plan
- [x] `TestAnalyzeFormatter_Write_HTML` passes with updated assertions