### PR TITLE
fix: make grouping clone-type tie breaks deterministic

### DIFF
--- a/internal/analyzer/connected_grouping.go
+++ b/internal/analyzer/connected_grouping.go
@@ -152,7 +152,7 @@ func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) Cl
 	var best CloneType
 	maxC := -1
 	for t, c := range counts {
-		if c > maxC || (c == maxC && (best == 0 || t < best)) {
+		if c > maxC || (c == maxC && t < best) {
 			maxC = c
 			best = t
 		}

--- a/internal/analyzer/connected_grouping.go
+++ b/internal/analyzer/connected_grouping.go
@@ -152,7 +152,7 @@ func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) Cl
 	var best CloneType
 	maxC := -1
 	for t, c := range counts {
-		if c > maxC {
+		if c > maxC || (c == maxC && (best == 0 || t < best)) {
 			maxC = c
 			best = t
 		}

--- a/internal/analyzer/grouping_strategies_test.go
+++ b/internal/analyzer/grouping_strategies_test.go
@@ -101,6 +101,26 @@ func TestGroupingStrategiesComparison(t *testing.T) {
 	}
 }
 
+func TestMajorityCloneType_TieBreaksDeterministically(t *testing.T) {
+	a := gf("a.py", 1, 3)
+	b := gf("b.py", 1, 3)
+	c := gf("c.py", 1, 3)
+	d := gf("d.py", 1, 3)
+
+	members := []*CodeFragment{a, b, c, d}
+	typeMap := map[string]CloneType{
+		pairKey(a, b): Type3Clone,
+		pairKey(a, c): Type1Clone,
+		pairKey(a, d): Type3Clone,
+		pairKey(b, c): Type1Clone,
+	}
+
+	got := majorityCloneType(typeMap, members)
+	if got != Type1Clone {
+		t.Fatalf("expected deterministic lower clone-type tie break, got %v", got)
+	}
+}
+
 func sizes(gs []*CloneGroup) []int {
 	out := make([]int, 0, len(gs))
 	for _, g := range gs {


### PR DESCRIPTION
This is a small follow-up I found while validating the complete-linkage work.

When multiple clone types had the same vote count inside a group, `majorityCloneType` could return different results depending on Go map iteration order. That made the output nondeterministic in tied cases.

This change makes the tie-break explicit and stable by preferring the lower `CloneType` when counts are equal.

Tests:
- add coverage for tied clone-type votes
- verify the result is deterministic in the tie case

Back with another PR after a short hiatus, this time for a small determinism cleanup before the larger grouping work.
