### PR TITLE
refactor: remove internal/config import from AnalyzeUseCase

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/ludo-technologies/pyscn/domain"
-	"github.com/ludo-technologies/pyscn/internal/config"
 	"github.com/ludo-technologies/pyscn/service"
 )
 
@@ -45,29 +44,12 @@ type AnalyzeUseCase struct {
 	systemUseCase     *SystemAnalysisUseCase
 
 	fileReader       domain.FileReader
+	configLoader     domain.AnalyzeConfigurationLoader
 	formatter        domain.AnalyzeOutputFormatter
 	progressManager  domain.ProgressManager
 	parallelExecutor domain.ParallelExecutor
 	errorCategorizer domain.ErrorCategorizer
 }
-
-type analyzeExecutionConfig struct {
-	includePatterns           []string
-	excludePatterns           []string
-	recursive                 bool
-	complexityEnabled         bool
-	reportUnchanged           bool
-	complexityMinComplexity   int
-	complexityLowThreshold    int
-	complexityMediumThreshold int
-	complexityMaxComplexity   int
-	lshEnabled                string
-	lshThreshold              int
-}
-
-// analyze includes stub files by default because they participate in the
-// same module surface as runtime Python files.
-var analyzeDefaultIncludePatterns = []string{"**/*.py", "*.pyi"}
 
 // AnalyzeUseCaseBuilder builds an AnalyzeUseCase
 type AnalyzeUseCaseBuilder struct {
@@ -79,6 +61,7 @@ type AnalyzeUseCaseBuilder struct {
 	systemUseCase     *SystemAnalysisUseCase
 
 	fileReader       domain.FileReader
+	configLoader     domain.AnalyzeConfigurationLoader
 	formatter        domain.AnalyzeOutputFormatter
 	progressManager  domain.ProgressManager
 	parallelExecutor domain.ParallelExecutor
@@ -132,6 +115,12 @@ func (b *AnalyzeUseCaseBuilder) WithFileReader(fr domain.FileReader) *AnalyzeUse
 	return b
 }
 
+// WithConfigLoader sets the analyze configuration loader.
+func (b *AnalyzeUseCaseBuilder) WithConfigLoader(cl domain.AnalyzeConfigurationLoader) *AnalyzeUseCaseBuilder {
+	b.configLoader = cl
+	return b
+}
+
 // WithFormatter sets the formatter
 func (b *AnalyzeUseCaseBuilder) WithFormatter(f domain.AnalyzeOutputFormatter) *AnalyzeUseCaseBuilder {
 	b.formatter = f
@@ -161,6 +150,9 @@ func (b *AnalyzeUseCaseBuilder) Build() (*AnalyzeUseCase, error) {
 	if b.fileReader == nil {
 		return nil, fmt.Errorf("file reader is required")
 	}
+	if b.configLoader == nil {
+		b.configLoader = service.NewAnalyzeConfigurationLoader()
+	}
 	if b.formatter == nil {
 		b.formatter = service.NewAnalyzeFormatter()
 	}
@@ -182,6 +174,7 @@ func (b *AnalyzeUseCaseBuilder) Build() (*AnalyzeUseCase, error) {
 		lcomUseCase:       b.lcomUseCase,
 		systemUseCase:     b.systemUseCase,
 		fileReader:        b.fileReader,
+		configLoader:      b.configLoader,
 		formatter:         b.formatter,
 		progressManager:   b.progressManager,
 		parallelExecutor:  b.parallelExecutor,
@@ -202,33 +195,22 @@ type AnalysisTask struct {
 func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCaseConfig, paths []string) (*domain.AnalyzeResponse, error) {
 	startTime := time.Now()
 
-	// Resolve config path once so file discovery and task setup use a single config source.
-	targetPath := ""
-	if len(paths) > 0 {
-		targetPath = paths[0]
-	}
-
-	tomlLoader := config.NewTomlConfigLoader()
-	resolvedConfigPath, err := tomlLoader.ResolveConfigPath(useCaseCfg.ConfigFile, targetPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve configuration: %w", err)
-	}
-	useCaseCfg.ConfigFile = resolvedConfigPath
-
-	executionCfg, err := uc.loadExecutionConfig(useCaseCfg.ConfigFile)
+	executionCfg, err := uc.loadExecutionConfig(useCaseCfg.ConfigFile, paths)
 	if err != nil {
 		return nil, err
 	}
-	if !executionCfg.complexityEnabled {
+	useCaseCfg.ConfigFile = executionCfg.ConfigPath
+
+	if !executionCfg.ComplexityEnabled {
 		useCaseCfg.SkipComplexity = true
 	}
 
 	// Validate and collect files using configured patterns
 	files, err := uc.fileReader.CollectPythonFiles(
 		paths,
-		executionCfg.recursive,
-		executionCfg.includePatterns,
-		executionCfg.excludePatterns,
+		executionCfg.Recursive,
+		executionCfg.IncludePatterns,
+		executionCfg.ExcludePatterns,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect Python files: %w", err)
@@ -297,7 +279,7 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 }
 
 // createAnalysisTasks creates the analysis tasks based on configuration
-func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files []string, executionCfg analyzeExecutionConfig) []*AnalysisTask {
+func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files []string, executionCfg domain.AnalyzeExecutionConfig) []*AnalysisTask {
 	tasks := []*AnalysisTask{}
 
 	// Complexity analysis task
@@ -458,10 +440,10 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	return tasks
 }
 
-func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig, files []string, executionCfg analyzeExecutionConfig) domain.ComplexityRequest {
+func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig, files []string, executionCfg domain.AnalyzeExecutionConfig) domain.ComplexityRequest {
 	minComplexity := config.MinComplexity
 	if minComplexity <= 0 {
-		minComplexity = executionCfg.complexityMinComplexity
+		minComplexity = executionCfg.ComplexityMinComplexity
 	}
 
 	return domain.ComplexityRequest{
@@ -472,12 +454,12 @@ func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig
 		OutputFormat:    domain.OutputFormatJSON,
 		OutputWriter:    io.Discard,
 		MinComplexity:   minComplexity,
-		MaxComplexity:   executionCfg.complexityMaxComplexity,
+		MaxComplexity:   executionCfg.ComplexityMaxComplexity,
 		SortBy:          domain.SortByComplexity,
-		LowThreshold:    executionCfg.complexityLowThreshold,
-		MediumThreshold: executionCfg.complexityMediumThreshold,
-		Enabled:         domain.BoolPtr(executionCfg.complexityEnabled),
-		ReportUnchanged: domain.BoolPtr(executionCfg.reportUnchanged),
+		LowThreshold:    executionCfg.ComplexityLowThreshold,
+		MediumThreshold: executionCfg.ComplexityMediumThreshold,
+		Enabled:         domain.BoolPtr(executionCfg.ComplexityEnabled),
+		ReportUnchanged: domain.BoolPtr(executionCfg.ComplexityReportUnchanged),
 		ConfigPath:      config.ConfigFile,
 	}
 }
@@ -657,73 +639,29 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 	}
 }
 
-func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string) (analyzeExecutionConfig, error) {
-	if configPath == "" {
-		return defaultAnalyzeExecutionConfig(), nil
+func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string, paths []string) (domain.AnalyzeExecutionConfig, error) {
+	if uc.configLoader == nil {
+		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("analyze configuration loader is required")
 	}
 
-	cfg, err := config.LoadConfig(configPath)
+	targetPath := ""
+	if len(paths) > 0 {
+		targetPath = paths[0]
+	}
+
+	executionCfg, err := uc.configLoader.LoadAnalyzeExecutionConfig(configPath, targetPath)
 	if err != nil {
-		return analyzeExecutionConfig{}, fmt.Errorf("failed to load configuration for analyze: %w", err)
+		return domain.AnalyzeExecutionConfig{}, err
+	}
+	if executionCfg == nil {
+		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("analyze configuration loader returned nil config")
 	}
 
-	return analyzeExecutionConfigFromConfig(cfg), nil
-}
-
-func defaultAnalyzeExecutionConfig() analyzeExecutionConfig {
-	defaultCfg := config.DefaultConfig()
-	defaultCloneReq := domain.DefaultCloneRequest()
-
-	return analyzeExecutionConfig{
-		includePatterns:           append([]string(nil), analyzeDefaultIncludePatterns...),
-		excludePatterns:           append([]string(nil), defaultCfg.Analysis.ExcludePatterns...),
-		recursive:                 defaultCfg.Analysis.Recursive,
-		complexityEnabled:         defaultCfg.Complexity.Enabled,
-		reportUnchanged:           defaultCfg.Complexity.ReportUnchanged,
-		complexityMinComplexity:   defaultCfg.Output.MinComplexity,
-		complexityLowThreshold:    defaultCfg.Complexity.LowThreshold,
-		complexityMediumThreshold: defaultCfg.Complexity.MediumThreshold,
-		complexityMaxComplexity:   defaultCfg.Complexity.MaxComplexity,
-		lshEnabled:                defaultCloneReq.LSHEnabled,
-		lshThreshold:              defaultCloneReq.LSHAutoThreshold,
-	}
-}
-
-func analyzeExecutionConfigFromConfig(cfg *config.Config) analyzeExecutionConfig {
-	executionCfg := defaultAnalyzeExecutionConfig()
-
-	if cfg == nil {
-		return executionCfg
-	}
-
-	if len(cfg.Analysis.IncludePatterns) > 0 {
-		executionCfg.includePatterns = append([]string(nil), cfg.Analysis.IncludePatterns...)
-	}
-	if len(cfg.Analysis.ExcludePatterns) > 0 {
-		executionCfg.excludePatterns = append([]string(nil), cfg.Analysis.ExcludePatterns...)
-	}
-	executionCfg.recursive = cfg.Analysis.Recursive
-	executionCfg.complexityEnabled = cfg.Complexity.Enabled
-	executionCfg.reportUnchanged = cfg.Complexity.ReportUnchanged
-	executionCfg.complexityMinComplexity = cfg.Output.MinComplexity
-	executionCfg.complexityLowThreshold = cfg.Complexity.LowThreshold
-	executionCfg.complexityMediumThreshold = cfg.Complexity.MediumThreshold
-	executionCfg.complexityMaxComplexity = cfg.Complexity.MaxComplexity
-
-	if cfg.Clones != nil {
-		if cfg.Clones.LSH.Enabled != "" {
-			executionCfg.lshEnabled = cfg.Clones.LSH.Enabled
-		}
-		if cfg.Clones.LSH.AutoThreshold > 0 {
-			executionCfg.lshThreshold = cfg.Clones.LSH.AutoThreshold
-		}
-	}
-
-	return executionCfg
+	return *executionCfg, nil
 }
 
 // calculateEstimatedTime estimates the total analysis time based on file count and enabled analyses
-func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUseCaseConfig, executionCfg analyzeExecutionConfig) float64 {
+func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUseCaseConfig, executionCfg domain.AnalyzeExecutionConfig) float64 {
 	n := float64(fileCount)
 	totalTime := 0.0
 
@@ -750,7 +688,7 @@ func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUs
 		estimatedFragments := n * 5.0
 
 		// Determine LSH usage using centralized logic
-		useLSH := domain.ShouldUseLSH(executionCfg.lshEnabled, int(estimatedFragments), executionCfg.lshThreshold)
+		useLSH := domain.ShouldUseLSH(executionCfg.CloneLSHEnabled, int(estimatedFragments), executionCfg.CloneLSHAutoThreshold)
 
 		if useLSH {
 			// LSH enabled: Near-linear O(n^1.1) complexity

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -640,24 +640,12 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 }
 
 func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string, paths []string) (domain.AnalyzeExecutionConfig, error) {
-	if uc.configLoader == nil {
-		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("analyze configuration loader is required")
-	}
-
 	targetPath := ""
 	if len(paths) > 0 {
 		targetPath = paths[0]
 	}
 
-	executionCfg, err := uc.configLoader.LoadAnalyzeExecutionConfig(configPath, targetPath)
-	if err != nil {
-		return domain.AnalyzeExecutionConfig{}, err
-	}
-	if executionCfg == nil {
-		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("analyze configuration loader returned nil config")
-	}
-
-	return *executionCfg, nil
+	return uc.configLoader.LoadAnalyzeExecutionConfig(configPath, targetPath)
 }
 
 // calculateEstimatedTime estimates the total analysis time based on file count and enabled analyses

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -157,41 +157,41 @@ enabled = false
 }
 
 func TestAnalyzeUseCase_LoadExecutionConfig(t *testing.T) {
-	useCase := &AnalyzeUseCase{}
+	useCase := &AnalyzeUseCase{configLoader: service.NewAnalyzeConfigurationLoader()}
 
 	t.Run("uses analyze defaults without config file", func(t *testing.T) {
-		executionCfg, err := useCase.loadExecutionConfig("")
+		executionCfg, err := useCase.loadExecutionConfig("", []string{t.TempDir()})
 		if err != nil {
 			t.Fatalf("loadExecutionConfig returned error: %v", err)
 		}
 
-		if !executionCfg.complexityEnabled {
+		if !executionCfg.ComplexityEnabled {
 			t.Error("Expected complexity to be enabled by default")
 		}
-		if !executionCfg.reportUnchanged {
+		if !executionCfg.ComplexityReportUnchanged {
 			t.Error("Expected report_unchanged to be true by default")
 		}
-		if executionCfg.complexityLowThreshold != domain.DefaultComplexityLowThreshold {
-			t.Errorf("Expected low threshold %d, got %d", domain.DefaultComplexityLowThreshold, executionCfg.complexityLowThreshold)
+		if executionCfg.ComplexityLowThreshold != domain.DefaultComplexityLowThreshold {
+			t.Errorf("Expected low threshold %d, got %d", domain.DefaultComplexityLowThreshold, executionCfg.ComplexityLowThreshold)
 		}
-		if executionCfg.complexityMediumThreshold != domain.DefaultComplexityMediumThreshold {
-			t.Errorf("Expected medium threshold %d, got %d", domain.DefaultComplexityMediumThreshold, executionCfg.complexityMediumThreshold)
+		if executionCfg.ComplexityMediumThreshold != domain.DefaultComplexityMediumThreshold {
+			t.Errorf("Expected medium threshold %d, got %d", domain.DefaultComplexityMediumThreshold, executionCfg.ComplexityMediumThreshold)
 		}
-		if executionCfg.complexityMaxComplexity != domain.DefaultComplexityMaxLimit {
-			t.Errorf("Expected max complexity %d, got %d", domain.DefaultComplexityMaxLimit, executionCfg.complexityMaxComplexity)
+		if executionCfg.ComplexityMaxComplexity != domain.DefaultComplexityMaxLimit {
+			t.Errorf("Expected max complexity %d, got %d", domain.DefaultComplexityMaxLimit, executionCfg.ComplexityMaxComplexity)
 		}
-		if executionCfg.complexityMinComplexity != domain.DefaultComplexityMinFilter {
-			t.Errorf("Expected min complexity %d, got %d", domain.DefaultComplexityMinFilter, executionCfg.complexityMinComplexity)
+		if executionCfg.ComplexityMinComplexity != domain.DefaultComplexityMinFilter {
+			t.Errorf("Expected min complexity %d, got %d", domain.DefaultComplexityMinFilter, executionCfg.ComplexityMinComplexity)
 		}
-		if len(executionCfg.includePatterns) != 2 || executionCfg.includePatterns[1] != "*.pyi" {
-			t.Errorf("Expected default include patterns to include .pyi files, got %v", executionCfg.includePatterns)
+		if len(executionCfg.IncludePatterns) != 2 || executionCfg.IncludePatterns[1] != "*.pyi" {
+			t.Errorf("Expected default include patterns to include .pyi files, got %v", executionCfg.IncludePatterns)
 		}
 		defaultCloneReq := domain.DefaultCloneRequest()
-		if executionCfg.lshEnabled != defaultCloneReq.LSHEnabled {
-			t.Errorf("Expected default LSH enabled %q, got %q", defaultCloneReq.LSHEnabled, executionCfg.lshEnabled)
+		if executionCfg.CloneLSHEnabled != defaultCloneReq.LSHEnabled {
+			t.Errorf("Expected default LSH enabled %q, got %q", defaultCloneReq.LSHEnabled, executionCfg.CloneLSHEnabled)
 		}
-		if executionCfg.lshThreshold != defaultCloneReq.LSHAutoThreshold {
-			t.Errorf("Expected default LSH threshold %d, got %d", defaultCloneReq.LSHAutoThreshold, executionCfg.lshThreshold)
+		if executionCfg.CloneLSHAutoThreshold != defaultCloneReq.LSHAutoThreshold {
+			t.Errorf("Expected default LSH threshold %d, got %d", defaultCloneReq.LSHAutoThreshold, executionCfg.CloneLSHAutoThreshold)
 		}
 	})
 
@@ -221,43 +221,43 @@ lsh_auto_threshold = 123
 			t.Fatalf("Failed to write config file: %v", err)
 		}
 
-		executionCfg, err := useCase.loadExecutionConfig(configPath)
+		executionCfg, err := useCase.loadExecutionConfig(configPath, []string{tempDir})
 		if err != nil {
 			t.Fatalf("loadExecutionConfig returned error: %v", err)
 		}
 
-		if executionCfg.complexityEnabled {
+		if executionCfg.ComplexityEnabled {
 			t.Error("Expected complexity to be disabled")
 		}
-		if executionCfg.reportUnchanged {
+		if executionCfg.ComplexityReportUnchanged {
 			t.Error("Expected report_unchanged to be false")
 		}
-		if executionCfg.complexityLowThreshold != 3 {
-			t.Errorf("Expected low threshold 3, got %d", executionCfg.complexityLowThreshold)
+		if executionCfg.ComplexityLowThreshold != 3 {
+			t.Errorf("Expected low threshold 3, got %d", executionCfg.ComplexityLowThreshold)
 		}
-		if executionCfg.complexityMediumThreshold != 7 {
-			t.Errorf("Expected medium threshold 7, got %d", executionCfg.complexityMediumThreshold)
+		if executionCfg.ComplexityMediumThreshold != 7 {
+			t.Errorf("Expected medium threshold 7, got %d", executionCfg.ComplexityMediumThreshold)
 		}
-		if executionCfg.complexityMaxComplexity != 11 {
-			t.Errorf("Expected max complexity 11, got %d", executionCfg.complexityMaxComplexity)
+		if executionCfg.ComplexityMaxComplexity != 11 {
+			t.Errorf("Expected max complexity 11, got %d", executionCfg.ComplexityMaxComplexity)
 		}
-		if executionCfg.complexityMinComplexity != 9 {
-			t.Errorf("Expected min complexity 9, got %d", executionCfg.complexityMinComplexity)
+		if executionCfg.ComplexityMinComplexity != 9 {
+			t.Errorf("Expected min complexity 9, got %d", executionCfg.ComplexityMinComplexity)
 		}
-		if executionCfg.recursive {
+		if executionCfg.Recursive {
 			t.Error("Expected recursive to be false")
 		}
-		if len(executionCfg.includePatterns) != 1 || executionCfg.includePatterns[0] != "pkg/**/*.py" {
-			t.Errorf("Expected custom include patterns, got %v", executionCfg.includePatterns)
+		if len(executionCfg.IncludePatterns) != 1 || executionCfg.IncludePatterns[0] != "pkg/**/*.py" {
+			t.Errorf("Expected custom include patterns, got %v", executionCfg.IncludePatterns)
 		}
-		if len(executionCfg.excludePatterns) != 1 || executionCfg.excludePatterns[0] != "tests/**/*.py" {
-			t.Errorf("Expected custom exclude patterns, got %v", executionCfg.excludePatterns)
+		if len(executionCfg.ExcludePatterns) != 1 || executionCfg.ExcludePatterns[0] != "tests/**/*.py" {
+			t.Errorf("Expected custom exclude patterns, got %v", executionCfg.ExcludePatterns)
 		}
-		if executionCfg.lshEnabled != "true" {
-			t.Errorf("Expected LSH enabled to be %q, got %q", "true", executionCfg.lshEnabled)
+		if executionCfg.CloneLSHEnabled != "true" {
+			t.Errorf("Expected LSH enabled to be %q, got %q", "true", executionCfg.CloneLSHEnabled)
 		}
-		if executionCfg.lshThreshold != 123 {
-			t.Errorf("Expected LSH threshold 123, got %d", executionCfg.lshThreshold)
+		if executionCfg.CloneLSHAutoThreshold != 123 {
+			t.Errorf("Expected LSH threshold 123, got %d", executionCfg.CloneLSHAutoThreshold)
 		}
 	})
 }

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -234,6 +234,7 @@ func (c *AnalyzeCommand) buildAnalyzeUseCase(cmd *cobra.Command) (*app.AnalyzeUs
 	// Set up file reader
 	fileReader := service.NewFileReader()
 	builder.WithFileReader(fileReader)
+	builder.WithConfigLoader(service.NewAnalyzeConfigurationLoader())
 
 	// Set up formatter
 	formatter := service.NewAnalyzeFormatter()

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -12,6 +12,31 @@ type AnalyzeOutputFormatter interface {
 	Write(response *AnalyzeResponse, format OutputFormat, writer io.Writer) error
 }
 
+// AnalyzeExecutionConfig contains the resolved configuration that AnalyzeUseCase
+// needs after config file discovery and loading.
+type AnalyzeExecutionConfig struct {
+	ConfigPath string
+
+	IncludePatterns []string
+	ExcludePatterns []string
+	Recursive       bool
+
+	ComplexityEnabled         bool
+	ComplexityReportUnchanged bool
+	ComplexityMinComplexity   int
+	ComplexityLowThreshold    int
+	ComplexityMediumThreshold int
+	ComplexityMaxComplexity   int
+
+	CloneLSHEnabled       string
+	CloneLSHAutoThreshold int
+}
+
+// AnalyzeConfigurationLoader resolves and loads configuration for AnalyzeUseCase.
+type AnalyzeConfigurationLoader interface {
+	LoadAnalyzeExecutionConfig(configPath string, targetPath string) (*AnalyzeExecutionConfig, error)
+}
+
 // Health Score Calculation Constants
 const (
 	// Complexity thresholds and penalties

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -34,7 +34,7 @@ type AnalyzeExecutionConfig struct {
 
 // AnalyzeConfigurationLoader resolves and loads configuration for AnalyzeUseCase.
 type AnalyzeConfigurationLoader interface {
-	LoadAnalyzeExecutionConfig(configPath string, targetPath string) (*AnalyzeExecutionConfig, error)
+	LoadAnalyzeExecutionConfig(configPath string, targetPath string) (AnalyzeExecutionConfig, error)
 }
 
 // Health Score Calculation Constants

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -21,27 +21,26 @@ var defaultAnalyzeIncludePatterns = []string{"**/*.py", "*.pyi"}
 
 // LoadAnalyzeExecutionConfig resolves the effective config path and loads the
 // AnalyzeUseCase-specific settings it needs.
-func (l *AnalyzeConfigurationLoaderImpl) LoadAnalyzeExecutionConfig(configPath string, targetPath string) (*domain.AnalyzeExecutionConfig, error) {
+func (l *AnalyzeConfigurationLoaderImpl) LoadAnalyzeExecutionConfig(configPath string, targetPath string) (domain.AnalyzeExecutionConfig, error) {
 	tomlLoader := config.NewTomlConfigLoader()
 	resolvedConfigPath, err := tomlLoader.ResolveConfigPath(configPath, targetPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve configuration: %w", err)
+		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("failed to resolve configuration: %w", err)
 	}
 
 	if resolvedConfigPath == "" {
-		cfg := defaultAnalyzeExecutionConfig()
-		return &cfg, nil
+		return defaultAnalyzeExecutionConfig(), nil
 	}
 
 	cfg, err := config.LoadConfig(resolvedConfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load configuration: %w", err)
+		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
 	executionCfg := analyzeExecutionConfigFromConfig(cfg)
 	executionCfg.ConfigPath = resolvedConfigPath
 
-	return &executionCfg, nil
+	return executionCfg, nil
 }
 
 func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/config"
+)
+
+// AnalyzeConfigurationLoaderImpl resolves and loads config for AnalyzeUseCase.
+type AnalyzeConfigurationLoaderImpl struct{}
+
+// NewAnalyzeConfigurationLoader creates a new analyze configuration loader.
+func NewAnalyzeConfigurationLoader() *AnalyzeConfigurationLoaderImpl {
+	return &AnalyzeConfigurationLoaderImpl{}
+}
+
+// analyze includes stub files by default because they participate in the same
+// module surface as runtime Python files.
+var defaultAnalyzeIncludePatterns = []string{"**/*.py", "*.pyi"}
+
+// LoadAnalyzeExecutionConfig resolves the effective config path and loads the
+// AnalyzeUseCase-specific settings it needs.
+func (l *AnalyzeConfigurationLoaderImpl) LoadAnalyzeExecutionConfig(configPath string, targetPath string) (*domain.AnalyzeExecutionConfig, error) {
+	tomlLoader := config.NewTomlConfigLoader()
+	resolvedConfigPath, err := tomlLoader.ResolveConfigPath(configPath, targetPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve configuration: %w", err)
+	}
+
+	if resolvedConfigPath == "" {
+		cfg := defaultAnalyzeExecutionConfig()
+		return &cfg, nil
+	}
+
+	cfg, err := config.LoadConfig(resolvedConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	executionCfg := analyzeExecutionConfigFromConfig(cfg)
+	executionCfg.ConfigPath = resolvedConfigPath
+
+	return &executionCfg, nil
+}
+
+func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
+	defaultCfg := config.DefaultConfig()
+	defaultCloneReq := domain.DefaultCloneRequest()
+
+	return domain.AnalyzeExecutionConfig{
+		ConfigPath:                "",
+		IncludePatterns:           append([]string(nil), defaultAnalyzeIncludePatterns...),
+		ExcludePatterns:           append([]string(nil), defaultCfg.Analysis.ExcludePatterns...),
+		Recursive:                 defaultCfg.Analysis.Recursive,
+		ComplexityEnabled:         defaultCfg.Complexity.Enabled,
+		ComplexityReportUnchanged: defaultCfg.Complexity.ReportUnchanged,
+		ComplexityMinComplexity:   defaultCfg.Output.MinComplexity,
+		ComplexityLowThreshold:    defaultCfg.Complexity.LowThreshold,
+		ComplexityMediumThreshold: defaultCfg.Complexity.MediumThreshold,
+		ComplexityMaxComplexity:   defaultCfg.Complexity.MaxComplexity,
+		CloneLSHEnabled:           defaultCloneReq.LSHEnabled,
+		CloneLSHAutoThreshold:     defaultCloneReq.LSHAutoThreshold,
+	}
+}
+
+func analyzeExecutionConfigFromConfig(cfg *config.Config) domain.AnalyzeExecutionConfig {
+	executionCfg := defaultAnalyzeExecutionConfig()
+	if cfg == nil {
+		return executionCfg
+	}
+
+	if len(cfg.Analysis.IncludePatterns) > 0 {
+		executionCfg.IncludePatterns = append([]string(nil), cfg.Analysis.IncludePatterns...)
+	}
+	if len(cfg.Analysis.ExcludePatterns) > 0 {
+		executionCfg.ExcludePatterns = append([]string(nil), cfg.Analysis.ExcludePatterns...)
+	}
+
+	executionCfg.Recursive = cfg.Analysis.Recursive
+	executionCfg.ComplexityEnabled = cfg.Complexity.Enabled
+	executionCfg.ComplexityReportUnchanged = cfg.Complexity.ReportUnchanged
+	executionCfg.ComplexityMinComplexity = cfg.Output.MinComplexity
+	executionCfg.ComplexityLowThreshold = cfg.Complexity.LowThreshold
+	executionCfg.ComplexityMediumThreshold = cfg.Complexity.MediumThreshold
+	executionCfg.ComplexityMaxComplexity = cfg.Complexity.MaxComplexity
+
+	if cfg.Clones != nil {
+		if cfg.Clones.LSH.Enabled != "" {
+			executionCfg.CloneLSHEnabled = cfg.Clones.LSH.Enabled
+		}
+		if cfg.Clones.LSH.AutoThreshold > 0 {
+			executionCfg.CloneLSHAutoThreshold = cfg.Clones.LSH.AutoThreshold
+		}
+	}
+
+	return executionCfg
+}

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+)
+
+func TestAnalyzeConfigurationLoader_LoadAnalyzeExecutionConfig(t *testing.T) {
+	loader := NewAnalyzeConfigurationLoader()
+
+	t.Run("uses analyze defaults when no config file is found", func(t *testing.T) {
+		cfg, err := loader.LoadAnalyzeExecutionConfig("", t.TempDir())
+		if err != nil {
+			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected non-nil execution config")
+		}
+
+		if cfg.ConfigPath != "" {
+			t.Errorf("expected empty config path, got %q", cfg.ConfigPath)
+		}
+		if len(cfg.IncludePatterns) != 2 || cfg.IncludePatterns[1] != "*.pyi" {
+			t.Errorf("expected default include patterns to include .pyi files, got %v", cfg.IncludePatterns)
+		}
+		if !cfg.ComplexityEnabled {
+			t.Error("expected complexity enabled by default")
+		}
+		if !cfg.ComplexityReportUnchanged {
+			t.Error("expected report_unchanged enabled by default")
+		}
+		defaultCloneReq := domain.DefaultCloneRequest()
+		if cfg.CloneLSHEnabled != defaultCloneReq.LSHEnabled {
+			t.Errorf("expected default LSH enabled %q, got %q", defaultCloneReq.LSHEnabled, cfg.CloneLSHEnabled)
+		}
+		if cfg.CloneLSHAutoThreshold != defaultCloneReq.LSHAutoThreshold {
+			t.Errorf("expected default LSH threshold %d, got %d", defaultCloneReq.LSHAutoThreshold, cfg.CloneLSHAutoThreshold)
+		}
+	})
+
+	t.Run("resolves config from target path and loads analyze settings", func(t *testing.T) {
+		projectDir := t.TempDir()
+		targetDir := filepath.Join(projectDir, "pkg")
+		if err := os.MkdirAll(targetDir, 0755); err != nil {
+			t.Fatalf("failed to create target dir: %v", err)
+		}
+
+		configPath := filepath.Join(projectDir, ".pyscn.toml")
+		configContent := `[analysis]
+include_patterns = ["pkg/**/*.py"]
+exclude_patterns = ["tests/**/*.py"]
+recursive = false
+
+[complexity]
+enabled = false
+report_unchanged = false
+low_threshold = 3
+medium_threshold = 7
+max_complexity = 11
+
+[output]
+min_complexity = 9
+
+[clones]
+lsh_enabled = "true"
+lsh_auto_threshold = 123
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		cfg, err := loader.LoadAnalyzeExecutionConfig("", targetDir)
+		if err != nil {
+			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected non-nil execution config")
+		}
+
+		if cfg.ConfigPath != configPath {
+			t.Errorf("expected config path %q, got %q", configPath, cfg.ConfigPath)
+		}
+		if cfg.Recursive {
+			t.Error("expected recursive false")
+		}
+		if len(cfg.IncludePatterns) != 1 || cfg.IncludePatterns[0] != "pkg/**/*.py" {
+			t.Errorf("expected custom include patterns, got %v", cfg.IncludePatterns)
+		}
+		if len(cfg.ExcludePatterns) != 1 || cfg.ExcludePatterns[0] != "tests/**/*.py" {
+			t.Errorf("expected custom exclude patterns, got %v", cfg.ExcludePatterns)
+		}
+		if cfg.ComplexityEnabled {
+			t.Error("expected complexity disabled")
+		}
+		if cfg.ComplexityReportUnchanged {
+			t.Error("expected report_unchanged false")
+		}
+		if cfg.ComplexityLowThreshold != 3 {
+			t.Errorf("expected low threshold 3, got %d", cfg.ComplexityLowThreshold)
+		}
+		if cfg.ComplexityMediumThreshold != 7 {
+			t.Errorf("expected medium threshold 7, got %d", cfg.ComplexityMediumThreshold)
+		}
+		if cfg.ComplexityMaxComplexity != 11 {
+			t.Errorf("expected max complexity 11, got %d", cfg.ComplexityMaxComplexity)
+		}
+		if cfg.ComplexityMinComplexity != 9 {
+			t.Errorf("expected min complexity 9, got %d", cfg.ComplexityMinComplexity)
+		}
+		if cfg.CloneLSHEnabled != "true" {
+			t.Errorf("expected LSH enabled true, got %q", cfg.CloneLSHEnabled)
+		}
+		if cfg.CloneLSHAutoThreshold != 123 {
+			t.Errorf("expected LSH threshold 123, got %d", cfg.CloneLSHAutoThreshold)
+		}
+	})
+}

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -16,9 +16,6 @@ func TestAnalyzeConfigurationLoader_LoadAnalyzeExecutionConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
 		}
-		if cfg == nil {
-			t.Fatal("expected non-nil execution config")
-		}
 
 		if cfg.ConfigPath != "" {
 			t.Errorf("expected empty config path, got %q", cfg.ConfigPath)
@@ -75,9 +72,6 @@ lsh_auto_threshold = 123
 		cfg, err := loader.LoadAnalyzeExecutionConfig("", targetDir)
 		if err != nil {
 			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
-		}
-		if cfg == nil {
-			t.Fatal("expected non-nil execution config")
 		}
 
 		if cfg.ConfigPath != configPath {


### PR DESCRIPTION
Closes #372

This moves the analyze-specific config resolution/loading behind a domain interface so AnalyzeUseCase no longer reaches into internal/config directly.

I added an AnalyzeConfigurationLoader in the domain layer, implemented it in service, and wired AnalyzeUseCase to use that loader for config discovery and execution settings. The behavior stays the same, including resolved config path handling and the analyze defaults around .pyi files and clone LSH settings.

Tests run:
go test ./service -run 'TestAnalyzeConfigurationLoader_|TestConfigurationLoader_|TestComplexityService_'
go test ./app -run 'TestAnalyzeUseCase_|TestComplexityUseCase_'
go test ./cmd/pyscn -run 'TestAnalyze'
go test ./...
