### PR TITLE
fix: add missing IsAbstract and Description fields to TOML layer/rule types

### DIFF
--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -411,6 +411,7 @@ func mergeArchitectureSection(defaults *PyscnConfig, arch *ArchitectureTomlConfi
 				Name:        l.Name,
 				Description: l.Description,
 				Packages:    l.Packages,
+				IsAbstract:  l.IsAbstract,
 			}
 		}
 		defaults.ArchitectureLayers = layers
@@ -418,11 +419,7 @@ func mergeArchitectureSection(defaults *PyscnConfig, arch *ArchitectureTomlConfi
 	if len(arch.Rules) > 0 {
 		rules := make([]LayerRule, len(arch.Rules))
 		for i, r := range arch.Rules {
-			rules[i] = LayerRule{
-				From:  r.From,
-				Allow: r.Allow,
-				Deny:  r.Deny,
-			}
+			rules[i] = LayerRule(r)
 		}
 		defaults.ArchitectureRules = rules
 	}

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -111,13 +111,15 @@ type LayerDefinitionToml struct {
 	Name        string   `toml:"name"`
 	Description string   `toml:"description"`
 	Packages    []string `toml:"packages"`
+	IsAbstract  bool     `toml:"is_abstract"`
 }
 
 // LayerRuleToml represents a layer rule in TOML
 type LayerRuleToml struct {
-	From  string   `toml:"from"`
-	Allow []string `toml:"allow"`
-	Deny  []string `toml:"deny"`
+	From        string   `toml:"from"`
+	Allow       []string `toml:"allow"`
+	Deny        []string `toml:"deny"`
+	Description string   `toml:"description"`
 }
 
 // SystemAnalysisTomlConfig represents the [system_analysis] section


### PR DESCRIPTION
## Summary
- Add `IsAbstract` field to `LayerDefinitionToml` and wire it through `mergeArchitectureSection`
- Add `Description` field to `LayerRuleToml` and wire it through `mergeArchitectureSection`
- Simplify rule conversion to direct type cast since structs now match

Closes #358

## Test plan
- [x] `make test` — all tests pass
- [x] `make lint` — no lint issues