### PR TITLE
test: add architecture layer integration tests for #352

### DIFF
--- a/integration/architecture_integration_test.go
+++ b/integration/architecture_integration_test.go
@@ -1,0 +1,161 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/app"
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fastapiLayersDir = "../testdata/python/fastapi_layers"
+
+func newArchitectureUseCase() *app.SystemAnalysisUseCase {
+	return app.NewSystemAnalysisUseCase(
+		service.NewSystemAnalysisService(),
+		service.NewFileReader(),
+		service.NewSystemAnalysisFormatter(),
+		service.NewSystemAnalysisConfigurationLoader(),
+	)
+}
+
+func analyzeArchitecture(t *testing.T, dir string) *domain.ArchitectureAnalysisResult {
+	t.Helper()
+	uc := newArchitectureUseCase()
+	var buf bytes.Buffer
+	result, err := uc.AnalyzeArchitectureOnly(context.Background(), domain.SystemAnalysisRequest{
+		Paths:        []string{dir},
+		ConfigPath:   dir,
+		OutputFormat: domain.OutputFormatJSON,
+		OutputWriter: &buf,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+// TestArchitecture_TOMLConfigLoading verifies that layers and rules defined in
+// .pyscn.toml are correctly parsed and propagated to the analysis request.
+// Regression test for PR #356 (TOML layers/rules silently ignored).
+func TestArchitecture_TOMLConfigLoading(t *testing.T) {
+	configLoader := service.NewSystemAnalysisConfigurationLoader()
+	cfg, err := configLoader.LoadConfig(fastapiLayersDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.ArchitectureRules)
+
+	// Verify layers
+	require.Len(t, cfg.ArchitectureRules.Layers, 3)
+
+	layersByName := make(map[string]domain.Layer)
+	for _, l := range cfg.ArchitectureRules.Layers {
+		layersByName[l.Name] = l
+	}
+
+	presentation := layersByName["presentation"]
+	assert.ElementsMatch(t, []string{"routers", "pages"}, presentation.Packages)
+
+	domainLayer := layersByName["domain"]
+	assert.ElementsMatch(t, []string{"domain"}, domainLayer.Packages)
+
+	infra := layersByName["infrastructure"]
+	assert.ElementsMatch(t, []string{"repositories"}, infra.Packages)
+
+	// Verify rules
+	require.Len(t, cfg.ArchitectureRules.Rules, 3)
+
+	rulesByFrom := make(map[string]domain.LayerRule)
+	for _, r := range cfg.ArchitectureRules.Rules {
+		rulesByFrom[r.From] = r
+	}
+
+	assert.ElementsMatch(t, []string{"presentation", "domain", "infrastructure"},
+		rulesByFrom["presentation"].Allow)
+	assert.ElementsMatch(t, []string{"domain"},
+		rulesByFrom["domain"].Allow)
+	assert.ElementsMatch(t, []string{"infrastructure", "domain"},
+		rulesByFrom["infrastructure"].Allow)
+}
+
+// TestArchitecture_LayerClassificationAndCoupling verifies that modules are
+// assigned to the correct layers and the dependency directions are as expected.
+// Regression test for discussion #352 (routers misclassified as "domain").
+func TestArchitecture_LayerClassificationAndCoupling(t *testing.T) {
+	result := analyzeArchitecture(t, fastapiLayersDir)
+	require.NotNil(t, result.LayerAnalysis)
+
+	coupling := result.LayerAnalysis.LayerCoupling
+
+	// presentation -> domain: routers and pages import domain models
+	require.Contains(t, coupling, "presentation")
+	assert.Contains(t, coupling["presentation"], "domain")
+
+	// presentation -> infrastructure: item_router imports item_repo
+	assert.Contains(t, coupling["presentation"], "infrastructure")
+
+	// infrastructure -> domain: repos import domain models
+	require.Contains(t, coupling, "infrastructure")
+	assert.Contains(t, coupling["infrastructure"], "domain")
+
+	// domain must NOT have cross-layer outgoing dependencies to presentation
+	// (except for the intentional violation fixture in domain/services/)
+	// The violation fixture adds domain -> presentation, so we check that
+	// it IS detected rather than asserting it doesn't exist.
+	if domainDeps, ok := coupling["domain"]; ok {
+		if _, hasPresentationDep := domainDeps["presentation"]; hasPresentationDep {
+			// This is expected due to domain/services/user_service.py importing pages
+			t.Logf("domain -> presentation coupling detected (expected from violation fixture)")
+		}
+	}
+}
+
+// TestArchitecture_ViolationDetection verifies that a domain -> presentation
+// dependency is flagged as a violation. The fixture domain/services/user_service.py
+// intentionally imports from the presentation layer.
+func TestArchitecture_ViolationDetection(t *testing.T) {
+	result := analyzeArchitecture(t, fastapiLayersDir)
+	require.NotNil(t, result.LayerAnalysis)
+
+	// There must be at least one violation: domain -> presentation
+	assert.Greater(t, result.TotalViolations, 0,
+		"should detect domain -> presentation violation")
+	assert.Less(t, result.ComplianceScore, 1.0,
+		"compliance should be less than 100%% with violations")
+
+	// Find the specific domain -> presentation violation
+	var found bool
+	for _, v := range result.LayerAnalysis.LayerViolations {
+		if v.FromLayer == "domain" && v.ToLayer == "presentation" {
+			found = true
+			assert.Contains(t, v.FromModule, "user_service",
+				"violation should originate from domain/services/user_service")
+			t.Logf("violation detected: %s (%s) -> %s (%s)", v.FromModule, v.FromLayer, v.ToModule, v.ToLayer)
+			break
+		}
+	}
+	assert.True(t, found, "should find a domain -> presentation layer violation")
+}
+
+// TestArchitecture_AllowedDepsNotFlagged verifies that dependencies permitted by
+// the rules (presentation -> domain, presentation -> infrastructure,
+// infrastructure -> domain) are NOT flagged as violations.
+func TestArchitecture_AllowedDepsNotFlagged(t *testing.T) {
+	result := analyzeArchitecture(t, fastapiLayersDir)
+	require.NotNil(t, result.LayerAnalysis)
+
+	for _, v := range result.LayerAnalysis.LayerViolations {
+		// presentation -> anything is allowed per config
+		if v.FromLayer == "presentation" {
+			t.Errorf("unexpected violation from presentation: %s (%s) -> %s (%s)",
+				v.FromModule, v.FromLayer, v.ToModule, v.ToLayer)
+		}
+		// infrastructure -> domain is allowed per config
+		if v.FromLayer == "infrastructure" && v.ToLayer == "domain" {
+			t.Errorf("unexpected violation: infrastructure -> domain: %s -> %s",
+				v.FromModule, v.ToModule)
+		}
+	}
+}

--- a/testdata/python/fastapi_layers/.pyscn.toml
+++ b/testdata/python/fastapi_layers/.pyscn.toml
@@ -1,0 +1,41 @@
+# Configuration for FastAPI layer classification test case
+# Reproduces the scenario from discussion #352:
+# - "routers" and "pages" should be classified as "presentation"
+# - "domain" should be classified as "domain"
+# - "repositories" should be classified as "infrastructure"
+#
+# Without this config, pyscn would misclassify "routers" as "domain"
+# because the default heuristic doesn't know about custom package names.
+
+[architecture]
+enabled = true
+
+[[architecture.layers]]
+name = "presentation"
+description = "HTTP routers and page renderers"
+packages = ["routers", "pages"]
+
+[[architecture.layers]]
+name = "domain"
+description = "Core business entities"
+packages = ["domain"]
+
+[[architecture.layers]]
+name = "infrastructure"
+description = "Data access and external services"
+packages = ["repositories"]
+
+# Presentation can depend on domain and infrastructure
+[[architecture.rules]]
+from = "presentation"
+allow = ["presentation", "domain", "infrastructure"]
+
+# Domain must not depend on presentation or infrastructure
+[[architecture.rules]]
+from = "domain"
+allow = ["domain"]
+
+# Infrastructure can depend on domain only
+[[architecture.rules]]
+from = "infrastructure"
+allow = ["infrastructure", "domain"]

--- a/testdata/python/fastapi_layers/app/__init__.py
+++ b/testdata/python/fastapi_layers/app/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application root package."""

--- a/testdata/python/fastapi_layers/app/domain/__init__.py
+++ b/testdata/python/fastapi_layers/app/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain package - core business logic."""

--- a/testdata/python/fastapi_layers/app/domain/item_model.py
+++ b/testdata/python/fastapi_layers/app/domain/item_model.py
@@ -1,0 +1,11 @@
+"""Item domain model."""
+
+
+class Item:
+    """Core item entity."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def validate(self):
+        return len(self.name) > 0

--- a/testdata/python/fastapi_layers/app/domain/services/__init__.py
+++ b/testdata/python/fastapi_layers/app/domain/services/__init__.py
@@ -1,0 +1,1 @@
+"""Domain services package."""

--- a/testdata/python/fastapi_layers/app/domain/services/user_service.py
+++ b/testdata/python/fastapi_layers/app/domain/services/user_service.py
@@ -1,0 +1,16 @@
+"""User service - domain layer module that violates architecture rules.
+
+This module intentionally imports from the presentation layer (pages),
+which is forbidden by the architecture rules (domain can only depend on domain).
+"""
+
+from app.pages import user_page
+from app.domain import user_model
+
+
+class UserService:
+    """Domain service with an architecture violation."""
+
+    def get_user_view(self, user_id: int):
+        user = user_model.User(user_id, "test")
+        return user_page.render_user_profile(user)

--- a/testdata/python/fastapi_layers/app/domain/user_model.py
+++ b/testdata/python/fastapi_layers/app/domain/user_model.py
@@ -1,0 +1,12 @@
+"""User domain model."""
+
+
+class User:
+    """Core user entity."""
+
+    def __init__(self, user_id: int, name: str):
+        self.user_id = user_id
+        self.name = name
+
+    def is_active(self):
+        return self.name != ""

--- a/testdata/python/fastapi_layers/app/pages/__init__.py
+++ b/testdata/python/fastapi_layers/app/pages/__init__.py
@@ -1,0 +1,1 @@
+"""Pages package - presentation layer (templates/views)."""

--- a/testdata/python/fastapi_layers/app/pages/user_page.py
+++ b/testdata/python/fastapi_layers/app/pages/user_page.py
@@ -1,0 +1,13 @@
+"""User page - renders user-related views."""
+
+from app.domain import user_model
+
+
+def render_user_profile(user):
+    """Render user profile page."""
+    return {"template": "user_profile.html", "context": {"user": user}}
+
+
+def render_user_list(users: list):
+    """Render user list page."""
+    return {"template": "user_list.html", "context": {"users": users}}

--- a/testdata/python/fastapi_layers/app/repositories/__init__.py
+++ b/testdata/python/fastapi_layers/app/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Repositories package - infrastructure/data access layer."""

--- a/testdata/python/fastapi_layers/app/repositories/item_repo.py
+++ b/testdata/python/fastapi_layers/app/repositories/item_repo.py
@@ -1,0 +1,17 @@
+"""Item repository - data access for items."""
+
+from app.domain import item_model
+
+
+class ItemRepository:
+    """Handles item persistence."""
+
+    def __init__(self):
+        self._store = {}
+
+    def find_by_id(self, item_id: int):
+        return self._store.get(item_id)
+
+    def save(self, item):
+        self._store[id(item)] = item
+        return item

--- a/testdata/python/fastapi_layers/app/repositories/user_repo.py
+++ b/testdata/python/fastapi_layers/app/repositories/user_repo.py
@@ -1,0 +1,17 @@
+"""User repository - data access for users."""
+
+from app.domain import user_model
+
+
+class UserRepository:
+    """Handles user persistence."""
+
+    def __init__(self):
+        self._store = {}
+
+    def find_by_id(self, user_id: int):
+        return self._store.get(user_id)
+
+    def save(self, user):
+        self._store[user.user_id] = user
+        return user

--- a/testdata/python/fastapi_layers/app/routers/__init__.py
+++ b/testdata/python/fastapi_layers/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""Router package - presentation layer."""

--- a/testdata/python/fastapi_layers/app/routers/item_router.py
+++ b/testdata/python/fastapi_layers/app/routers/item_router.py
@@ -1,0 +1,18 @@
+"""Item router - handles HTTP endpoints for item operations."""
+
+from app.domain import item_model
+from app.repositories import item_repo
+
+
+class ItemRouter:
+    """Routes item-related HTTP requests."""
+
+    def __init__(self):
+        self.repo = item_repo.ItemRepository()
+
+    def get_item(self, item_id: int):
+        return self.repo.find_by_id(item_id)
+
+    def create_item(self, name: str):
+        item = item_model.Item(name)
+        return self.repo.save(item)

--- a/testdata/python/fastapi_layers/app/routers/user_router.py
+++ b/testdata/python/fastapi_layers/app/routers/user_router.py
@@ -1,0 +1,15 @@
+"""User router - handles HTTP endpoints for user operations."""
+
+from app.domain import user_model
+from app.pages import user_page
+
+
+class UserRouter:
+    """Routes user-related HTTP requests."""
+
+    def get_user(self, user_id: int):
+        user = user_model.User(user_id, "test")
+        return user_page.render_user_profile(user)
+
+    def list_users(self):
+        return {"users": []}

--- a/testdata/python/fastapi_layers/pyproject.toml
+++ b/testdata/python/fastapi_layers/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "fastapi-layers-test"
+version = "0.1.0"


### PR DESCRIPTION
## Summary
- Add integration tests and FastAPI-like test fixtures to verify TOML-based architecture layer configuration works end-to-end
- Regression tests for the bugs fixed across PRs #356, #359, #354, #360, #361, #362 (all related to discussion #352)
- Includes both positive tests (allowed deps not flagged) and negative tests (violations detected)

## Test fixtures

`testdata/python/fastapi_layers/` — FastAPI app structure reproducing the discussion #352 scenario:
- `app/routers/`, `app/pages/` → configured as **presentation** layer
- `app/domain/` → **domain** layer
- `app/repositories/` → **infrastructure** layer
- `app/domain/services/user_service.py` → intentional **domain → presentation violation**

## Test coverage

| Test | Verifies | Regression for |
|---|---|---|
| `TOMLConfigLoading` | layers/rules parsed from .pyscn.toml | PR #356 |
| `LayerClassificationAndCoupling` | modules assigned to correct layers | #352, PR #354/#360/#361 |
| `ViolationDetection` | domain→presentation violation detected | PR #359 |
| `AllowedDepsNotFlagged` | permitted deps not flagged | Rule evaluation correctness |

## Test plan
- [x] `go test -v -run TestArchitecture ./integration/` — all 4 tests pass
- [x] `go test ./integration/` — no regressions in existing integration tests