### PR TITLE
perf: deduplicate AST parsing via ParseCache

### DIFF
--- a/app/cbo_usecase.go
+++ b/app/cbo_usecase.go
@@ -34,6 +34,13 @@ func NewCBOUseCase(
 	}
 }
 
+// SetParseCache injects a shared parse cache into the underlying service.
+func (uc *CBOUseCase) SetParseCache(cache *svc.ParseCache) {
+	if cacheable, ok := uc.service.(svc.ParseCacheAware); ok {
+		cacheable.SetParseCache(cache)
+	}
+}
+
 // prepareAnalysis handles common preparation steps for analysis
 func (uc *CBOUseCase) prepareAnalysis(ctx context.Context, req domain.CBORequest) (domain.CBORequest, error) {
 	// Validate input

--- a/app/clone_usecase.go
+++ b/app/clone_usecase.go
@@ -37,6 +37,13 @@ func NewCloneUseCase(
 	}
 }
 
+// SetParseCache injects a shared parse cache into the underlying service.
+func (uc *CloneUseCase) SetParseCache(cache *svc.ParseCache) {
+	if cacheable, ok := uc.service.(svc.ParseCacheAware); ok {
+		cacheable.SetParseCache(cache)
+	}
+}
+
 // Execute executes the clone detection use case
 func (uc *CloneUseCase) Execute(ctx context.Context, req domain.CloneRequest) error {
 	startTime := time.Now()

--- a/app/complexity_usecase.go
+++ b/app/complexity_usecase.go
@@ -35,6 +35,13 @@ func NewComplexityUseCase(
 	}
 }
 
+// SetParseCache injects a shared parse cache into the underlying service.
+func (uc *ComplexityUseCase) SetParseCache(cache *svc.ParseCache) {
+	if cacheable, ok := uc.service.(svc.ParseCacheAware); ok {
+		cacheable.SetParseCache(cache)
+	}
+}
+
 // Execute performs the complete complexity analysis workflow
 func (uc *ComplexityUseCase) Execute(ctx context.Context, req domain.ComplexityRequest) error {
 	// Validate input

--- a/app/dead_code_usecase.go
+++ b/app/dead_code_usecase.go
@@ -36,6 +36,13 @@ func NewDeadCodeUseCase(
 	}
 }
 
+// SetParseCache injects a shared parse cache into the underlying service.
+func (uc *DeadCodeUseCase) SetParseCache(cache *svc.ParseCache) {
+	if cacheable, ok := uc.service.(svc.ParseCacheAware); ok {
+		cacheable.SetParseCache(cache)
+	}
+}
+
 // Execute performs the complete dead code analysis workflow
 func (uc *DeadCodeUseCase) Execute(ctx context.Context, req domain.DeadCodeRequest) error {
 	// Validate input

--- a/app/lcom_usecase.go
+++ b/app/lcom_usecase.go
@@ -34,6 +34,13 @@ func NewLCOMUseCase(
 	}
 }
 
+// SetParseCache injects a shared parse cache into the underlying service.
+func (uc *LCOMUseCase) SetParseCache(cache *svc.ParseCache) {
+	if cacheable, ok := uc.service.(svc.ParseCacheAware); ok {
+		cacheable.SetParseCache(cache)
+	}
+}
+
 // prepareAnalysis handles common preparation steps for analysis.
 // Config is merged before validation so that callers may leave threshold
 // fields at zero and rely on the config file (or built-in defaults) to

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -16,7 +16,8 @@ import (
 
 // ComplexityServiceImpl implements the ComplexityService interface
 type ComplexityServiceImpl struct {
-	parser *parser.Parser
+	parser     *parser.Parser
+	parseCache *ParseCache
 }
 
 // NewComplexityService creates a new complexity service implementation
@@ -24,6 +25,11 @@ func NewComplexityService() *ComplexityServiceImpl {
 	return &ComplexityServiceImpl{
 		parser: parser.New(),
 	}
+}
+
+// SetParseCache injects a shared parse cache to avoid redundant parsing.
+func (s *ComplexityServiceImpl) SetParseCache(cache *ParseCache) {
+	s.parseCache = cache
 }
 
 // Analyze performs complexity analysis on multiple files
@@ -93,28 +99,59 @@ func (s *ComplexityServiceImpl) analyzeFile(ctx context.Context, filePath string
 	var warnings []string
 	var errors []string
 
-	// Parse the file
-	content, err := s.readFile(filePath)
-	if err != nil {
-		errors = append(errors, fmt.Sprintf("[%s] Failed to read file: %v", filePath, err))
-		return functions, warnings, errors
+	var cfgs map[string]*analyzer.CFG
+
+	// Try cache first
+	if s.parseCache != nil {
+		if cached, ok := s.parseCache.Get(filePath); ok {
+			if cached.ParseErr != nil {
+				errors = append(errors, fmt.Sprintf("[%s] %v", filePath, cached.ParseErr))
+				return functions, warnings, errors
+			}
+			if cached.CFGs != nil {
+				cfgs = cached.CFGs
+			} else if cached.ParseResult != nil && cached.ParseResult.AST != nil {
+				// Cache has AST but no CFGs — build them
+				builder := analyzer.NewCFGBuilder()
+				built, err := builder.BuildAll(cached.ParseResult.AST)
+				if err != nil {
+					errors = append(errors, fmt.Sprintf("[%s] CFG construction failed: %v", filePath, err))
+					return functions, warnings, errors
+				}
+				cfgs = built
+			}
+			if cached.CFGErr != nil {
+				errors = append(errors, fmt.Sprintf("[%s] %v", filePath, cached.CFGErr))
+				return functions, warnings, errors
+			}
+			goto analyzeCFGs
+		}
 	}
 
-	result, err := s.parser.Parse(ctx, content)
-	if err != nil {
-		// Enhanced error context with file path
-		errors = append(errors, fmt.Sprintf("[%s] Parse error: %v", filePath, err))
-		return functions, warnings, errors
+	// Fallback: parse the file directly
+	{
+		content, err := s.readFile(filePath)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("[%s] Failed to read file: %v", filePath, err))
+			return functions, warnings, errors
+		}
+
+		result, err := s.parser.Parse(ctx, content)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("[%s] Parse error: %v", filePath, err))
+			return functions, warnings, errors
+		}
+
+		builder := analyzer.NewCFGBuilder()
+		built, err := builder.BuildAll(result.AST)
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("[%s] CFG construction failed: %v", filePath, err))
+			return functions, warnings, errors
+		}
+		cfgs = built
 	}
 
-	// Build CFGs for all functions
-	builder := analyzer.NewCFGBuilder()
-	cfgs, err := builder.BuildAll(result.AST)
-	if err != nil {
-		// Enhanced error context with file path
-		errors = append(errors, fmt.Sprintf("[%s] CFG construction failed: %v", filePath, err))
-		return functions, warnings, errors
-	}
+analyzeCFGs:
 
 	if len(cfgs) == 0 {
 		warnings = append(warnings, fmt.Sprintf("[%s] No functions found in file", filePath))

--- a/service/parse_cache.go
+++ b/service/parse_cache.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/ludo-technologies/pyscn/internal/analyzer"
+	"github.com/ludo-technologies/pyscn/internal/parser"
+)
+
+// FileParseResult holds the cached parse result for a single file.
+type FileParseResult struct {
+	Content     []byte
+	ParseResult *parser.ParseResult
+	CFGs        map[string]*analyzer.CFG // nil if not computed
+	ParseErr    error
+	CFGErr      error
+}
+
+// ParseCache stores pre-parsed results for sharing across analysis services.
+// After Seal() is called the cache is read-only and safe for concurrent access
+// without locks.
+type ParseCache struct {
+	results map[string]*FileParseResult
+	sealed  bool
+}
+
+// NewParseCache creates a new empty ParseCache.
+func NewParseCache() *ParseCache {
+	return &ParseCache{
+		results: make(map[string]*FileParseResult),
+	}
+}
+
+// Put stores a parse result. Must be called before Seal().
+func (c *ParseCache) Put(filePath string, result *FileParseResult) {
+	if c.sealed {
+		return
+	}
+	c.results[filePath] = result
+}
+
+// Seal marks the cache as read-only. After this call no more Put() is allowed
+// and Get() can be safely called from multiple goroutines without locks.
+func (c *ParseCache) Seal() {
+	c.sealed = true
+}
+
+// Get retrieves a cached parse result. Returns (result, true) on hit.
+func (c *ParseCache) Get(filePath string) (*FileParseResult, bool) {
+	r, ok := c.results[filePath]
+	return r, ok
+}
+
+// Len returns the number of entries in the cache.
+func (c *ParseCache) Len() int {
+	return len(c.results)
+}
+
+// ParseCacheAware is implemented by services that can accept a pre-populated
+// parse cache to avoid redundant file parsing.
+type ParseCacheAware interface {
+	SetParseCache(cache *ParseCache)
+}
+
+// ParseCachePopulatorConfig controls how PopulateParseCache works.
+type ParseCachePopulatorConfig struct {
+	BuildCFGs   bool // whether to also build CFGs for each file
+	Concurrency int  // 0 means runtime.GOMAXPROCS(0)
+}
+
+// PopulateParseCache parses all files in parallel and returns a sealed cache.
+// Each goroutine creates its own parser.Parser because tree-sitter is not
+// thread-safe.
+func PopulateParseCache(ctx context.Context, files []string, cfg ParseCachePopulatorConfig) *ParseCache {
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = runtime.GOMAXPROCS(0)
+	}
+
+	cache := NewParseCache()
+
+	type indexedResult struct {
+		path   string
+		result *FileParseResult
+	}
+
+	results := make([]indexedResult, len(files))
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, concurrency)
+
+	for i, filePath := range files {
+		wg.Add(1)
+		go func(idx int, fp string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			r := &FileParseResult{}
+
+			// Read file
+			content, err := os.ReadFile(fp)
+			if err != nil {
+				r.ParseErr = fmt.Errorf("failed to read file %s: %w", fp, err)
+				results[idx] = indexedResult{path: fp, result: r}
+				return
+			}
+			r.Content = content
+
+			// Parse — each goroutine gets its own parser (tree-sitter is not thread-safe)
+			p := parser.New()
+			parseResult, err := p.Parse(ctx, content)
+			if err != nil {
+				r.ParseErr = fmt.Errorf("parse error: %w", err)
+				results[idx] = indexedResult{path: fp, result: r}
+				return
+			}
+			r.ParseResult = parseResult
+
+			// Optionally build CFGs
+			if cfg.BuildCFGs && parseResult.AST != nil {
+				builder := analyzer.NewCFGBuilder()
+				cfgs, err := builder.BuildAll(parseResult.AST)
+				if err != nil {
+					r.CFGErr = fmt.Errorf("CFG construction failed: %w", err)
+				}
+				r.CFGs = cfgs
+			}
+
+			results[idx] = indexedResult{path: fp, result: r}
+		}(i, filePath)
+	}
+
+	wg.Wait()
+
+	// Populate cache from collected results (single-threaded, no lock needed)
+	for _, ir := range results {
+		if ir.result != nil {
+			cache.Put(ir.path, ir.result)
+		}
+	}
+	cache.Seal()
+
+	return cache
+}

--- a/service/parse_cache_test.go
+++ b/service/parse_cache_test.go
@@ -1,0 +1,210 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestNewParseCache(t *testing.T) {
+	cache := NewParseCache()
+	if cache == nil {
+		t.Fatal("NewParseCache returned nil")
+	}
+	if cache.Len() != 0 {
+		t.Fatalf("expected empty cache, got %d entries", cache.Len())
+	}
+}
+
+func TestParseCachePutAndGet(t *testing.T) {
+	cache := NewParseCache()
+
+	result := &FileParseResult{
+		Content: []byte("print('hello')"),
+	}
+	cache.Put("test.py", result)
+
+	got, ok := cache.Get("test.py")
+	if !ok {
+		t.Fatal("expected cache hit for test.py")
+	}
+	if string(got.Content) != "print('hello')" {
+		t.Fatalf("unexpected content: %s", got.Content)
+	}
+}
+
+func TestParseCacheGetMiss(t *testing.T) {
+	cache := NewParseCache()
+
+	_, ok := cache.Get("nonexistent.py")
+	if ok {
+		t.Fatal("expected cache miss for nonexistent.py")
+	}
+}
+
+func TestParseCacheSealPreventsWrite(t *testing.T) {
+	cache := NewParseCache()
+	cache.Put("a.py", &FileParseResult{Content: []byte("a")})
+	cache.Seal()
+
+	// Put after Seal should be a no-op
+	cache.Put("b.py", &FileParseResult{Content: []byte("b")})
+
+	_, ok := cache.Get("b.py")
+	if ok {
+		t.Fatal("expected Put after Seal to be ignored")
+	}
+	if cache.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", cache.Len())
+	}
+}
+
+func TestParseCacheSealedConcurrentReads(t *testing.T) {
+	cache := NewParseCache()
+	for i := 0; i < 100; i++ {
+		cache.Put(filepath.Join("dir", "file"+string(rune('0'+i%10))+".py"),
+			&FileParseResult{Content: []byte("content")})
+	}
+	cache.Seal()
+
+	var wg sync.WaitGroup
+	for i := 0; i < runtime.GOMAXPROCS(0)*2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				cache.Get(filepath.Join("dir", "file"+string(rune('0'+j%10))+".py"))
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestParseCacheLen(t *testing.T) {
+	cache := NewParseCache()
+	cache.Put("a.py", &FileParseResult{})
+	cache.Put("b.py", &FileParseResult{})
+	cache.Put("c.py", &FileParseResult{})
+
+	if cache.Len() != 3 {
+		t.Fatalf("expected 3 entries, got %d", cache.Len())
+	}
+}
+
+func TestPopulateParseCache(t *testing.T) {
+	// Use a real testdata file
+	testFile := filepath.Join("..", "testdata", "python", "simple", "functions.py")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("testdata file not found")
+	}
+
+	ctx := context.Background()
+	cache := PopulateParseCache(ctx, []string{testFile}, ParseCachePopulatorConfig{
+		BuildCFGs:   true,
+		Concurrency: 2,
+	})
+
+	if cache.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", cache.Len())
+	}
+
+	result, ok := cache.Get(testFile)
+	if !ok {
+		t.Fatal("expected cache hit for test file")
+	}
+	if result.ParseErr != nil {
+		t.Fatalf("unexpected parse error: %v", result.ParseErr)
+	}
+	if result.ParseResult == nil {
+		t.Fatal("expected non-nil ParseResult")
+	}
+	if result.ParseResult.AST == nil {
+		t.Fatal("expected non-nil AST")
+	}
+	if result.Content == nil {
+		t.Fatal("expected non-nil Content")
+	}
+	if result.CFGs == nil {
+		t.Fatal("expected non-nil CFGs when BuildCFGs=true")
+	}
+}
+
+func TestPopulateParseCacheWithoutCFGs(t *testing.T) {
+	testFile := filepath.Join("..", "testdata", "python", "simple", "functions.py")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("testdata file not found")
+	}
+
+	ctx := context.Background()
+	cache := PopulateParseCache(ctx, []string{testFile}, ParseCachePopulatorConfig{
+		BuildCFGs:   false,
+		Concurrency: 1,
+	})
+
+	result, ok := cache.Get(testFile)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if result.CFGs != nil {
+		t.Fatal("expected nil CFGs when BuildCFGs=false")
+	}
+}
+
+func TestPopulateParseCacheNonexistentFile(t *testing.T) {
+	ctx := context.Background()
+	cache := PopulateParseCache(ctx, []string{"/nonexistent/file.py"}, ParseCachePopulatorConfig{
+		BuildCFGs: false,
+	})
+
+	if cache.Len() != 1 {
+		t.Fatalf("expected 1 entry (with error), got %d", cache.Len())
+	}
+
+	result, ok := cache.Get("/nonexistent/file.py")
+	if !ok {
+		t.Fatal("expected cache entry for nonexistent file")
+	}
+	if result.ParseErr == nil {
+		t.Fatal("expected parse error for nonexistent file")
+	}
+}
+
+func TestPopulateParseCacheMultipleFiles(t *testing.T) {
+	files := []string{
+		filepath.Join("..", "testdata", "python", "simple", "functions.py"),
+		filepath.Join("..", "testdata", "python", "simple", "classes.py"),
+		filepath.Join("..", "testdata", "python", "simple", "control_flow.py"),
+	}
+
+	for _, f := range files {
+		if _, err := os.Stat(f); os.IsNotExist(err) {
+			t.Skipf("testdata file not found: %s", f)
+		}
+	}
+
+	ctx := context.Background()
+	cache := PopulateParseCache(ctx, files, ParseCachePopulatorConfig{
+		BuildCFGs:   true,
+		Concurrency: 2,
+	})
+
+	if cache.Len() != 3 {
+		t.Fatalf("expected 3 entries, got %d", cache.Len())
+	}
+
+	for _, f := range files {
+		result, ok := cache.Get(f)
+		if !ok {
+			t.Fatalf("expected cache hit for %s", f)
+		}
+		if result.ParseErr != nil {
+			t.Fatalf("unexpected parse error for %s: %v", f, result.ParseErr)
+		}
+		if result.ParseResult == nil {
+			t.Fatalf("expected non-nil ParseResult for %s", f)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `ParseCache` to eliminate redundant tree-sitter parsing during `pyscn analyze`
- Previously, 5 analysis services each parsed every file independently — the same file was parsed up to 5 times
- Now a pre-parse phase in `AnalyzeUseCase.Execute` parses all files once into a sealed, read-only cache before dispatching parallel analysis tasks
- Each service checks the cache first and falls back to self-parsing when invoked standalone (backward compatible)

### Key design decisions
- `ParseCache` is sealed after population — concurrent reads require no locks
- Each goroutine in `PopulateParseCache` creates its own `parser.Parser` since tree-sitter is not thread-safe
- CFGs are optionally pre-built when Complexity or DeadCode analysis is enabled
- Domain interfaces remain unchanged — `SetParseCache` lives on concrete types only, injected via type assertion through `ParseCacheAware` interface

### Files changed
- **New**: `service/parse_cache.go`, `service/parse_cache_test.go`
- **Modified**: 5 services (complexity, dead_code, cbo, lcom, clone), 5 use cases, `analyze_usecase.go`
