### PR TITLE
docs: default to uvx and link README to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ directory = "reports"
 
 ## Documentation
 
-📚 **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)**
+📖 **[pyscn documentation site](https://ludo-technologies.github.io/pyscn/)** — installation, rule catalog, CLI reference, configuration, output specification
+
+For contributors: **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)**
 
 ## Enterprise Support
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -131,7 +131,7 @@ The install location isn't on PATH. Inspect with:
 python -m pip show -f pyscn | grep bin/pyscn
 ```
 
-On Linux/macOS, add `~/.local/bin` to PATH or use `pipx install pyscn`.
+On Linux/macOS, add `~/.local/bin` to PATH, or install with `uvx pyscn@latest <command>` (no install step), `uv tool install pyscn`, or `pipx install pyscn`.
 
 ### The report shows 0 files analyzed.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -7,15 +7,15 @@
 
 ## Install
 
-| Method | Command |
-| --- | --- |
-| pip | `pip install pyscn` |
-| pipx | `pipx install pyscn` |
-| uv | `uv tool install pyscn` |
-| uvx (no install) | `uvx pyscn@latest <command>` |
-| Go | `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest` |
+| Method | Command | Notes |
+| --- | --- | --- |
+| **uvx** (recommended) | `uvx pyscn@latest <command>` | Runs without installing; caches after first call. |
+| uv tool | `uv tool install pyscn` | Persistent install, isolated from project deps. |
+| pipx | `pipx install pyscn` | Persistent install, isolated from project deps. |
+| pip | `pip install pyscn` | Installs into the current environment. |
+| Go | `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest` | Does not install `pyscn-mcp`. |
 
-`pipx`, `uv tool install`, and `uvx` isolate pyscn from project dependencies. The Go install path does not include `pyscn-mcp`.
+`uvx` is the fastest path for one-off use and works well in CI. Use `uv tool install` or `pipx` for repeated local use without polluting project dependencies.
 
 Pre-built binaries are attached to every [GitHub release](https://github.com/ludo-technologies/pyscn/releases).
 
@@ -29,15 +29,17 @@ pyscn version --short    # just the version number
 ## Upgrade
 
 ```bash
-pip install --upgrade pyscn
-pipx upgrade pyscn
-uv tool upgrade pyscn
+uv tool upgrade pyscn        # if installed with uv tool
+pipx upgrade pyscn           # if installed with pipx
+pip install --upgrade pyscn  # if installed with pip
 ```
+
+`uvx pyscn@latest` always resolves to the latest version, so no upgrade step is needed.
 
 ## Uninstall
 
 ```bash
-pip uninstall pyscn
-pipx uninstall pyscn
 uv tool uninstall pyscn
+pipx uninstall pyscn
+pip uninstall pyscn
 ```

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -3,6 +3,12 @@
 ## Run an analysis
 
 ```bash
+uvx pyscn@latest analyze .
+```
+
+If `pyscn` is already installed (via `uv tool install pyscn`, `pipx install pyscn`, or `pip install pyscn`), drop the `uvx pyscn@latest` prefix:
+
+```bash
 pyscn analyze .
 ```
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -9,8 +9,7 @@ hide:
 A structural static analyzer for Python. Detects dead code, duplication, complexity, and coupling issues via control-flow and tree analysis.
 
 ```bash
-pip install pyscn
-pyscn analyze .
+uvx pyscn@latest analyze .
 ```
 
 ## Features
@@ -29,9 +28,10 @@ Written in Go. 100,000+ lines/sec on typical hardware. No Python runtime depende
 ## Installation
 
 ```bash
-pip install pyscn        # or pipx install pyscn
-                         # or uv tool install pyscn
-                         # or uvx pyscn@latest
+uvx pyscn@latest <command>   # run without installing (recommended)
+uv tool install pyscn        # install with uv
+pipx install pyscn           # install with pipx
+pip install pyscn            # install with pip
 ```
 
 See [Installation](getting-started/installation.md) for all options.

--- a/website/docs/integrations/ci-cd.md
+++ b/website/docs/integrations/ci-cd.md
@@ -12,7 +12,7 @@ Findings are written to **stderr** in linter format. Capture them with `2>` in s
 
 ## GitHub Actions
 
-Minimal:
+Minimal (recommended — uvx, no install step):
 
 ```yaml
 # .github/workflows/quality.yml
@@ -24,11 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install pyscn
-      - run: pyscn check .
+      - uses: astral-sh/setup-uv@v3
+      - run: uvx pyscn@latest check .
 ```
 
 With full report as an artifact:
@@ -39,18 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - run: pip install pyscn
+      - uses: astral-sh/setup-uv@v3
 
       - name: Quality gate
-        run: pyscn check --max-complexity 15 src/
+        run: uvx pyscn@latest check --max-complexity 15 src/
 
       - name: Full report
         if: always()
-        run: pyscn analyze --no-open --html src/
+        run: uvx pyscn@latest analyze --no-open --html src/
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -70,11 +63,14 @@ on:
       - 'pyproject.toml'
 ```
 
-With uvx (no install step):
+With `pip` instead of uvx:
 
 ```yaml
-      - uses: astral-sh/setup-uv@v3
-      - run: uvx pyscn@latest check .
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pyscn
+      - run: pyscn check .
 ```
 
 ## pre-commit

--- a/website/docs/integrations/python-packaging.md
+++ b/website/docs/integrations/python-packaging.md
@@ -6,12 +6,12 @@ pyscn is distributed on PyPI as a wheel containing a native Go binary. The Pytho
 
 | Tool | Good for | Notes |
 | --- | --- | --- |
-| `pipx` | Standalone CLI use | Isolated from project deps. |
-| `uv tool install` | Modern tool management | Fast, isolated. |
-| `uvx` | One-off runs | Caches after first call. |
-| `pip` | Inside a venv | No isolation. |
+| `uvx` (recommended) | One-off runs, CI | Runs without installing; caches after first call. |
+| `uv tool install` | Persistent tool management | Fast, isolated. |
+| `pipx` | Persistent CLI install | Isolated from project deps. |
+| `pip` | Installing into a venv | No isolation. |
 
-CI: `pip install pyscn`. Local dev: `pipx` or `uv tool install`.
+CI: `uvx pyscn@latest check .`. Local dev: `uv tool install pyscn` or `pipx install pyscn`.
 
 ## Platform support
 


### PR DESCRIPTION
## Summary

- Reorder installation guidance across the docs site so `uvx pyscn@latest` is the first-class path on the home page, Getting Started, Quick Start, FAQ, and Python Packaging page.
- Make `uvx` the recommended GitHub Actions pattern in the CI/CD integration page; keep `pip install pyscn` as a fallback example.
- Add the published docs site (https://ludo-technologies.github.io/pyscn/) to the Documentation section of `README.md`; contributor links are preserved underneath.

## Test plan

- [ ] CI \`Documentation / build\` job passes (mkdocs strict build).
- [ ] After merge, the home page of the docs site shows `uvx pyscn@latest analyze .` as the first command.
- [ ] README renders on GitHub with the new docs-site link.