### PR TITLE
honor complexity config settings in analyze

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -51,6 +51,19 @@ type AnalyzeUseCase struct {
 	errorCategorizer domain.ErrorCategorizer
 }
 
+type analyzeExecutionConfig struct {
+	includePatterns           []string
+	excludePatterns           []string
+	recursive                 bool
+	complexityEnabled         bool
+	reportUnchanged           bool
+	complexityLowThreshold    int
+	complexityMediumThreshold int
+	complexityMaxComplexity   int
+	lshEnabled                string
+	lshThreshold              int
+}
+
 // AnalyzeUseCaseBuilder builds an AnalyzeUseCase
 type AnalyzeUseCaseBuilder struct {
 	complexityUseCase *ComplexityUseCase
@@ -184,7 +197,7 @@ type AnalysisTask struct {
 func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCaseConfig, paths []string) (*domain.AnalyzeResponse, error) {
 	startTime := time.Now()
 
-	// Resolve config path once so all analysis phases read the same file.
+	// Resolve config path once so file discovery and task setup use a single config source.
 	targetPath := ""
 	if len(paths) > 0 {
 		targetPath = paths[0]
@@ -197,18 +210,20 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 	useCaseCfg.ConfigFile = resolvedConfigPath
 
-	// Load configuration to get file patterns and recursive setting
-	includePatterns, excludePatterns, recursive, patternErr := uc.getFilePatterns(useCaseCfg.ConfigFile)
-	if patternErr != nil {
-		return nil, patternErr
+	executionCfg, err := uc.loadExecutionConfig(useCaseCfg.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	if !executionCfg.complexityEnabled {
+		useCaseCfg.SkipComplexity = true
 	}
 
 	// Validate and collect files using configured patterns
 	files, err := uc.fileReader.CollectPythonFiles(
 		paths,
-		recursive, // Use recursive setting from config
-		includePatterns,
-		excludePatterns,
+		executionCfg.recursive,
+		executionCfg.includePatterns,
+		executionCfg.excludePatterns,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect Python files: %w", err)
@@ -219,7 +234,7 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 
 	// Calculate estimated time based on file count and enabled analyses
-	estimatedTime := uc.calculateEstimatedTime(len(files), useCaseCfg)
+	estimatedTime := uc.calculateEstimatedTime(len(files), useCaseCfg, executionCfg)
 
 	// Start unified progress tracking with time-based estimation
 	var progressDone chan struct{}
@@ -229,7 +244,7 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 
 	// Create analysis tasks
-	tasks := uc.createAnalysisTasks(useCaseCfg, files)
+	tasks := uc.createAnalysisTasks(useCaseCfg, files, executionCfg)
 
 	// Execute tasks in parallel
 	var wg sync.WaitGroup
@@ -277,16 +292,31 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 }
 
 // createAnalysisTasks creates the analysis tasks based on configuration
-func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files []string) []*AnalysisTask {
+func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files []string, executionCfg analyzeExecutionConfig) []*AnalysisTask {
 	tasks := []*AnalysisTask{}
 
 	// Complexity analysis task
 	if uc.complexityUseCase != nil {
-		request := uc.buildComplexityTaskRequest(config, files)
 		tasks = append(tasks, &AnalysisTask{
 			Name:    "Complexity Analysis",
-			Enabled: !config.SkipComplexity && uc.isComplexityTaskEnabled(request),
+			Enabled: !config.SkipComplexity,
 			Execute: func(ctx context.Context) (interface{}, error) {
+				request := domain.ComplexityRequest{
+					Paths:           files,
+					Recursive:       false,
+					IncludePatterns: []string{},
+					ExcludePatterns: []string{},
+					OutputFormat:    domain.OutputFormatJSON,
+					OutputWriter:    io.Discard,
+					MinComplexity:   config.MinComplexity,
+					MaxComplexity:   executionCfg.complexityMaxComplexity,
+					SortBy:          domain.SortByComplexity,
+					LowThreshold:    executionCfg.complexityLowThreshold,
+					MediumThreshold: executionCfg.complexityMediumThreshold,
+					Enabled:         domain.BoolPtr(executionCfg.complexityEnabled),
+					ReportUnchanged: domain.BoolPtr(executionCfg.reportUnchanged),
+					ConfigPath:      config.ConfigFile,
+				}
 				return uc.complexityUseCase.AnalyzeAndReturn(ctx, request)
 			},
 		})
@@ -436,31 +466,6 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	}
 
 	return tasks
-}
-
-func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig, files []string) domain.ComplexityRequest {
-	return domain.ComplexityRequest{
-		Paths:           files,
-		Recursive:       false,
-		IncludePatterns: []string{},
-		ExcludePatterns: []string{},
-		OutputFormat:    domain.OutputFormatJSON,
-		OutputWriter:    io.Discard,
-		MinComplexity:   config.MinComplexity,
-		LowThreshold:    9,
-		MediumThreshold: 19,
-		SortBy:          domain.SortByComplexity,
-		ConfigPath:      config.ConfigFile,
-	}
-}
-
-func (uc *AnalyzeUseCase) isComplexityTaskEnabled(req domain.ComplexityRequest) bool {
-	mergedReq, err := uc.complexityUseCase.loadAndMergeConfig(req)
-	if err != nil {
-		return true
-	}
-
-	return domain.BoolValue(mergedReq.Enabled, true)
 }
 
 // buildResponse builds the analyze response from task results
@@ -638,69 +643,63 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 	}
 }
 
-// getFilePatterns loads file patterns and recursive setting from configuration or returns defaults
-func (uc *AnalyzeUseCase) getFilePatterns(configPath string) ([]string, []string, bool, error) {
+func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string) (analyzeExecutionConfig, error) {
 	// Default patterns
 	defaultInclude := []string{"**/*.py", "*.pyi"}
 	defaultExclude := []string{"test_*.py", "*_test.py"}
-	defaultRecursive := true
+	defaultCloneReq := domain.DefaultCloneRequest()
+	executionCfg := analyzeExecutionConfig{
+		includePatterns:           defaultInclude,
+		excludePatterns:           defaultExclude,
+		recursive:                 true,
+		complexityEnabled:         true,
+		reportUnchanged:           true,
+		complexityLowThreshold:    config.DefaultLowComplexityThreshold,
+		complexityMediumThreshold: config.DefaultMediumComplexityThreshold,
+		complexityMaxComplexity:   config.DefaultMaxComplexityLimit,
+		lshEnabled:                defaultCloneReq.LSHEnabled,
+		lshThreshold:              defaultCloneReq.LSHAutoThreshold,
+	}
 
 	if configPath == "" {
-		return defaultInclude, defaultExclude, defaultRecursive, nil
+		return executionCfg, nil
 	}
 
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("failed to load configuration for pattern resolution: %w", err)
+		return analyzeExecutionConfig{}, fmt.Errorf("failed to load configuration for analyze: %w", err)
 	}
 	if cfg == nil {
-		return defaultInclude, defaultExclude, defaultRecursive, nil
+		return executionCfg, nil
 	}
 
-	// Use configured patterns if available
-	includePatterns := cfg.Analysis.IncludePatterns
-	excludePatterns := cfg.Analysis.ExcludePatterns
-	recursive := cfg.Analysis.Recursive
-
-	// Fall back to defaults if not specified
-	if len(includePatterns) == 0 {
-		includePatterns = defaultInclude
+	if len(cfg.Analysis.IncludePatterns) > 0 {
+		executionCfg.includePatterns = cfg.Analysis.IncludePatterns
 	}
-	if len(excludePatterns) == 0 {
-		excludePatterns = defaultExclude
+	if len(cfg.Analysis.ExcludePatterns) > 0 {
+		executionCfg.excludePatterns = cfg.Analysis.ExcludePatterns
 	}
+	executionCfg.recursive = cfg.Analysis.Recursive
+	executionCfg.complexityEnabled = cfg.Complexity.Enabled
+	executionCfg.reportUnchanged = cfg.Complexity.ReportUnchanged
+	executionCfg.complexityLowThreshold = cfg.Complexity.LowThreshold
+	executionCfg.complexityMediumThreshold = cfg.Complexity.MediumThreshold
+	executionCfg.complexityMaxComplexity = cfg.Complexity.MaxComplexity
 
-	return includePatterns, excludePatterns, recursive, nil
-}
-
-// getLSHConfig loads LSH configuration settings for clone detection
-func (uc *AnalyzeUseCase) getLSHConfig(configPath string) (enabled string, threshold int) {
-	// Default values from domain.DefaultCloneRequest()
-	enabled = "auto"
-	threshold = 500
-
-	if configPath == "" {
-		return enabled, threshold
+	if cfg.Clones != nil {
+		if cfg.Clones.LSH.Enabled != "" {
+			executionCfg.lshEnabled = cfg.Clones.LSH.Enabled
+		}
+		if cfg.Clones.LSH.AutoThreshold > 0 {
+			executionCfg.lshThreshold = cfg.Clones.LSH.AutoThreshold
+		}
 	}
 
-	cfg, err := config.LoadConfig(configPath)
-	if err != nil || cfg == nil {
-		return enabled, threshold
-	}
-
-	// Extract LSH settings from config if available
-	if cfg.Clones.LSH.Enabled != "" {
-		enabled = cfg.Clones.LSH.Enabled
-	}
-	if cfg.Clones.LSH.AutoThreshold > 0 {
-		threshold = cfg.Clones.LSH.AutoThreshold
-	}
-
-	return enabled, threshold
+	return executionCfg, nil
 }
 
 // calculateEstimatedTime estimates the total analysis time based on file count and enabled analyses
-func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUseCaseConfig) float64 {
+func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUseCaseConfig, executionCfg analyzeExecutionConfig) float64 {
 	n := float64(fileCount)
 	totalTime := 0.0
 
@@ -726,11 +725,8 @@ func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUs
 		// Estimate fragment count (empirical average: ~5.0 fragments per file)
 		estimatedFragments := n * 5.0
 
-		// Load LSH config to determine if LSH will be used
-		lshEnabled, lshThreshold := uc.getLSHConfig(config.ConfigFile)
-
 		// Determine LSH usage using centralized logic
-		useLSH := domain.ShouldUseLSH(lshEnabled, int(estimatedFragments), lshThreshold)
+		useLSH := domain.ShouldUseLSH(executionCfg.lshEnabled, int(estimatedFragments), executionCfg.lshThreshold)
 
 		if useLSH {
 			// LSH enabled: Near-linear O(n^1.1) complexity

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -282,23 +282,11 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 
 	// Complexity analysis task
 	if uc.complexityUseCase != nil {
+		request := uc.buildComplexityTaskRequest(config, files)
 		tasks = append(tasks, &AnalysisTask{
 			Name:    "Complexity Analysis",
-			Enabled: !config.SkipComplexity,
+			Enabled: !config.SkipComplexity && uc.isComplexityTaskEnabled(request),
 			Execute: func(ctx context.Context) (interface{}, error) {
-				request := domain.ComplexityRequest{
-					Paths:           files,
-					Recursive:       false,
-					IncludePatterns: []string{},
-					ExcludePatterns: []string{},
-					OutputFormat:    domain.OutputFormatJSON,
-					OutputWriter:    io.Discard,
-					MinComplexity:   config.MinComplexity,
-					LowThreshold:    9,
-					MediumThreshold: 19,
-					SortBy:          domain.SortByComplexity,
-					ConfigPath:      config.ConfigFile,
-				}
 				return uc.complexityUseCase.AnalyzeAndReturn(ctx, request)
 			},
 		})
@@ -448,6 +436,31 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	}
 
 	return tasks
+}
+
+func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig, files []string) domain.ComplexityRequest {
+	return domain.ComplexityRequest{
+		Paths:           files,
+		Recursive:       false,
+		IncludePatterns: []string{},
+		ExcludePatterns: []string{},
+		OutputFormat:    domain.OutputFormatJSON,
+		OutputWriter:    io.Discard,
+		MinComplexity:   config.MinComplexity,
+		LowThreshold:    9,
+		MediumThreshold: 19,
+		SortBy:          domain.SortByComplexity,
+		ConfigPath:      config.ConfigFile,
+	}
+}
+
+func (uc *AnalyzeUseCase) isComplexityTaskEnabled(req domain.ComplexityRequest) bool {
+	mergedReq, err := uc.complexityUseCase.loadAndMergeConfig(req)
+	if err != nil {
+		return true
+	}
+
+	return domain.BoolValue(mergedReq.Enabled, true)
 }
 
 // buildResponse builds the analyze response from task results

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -57,12 +57,17 @@ type analyzeExecutionConfig struct {
 	recursive                 bool
 	complexityEnabled         bool
 	reportUnchanged           bool
+	complexityMinComplexity   int
 	complexityLowThreshold    int
 	complexityMediumThreshold int
 	complexityMaxComplexity   int
 	lshEnabled                string
 	lshThreshold              int
 }
+
+// analyze includes stub files by default because they participate in the
+// same module surface as runtime Python files.
+var analyzeDefaultIncludePatterns = []string{"**/*.py", "*.pyi"}
 
 // AnalyzeUseCaseBuilder builds an AnalyzeUseCase
 type AnalyzeUseCaseBuilder struct {
@@ -301,23 +306,8 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 			Name:    "Complexity Analysis",
 			Enabled: !config.SkipComplexity,
 			Execute: func(ctx context.Context) (interface{}, error) {
-				request := domain.ComplexityRequest{
-					Paths:           files,
-					Recursive:       false,
-					IncludePatterns: []string{},
-					ExcludePatterns: []string{},
-					OutputFormat:    domain.OutputFormatJSON,
-					OutputWriter:    io.Discard,
-					MinComplexity:   config.MinComplexity,
-					MaxComplexity:   executionCfg.complexityMaxComplexity,
-					SortBy:          domain.SortByComplexity,
-					LowThreshold:    executionCfg.complexityLowThreshold,
-					MediumThreshold: executionCfg.complexityMediumThreshold,
-					Enabled:         domain.BoolPtr(executionCfg.complexityEnabled),
-					ReportUnchanged: domain.BoolPtr(executionCfg.reportUnchanged),
-					ConfigPath:      config.ConfigFile,
-				}
-				return uc.complexityUseCase.AnalyzeAndReturn(ctx, request)
+				request := uc.buildComplexityTaskRequest(config, files, executionCfg)
+				return uc.complexityUseCase.analyzeResolvedRequest(ctx, request)
 			},
 		})
 	}
@@ -466,6 +456,30 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	}
 
 	return tasks
+}
+
+func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig, files []string, executionCfg analyzeExecutionConfig) domain.ComplexityRequest {
+	minComplexity := config.MinComplexity
+	if minComplexity <= 0 {
+		minComplexity = executionCfg.complexityMinComplexity
+	}
+
+	return domain.ComplexityRequest{
+		Paths:           files,
+		Recursive:       false,
+		IncludePatterns: []string{},
+		ExcludePatterns: []string{},
+		OutputFormat:    domain.OutputFormatJSON,
+		OutputWriter:    io.Discard,
+		MinComplexity:   minComplexity,
+		MaxComplexity:   executionCfg.complexityMaxComplexity,
+		SortBy:          domain.SortByComplexity,
+		LowThreshold:    executionCfg.complexityLowThreshold,
+		MediumThreshold: executionCfg.complexityMediumThreshold,
+		Enabled:         domain.BoolPtr(executionCfg.complexityEnabled),
+		ReportUnchanged: domain.BoolPtr(executionCfg.reportUnchanged),
+		ConfigPath:      config.ConfigFile,
+	}
 }
 
 // buildResponse builds the analyze response from task results
@@ -644,44 +658,54 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 }
 
 func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string) (analyzeExecutionConfig, error) {
-	// Default patterns
-	defaultInclude := []string{"**/*.py", "*.pyi"}
-	defaultExclude := []string{"test_*.py", "*_test.py"}
-	defaultCloneReq := domain.DefaultCloneRequest()
-	executionCfg := analyzeExecutionConfig{
-		includePatterns:           defaultInclude,
-		excludePatterns:           defaultExclude,
-		recursive:                 true,
-		complexityEnabled:         true,
-		reportUnchanged:           true,
-		complexityLowThreshold:    config.DefaultLowComplexityThreshold,
-		complexityMediumThreshold: config.DefaultMediumComplexityThreshold,
-		complexityMaxComplexity:   config.DefaultMaxComplexityLimit,
-		lshEnabled:                defaultCloneReq.LSHEnabled,
-		lshThreshold:              defaultCloneReq.LSHAutoThreshold,
-	}
-
 	if configPath == "" {
-		return executionCfg, nil
+		return defaultAnalyzeExecutionConfig(), nil
 	}
 
 	cfg, err := config.LoadConfig(configPath)
 	if err != nil {
 		return analyzeExecutionConfig{}, fmt.Errorf("failed to load configuration for analyze: %w", err)
 	}
+
+	return analyzeExecutionConfigFromConfig(cfg), nil
+}
+
+func defaultAnalyzeExecutionConfig() analyzeExecutionConfig {
+	defaultCfg := config.DefaultConfig()
+	defaultCloneReq := domain.DefaultCloneRequest()
+
+	return analyzeExecutionConfig{
+		includePatterns:           append([]string(nil), analyzeDefaultIncludePatterns...),
+		excludePatterns:           append([]string(nil), defaultCfg.Analysis.ExcludePatterns...),
+		recursive:                 defaultCfg.Analysis.Recursive,
+		complexityEnabled:         defaultCfg.Complexity.Enabled,
+		reportUnchanged:           defaultCfg.Complexity.ReportUnchanged,
+		complexityMinComplexity:   defaultCfg.Output.MinComplexity,
+		complexityLowThreshold:    defaultCfg.Complexity.LowThreshold,
+		complexityMediumThreshold: defaultCfg.Complexity.MediumThreshold,
+		complexityMaxComplexity:   defaultCfg.Complexity.MaxComplexity,
+		lshEnabled:                defaultCloneReq.LSHEnabled,
+		lshThreshold:              defaultCloneReq.LSHAutoThreshold,
+	}
+}
+
+func analyzeExecutionConfigFromConfig(cfg *config.Config) analyzeExecutionConfig {
+	executionCfg := defaultAnalyzeExecutionConfig()
+
 	if cfg == nil {
-		return executionCfg, nil
+		return executionCfg
 	}
 
 	if len(cfg.Analysis.IncludePatterns) > 0 {
-		executionCfg.includePatterns = cfg.Analysis.IncludePatterns
+		executionCfg.includePatterns = append([]string(nil), cfg.Analysis.IncludePatterns...)
 	}
 	if len(cfg.Analysis.ExcludePatterns) > 0 {
-		executionCfg.excludePatterns = cfg.Analysis.ExcludePatterns
+		executionCfg.excludePatterns = append([]string(nil), cfg.Analysis.ExcludePatterns...)
 	}
 	executionCfg.recursive = cfg.Analysis.Recursive
 	executionCfg.complexityEnabled = cfg.Complexity.Enabled
 	executionCfg.reportUnchanged = cfg.Complexity.ReportUnchanged
+	executionCfg.complexityMinComplexity = cfg.Output.MinComplexity
 	executionCfg.complexityLowThreshold = cfg.Complexity.LowThreshold
 	executionCfg.complexityMediumThreshold = cfg.Complexity.MediumThreshold
 	executionCfg.complexityMaxComplexity = cfg.Complexity.MaxComplexity
@@ -695,7 +719,7 @@ func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string) (analyzeExecuti
 		}
 	}
 
-	return executionCfg, nil
+	return executionCfg
 }
 
 // calculateEstimatedTime estimates the total analysis time based on file count and enabled analyses

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -180,6 +180,9 @@ func TestAnalyzeUseCase_LoadExecutionConfig(t *testing.T) {
 		if executionCfg.complexityMaxComplexity != domain.DefaultComplexityMaxLimit {
 			t.Errorf("Expected max complexity %d, got %d", domain.DefaultComplexityMaxLimit, executionCfg.complexityMaxComplexity)
 		}
+		if executionCfg.complexityMinComplexity != domain.DefaultComplexityMinFilter {
+			t.Errorf("Expected min complexity %d, got %d", domain.DefaultComplexityMinFilter, executionCfg.complexityMinComplexity)
+		}
 		if len(executionCfg.includePatterns) != 2 || executionCfg.includePatterns[1] != "*.pyi" {
 			t.Errorf("Expected default include patterns to include .pyi files, got %v", executionCfg.includePatterns)
 		}
@@ -206,6 +209,9 @@ report_unchanged = false
 low_threshold = 3
 medium_threshold = 7
 max_complexity = 11
+
+[output]
+min_complexity = 9
 
 [clones]
 lsh_enabled = "true"
@@ -234,6 +240,9 @@ lsh_auto_threshold = 123
 		}
 		if executionCfg.complexityMaxComplexity != 11 {
 			t.Errorf("Expected max complexity 11, got %d", executionCfg.complexityMaxComplexity)
+		}
+		if executionCfg.complexityMinComplexity != 9 {
+			t.Errorf("Expected min complexity 9, got %d", executionCfg.complexityMinComplexity)
 		}
 		if executionCfg.recursive {
 			t.Error("Expected recursive to be false")

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -97,5 +99,59 @@ func TestAnalyzeUseCaseBuilder(t *testing.T) {
 
 	if useCase == nil {
 		t.Error("Expected non-nil use case, got nil")
+	}
+}
+
+func TestAnalyzeUseCase_Execute_DisablesComplexityFromConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, ".pyscn.toml")
+	configContent := `[complexity]
+enabled = false
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	config := AnalyzeUseCaseConfig{
+		ConfigFile:      configPath,
+		SkipComplexity:  false,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		MinComplexity:   1,
+		MinSeverity:     domain.DeadCodeSeverityWarning,
+		CloneSimilarity: 0.8,
+	}
+
+	builder := NewAnalyzeUseCaseBuilder()
+	builder.WithFileReader(service.NewFileReader())
+	builder.WithFormatter(service.NewAnalyzeFormatter())
+	builder.WithProgressManager(service.NewProgressManager())
+	builder.WithParallelExecutor(service.NewParallelExecutor())
+	builder.WithErrorCategorizer(service.NewErrorCategorizer())
+	builder.WithComplexityUseCase(NewComplexityUseCase(
+		service.NewComplexityService(),
+		service.NewFileReader(),
+		service.NewOutputFormatter(),
+		service.NewConfigurationLoader(),
+	))
+
+	useCase, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Failed to build AnalyzeUseCase: %v", err)
+	}
+
+	response, err := useCase.Execute(context.Background(), config, []string{"../testdata/python/simple"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if response.Summary.ComplexityEnabled {
+		t.Errorf("Expected complexity to be disabled, got %v", response.Summary.ComplexityEnabled)
+	}
+	if response.Complexity != nil {
+		t.Errorf("Expected no complexity response, got %+v", response.Complexity)
 	}
 }

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -155,3 +155,100 @@ enabled = false
 		t.Errorf("Expected no complexity response, got %+v", response.Complexity)
 	}
 }
+
+func TestAnalyzeUseCase_LoadExecutionConfig(t *testing.T) {
+	useCase := &AnalyzeUseCase{}
+
+	t.Run("uses analyze defaults without config file", func(t *testing.T) {
+		executionCfg, err := useCase.loadExecutionConfig("")
+		if err != nil {
+			t.Fatalf("loadExecutionConfig returned error: %v", err)
+		}
+
+		if !executionCfg.complexityEnabled {
+			t.Error("Expected complexity to be enabled by default")
+		}
+		if !executionCfg.reportUnchanged {
+			t.Error("Expected report_unchanged to be true by default")
+		}
+		if executionCfg.complexityLowThreshold != domain.DefaultComplexityLowThreshold {
+			t.Errorf("Expected low threshold %d, got %d", domain.DefaultComplexityLowThreshold, executionCfg.complexityLowThreshold)
+		}
+		if executionCfg.complexityMediumThreshold != domain.DefaultComplexityMediumThreshold {
+			t.Errorf("Expected medium threshold %d, got %d", domain.DefaultComplexityMediumThreshold, executionCfg.complexityMediumThreshold)
+		}
+		if executionCfg.complexityMaxComplexity != domain.DefaultComplexityMaxLimit {
+			t.Errorf("Expected max complexity %d, got %d", domain.DefaultComplexityMaxLimit, executionCfg.complexityMaxComplexity)
+		}
+		if len(executionCfg.includePatterns) != 2 || executionCfg.includePatterns[1] != "*.pyi" {
+			t.Errorf("Expected default include patterns to include .pyi files, got %v", executionCfg.includePatterns)
+		}
+		defaultCloneReq := domain.DefaultCloneRequest()
+		if executionCfg.lshEnabled != defaultCloneReq.LSHEnabled {
+			t.Errorf("Expected default LSH enabled %q, got %q", defaultCloneReq.LSHEnabled, executionCfg.lshEnabled)
+		}
+		if executionCfg.lshThreshold != defaultCloneReq.LSHAutoThreshold {
+			t.Errorf("Expected default LSH threshold %d, got %d", defaultCloneReq.LSHAutoThreshold, executionCfg.lshThreshold)
+		}
+	})
+
+	t.Run("uses resolved config values when config file exists", func(t *testing.T) {
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, ".pyscn.toml")
+		configContent := `[analysis]
+include_patterns = ["pkg/**/*.py"]
+exclude_patterns = ["tests/**/*.py"]
+recursive = false
+
+[complexity]
+enabled = false
+report_unchanged = false
+low_threshold = 3
+medium_threshold = 7
+max_complexity = 11
+
+[clones]
+lsh_enabled = "true"
+lsh_auto_threshold = 123
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write config file: %v", err)
+		}
+
+		executionCfg, err := useCase.loadExecutionConfig(configPath)
+		if err != nil {
+			t.Fatalf("loadExecutionConfig returned error: %v", err)
+		}
+
+		if executionCfg.complexityEnabled {
+			t.Error("Expected complexity to be disabled")
+		}
+		if executionCfg.reportUnchanged {
+			t.Error("Expected report_unchanged to be false")
+		}
+		if executionCfg.complexityLowThreshold != 3 {
+			t.Errorf("Expected low threshold 3, got %d", executionCfg.complexityLowThreshold)
+		}
+		if executionCfg.complexityMediumThreshold != 7 {
+			t.Errorf("Expected medium threshold 7, got %d", executionCfg.complexityMediumThreshold)
+		}
+		if executionCfg.complexityMaxComplexity != 11 {
+			t.Errorf("Expected max complexity 11, got %d", executionCfg.complexityMaxComplexity)
+		}
+		if executionCfg.recursive {
+			t.Error("Expected recursive to be false")
+		}
+		if len(executionCfg.includePatterns) != 1 || executionCfg.includePatterns[0] != "pkg/**/*.py" {
+			t.Errorf("Expected custom include patterns, got %v", executionCfg.includePatterns)
+		}
+		if len(executionCfg.excludePatterns) != 1 || executionCfg.excludePatterns[0] != "tests/**/*.py" {
+			t.Errorf("Expected custom exclude patterns, got %v", executionCfg.excludePatterns)
+		}
+		if executionCfg.lshEnabled != "true" {
+			t.Errorf("Expected LSH enabled to be %q, got %q", "true", executionCfg.lshEnabled)
+		}
+		if executionCfg.lshThreshold != 123 {
+			t.Errorf("Expected LSH threshold 123, got %d", executionCfg.lshThreshold)
+		}
+	})
+}

--- a/app/complexity_usecase.go
+++ b/app/complexity_usecase.go
@@ -37,7 +37,8 @@ func NewComplexityUseCase(
 
 // Execute performs the complete complexity analysis workflow
 func (uc *ComplexityUseCase) Execute(ctx context.Context, req domain.ComplexityRequest) error {
-	// Validate input
+	// Validate input before attempting to load configuration to preserve
+	// the existing error precedence for malformed requests.
 	if err := uc.validateRequest(req); err != nil {
 		return domain.NewInvalidInputError("invalid request", err)
 	}
@@ -88,7 +89,8 @@ func (uc *ComplexityUseCase) Execute(ctx context.Context, req domain.ComplexityR
 
 // AnalyzeAndReturn performs complexity analysis and returns the response without formatting
 func (uc *ComplexityUseCase) AnalyzeAndReturn(ctx context.Context, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
-	// Validate input
+	// Validate input before attempting to load configuration to preserve
+	// the existing error precedence for malformed requests.
 	if err := uc.validateRequest(req); err != nil {
 		return nil, domain.NewInvalidInputError("invalid request", err)
 	}
@@ -99,13 +101,23 @@ func (uc *ComplexityUseCase) AnalyzeAndReturn(ctx context.Context, req domain.Co
 		return nil, domain.NewConfigError("failed to load configuration", err)
 	}
 
+	return uc.analyzeResolvedRequest(ctx, finalReq)
+}
+
+func (uc *ComplexityUseCase) analyzeResolvedRequest(ctx context.Context, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
+	// Validate again on the resolved request so internal callers that bypass the
+	// config loader still execute through the same request contract.
+	if err := uc.validateRequest(req); err != nil {
+		return nil, domain.NewInvalidInputError("invalid request", err)
+	}
+
 	// Resolve file paths (use helper to avoid duplication)
 	files, err := ResolveFilePaths(
 		uc.fileReader,
-		finalReq.Paths,
-		finalReq.Recursive,
-		finalReq.IncludePatterns,
-		finalReq.ExcludePatterns,
+		req.Paths,
+		req.Recursive,
+		req.IncludePatterns,
+		req.ExcludePatterns,
 		false, // validatePythonFile: complexity doesn't need strict Python validation
 	)
 	if err != nil {
@@ -117,16 +129,16 @@ func (uc *ComplexityUseCase) AnalyzeAndReturn(ctx context.Context, req domain.Co
 	}
 
 	// Update request with collected files
-	finalReq.Paths = files
+	req.Paths = files
 
 	// Perform analysis and return the response
-	response, err := uc.service.Analyze(ctx, finalReq)
+	response, err := uc.service.Analyze(ctx, req)
 	if err != nil {
 		return nil, domain.NewAnalysisError("complexity analysis failed", err)
 	}
 
 	// Store merged configuration in response for caller access
-	response.Request = &finalReq
+	response.Request = &req
 
 	return response, nil
 }

--- a/app/complexity_usecase_test.go
+++ b/app/complexity_usecase_test.go
@@ -369,6 +369,28 @@ func TestComplexityUseCase_Execute(t *testing.T) {
 	}
 }
 
+func TestComplexityUseCase_analyzeResolvedRequest(t *testing.T) {
+	useCase, service, fileReader, _, configLoader := setupComplexityUseCaseMocks()
+	req := createValidComplexityRequest()
+	response := createMockComplexityResponse()
+
+	fileReader.On("FileExists", "/test/file.py").Return(true, nil)
+	service.On("Analyze", mock.Anything, mock.AnythingOfType("domain.ComplexityRequest")).
+		Return(response, nil)
+
+	result, err := useCase.analyzeResolvedRequest(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, response, result)
+	if assert.NotNil(t, result.Request) {
+		assert.Equal(t, req.Paths, result.Request.Paths)
+		assert.Equal(t, req.MinComplexity, result.Request.MinComplexity)
+	}
+	configLoader.AssertNotCalled(t, "LoadDefaultConfig")
+	configLoader.AssertNotCalled(t, "LoadConfig", mock.Anything)
+	configLoader.AssertNotCalled(t, "MergeConfig", mock.Anything, mock.Anything)
+}
+
 func TestComplexityUseCase_AnalyzeAndReturn(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/domain/complexity.go
+++ b/domain/complexity.go
@@ -61,6 +61,11 @@ type ComplexityRequest struct {
 	LowThreshold    int
 	MediumThreshold int
 
+	// Analysis toggles loaded from configuration when present.
+	// Nil means "use the default enabled behavior".
+	Enabled         *bool
+	ReportUnchanged *bool
+
 	// Configuration
 	ConfigPath string
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -306,6 +306,7 @@ func PyscnConfigToConfig(pyscn *PyscnConfig) *Config {
 	if pyscn.ComplexityMaxComplexity > 0 {
 		cfg.Complexity.MaxComplexity = pyscn.ComplexityMaxComplexity
 	}
+	cfg.Output.MinComplexity = pyscn.EffectiveOutputMinComplexity()
 
 	// DeadCode settings
 	if pyscn.DeadCodeEnabled != nil {
@@ -351,9 +352,6 @@ func PyscnConfigToConfig(pyscn *PyscnConfig) *Config {
 	}
 	if pyscn.OutputSortBy != "" {
 		cfg.Output.SortBy = pyscn.OutputSortBy
-	}
-	if pyscn.OutputMinComplexity > 0 {
-		cfg.Output.MinComplexity = pyscn.OutputMinComplexity
 	}
 	if pyscn.OutputDirectory != "" {
 		cfg.Output.Directory = pyscn.OutputDirectory

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -291,6 +291,12 @@ func PyscnConfigToConfig(pyscn *PyscnConfig) *Config {
 	cfg := DefaultConfig()
 
 	// Complexity settings
+	if pyscn.ComplexityEnabled != nil {
+		cfg.Complexity.Enabled = *pyscn.ComplexityEnabled
+	}
+	if pyscn.ComplexityReportUnchanged != nil {
+		cfg.Complexity.ReportUnchanged = *pyscn.ComplexityReportUnchanged
+	}
 	if pyscn.ComplexityLowThreshold > 0 {
 		cfg.Complexity.LowThreshold = pyscn.ComplexityLowThreshold
 	}
@@ -645,6 +651,8 @@ func SaveConfig(config *Config, path string) error {
 func ConfigToPyscnTomlConfig(cfg *Config) *PyscnTomlConfig {
 	return &PyscnTomlConfig{
 		Complexity: ComplexityTomlConfig{
+			Enabled:         &cfg.Complexity.Enabled,
+			ReportUnchanged: &cfg.Complexity.ReportUnchanged,
 			LowThreshold:    &cfg.Complexity.LowThreshold,
 			MediumThreshold: &cfg.Complexity.MediumThreshold,
 			MaxComplexity:   &cfg.Complexity.MaxComplexity,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -316,10 +316,12 @@ func TestLoadConfig(t *testing.T) {
 		configPath := filepath.Join(tempDir, ".pyscn.toml")
 
 		tomlContent := `
-[complexity]
-low_threshold = 5
-medium_threshold = 15
-max_complexity = 50
+	[complexity]
+	enabled = false
+	report_unchanged = false
+	low_threshold = 5
+	medium_threshold = 15
+	max_complexity = 50
 
 [output]
 format = "json"
@@ -351,8 +353,11 @@ follow_symlinks = false
 		if config.Complexity.MediumThreshold != 15 {
 			t.Errorf("Expected medium threshold 15, got %d", config.Complexity.MediumThreshold)
 		}
-		if !config.Complexity.ReportUnchanged {
-			t.Error("Expected report_unchanged to be true")
+		if config.Complexity.Enabled {
+			t.Error("Expected enabled to be false")
+		}
+		if config.Complexity.ReportUnchanged {
+			t.Error("Expected report_unchanged to be false")
 		}
 		if config.Complexity.MaxComplexity != 50 {
 			t.Errorf("Expected max complexity 50, got %d", config.Complexity.MaxComplexity)
@@ -403,6 +408,8 @@ func TestSaveConfig(t *testing.T) {
 	configPath := filepath.Join(tempDir, ".pyscn.toml")
 
 	config := DefaultConfig()
+	config.Complexity.Enabled = false
+	config.Complexity.ReportUnchanged = false
 	config.Complexity.LowThreshold = 7
 	config.Output.Format = "json"
 
@@ -424,6 +431,12 @@ func TestSaveConfig(t *testing.T) {
 
 	if loadedConfig.Complexity.LowThreshold != 7 {
 		t.Errorf("Expected saved low threshold 7, got %d", loadedConfig.Complexity.LowThreshold)
+	}
+	if loadedConfig.Complexity.Enabled {
+		t.Error("Expected saved enabled false")
+	}
+	if loadedConfig.Complexity.ReportUnchanged {
+		t.Error("Expected saved report_unchanged false")
 	}
 	if loadedConfig.Output.Format != "json" {
 		t.Errorf("Expected saved format json, got %s", loadedConfig.Output.Format)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -281,6 +281,53 @@ func TestPyscnConfigToConfigArchitectureLayersAndRules(t *testing.T) {
 	}
 }
 
+func TestPyscnConfigToConfigComplexitySettings(t *testing.T) {
+	pyscn := DefaultPyscnConfig()
+	enabled := false
+	reportUnchanged := false
+
+	pyscn.ComplexityEnabled = &enabled
+	pyscn.ComplexityReportUnchanged = &reportUnchanged
+	pyscn.ComplexityLowThreshold = 4
+	pyscn.ComplexityMediumThreshold = 8
+	pyscn.ComplexityMaxComplexity = 13
+	pyscn.ComplexityMinComplexity = 3
+
+	cfg := PyscnConfigToConfig(pyscn)
+
+	if cfg.Complexity.Enabled {
+		t.Error("Expected complexity to be disabled")
+	}
+	if cfg.Complexity.ReportUnchanged {
+		t.Error("Expected report_unchanged to be false")
+	}
+	if cfg.Complexity.LowThreshold != 4 {
+		t.Errorf("Expected low threshold 4, got %d", cfg.Complexity.LowThreshold)
+	}
+	if cfg.Complexity.MediumThreshold != 8 {
+		t.Errorf("Expected medium threshold 8, got %d", cfg.Complexity.MediumThreshold)
+	}
+	if cfg.Complexity.MaxComplexity != 13 {
+		t.Errorf("Expected max complexity 13, got %d", cfg.Complexity.MaxComplexity)
+	}
+	if cfg.Output.MinComplexity != 3 {
+		t.Errorf("Expected output min complexity 3, got %d", cfg.Output.MinComplexity)
+	}
+}
+
+func TestPyscnConfigToConfigExplicitOutputMinComplexityOverridesComplexity(t *testing.T) {
+	pyscn := DefaultPyscnConfig()
+	pyscn.ComplexityMinComplexity = 3
+	minComplexity := 1
+
+	mergeOutputSection(pyscn, &OutputTomlConfig{MinComplexity: &minComplexity})
+
+	cfg := PyscnConfigToConfig(pyscn)
+	if cfg.Output.MinComplexity != 1 {
+		t.Errorf("Expected explicit output min complexity 1, got %d", cfg.Output.MinComplexity)
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
 	t.Run("LoadNonExistentConfig", func(t *testing.T) {
 		// Explicit config path must exist.

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -84,6 +84,12 @@ func loadPyprojectConfigData(data []byte) (*PyscnConfig, error) {
 // mergeComplexitySection merges settings from the [complexity] section
 // This function is shared between .pyscn.toml and pyproject.toml loaders
 func mergeComplexitySection(defaults *PyscnConfig, complexity *ComplexityTomlConfig) {
+	if complexity.Enabled != nil {
+		defaults.ComplexityEnabled = complexity.Enabled
+	}
+	if complexity.ReportUnchanged != nil {
+		defaults.ComplexityReportUnchanged = complexity.ReportUnchanged
+	}
 	if complexity.LowThreshold != nil {
 		defaults.ComplexityLowThreshold = *complexity.LowThreshold
 	}

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -293,7 +293,7 @@ func mergeOutputSection(defaults *PyscnConfig, output *OutputTomlConfig) {
 		defaults.OutputSortBy = output.SortBy
 	}
 	if output.MinComplexity != nil {
-		defaults.OutputMinComplexity = *output.MinComplexity
+		defaults.setOutputMinComplexity(*output.MinComplexity)
 	}
 	if output.Directory != "" {
 		defaults.OutputDirectory = output.Directory

--- a/internal/config/pyproject_loader_test.go
+++ b/internal/config/pyproject_loader_test.go
@@ -12,10 +12,12 @@ func TestLoadComplexityFromPyprojectToml(t *testing.T) {
 
 	// Create pyproject.toml with complexity settings
 	configContent := `[tool.pyscn.complexity]
-low_threshold = 4
-medium_threshold = 6
-max_complexity = 10
-min_complexity = 2
+	enabled = false
+	report_unchanged = false
+	low_threshold = 4
+	medium_threshold = 6
+	max_complexity = 10
+	min_complexity = 2
 `
 	configPath := filepath.Join(tempDir, "pyproject.toml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -29,6 +31,12 @@ min_complexity = 2
 	}
 
 	// Verify complexity settings were loaded
+	if config.ComplexityEnabled == nil || *config.ComplexityEnabled {
+		t.Errorf("Expected enabled false, got %v", config.ComplexityEnabled)
+	}
+	if config.ComplexityReportUnchanged == nil || *config.ComplexityReportUnchanged {
+		t.Errorf("Expected report_unchanged false, got %v", config.ComplexityReportUnchanged)
+	}
 	if config.ComplexityLowThreshold != 4 {
 		t.Errorf("Expected low_threshold 4, got %d", config.ComplexityLowThreshold)
 	}

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -35,10 +35,12 @@ type PyscnConfig struct {
 	LSH LSHConfig `mapstructure:"lsh" yaml:"lsh" json:"lsh"`
 
 	// Complexity Configuration (from [complexity] section in TOML)
-	ComplexityLowThreshold    int `mapstructure:"complexity_low_threshold" yaml:"complexity_low_threshold" json:"complexity_low_threshold"`
-	ComplexityMediumThreshold int `mapstructure:"complexity_medium_threshold" yaml:"complexity_medium_threshold" json:"complexity_medium_threshold"`
-	ComplexityMaxComplexity   int `mapstructure:"complexity_max_complexity" yaml:"complexity_max_complexity" json:"complexity_max_complexity"`
-	ComplexityMinComplexity   int `mapstructure:"complexity_min_complexity" yaml:"complexity_min_complexity" json:"complexity_min_complexity"`
+	ComplexityEnabled         *bool `mapstructure:"complexity_enabled" yaml:"complexity_enabled" json:"complexity_enabled"`
+	ComplexityReportUnchanged *bool `mapstructure:"complexity_report_unchanged" yaml:"complexity_report_unchanged" json:"complexity_report_unchanged"`
+	ComplexityLowThreshold    int   `mapstructure:"complexity_low_threshold" yaml:"complexity_low_threshold" json:"complexity_low_threshold"`
+	ComplexityMediumThreshold int   `mapstructure:"complexity_medium_threshold" yaml:"complexity_medium_threshold" json:"complexity_medium_threshold"`
+	ComplexityMaxComplexity   int   `mapstructure:"complexity_max_complexity" yaml:"complexity_max_complexity" json:"complexity_max_complexity"`
+	ComplexityMinComplexity   int   `mapstructure:"complexity_min_complexity" yaml:"complexity_min_complexity" json:"complexity_min_complexity"`
 
 	// DeadCode Configuration (from [dead_code] section in TOML)
 	DeadCodeEnabled                   *bool    `mapstructure:"dead_code_enabled" yaml:"dead_code_enabled" json:"dead_code_enabled"`
@@ -320,6 +322,8 @@ func DefaultPyscnConfig() *PyscnConfig {
 		},
 
 		// Complexity defaults (from [complexity] section)
+		ComplexityEnabled:         domain.BoolPtr(true),
+		ComplexityReportUnchanged: domain.BoolPtr(true),
 		ComplexityLowThreshold:    DefaultLowComplexityThreshold,
 		ComplexityMediumThreshold: DefaultMediumComplexityThreshold,
 		ComplexityMaxComplexity:   DefaultMaxComplexityLimit,

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -143,6 +143,10 @@ type PyscnConfig struct {
 	MockDataKeywords       []string `mapstructure:"mock_data_keywords" yaml:"mock_data_keywords" json:"mock_data_keywords"`
 	MockDataDomains        []string `mapstructure:"mock_data_domains" yaml:"mock_data_domains" json:"mock_data_domains"`
 	MockDataIgnorePatterns []string `mapstructure:"mock_data_ignore_patterns" yaml:"mock_data_ignore_patterns" json:"mock_data_ignore_patterns"`
+
+	// Track whether [output].min_complexity was explicitly set so it can
+	// override [complexity].min_complexity even when both resolve to defaults.
+	outputMinComplexityExplicit bool `mapstructure:"-" yaml:"-" json:"-"`
 }
 
 // CloneAnalysisConfig holds core analysis parameters
@@ -428,6 +432,44 @@ func DefaultPyscnConfig() *PyscnConfig {
 		MockDataDomains:        domain.DefaultMockDataDomains(),
 		MockDataIgnorePatterns: []string{},
 	}
+}
+
+func (c *PyscnConfig) setOutputMinComplexity(min int) {
+	c.OutputMinComplexity = min
+	c.outputMinComplexityExplicit = true
+}
+
+func (c *PyscnConfig) hasExplicitOutputMinComplexity() bool {
+	if c == nil {
+		return false
+	}
+
+	if c.outputMinComplexityExplicit {
+		return true
+	}
+
+	return c.OutputMinComplexity > 0 && c.OutputMinComplexity != DefaultMinComplexityFilter
+}
+
+// EffectiveOutputMinComplexity resolves the output filter precedence.
+// [output].min_complexity overrides [complexity].min_complexity only when
+// the output value was explicitly set.
+func (c *PyscnConfig) EffectiveOutputMinComplexity() int {
+	if c == nil {
+		return DefaultMinComplexityFilter
+	}
+
+	if c.hasExplicitOutputMinComplexity() {
+		return c.OutputMinComplexity
+	}
+	if c.ComplexityMinComplexity > 0 {
+		return c.ComplexityMinComplexity
+	}
+	if c.OutputMinComplexity > 0 {
+		return c.OutputMinComplexity
+	}
+
+	return DefaultMinComplexityFilter
 }
 
 // Validate checks if the configuration is valid

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -26,10 +26,12 @@ type PyscnTomlConfig struct {
 
 // ComplexityTomlConfig represents the [complexity] section
 type ComplexityTomlConfig struct {
-	LowThreshold    *int `toml:"low_threshold"`    // pointer to detect unset
-	MediumThreshold *int `toml:"medium_threshold"` // pointer to detect unset
-	MaxComplexity   *int `toml:"max_complexity"`   // pointer to detect unset
-	MinComplexity   *int `toml:"min_complexity"`   // pointer to detect unset
+	Enabled         *bool `toml:"enabled"`          // pointer to detect unset
+	ReportUnchanged *bool `toml:"report_unchanged"` // pointer to detect unset
+	LowThreshold    *int  `toml:"low_threshold"`    // pointer to detect unset
+	MediumThreshold *int  `toml:"medium_threshold"` // pointer to detect unset
+	MaxComplexity   *int  `toml:"max_complexity"`   // pointer to detect unset
+	MinComplexity   *int  `toml:"min_complexity"`   // pointer to detect unset
 }
 
 // DeadCodeTomlConfig represents the [dead_code] section

--- a/internal/config/toml_loader_test.go
+++ b/internal/config/toml_loader_test.go
@@ -15,11 +15,13 @@ func TestLoadComplexityFromPyscnToml(t *testing.T) {
 
 	// Create .pyscn.toml with complexity settings
 	configContent := `[complexity]
-low_threshold = 5
-medium_threshold = 7
-max_complexity = 9
-min_complexity = 3
-`
+	enabled = false
+	report_unchanged = false
+	low_threshold = 5
+	medium_threshold = 7
+	max_complexity = 9
+	min_complexity = 3
+	`
 	configPath := filepath.Join(tempDir, ".pyscn.toml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("Failed to write config file: %v", err)
@@ -33,6 +35,12 @@ min_complexity = 3
 	}
 
 	// Verify complexity settings were loaded
+	if domain.BoolValue(config.ComplexityEnabled, true) {
+		t.Errorf("Expected enabled false, got %v", config.ComplexityEnabled)
+	}
+	if domain.BoolValue(config.ComplexityReportUnchanged, true) {
+		t.Errorf("Expected report_unchanged false, got %v", config.ComplexityReportUnchanged)
+	}
 	if config.ComplexityLowThreshold != 5 {
 		t.Errorf("Expected low_threshold 5, got %d", config.ComplexityLowThreshold)
 	}
@@ -91,6 +99,8 @@ func TestMergeComplexitySection(t *testing.T) {
 
 	// Create complexity settings
 	complexity := ComplexityTomlConfig{
+		Enabled:         domain.BoolPtr(false),
+		ReportUnchanged: domain.BoolPtr(false),
 		LowThreshold:    intPtr(3),
 		MediumThreshold: intPtr(5),
 		MaxComplexity:   intPtr(10),
@@ -101,6 +111,12 @@ func TestMergeComplexitySection(t *testing.T) {
 	mergeComplexitySection(config, &complexity)
 
 	// Verify settings were merged
+	if domain.BoolValue(config.ComplexityEnabled, true) {
+		t.Errorf("Expected enabled false, got %v", config.ComplexityEnabled)
+	}
+	if domain.BoolValue(config.ComplexityReportUnchanged, true) {
+		t.Errorf("Expected report_unchanged false, got %v", config.ComplexityReportUnchanged)
+	}
 	if config.ComplexityLowThreshold != 3 {
 		t.Errorf("Expected low_threshold 3, got %d", config.ComplexityLowThreshold)
 	}
@@ -122,6 +138,8 @@ func TestMergeComplexitySectionNilValues(t *testing.T) {
 
 	// Create complexity settings with nil values
 	complexity := ComplexityTomlConfig{
+		Enabled:         nil,
+		ReportUnchanged: nil,
 		LowThreshold:    nil,
 		MediumThreshold: nil,
 		MaxComplexity:   nil,

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -139,6 +139,9 @@ func (s *ComplexityServiceImpl) analyzeFile(ctx context.Context, filePath string
 			warnings = append(warnings, fmt.Sprintf("[%s:%s] Failed to calculate complexity for function", filePath, functionName))
 			continue
 		}
+		if !complexityConfig.ShouldReport(result.Complexity) {
+			continue
+		}
 
 		// Calculate cognitive complexity independently from CFG-based McCabe calculation
 		cognitiveComplexity := 0
@@ -328,8 +331,8 @@ func (s *ComplexityServiceImpl) buildComplexityConfig(req domain.ComplexityReque
 	return &config.ComplexityConfig{
 		LowThreshold:    req.LowThreshold,
 		MediumThreshold: req.MediumThreshold,
-		Enabled:         true,
-		ReportUnchanged: true,
+		Enabled:         domain.BoolValue(req.Enabled, true),
+		ReportUnchanged: domain.BoolValue(req.ReportUnchanged, true),
 		MaxComplexity:   req.MaxComplexity,
 	}
 }
@@ -341,6 +344,8 @@ func (s *ComplexityServiceImpl) buildConfigForResponse(req domain.ComplexityRequ
 		"max_complexity":   req.MaxComplexity,
 		"low_threshold":    req.LowThreshold,
 		"medium_threshold": req.MediumThreshold,
+		"enabled":          domain.BoolValue(req.Enabled, true),
+		"report_unchanged": domain.BoolValue(req.ReportUnchanged, true),
 		"sort_by":          string(req.SortBy),
 		"show_details":     req.ShowDetails,
 		"recursive":        req.Recursive,

--- a/service/complexity_service_test.go
+++ b/service/complexity_service_test.go
@@ -101,6 +101,36 @@ func TestComplexityService_Analyze(t *testing.T) {
 		}
 	})
 
+	t.Run("report_unchanged false filters complexity one functions", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := tempDir + "/mixed.py"
+		content := []byte("def unchanged():\n    return 1\n\n\ndef branch(x):\n    if x:\n        return 1\n    return 0\n")
+		err := os.WriteFile(filePath, content, 0644)
+		require.NoError(t, err)
+
+		req := newDefaultComplexityRequest(filePath)
+		req.ReportUnchanged = domain.BoolPtr(false)
+
+		response, err := service.Analyze(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.Len(t, response.Functions, 1)
+		assert.Equal(t, "branch", response.Functions[0].Name)
+	})
+
+	t.Run("enabled false suppresses complexity results", func(t *testing.T) {
+		req := newDefaultComplexityRequest("../testdata/python/simple/functions.py")
+		req.Enabled = domain.BoolPtr(false)
+
+		response, err := service.Analyze(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Empty(t, response.Functions)
+		assert.NotEmpty(t, response.RawMetrics)
+	})
+
 	t.Run("analyze multiple files", func(t *testing.T) {
 		req := newDefaultComplexityRequest(
 			"../testdata/python/simple/functions.py",
@@ -492,6 +522,8 @@ func TestComplexityService_BuildConfigForResponse(t *testing.T) {
 	assert.Equal(t, 20, configMap["max_complexity"])
 	assert.Equal(t, 5, configMap["low_threshold"])
 	assert.Equal(t, 10, configMap["medium_threshold"])
+	assert.Equal(t, true, configMap["enabled"])
+	assert.Equal(t, true, configMap["report_unchanged"])
 	assert.Equal(t, "complexity", configMap["sort_by"])
 	assert.Equal(t, true, configMap["show_details"])
 	assert.Equal(t, true, configMap["recursive"])

--- a/service/config_loader.go
+++ b/service/config_loader.go
@@ -92,6 +92,14 @@ func (c *ConfigurationLoaderImpl) MergeConfig(base *domain.ComplexityRequest, ov
 		merged.MediumThreshold = override.MediumThreshold
 	}
 
+	if override.Enabled != nil {
+		merged.Enabled = override.Enabled
+	}
+
+	if override.ReportUnchanged != nil {
+		merged.ReportUnchanged = override.ReportUnchanged
+	}
+
 	// Config path is always from override if provided
 	if override.ConfigPath != "" {
 		merged.ConfigPath = override.ConfigPath
@@ -149,6 +157,8 @@ func (c *ConfigurationLoaderImpl) convertToComplexityRequest(cfg *config.Config)
 		SortBy:          sortBy,
 		LowThreshold:    cfg.Complexity.LowThreshold,
 		MediumThreshold: cfg.Complexity.MediumThreshold,
+		Enabled:         domain.BoolPtr(cfg.Complexity.Enabled),
+		ReportUnchanged: domain.BoolPtr(cfg.Complexity.ReportUnchanged),
 		Recursive:       cfg.Analysis.Recursive,
 		IncludePatterns: cfg.Analysis.IncludePatterns,
 		ExcludePatterns: cfg.Analysis.ExcludePatterns,
@@ -211,6 +221,8 @@ func (c *ConfigurationLoaderImpl) pyscnConfigToUnifiedConfig(pyscnCfg *config.Py
 	cfg.Output.ShowDetails = domain.BoolValue(pyscnCfg.Output.ShowDetails, false)
 
 	// Map complexity settings from [complexity] section
+	cfg.Complexity.Enabled = domain.BoolValue(pyscnCfg.ComplexityEnabled, true)
+	cfg.Complexity.ReportUnchanged = domain.BoolValue(pyscnCfg.ComplexityReportUnchanged, true)
 	cfg.Complexity.LowThreshold = pyscnCfg.ComplexityLowThreshold
 	cfg.Complexity.MediumThreshold = pyscnCfg.ComplexityMediumThreshold
 	cfg.Complexity.MaxComplexity = pyscnCfg.ComplexityMaxComplexity

--- a/service/config_loader.go
+++ b/service/config_loader.go
@@ -226,7 +226,7 @@ func (c *ConfigurationLoaderImpl) pyscnConfigToUnifiedConfig(pyscnCfg *config.Py
 	cfg.Complexity.LowThreshold = pyscnCfg.ComplexityLowThreshold
 	cfg.Complexity.MediumThreshold = pyscnCfg.ComplexityMediumThreshold
 	cfg.Complexity.MaxComplexity = pyscnCfg.ComplexityMaxComplexity
-	cfg.Output.MinComplexity = pyscnCfg.ComplexityMinComplexity
+	cfg.Output.MinComplexity = pyscnCfg.EffectiveOutputMinComplexity()
 
 	// Map dead code settings from [dead_code] section
 	cfg.DeadCode.Enabled = domain.BoolValue(pyscnCfg.DeadCodeEnabled, true)
@@ -255,10 +255,6 @@ func (c *ConfigurationLoaderImpl) pyscnConfigToUnifiedConfig(pyscnCfg *config.Py
 	if pyscnCfg.OutputShowDetails != nil {
 		cfg.Output.ShowDetails = *pyscnCfg.OutputShowDetails
 	}
-	if pyscnCfg.OutputMinComplexity > 0 {
-		cfg.Output.MinComplexity = pyscnCfg.OutputMinComplexity
-	}
-
 	// Map general analysis settings from [analysis] section (override clone-specific if set)
 	if len(pyscnCfg.AnalysisIncludePatterns) > 0 {
 		cfg.Analysis.IncludePatterns = pyscnCfg.AnalysisIncludePatterns

--- a/service/config_loader_test.go
+++ b/service/config_loader_test.go
@@ -152,6 +152,27 @@ func TestConfigurationLoader_LoadConfig_ValidFile(t *testing.T) {
 	assert.False(t, *req.ReportUnchanged)
 }
 
+func TestConfigurationLoader_LoadConfig_MinComplexityPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".pyscn.toml")
+
+	configContent := `
+	[complexity]
+	min_complexity = 3
+
+	[output]
+	min_complexity = 1
+	`
+	err := os.WriteFile(configPath, []byte(configContent), 0644)
+	require.NoError(t, err)
+
+	loader := NewConfigurationLoader()
+	req, err := loader.LoadConfig(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+	assert.Equal(t, 1, req.MinComplexity)
+}
+
 func TestConfigurationLoader_FindDefaultConfigFile(t *testing.T) {
 	loader := NewConfigurationLoader()
 

--- a/service/config_loader_test.go
+++ b/service/config_loader_test.go
@@ -26,6 +26,10 @@ func TestConfigurationLoader_LoadDefaultConfig(t *testing.T) {
 	assert.Equal(t, domain.DefaultComplexityMinFilter, req.MinComplexity)
 	assert.Equal(t, domain.DefaultComplexityLowThreshold, req.LowThreshold)
 	assert.Equal(t, domain.DefaultComplexityMediumThreshold, req.MediumThreshold)
+	require.NotNil(t, req.Enabled)
+	require.NotNil(t, req.ReportUnchanged)
+	assert.True(t, *req.Enabled)
+	assert.True(t, *req.ReportUnchanged)
 }
 
 func TestConfigurationLoader_MergeConfig(t *testing.T) {
@@ -129,12 +133,12 @@ func TestConfigurationLoader_LoadConfig_ValidFile(t *testing.T) {
 	configPath := filepath.Join(tmpDir, ".pyscn.toml")
 
 	configContent := `
-[complexity]
-min = 5
-max = 20
-low_threshold = 10
-medium_threshold = 15
-`
+	[complexity]
+	enabled = false
+	report_unchanged = false
+	low_threshold = 10
+	medium_threshold = 15
+	`
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	require.NoError(t, err)
 
@@ -142,6 +146,10 @@ medium_threshold = 15
 	req, err := loader.LoadConfig(configPath)
 	require.NoError(t, err)
 	require.NotNil(t, req)
+	require.NotNil(t, req.Enabled)
+	require.NotNil(t, req.ReportUnchanged)
+	assert.False(t, *req.Enabled)
+	assert.False(t, *req.ReportUnchanged)
 }
 
 func TestConfigurationLoader_FindDefaultConfigFile(t *testing.T) {


### PR DESCRIPTION
Closes #368

This fixes the gap where the complexity config was getting loaded but not actually respected all the way through analyze.

[complexity].enabled and report_unchanged now flow through config loading, request conversion, and runtime behavior. I also fixed min_complexity precedence so the value from [complexity] doesn't get quietly overwritten by the default output filter, while an explicit [output].min_complexity still wins if that's what someone set.

I cleaned up the analyze/complexity handoff too so it isn't resolving the same config in a couple diff places.

Tests run:
go test ./internal/config
go test ./app -run 'TestAnalyzeUseCase_|TestComplexityUseCase_'
go test ./service -run 'TestConfigurationLoader_|TestComplexityService_'
go test ./...
