### PR TITLE
ci: auto-assign PR author on open/reopen

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,23 @@
+name: Auto Assign PR Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login]
+            });


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that auto-assigns the PR author as assignee on `opened` / `reopened`
- Uses `actions/github-script@v9` — no third-party action dependency
- Runs on `pull_request_target` so forks are covered, with `pull-requests: write` as the only permission and bot authors skipped

## Test plan
- [ ] Merge to `main` and open a new PR from a branch → confirm author is auto-assigned
- [ ] Re-open a closed PR → confirm author is auto-assigned
- [ ] Dependabot / bot PR → confirm it is skipped (no assignee added)
- [ ] Fork-originated PR → confirm it still receives the assignee