### PR TITLE
refactor(cli): remove top suggestions from terminal output

### DIFF
--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -492,27 +492,6 @@ func (c *AnalyzeCommand) printSummary(cmd *cobra.Command, response *domain.Analy
 
 	fmt.Fprintf(cmd.ErrOrStderr(), "\n")
 
-	// Print top suggestions
-	if len(response.Suggestions) > 0 {
-		maxShow := 5
-		if len(response.Suggestions) < maxShow {
-			maxShow = len(response.Suggestions)
-		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "💡 Top Suggestions:\n")
-		for _, s := range response.Suggestions[:maxShow] {
-			fmt.Fprintf(cmd.ErrOrStderr(), "  %s [%s] %s (%s)\n",
-				s.SeverityIcon(), s.Category, s.Title, s.Effort)
-			if len(s.Steps) > 0 {
-				fmt.Fprintf(cmd.ErrOrStderr(), "     → %s\n", s.Steps[0])
-			}
-		}
-		remaining := len(response.Suggestions) - maxShow
-		if remaining > 0 {
-			fmt.Fprintf(cmd.ErrOrStderr(), "  ... and %d more (see full report)\n", remaining)
-		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "\n")
-	}
-
 	// Print README badge snippet
 	c.printBadge(cmd, response.Summary.Grade)
 }

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -97,39 +97,6 @@ func (f *AnalyzeFormatter) writeText(response *domain.AnalyzeResponse, writer io
 		fmt.Fprint(writer, utils.FormatSectionSeparator())
 	}
 
-	// Suggestions
-	fmt.Fprint(writer, utils.FormatSectionHeader("SUGGESTIONS"))
-	if len(response.Suggestions) == 0 {
-		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Status", "No actionable suggestions"))
-	} else {
-		maxShow := 20
-		if len(response.Suggestions) < maxShow {
-			maxShow = len(response.Suggestions)
-		}
-		for _, s := range response.Suggestions[:maxShow] {
-			location := ""
-			if s.FilePath != "" {
-				location = s.FilePath
-				if s.StartLine > 0 {
-					location = fmt.Sprintf("%s:%d", s.FilePath, s.StartLine)
-				}
-			}
-			label := fmt.Sprintf("[%s/%s]", s.Severity, s.Effort)
-			detail := s.Title
-			if location != "" {
-				detail = fmt.Sprintf("%s (%s)", s.Title, location)
-			}
-			fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, label, detail))
-			for i, step := range s.Steps {
-				fmt.Fprintf(writer, "%s    %d. %s\n", strings.Repeat(" ", SectionPadding), i+1, step)
-			}
-		}
-		if len(response.Suggestions) > maxShow {
-			fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "...",
-				fmt.Sprintf("and %d more suggestions", len(response.Suggestions)-maxShow)))
-		}
-	}
-
 	return nil
 }
 

--- a/service/analyze_formatter_test.go
+++ b/service/analyze_formatter_test.go
@@ -124,7 +124,6 @@ func TestAnalyzeFormatter_Write_Text(t *testing.T) {
 				"DEAD CODE DETECTION",
 				"CLONE DETECTION",
 				"DEPENDENCY ANALYSIS",
-				"SUGGESTIONS",
 			},
 		},
 		{
@@ -134,7 +133,6 @@ func TestAnalyzeFormatter_Write_Text(t *testing.T) {
 				"Comprehensive Analysis Report",
 				"Health Score",
 				"100/100",
-				"No actionable suggestions",
 			},
 			notExpected: []string{
 				"COMPLEXITY ANALYSIS",
@@ -249,81 +247,6 @@ func TestAnalyzeFormatter_Write_UnsupportedFormat(t *testing.T) {
 	err := formatter.Write(response, domain.OutputFormat("invalid"), &buf)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid")
-}
-
-func TestAnalyzeFormatter_WriteText_Suggestions(t *testing.T) {
-	tests := []struct {
-		name             string
-		modifyResponse   func(*domain.AnalyzeResponse)
-		expectedContains []string
-	}{
-		{
-			name: "no suggestions shows status message",
-			modifyResponse: func(r *domain.AnalyzeResponse) {
-				// No suggestions
-			},
-			expectedContains: []string{"SUGGESTIONS", "No actionable suggestions"},
-		},
-		{
-			name: "complexity suggestion displayed",
-			modifyResponse: func(r *domain.AnalyzeResponse) {
-				r.Suggestions = []domain.Suggestion{
-					{
-						Category: domain.SuggestionCategoryComplexity,
-						Severity: domain.SuggestionSeverityCritical,
-						Effort:   domain.SuggestionEffortModerate,
-						Title:    "Refactor high-complexity function 'process_data'",
-						FilePath: "main.py",
-					},
-				}
-			},
-			expectedContains: []string{"SUGGESTIONS", "Refactor high-complexity function 'process_data'", "critical/moderate"},
-		},
-		{
-			name: "multiple suggestions displayed",
-			modifyResponse: func(r *domain.AnalyzeResponse) {
-				r.Suggestions = []domain.Suggestion{
-					{
-						Category:  domain.SuggestionCategoryDeadCode,
-						Severity:  domain.SuggestionSeverityWarning,
-						Effort:    domain.SuggestionEffortEasy,
-						Title:     "Remove dead code after return in 'validate'",
-						FilePath:  "utils.py",
-						StartLine: 42,
-					},
-					{
-						Category: domain.SuggestionCategoryCoupling,
-						Severity: domain.SuggestionSeverityCritical,
-						Effort:   domain.SuggestionEffortHard,
-						Title:    "Reduce coupling in class 'UserService'",
-					},
-				}
-			},
-			expectedContains: []string{
-				"Remove dead code after return in 'validate'",
-				"Reduce coupling in class 'UserService'",
-				"utils.py:42",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			response := createMinimalAnalyzeResponse()
-			tt.modifyResponse(response)
-
-			formatter := NewAnalyzeFormatter()
-			var buf bytes.Buffer
-
-			err := formatter.Write(response, domain.OutputFormatText, &buf)
-			require.NoError(t, err)
-
-			output := buf.String()
-			for _, expected := range tt.expectedContains {
-				assert.Contains(t, output, expected)
-			}
-		})
-	}
 }
 
 func TestAnalyzeFormatter_WriteHTML_ScoreQuality(t *testing.T) {


### PR DESCRIPTION
## Summary
Removes the verbose `💡 Top Suggestions:` block from the terminal output to improve UX. Detailed suggestions are already provided in the generated HTML report, making the terminal output redundant and cluttered. Tests have been updated accordingly to reflect this intended behavior.

## Type of Change
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring

## Related Issues
Closes #<367

## Changes
- Removed the `Top Suggestions` printing block in `cmd/pyscn/analyze.go`.
- Removed the `SUGGESTIONS` section from `writeTerminal()` in `service/analyze_formatter.go`.
- Updated assertions in `service/analyze_formatter_test.go` that expected suggestion output in terminal format.
- Verified that JSON/YAML/CSV output tests and logic remain untouched.

## Testing
- [x] `make test` passes locally
- [ ] `make lint` passes locally
- [ ] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (if needed)

## Additional Context
Tested locally on Linux. The terminal output is now clean, focused on the summary scores, and correctly directs the user to the HTML report.