### PR TITLE
style(html): restyle output with professional data-first palette

### DIFF
--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -206,7 +206,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             line-height: 1.6;
             color: #333;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background-color: #f1f5f9;
             min-height: 100vh;
         }
         .container {
@@ -219,10 +219,10 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             border-radius: 10px;
             padding: 30px;
             margin-bottom: 20px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
         }
         .header h1 {
-            color: #667eea;
+            color: #0f172a;
             margin-bottom: 10px;
         }
         .score-badge {
@@ -233,17 +233,17 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             font-weight: bold;
             margin: 10px 0;
         }
-        .grade-a { background: #4caf50; color: white; }
-        .grade-b { background: #8bc34a; color: white; }
-        .grade-c { background: #ff9800; color: white; }
-        .grade-d { background: #ff5722; color: white; }
-        .grade-f { background: #f44336; color: white; }
-        
+        .grade-a { background: #14532d; color: white; }
+        .grade-b { background: #365314; color: white; }
+        .grade-c { background: #713f12; color: white; }
+        .grade-d { background: #7c2d12; color: white; }
+        .grade-f { background: #7f1d1d; color: white; }
+
         .tabs {
             background: white;
             border-radius: 10px;
             overflow: hidden;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
         }
         .tab-buttons {
             display: flex;
@@ -260,8 +260,9 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
         }
         .tab-button.active {
             background: white;
-            color: #667eea;
+            color: #334155;
             font-weight: bold;
+            border-bottom: 2px solid #334155;
         }
         .tab-content {
             display: none;
@@ -286,7 +287,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
         .metric-value {
             font-size: 32px;
             font-weight: bold;
-            color: #667eea;
+            color: #0f172a;
         }
         .metric-label {
             color: #666;
@@ -308,13 +309,13 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             font-weight: 600;
         }
         
-        .risk-low { color: #4caf50; }
-        .risk-medium { color: #ff9800; }
-        .risk-high { color: #f44336; }
-        
-        .severity-critical { color: #f44336; }
-        .severity-warning { color: #ff9800; }
-        .severity-info { color: #2196f3; }
+        .risk-low { color: #15803d; }
+        .risk-medium { color: #a16207; }
+        .risk-high { color: #b91c1c; }
+
+        .severity-critical { color: #b91c1c; }
+        .severity-warning { color: #a16207; }
+        .severity-info { color: #1e40af; }
 
         /* Score bars */
         .score-bars {
@@ -335,7 +336,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
         }
         .score-value {
             font-weight: 700;
-            color: #667eea;
+            color: #334155;
         }
         .score-bar-container {
             width: 100%;
@@ -350,10 +351,10 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             transition: width 0.3s ease;
             border-radius: 6px;
         }
-        .score-excellent { background: linear-gradient(90deg, #4caf50, #66bb6a); }
-        .score-good { background: linear-gradient(90deg, #8bc34a, #9ccc65); }
-        .score-fair { background: linear-gradient(90deg, #ff9800, #ffa726); }
-        .score-poor { background: linear-gradient(90deg, #f44336, #ef5350); }
+        .score-excellent { background: #15803d; }
+        .score-good { background: #4d7c0f; }
+        .score-fair { background: #a16207; }
+        .score-poor { background: #b91c1c; }
         .score-detail {
             margin-top: 4px;
             font-size: 12px;
@@ -380,20 +381,20 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             white-space: nowrap;
         }
         .score-badge-compact.score-excellent {
-            background: linear-gradient(135deg, #4caf50, #66bb6a);
-            box-shadow: 0 2px 6px rgba(76, 175, 80, 0.4);
+            background: #15803d;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.15);
         }
         .score-badge-compact.score-good {
-            background: linear-gradient(135deg, #8bc34a, #9ccc65);
-            box-shadow: 0 2px 6px rgba(139, 195, 74, 0.4);
+            background: #4d7c0f;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.15);
         }
         .score-badge-compact.score-fair {
-            background: linear-gradient(135deg, #ff9800, #ffa726);
-            box-shadow: 0 2px 6px rgba(255, 152, 0, 0.4);
+            background: #a16207;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.15);
         }
         .score-badge-compact.score-poor {
-            background: linear-gradient(135deg, #f44336, #ef5350);
-            box-shadow: 0 2px 6px rgba(244, 67, 54, 0.4);
+            background: #b91c1c;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.15);
         }
     </style>
 </head>
@@ -438,7 +439,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
             <div id="summary" class="tab-content active">
                 <h2>Analysis Summary</h2>
 
-                <h3 style="margin-top: 20px; margin-bottom: 16px; color: #2c3e50;">Quality Scores</h3>
+                <h3 style="margin-top: 20px; margin-bottom: 16px; color: #0f172a;">Quality Scores</h3>
                 <div class="score-bars">
                     {{if .Summary.ComplexityEnabled}}
                     <div class="score-bar-item">
@@ -532,7 +533,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                     {{end}}
                 </div>
 
-                <h3 style="margin-top: 24px; margin-bottom: 16px; color: #2c3e50;">File Statistics</h3>
+                <h3 style="margin-top: 24px; margin-bottom: 16px; color: #0f172a;">File Statistics</h3>
                 <div class="metric-grid">
                     <div class="metric-card">
                         <div class="metric-value">{{.Summary.TotalFiles}}</div>
@@ -591,7 +592,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 {{/* System-level quick glance */}}
                 {{if .System}}
                 {{if .System.DependencyAnalysis}}
-                <h3 style="margin-top: 16px; color: #2c3e50;">Dependencies</h3>
+                <h3 style="margin-top: 16px; color: #0f172a;">Dependencies</h3>
                 <div class="metric-grid">
                     <div class="metric-card">
                         <div class="metric-value">{{.System.DependencyAnalysis.TotalModules}}</div>
@@ -615,7 +616,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 {{end}}
 
                 {{if .System.ArchitectureAnalysis}}
-                <h3 style="margin-top: 8px; color: #2c3e50;">Architecture</h3>
+                <h3 style="margin-top: 8px; color: #0f172a;">Architecture</h3>
                 <div class="metric-grid">
                     <div class="metric-card">
                         <div class="metric-value">{{.System.ArchitectureAnalysis.TotalViolations}}</div>
@@ -752,7 +753,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 <p style="color: #666; margin-top: 10px;">Showing top 10 of {{.DeadCode.Summary.TotalFindings}} dead code issues</p>
                 {{end}}
                 {{else}}
-                <p style="color: #4caf50; font-weight: bold; margin-top: 20px;">✓ No dead code detected</p>
+                <p style="color: #15803d; font-weight: bold; margin-top: 20px;">✓ No dead code detected</p>
                 {{end}}
                 {{end}}
             </div>
@@ -787,7 +788,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 <p style="color: #666; margin-bottom: 15px;">Code fragments grouped by similarity</p>
                 {{range $i, $group := .Clone.CloneGroups}}
                 {{if lt $i 10}}
-                <div style="background: #f8f9fa; padding: 15px; margin-bottom: 15px; border-radius: 8px; border-left: 4px solid #667eea;">
+                <div style="background: #f8fafc; padding: 15px; margin-bottom: 15px; border-radius: 8px; border-left: 4px solid #cbd5e1;">
                     <h4 style="margin-top: 0; color: #333;">Group {{$group.ID}} - {{len $group.Clones}} clones (Type {{$group.Type}}, similarity: {{printf "%.2f" $group.Similarity}})</h4>
                     <table class="table" style="margin-bottom: 0;">
                         <thead>
@@ -853,7 +854,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 <p style="color: #666; margin-top: 10px;">Showing top 15 of {{.Clone.Statistics.TotalClonePairs}} clone pairs</p>
                 {{end}}
                 {{else}}
-                <p style="color: #4caf50; font-weight: bold; margin-top: 20px;">✓ No clones detected</p>
+                <p style="color: #15803d; font-weight: bold; margin-top: 20px;">✓ No clones detected</p>
                 {{end}}
                 {{end}}
             </div>
@@ -1018,9 +1019,9 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 {{if .System.DependencyAnalysis.CircularDependencies}}
                 <h3 style="margin-top: 30px;">Circular Dependencies</h3>
                 {{if not .System.DependencyAnalysis.CircularDependencies.HasCircularDependencies}}
-                <div style="padding: 20px; background: #d4edda; border-left: 4px solid #28a745; border-radius: 4px; margin: 20px 0;">
-                    <strong style="color: #155724;">✅ No circular dependencies detected</strong>
-                    <p style="color: #155724; margin: 10px 0 0 0;">All modules have acyclic dependency relationships.</p>
+                <div style="padding: 20px; background: #f0fdf4; border-left: 4px solid #bbf7d0; border-radius: 4px; margin: 20px 0;">
+                    <strong style="color: #14532d;">✅ No circular dependencies detected</strong>
+                    <p style="color: #14532d; margin: 10px 0 0 0;">All modules have acyclic dependency relationships.</p>
                 </div>
                 {{else}}
                 <table class="table">
@@ -1066,17 +1067,17 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
 
                 {{/* Core Infrastructure Modules */}}
                 {{if gt (len .System.DependencyAnalysis.CircularDependencies.CoreInfrastructure) 0}}
-                <div style="padding: 15px; background: #fff3cd; border-left: 4px solid #ffc107; border-radius: 4px; margin: 20px 0;">
-                    <strong style="color: #856404;">⚠️ Core Infrastructure Modules (appear in multiple cycles):</strong>
-                    <p style="color: #856404; margin: 10px 0 0 0;">{{join .System.DependencyAnalysis.CircularDependencies.CoreInfrastructure ", "}}</p>
+                <div style="padding: 15px; background: #fefce8; border-left: 4px solid #fde68a; border-radius: 4px; margin: 20px 0;">
+                    <strong style="color: #713f12;">⚠️ Core Infrastructure Modules (appear in multiple cycles):</strong>
+                    <p style="color: #713f12; margin: 10px 0 0 0;">{{join .System.DependencyAnalysis.CircularDependencies.CoreInfrastructure ", "}}</p>
                 </div>
                 {{end}}
 
                 {{/* Cycle Breaking Suggestions */}}
                 {{if gt (len .System.DependencyAnalysis.CircularDependencies.CycleBreakingSuggestions) 0}}
-                <div style="padding: 15px; background: #d1ecf1; border-left: 4px solid #17a2b8; border-radius: 4px; margin: 20px 0;">
-                    <strong style="color: #0c5460;">💡 Suggestions for Breaking Cycles:</strong>
-                    <ul style="margin: 10px 0 0 20px; color: #0c5460;">
+                <div style="padding: 15px; background: #eff6ff; border-left: 4px solid #bfdbfe; border-radius: 4px; margin: 20px 0;">
+                    <strong style="color: #1e3a8a;">💡 Suggestions for Breaking Cycles:</strong>
+                    <ul style="margin: 10px 0 0 20px; color: #1e3a8a;">
                         {{range .System.DependencyAnalysis.CircularDependencies.CycleBreakingSuggestions}}
                         <li>{{.}}</li>
                         {{end}}
@@ -1164,7 +1165,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                     </tbody>
                 </table>
                 {{else}}
-                <p style="color: #4caf50; font-weight: bold; margin-top: 20px;">✓ No architecture violations</p>
+                <p style="color: #15803d; font-weight: bold; margin-top: 20px;">✓ No architecture violations</p>
                 {{end}}
             </div>
             {{end}}

--- a/service/html_formatter.go
+++ b/service/html_formatter.go
@@ -64,7 +64,7 @@ func (f *HTMLFormatterImpl) CalculateComplexityScore(response *domain.Complexity
 		return ScoreData{
 			Score:    100,
 			Label:    "No Functions",
-			Color:    "#0CCE6B",
+			Color:    "#15803d",
 			Status:   "pass",
 			Category: "complexity",
 		}
@@ -81,13 +81,13 @@ func (f *HTMLFormatterImpl) CalculateComplexityScore(response *domain.Complexity
 	var color, status string
 	switch {
 	case score >= 90:
-		color = "#0CCE6B" // Green
+		color = "#15803d" // Green
 		status = "pass"
 	case score >= 50:
-		color = "#FFA500" // Orange
+		color = "#a16207" // Orange
 		status = "average"
 	default:
-		color = "#FF5722" // Red
+		color = "#b91c1c" // Red
 		status = "fail"
 	}
 
@@ -106,7 +106,7 @@ func (f *HTMLFormatterImpl) CalculateDeadCodeScore(response *domain.DeadCodeResp
 		return ScoreData{
 			Score:    100,
 			Label:    "No Code Blocks",
-			Color:    "#0CCE6B",
+			Color:    "#15803d",
 			Status:   "pass",
 			Category: "dead_code",
 		}
@@ -119,13 +119,13 @@ func (f *HTMLFormatterImpl) CalculateDeadCodeScore(response *domain.DeadCodeResp
 	var color, status string
 	switch {
 	case score >= 90:
-		color = "#0CCE6B" // Green
+		color = "#15803d" // Green
 		status = "pass"
 	case score >= 50:
-		color = "#FFA500" // Orange
+		color = "#a16207" // Orange
 		status = "average"
 	default:
-		color = "#FF5722" // Red
+		color = "#b91c1c" // Red
 		status = "fail"
 	}
 
@@ -144,7 +144,7 @@ func (f *HTMLFormatterImpl) CalculateCloneScore(response *domain.CloneResponse) 
 		return ScoreData{
 			Score:    100,
 			Label:    "No Lines Analyzed",
-			Color:    "#0CCE6B",
+			Color:    "#15803d",
 			Status:   "pass",
 			Category: "clone",
 		}
@@ -171,13 +171,13 @@ func (f *HTMLFormatterImpl) CalculateCloneScore(response *domain.CloneResponse) 
 	var color, status string
 	switch {
 	case score >= 90:
-		color = "#0CCE6B" // Green
+		color = "#15803d" // Green
 		status = "pass"
 	case score >= 50:
-		color = "#FFA500" // Orange
+		color = "#a16207" // Orange
 		status = "average"
 	default:
-		color = "#FF5722" // Red
+		color = "#b91c1c" // Red
 		status = "fail"
 	}
 
@@ -195,7 +195,7 @@ func (f *HTMLFormatterImpl) CalculateOverallScore(scores []ScoreData, projectNam
 	if len(scores) == 0 {
 		return OverallScoreData{
 			Score:       100,
-			Color:       "#0CCE6B",
+			Color:       "#15803d",
 			Status:      "pass",
 			Breakdown:   []ScoreData{},
 			ProjectName: projectName,
@@ -229,13 +229,13 @@ func (f *HTMLFormatterImpl) CalculateOverallScore(scores []ScoreData, projectNam
 	var color, status string
 	switch {
 	case overallScore >= 90:
-		color = "#0CCE6B" // Green
+		color = "#15803d" // Green
 		status = "pass"
 	case overallScore >= 50:
-		color = "#FFA500" // Orange
+		color = "#a16207" // Orange
 		status = "average"
 	default:
-		color = "#FF5722" // Red
+		color = "#b91c1c" // Red
 		status = "fail"
 	}
 
@@ -268,7 +268,7 @@ func (f *HTMLFormatterImpl) getHTMLTemplate() string {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             line-height: 1.6;
             color: #333;
-            background-color: #f5f5f5;
+            background-color: #f1f5f9;
         }
         
         .container {
@@ -397,9 +397,9 @@ func (f *HTMLFormatterImpl) getHTMLTemplate() string {
             transition: width 0.3s ease;
         }
         
-        .risk-high { background-color: #FF5722; }
-        .risk-medium { background-color: #FFA500; }
-        .risk-low { background-color: #0CCE6B; }
+        .risk-high { background-color: #b91c1c; }
+        .risk-medium { background-color: #a16207; }
+        .risk-low { background-color: #15803d; }
         
         @media (max-width: 768px) {
             .score-section {

--- a/service/html_template.go
+++ b/service/html_template.go
@@ -40,7 +40,7 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
             line-height: 1.6;
             color: #333;
-            background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%);
+            background-color: #f1f5f9;
             min-height: 100vh;
         }
         .container {
@@ -53,10 +53,10 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             border-radius: 10px;
             padding: 30px;
             margin-bottom: 20px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
         }
         .header h1 {
-            color: #667eea;
+            color: #0f172a;
             margin-bottom: 10px;
         }
         .header p {
@@ -71,17 +71,17 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             font-weight: bold;
             margin: 10px 0;
         }
-        .grade-a { background: #4caf50; color: white; }
-        .grade-b { background: #8bc34a; color: white; }
-        .grade-c { background: #ff9800; color: white; }
-        .grade-d { background: #ff5722; color: white; }
-        .grade-f { background: #f44336; color: white; }
-        
+        .grade-a { background: #14532d; color: white; }
+        .grade-b { background: #365314; color: white; }
+        .grade-c { background: #713f12; color: white; }
+        .grade-d { background: #7c2d12; color: white; }
+        .grade-f { background: #7f1d1d; color: white; }
+
         .tabs {
             background: white;
             border-radius: 10px;
             overflow: hidden;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
         }
         .tab-buttons {
             display: flex;
@@ -101,8 +101,9 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
         }
         .tab-button.active {
             background: white;
-            color: #667eea;
+            color: #334155;
             font-weight: bold;
+            border-bottom: 2px solid #334155;
         }
         .tab-content {
             display: none;
@@ -117,7 +118,7 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             background: white;
             border-radius: 10px;
             padding: 30px;
-            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
         }
         
         .metric-grid {
@@ -127,16 +128,16 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             margin: 20px 0;
         }
         .metric-card {
-            background: #f8f9fa;
+            background: #f8fafc;
             padding: 20px;
             border-radius: 8px;
             text-align: center;
-            border-left: 4px solid #667eea;
+            border-left: 4px solid #cbd5e1;
         }
         .metric-value {
             font-size: 32px;
             font-weight: bold;
-            color: #667eea;
+            color: #0f172a;
         }
         .metric-label {
             color: #666;
@@ -160,11 +161,12 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             margin: 20px 0;
         }
         .table th {
-            background: #667eea;
-            color: white;
+            background: #f1f5f9;
+            color: #334155;
             padding: 12px;
             text-align: left;
             font-weight: 600;
+            border-bottom: 2px solid #e2e8f0;
         }
         .table td {
             padding: 12px;
@@ -190,7 +192,7 @@ func (t *HTMLTemplate) GenerateHTMLHeader() string {
             margin-top: 40px;
             padding: 20px;
             text-align: center;
-            color: white;
+            color: #94a3b8;
             font-size: 14px;
         }
         


### PR DESCRIPTION
## Summary

- Replace gradient purple body background with flat `#f1f5f9` — removes the "AI vibe-coding" aesthetic
- Reserve color exclusively for data signals (scores, risk levels, pass/fail); all structural chrome is now neutral slate/gray
- Consistent with how tools like GitHub, SonarQube, Linear, and Stripe dashboards look

## Changes

**Chrome / structural elements (now near-colorless)**
- Body: gradient removed → flat `#f1f5f9`
- Box shadows: heavy `10px` → subtle `1px`
- H1 and structural headings: `#667eea` → `#0f172a` (dark charcoal)
- Table `<th>`: colored fill → `#f1f5f9` bg + `#334155` text
- Metric card left border: `#667eea` → `#cbd5e1` (neutral gray)
- Metric value numbers: `#667eea` → `#0f172a`
- Active tab: color text → bottom-border underline (`#334155`)
- Footer: `white` → `#94a3b8` (muted gray)

**Data / semantic elements (muted, appropriate color)**
- Grade badges: vivid greens/reds → muted spectrum (`#14532d` → `#7f1d1d`)
- Score bars: vivid gradients → flat muted single colors
- Score badge compact: gradient + colored glow → flat + neutral shadow
- Risk/severity classes: vivid → muted (`#15803d` / `#a16207` / `#b91c1c`)
- `ScoreData.Color` constants: `#0CCE6B` → `#15803d`, `#FFA500` → `#a16207`, `#FF5722` → `#b91c1c`
- Info boxes (circular deps, suggestions, warnings): updated to muted tonal palettes

## Files modified

- `service/html_template.go` — shared header CSS
- `service/analyze_formatter.go` — unified report template
- `service/html_formatter.go` — Lighthouse-style score template + score color constants

## Test plan

- [x] `go build ./...` passes with no errors
- [ ] Open generated HTML report and verify: flat gray background, dark headings, gray table headers, muted score colors, no purple anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)