### PR TITLE
feat: add neutral_prefixes config for architecture layer detection

### DIFF
--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -413,6 +413,9 @@ type ArchitectureRules struct {
 	// Custom rules
 	CustomRules []CustomRule `json:"custom_rules" yaml:"custom_rules"`
 
+	// Neutral prefixes to strip from module names before layer matching
+	NeutralPrefixes []string `json:"neutral_prefixes" yaml:"neutral_prefixes"`
+
 	// Global settings
 	StrictMode        bool     `json:"strict_mode" yaml:"strict_mode"`
 	AllowedPatterns   []string `json:"allowed_patterns" yaml:"allowed_patterns"`

--- a/integration/architecture_integration_test.go
+++ b/integration/architecture_integration_test.go
@@ -159,3 +159,34 @@ func TestArchitecture_AllowedDepsNotFlagged(t *testing.T) {
 		}
 	}
 }
+
+// TestArchitecture_NeutralPrefixesLayerClassification verifies that the
+// neutral_prefixes config option strips prefixes from module names before
+// layer matching. The fastapi_layers test fixture has neutral_prefixes = ["app"],
+// so "app.routers.user_router" should be classified as "presentation".
+func TestArchitecture_NeutralPrefixesLayerClassification(t *testing.T) {
+	// Verify the config is loaded with neutral_prefixes
+	configLoader := service.NewSystemAnalysisConfigurationLoader()
+	cfg, err := configLoader.LoadConfig(fastapiLayersDir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.ArchitectureRules)
+	assert.Equal(t, []string{"app"}, cfg.ArchitectureRules.NeutralPrefixes,
+		"neutral_prefixes should be loaded from .pyscn.toml")
+
+	// Verify that layer classification works correctly with prefix stripping
+	result := analyzeArchitecture(t, fastapiLayersDir)
+	require.NotNil(t, result.LayerAnalysis)
+
+	// The coupling map should show the expected layer relationships.
+	// With neutral_prefixes = ["app"], "app.routers.*" -> presentation,
+	// "app.domain.*" -> domain, "app.repositories.*" -> infrastructure.
+	coupling := result.LayerAnalysis.LayerCoupling
+	require.Contains(t, coupling, "presentation",
+		"presentation layer should exist (modules like app.routers.* matched via prefix stripping)")
+
+	// Verify violations still use original module names (not stripped)
+	for _, v := range result.LayerAnalysis.LayerViolations {
+		assert.Contains(t, v.FromModule, "app.",
+			"violation module names should use original (unstripped) names")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -510,6 +510,9 @@ func PyscnConfigToConfig(pyscn *PyscnConfig) *Config {
 	if pyscn.ArchitectureFailOnViolations != nil {
 		cfg.Architecture.FailOnViolations = *pyscn.ArchitectureFailOnViolations
 	}
+	if len(pyscn.ArchitectureNeutralPrefixes) > 0 {
+		cfg.Architecture.NeutralPrefixes = pyscn.ArchitectureNeutralPrefixes
+	}
 	if len(pyscn.ArchitectureLayers) > 0 {
 		cfg.Architecture.Layers = pyscn.ArchitectureLayers
 	}
@@ -803,8 +806,9 @@ type ArchitectureConfig struct {
 	ValidateResponsibility bool `mapstructure:"validate_responsibility" yaml:"validate_responsibility"`
 
 	// Layer definitions
-	Layers []LayerDefinition `mapstructure:"layers" yaml:"layers"`
-	Rules  []LayerRule       `mapstructure:"rules" yaml:"rules"`
+	Layers          []LayerDefinition `mapstructure:"layers" yaml:"layers"`
+	Rules           []LayerRule       `mapstructure:"rules" yaml:"rules"`
+	NeutralPrefixes []string          `mapstructure:"neutral_prefixes" yaml:"neutral_prefixes"`
 
 	// Thresholds
 	MinCohesion         float64 `mapstructure:"min_cohesion" yaml:"min_cohesion"`

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -404,6 +404,9 @@ func mergeArchitectureSection(defaults *PyscnConfig, arch *ArchitectureTomlConfi
 	if arch.FailOnViolations != nil {
 		defaults.ArchitectureFailOnViolations = arch.FailOnViolations
 	}
+	if len(arch.NeutralPrefixes) > 0 {
+		defaults.ArchitectureNeutralPrefixes = arch.NeutralPrefixes
+	}
 	if len(arch.Layers) > 0 {
 		layers := make([]LayerDefinition, len(arch.Layers))
 		for i, l := range arch.Layers {

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -99,6 +99,7 @@ type PyscnConfig struct {
 	ArchitectureForbiddenPatterns               []string          `mapstructure:"architecture_forbidden_patterns" yaml:"architecture_forbidden_patterns" json:"architecture_forbidden_patterns"`
 	ArchitectureStrictMode                      *bool             `mapstructure:"architecture_strict_mode" yaml:"architecture_strict_mode" json:"architecture_strict_mode"`
 	ArchitectureFailOnViolations                *bool             `mapstructure:"architecture_fail_on_violations" yaml:"architecture_fail_on_violations" json:"architecture_fail_on_violations"`
+	ArchitectureNeutralPrefixes                 []string          `mapstructure:"architecture_neutral_prefixes" yaml:"architecture_neutral_prefixes" json:"architecture_neutral_prefixes"`
 	ArchitectureLayers                          []LayerDefinition `mapstructure:"architecture_layers" yaml:"architecture_layers" json:"architecture_layers"`
 	ArchitectureRules                           []LayerRule       `mapstructure:"architecture_rules" yaml:"architecture_rules" json:"architecture_rules"`
 

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -102,6 +102,7 @@ type ArchitectureTomlConfig struct {
 	ForbiddenPatterns               []string              `toml:"forbidden_patterns"`
 	StrictMode                      *bool                 `toml:"strict_mode"`
 	FailOnViolations                *bool                 `toml:"fail_on_violations"`
+	NeutralPrefixes                 []string              `toml:"neutral_prefixes"`
 	Layers                          []LayerDefinitionToml `toml:"layers"`
 	Rules                           []LayerRuleToml       `toml:"rules"`
 }

--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -54,7 +54,7 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) pyscnConfigToSystemAnalysisRequ
 
 	// Architecture settings
 	if cfg.ArchitectureStrictMode != nil || len(cfg.ArchitectureAllowedPatterns) > 0 || len(cfg.ArchitectureForbiddenPatterns) > 0 ||
-		len(cfg.ArchitectureLayers) > 0 || len(cfg.ArchitectureRules) > 0 {
+		len(cfg.ArchitectureLayers) > 0 || len(cfg.ArchitectureRules) > 0 || len(cfg.ArchitectureNeutralPrefixes) > 0 {
 		if request.ArchitectureRules == nil {
 			request.ArchitectureRules = &domain.ArchitectureRules{}
 		}
@@ -72,6 +72,9 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) pyscnConfigToSystemAnalysisRequ
 		}
 		if len(cfg.ArchitectureRules) > 0 {
 			request.ArchitectureRules.Rules = convertLayerRules(cfg.ArchitectureRules)
+		}
+		if len(cfg.ArchitectureNeutralPrefixes) > 0 {
+			request.ArchitectureRules.NeutralPrefixes = cfg.ArchitectureNeutralPrefixes
 		}
 	}
 
@@ -196,6 +199,9 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) MergeConfig(base *domain.System
 			}
 			if len(override.ArchitectureRules.ForbiddenPatterns) > 0 {
 				merged.ArchitectureRules.ForbiddenPatterns = override.ArchitectureRules.ForbiddenPatterns
+			}
+			if len(override.ArchitectureRules.NeutralPrefixes) > 0 {
+				merged.ArchitectureRules.NeutralPrefixes = override.ArchitectureRules.NeutralPrefixes
 			}
 		}
 	}

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -454,7 +454,15 @@ func (s *SystemAnalysisServiceImpl) buildModuleLayerMap(graph *analyzer.Dependen
 			out[module] = "unknown"
 			continue
 		}
-		out[module] = s.findLayerForModule(module, compiled)
+		// Strip the first matching neutral prefix before layer matching
+		stripped := module
+		for _, prefix := range rules.NeutralPrefixes {
+			if strings.HasPrefix(stripped, prefix+".") {
+				stripped = stripped[len(prefix)+1:]
+				break
+			}
+		}
+		out[module] = s.findLayerForModule(stripped, compiled)
 		if out[module] == "" {
 			out[module] = "unknown"
 		}
@@ -687,6 +695,7 @@ func (s *SystemAnalysisServiceImpl) resolveArchitectureRules(graph *analyzer.Dep
 	resolved := &domain.ArchitectureRules{
 		Layers:            append([]domain.Layer(nil), orig.Layers...),
 		Rules:             append([]domain.LayerRule(nil), orig.Rules...),
+		NeutralPrefixes:   append([]string(nil), orig.NeutralPrefixes...),
 		StrictMode:        orig.StrictMode,
 		AllowedPatterns:   orig.AllowedPatterns,
 		ForbiddenPatterns: orig.ForbiddenPatterns,

--- a/service/system_analysis_service_patterns_test.go
+++ b/service/system_analysis_service_patterns_test.go
@@ -293,3 +293,129 @@ func TestBuildModuleLayerMap_AmbiguousPackagesPrefixWins(t *testing.T) {
 	assert.Equal(t, "application", moduleToLayer["app.services.billing"],
 		"app.services.billing: prefix 'app.services' → application")
 }
+
+func TestBuildModuleLayerMap_NeutralPrefixes(t *testing.T) {
+	svc := NewSystemAnalysisService()
+
+	t.Run("strips prefix before layer matching", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("app.routers.user_router", "/project/app/routers/user_router.py")
+		graph.AddModule("app.domain.models", "/project/app/domain/models.py")
+		graph.AddModule("app.repositories.user_repo", "/project/app/repositories/user_repo.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{"app"},
+			Layers: []domain.Layer{
+				{Name: "presentation", Packages: []string{"routers"}},
+				{Name: "domain", Packages: []string{"domain"}},
+				{Name: "infrastructure", Packages: []string{"repositories"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+
+		// Keys must use original (unstripped) module names
+		assert.Equal(t, "presentation", moduleToLayer["app.routers.user_router"],
+			"app.routers.user_router with prefix 'app' stripped should match presentation")
+		assert.Equal(t, "domain", moduleToLayer["app.domain.models"],
+			"app.domain.models with prefix 'app' stripped should match domain")
+		assert.Equal(t, "infrastructure", moduleToLayer["app.repositories.user_repo"],
+			"app.repositories.user_repo with prefix 'app' stripped should match infrastructure")
+	})
+
+	t.Run("src prefix strips correctly", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("src.domain.models", "/project/src/domain/models.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{"src"},
+			Layers: []domain.Layer{
+				{Name: "domain", Packages: []string{"domain"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+		assert.Equal(t, "domain", moduleToLayer["src.domain.models"])
+	})
+
+	t.Run("first matching prefix wins", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("app.src.domain.models", "/project/app/src/domain/models.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{"app", "src"},
+			Layers: []domain.Layer{
+				{Name: "domain", Packages: []string{"domain"}},
+				{Name: "source", Packages: []string{"src"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+		// "app" is stripped first, leaving "src.domain.models" → matches "src" prefix → source
+		assert.Equal(t, "source", moduleToLayer["app.src.domain.models"],
+			"first matching prefix 'app' should be stripped, leaving 'src.domain.models'")
+	})
+
+	t.Run("non-matching prefixes don't affect results", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("routers.user_router", "/project/routers/user_router.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{"app", "src"},
+			Layers: []domain.Layer{
+				{Name: "presentation", Packages: []string{"routers"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+		assert.Equal(t, "presentation", moduleToLayer["routers.user_router"],
+			"module without matching prefix should still classify correctly")
+	})
+
+	t.Run("module without prefix still works", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("domain.models", "/project/domain/models.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{"app"},
+			Layers: []domain.Layer{
+				{Name: "domain", Packages: []string{"domain"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+		assert.Equal(t, "domain", moduleToLayer["domain.models"])
+	})
+
+	t.Run("partial prefix doesn't match", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("application.foo", "/project/application/foo.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{"app"},
+			Layers: []domain.Layer{
+				{Name: "app_layer", Packages: []string{"application"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+		assert.Equal(t, "app_layer", moduleToLayer["application.foo"],
+			"prefix 'app' must not strip from 'application.foo' (requires dot boundary)")
+	})
+
+	t.Run("empty neutral prefixes has no effect", func(t *testing.T) {
+		graph := analyzer.NewDependencyGraph("/project")
+		graph.AddModule("app.routers.user_router", "/project/app/routers/user_router.py")
+
+		rules := &domain.ArchitectureRules{
+			NeutralPrefixes: []string{},
+			Layers: []domain.Layer{
+				{Name: "presentation", Packages: []string{"routers"}},
+			},
+		}
+
+		moduleToLayer := svc.buildModuleLayerMap(graph, rules)
+		// Without stripping, "app.routers.user_router" should still match "routers" via suffix
+		assert.Equal(t, "presentation", moduleToLayer["app.routers.user_router"])
+	})
+}

--- a/testdata/python/fastapi_layers/.pyscn.toml
+++ b/testdata/python/fastapi_layers/.pyscn.toml
@@ -9,6 +9,7 @@
 
 [architecture]
 enabled = true
+neutral_prefixes = ["app"]
 
 [[architecture.layers]]
 name = "presentation"


### PR DESCRIPTION
Closes #364

## Summary
- Add `neutral_prefixes` option to `[architecture]` config that strips specified prefixes from module names before layer pattern matching
- e.g., `neutral_prefixes = ["app"]` causes `app.routers.user_router` → `routers.user_router` → matches `presentation` layer
- Original module names are preserved in dependency graph and violation reports

## Changes
- **Domain**: `NeutralPrefixes` field on `ArchitectureRules`
- **Config**: TOML/mapstructure/yaml tags across config structs + propagation through loaders
- **Core logic**: Prefix stripping in `buildModuleLayerMap()` before `findLayerForModule()` call
- **Clone safety**: `resolveArchitectureRules` preserves `NeutralPrefixes` in cloned rules

## Tests
- 7 unit tests (`TestBuildModuleLayerMap_NeutralPrefixes`): prefix stripping, first-match-wins, partial prefix rejection, empty prefixes, etc.
- 1 integration test (`TestArchitecture_NeutralPrefixesLayerClassification`): end-to-end with `.pyscn.toml`

## Config example

```toml
[architecture]
neutral_prefixes = ["app", "src", "myproject"]
```

## Test plan
- [x] `go test -run TestBuildModuleLayerMap_NeutralPrefixes ./service/` — 7/7 pass
- [x] `go test -run TestArchitecture ./integration/` — 5/5 pass
- [x] `go test ./...` — all pass