### PR TITLE
perf: optimize complete-linkage grouping

### DIFF
--- a/internal/analyzer/complete_linkage_clusterer.go
+++ b/internal/analyzer/complete_linkage_clusterer.go
@@ -1,0 +1,170 @@
+package analyzer
+
+// completeLinkageClusterer stores only threshold-qualified inter-cluster edges.
+// That keeps sparse workloads sparse while still supporting exact complete-linkage
+// merges, since a merged cluster can stay adjacent to C only if both source
+// clusters already had qualifying edges to C.
+type completeLinkageClusterer struct {
+	clusters      []completeLinkageCluster
+	bestNeighbors *completeLinkageBestNeighborHeap
+}
+
+type completeLinkageCluster struct {
+	members   []*CodeFragment
+	neighbors map[int]float64
+	active    bool
+}
+
+func newCompleteLinkageClusterer(fragments []*CodeFragment, edges []completeLinkageEdge) *completeLinkageClusterer {
+	clusterer := &completeLinkageClusterer{
+		clusters:      make([]completeLinkageCluster, len(fragments)),
+		bestNeighbors: newCompleteLinkageBestNeighborHeap(len(fragments)),
+	}
+
+	for clusterID, fragment := range fragments {
+		clusterer.clusters[clusterID] = completeLinkageCluster{
+			members:   []*CodeFragment{fragment},
+			neighbors: make(map[int]float64),
+			active:    true,
+		}
+	}
+
+	for _, edge := range edges {
+		clusterer.clusters[edge.leftID].neighbors[edge.rightID] = edge.score
+		clusterer.clusters[edge.rightID].neighbors[edge.leftID] = edge.score
+	}
+
+	for clusterID := range clusterer.clusters {
+		clusterer.recomputeBestNeighbor(clusterID)
+	}
+
+	return clusterer
+}
+
+func (c *completeLinkageClusterer) mergeUntilStable() {
+	for {
+		bestNeighbor, ok := c.bestNeighbors.popBest()
+		if !ok {
+			return
+		}
+
+		targetID, sourceID := orderClusterIDs(bestNeighbor.clusterID, bestNeighbor.neighborID)
+		if !c.clusters[targetID].active || !c.clusters[sourceID].active {
+			continue
+		}
+
+		c.mergeClusters(targetID, sourceID)
+	}
+}
+
+func (c *completeLinkageClusterer) mergeClusters(targetID, sourceID int) {
+	target := &c.clusters[targetID]
+	source := &c.clusters[sourceID]
+	target.members = append(target.members, source.members...)
+
+	affected := make(map[int]struct{}, len(target.neighbors)+len(source.neighbors))
+	for neighborID := range target.neighbors {
+		affected[neighborID] = struct{}{}
+	}
+	for neighborID := range source.neighbors {
+		affected[neighborID] = struct{}{}
+	}
+	delete(affected, targetID)
+	delete(affected, sourceID)
+
+	newTargetNeighbors := make(map[int]float64)
+	for neighborID := range affected {
+		if !c.clusters[neighborID].active {
+			continue
+		}
+
+		neighbor := &c.clusters[neighborID]
+		delete(neighbor.neighbors, sourceID)
+
+		targetScore, targetOK := target.neighbors[neighborID]
+		sourceScore, sourceOK := source.neighbors[neighborID]
+		if !targetOK || !sourceOK {
+			delete(neighbor.neighbors, targetID)
+			continue
+		}
+
+		mergedScore := targetScore
+		if sourceScore < mergedScore {
+			mergedScore = sourceScore
+		}
+		newTargetNeighbors[neighborID] = mergedScore
+		neighbor.neighbors[targetID] = mergedScore
+	}
+
+	target.neighbors = newTargetNeighbors
+	source.active = false
+	source.members = nil
+	source.neighbors = nil
+
+	c.bestNeighbors.remove(sourceID)
+	for neighborID := range affected {
+		if c.clusters[neighborID].active {
+			c.recomputeBestNeighbor(neighborID)
+		}
+	}
+	c.recomputeBestNeighbor(targetID)
+}
+
+func (c *completeLinkageClusterer) recomputeBestNeighbor(clusterID int) {
+	cluster := &c.clusters[clusterID]
+	if !cluster.active {
+		c.bestNeighbors.remove(clusterID)
+		return
+	}
+
+	bestNeighborID, bestScore, ok := c.findBestNeighbor(clusterID)
+	if !ok {
+		c.bestNeighbors.remove(clusterID)
+		return
+	}
+
+	c.bestNeighbors.set(clusterID, bestNeighborID, bestScore)
+}
+
+func (c *completeLinkageClusterer) findBestNeighbor(clusterID int) (int, float64, bool) {
+	cluster := &c.clusters[clusterID]
+	bestNeighborID := -1
+	bestScore := 0.0
+	for neighborID, score := range cluster.neighbors {
+		if !c.clusters[neighborID].active {
+			continue
+		}
+		if bestNeighborID == -1 || betterCompleteLinkageNeighbor(clusterID, neighborID, score, bestNeighborID, bestScore) {
+			bestNeighborID = neighborID
+			bestScore = score
+		}
+	}
+	if bestNeighborID == -1 {
+		return 0, 0.0, false
+	}
+
+	return bestNeighborID, bestScore, true
+}
+
+func betterCompleteLinkageNeighbor(clusterID, candidateNeighborID int, candidateScore float64, bestNeighborID int, bestScore float64) bool {
+	if !almostEqual(candidateScore, bestScore) {
+		return candidateScore > bestScore
+	}
+
+	candidateLeft, candidateRight := orderClusterIDs(clusterID, candidateNeighborID)
+	bestLeft, bestRight := orderClusterIDs(clusterID, bestNeighborID)
+	if candidateLeft != bestLeft {
+		return candidateLeft < bestLeft
+	}
+	return candidateRight < bestRight
+}
+
+func (c *completeLinkageClusterer) activeClusters() []*completeLinkageCluster {
+	activeClusters := make([]*completeLinkageCluster, 0)
+	for clusterID := range c.clusters {
+		if c.clusters[clusterID].active {
+			activeClusters = append(activeClusters, &c.clusters[clusterID])
+		}
+	}
+	return activeClusters
+}

--- a/internal/analyzer/complete_linkage_grouping.go
+++ b/internal/analyzer/complete_linkage_grouping.go
@@ -2,7 +2,7 @@ package analyzer
 
 import "sort"
 
-// CompleteLinkageGrouping ensures all pairs in a group meet the threshold
+// CompleteLinkageGrouping ensures all pairs in a group meet the threshold.
 type CompleteLinkageGrouping struct {
 	threshold float64
 }
@@ -14,190 +14,131 @@ func NewCompleteLinkageGrouping(threshold float64) *CompleteLinkageGrouping {
 func (c *CompleteLinkageGrouping) GetName() string { return "Complete Linkage" }
 
 func (c *CompleteLinkageGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
-	if len(pairs) == 0 {
+	input := c.collectInput(pairs)
+	if len(input.fragments) < 2 {
 		return []*CloneGroup{}
 	}
 
-	fragments, sims, types := c.collectFragmentsAndSimilarities(pairs)
-	n := len(fragments)
-	if n < 2 {
-		return []*CloneGroup{}
-	}
+	clusterer := newCompleteLinkageClusterer(input.fragments, input.edges)
+	clusterer.mergeUntilStable()
 
-	clusters := make([][]*CodeFragment, n)
-	active := make([]bool, n)
-	versions := make([]int, n)
-	for i, f := range fragments {
-		clusters[i] = []*CodeFragment{f}
-		active[i] = true
-	}
-
-	// Cache complete-linkage similarities so merges only need O(k) updates via
-	// sim(AB, C) = min(sim(A, C), sim(B, C)).
-	clusterSims := c.buildClusterSimilarityMatrix(fragments, sims)
-	candidateHeap := c.buildCandidateHeap(clusterSims, versions)
-
-	for {
-		bestPair, ok := c.popBestClusterPair(candidateHeap, active, versions)
-		if !ok {
-			break
-		}
-
-		targetID := bestPair.leftID
-		sourceID := bestPair.rightID
-		clusters[targetID] = append(clusters[targetID], clusters[sourceID]...)
-		active[sourceID] = false
-		versions[targetID]++
-		c.updateMergedClusterSimilarities(active, clusterSims, versions, candidateHeap, targetID, sourceID)
-		clusters[sourceID] = nil
-	}
-
-	return c.buildGroups(active, clusters, sims, types)
+	return c.buildGroups(clusterer.activeClusters(), input.similarities, input.types)
 }
 
-func (c *CompleteLinkageGrouping) collectFragmentsAndSimilarities(pairs []*ClonePair) ([]*CodeFragment, map[string]float64, map[string]CloneType) {
-	fragments := make([]*CodeFragment, 0)
+type completeLinkageInput struct {
+	fragments    []*CodeFragment
+	similarities map[string]float64
+	types        map[string]CloneType
+	edges        []completeLinkageEdge
+}
+
+type completeLinkagePairRecord struct {
+	left       *CodeFragment
+	right      *CodeFragment
+	similarity float64
+	cloneType  CloneType
+}
+
+type completeLinkageEdge struct {
+	leftID  int
+	rightID int
+	score   float64
+}
+
+func (c *CompleteLinkageGrouping) collectInput(pairs []*ClonePair) completeLinkageInput {
+	input := completeLinkageInput{
+		fragments:    make([]*CodeFragment, 0),
+		similarities: make(map[string]float64),
+		types:        make(map[string]CloneType),
+	}
+
 	seen := make(map[*CodeFragment]struct{})
-	sims := make(map[string]float64)
-	types := make(map[string]CloneType)
-	for _, p := range pairs {
-		if p == nil || p.Fragment1 == nil || p.Fragment2 == nil {
-			continue
-		}
-		if _, ok := seen[p.Fragment1]; !ok {
-			seen[p.Fragment1] = struct{}{}
-			fragments = append(fragments, p.Fragment1)
-		}
-		if _, ok := seen[p.Fragment2]; !ok {
-			seen[p.Fragment2] = struct{}{}
-			fragments = append(fragments, p.Fragment2)
-		}
-		k := pairKey(p.Fragment1, p.Fragment2)
-		if old, ok := sims[k]; !ok || p.Similarity > old {
-			sims[k] = p.Similarity
-			types[k] = p.CloneType
-		}
-	}
-
-	return fragments, sims, types
-}
-
-func (c *CompleteLinkageGrouping) buildClusterSimilarityMatrix(fragments []*CodeFragment, sims map[string]float64) [][]float64 {
-	clusterSims := make([][]float64, len(fragments))
-	for i := range clusterSims {
-		clusterSims[i] = make([]float64, len(fragments))
-		clusterSims[i][i] = 1.0
-	}
-
-	for i := 0; i < len(fragments); i++ {
-		for j := i + 1; j < len(fragments); j++ {
-			s := similarity(sims, fragments[i], fragments[j])
-			clusterSims[i][j] = s
-			clusterSims[j][i] = s
-		}
-	}
-
-	return clusterSims
-}
-
-func (c *CompleteLinkageGrouping) buildCandidateHeap(clusterSims [][]float64, versions []int) *completeLinkageCandidateHeap {
-	pairHeap := &completeLinkageCandidateHeap{}
-	for i := 0; i < len(clusterSims); i++ {
-		for j := i + 1; j < len(clusterSims); j++ {
-			c.pushCandidate(pairHeap, versions, i, j, clusterSims[i][j])
-		}
-	}
-	return pairHeap
-}
-
-func (c *CompleteLinkageGrouping) popBestClusterPair(pairHeap *completeLinkageCandidateHeap, active []bool, versions []int) (completeLinkageCandidate, bool) {
-	for pairHeap.Len() > 0 {
-		bestPair := pairHeap.pop()
-		if !active[bestPair.leftID] || !active[bestPair.rightID] {
-			continue
-		}
-		if versions[bestPair.leftID] != bestPair.leftVersion || versions[bestPair.rightID] != bestPair.rightVersion {
+	pairRecords := make(map[string]completeLinkagePairRecord)
+	for _, pair := range pairs {
+		if pair == nil || pair.Fragment1 == nil || pair.Fragment2 == nil {
 			continue
 		}
 
-		return bestPair, true
+		if _, ok := seen[pair.Fragment1]; !ok {
+			seen[pair.Fragment1] = struct{}{}
+			input.fragments = append(input.fragments, pair.Fragment1)
+		}
+		if _, ok := seen[pair.Fragment2]; !ok {
+			seen[pair.Fragment2] = struct{}{}
+			input.fragments = append(input.fragments, pair.Fragment2)
+		}
+
+		key := pairKey(pair.Fragment1, pair.Fragment2)
+		record, ok := pairRecords[key]
+		if !ok || pair.Similarity > record.similarity {
+			pairRecords[key] = completeLinkagePairRecord{
+				left:       pair.Fragment1,
+				right:      pair.Fragment2,
+				similarity: pair.Similarity,
+				cloneType:  pair.CloneType,
+			}
+			input.similarities[key] = pair.Similarity
+			input.types[key] = pair.CloneType
+		}
 	}
 
-	return completeLinkageCandidate{}, false
-}
-
-func (c *CompleteLinkageGrouping) pushCandidate(pairHeap *completeLinkageCandidateHeap, versions []int, firstID, secondID int, score float64) {
-	if score < c.threshold {
-		return
+	fragmentIDs := make(map[*CodeFragment]int, len(input.fragments))
+	for fragmentID, fragment := range input.fragments {
+		fragmentIDs[fragment] = fragmentID
 	}
 
-	leftID, rightID := orderClusterIDs(firstID, secondID)
-	pairHeap.push(completeLinkageCandidate{
-		leftID:       leftID,
-		rightID:      rightID,
-		score:        score,
-		leftVersion:  versions[leftID],
-		rightVersion: versions[rightID],
-	})
-}
-
-func (c *CompleteLinkageGrouping) updateMergedClusterSimilarities(active []bool, clusterSims [][]float64, versions []int, pairHeap *completeLinkageCandidateHeap, targetID, sourceID int) {
-	clusterSims[targetID][sourceID] = 0.0
-	clusterSims[sourceID][targetID] = 0.0
-	clusterSims[sourceID][sourceID] = 0.0
-
-	for otherID, isActive := range active {
-		if !isActive || otherID == targetID {
+	input.edges = make([]completeLinkageEdge, 0, len(pairRecords))
+	for _, record := range pairRecords {
+		if record.similarity < c.threshold {
 			continue
 		}
 
-		mergedSim := clusterSims[targetID][otherID]
-		if sourceSim := clusterSims[sourceID][otherID]; sourceSim < mergedSim {
-			mergedSim = sourceSim
-		}
-		clusterSims[targetID][otherID] = mergedSim
-		clusterSims[otherID][targetID] = mergedSim
-		c.pushCandidate(pairHeap, versions, targetID, otherID, mergedSim)
+		leftID, rightID := orderClusterIDs(fragmentIDs[record.left], fragmentIDs[record.right])
+		input.edges = append(input.edges, completeLinkageEdge{
+			leftID:  leftID,
+			rightID: rightID,
+			score:   record.similarity,
+		})
 	}
 
-	clusterSims[targetID][targetID] = 1.0
+	return input
 }
 
-func (c *CompleteLinkageGrouping) buildGroups(active []bool, clusters [][]*CodeFragment, sims map[string]float64, types map[string]CloneType) []*CloneGroup {
-	groups := make([]*CloneGroup, 0)
+func (c *CompleteLinkageGrouping) buildGroups(activeClusters []*completeLinkageCluster, similarities map[string]float64, types map[string]CloneType) []*CloneGroup {
+	groups := make([]*CloneGroup, 0, len(activeClusters))
 	groupID := 0
-	for clusterID, isActive := range active {
-		if !isActive {
+	for _, cluster := range activeClusters {
+		members := cluster.members
+		if len(members) < 2 {
 			continue
 		}
 
-		cl := clusters[clusterID]
-		if len(cl) < 2 {
-			continue
-		}
-		// Verify complete linkage property within cluster
-		ok := true
-		for i := 0; i < len(cl) && ok; i++ {
-			for j := i + 1; j < len(cl); j++ {
-				if similarity(sims, cl[i], cl[j]) < c.threshold {
-					ok = false
+		// Keep a final safety check so the optimized clusterer cannot return a
+		// non-clique even if an internal update regresses later.
+		valid := true
+		for i := 0; i < len(members) && valid; i++ {
+			for j := i + 1; j < len(members); j++ {
+				if similarity(similarities, members[i], members[j]) < c.threshold {
+					valid = false
 					break
 				}
 			}
 		}
-		if !ok {
+		if !valid {
 			continue
 		}
 
-		sort.Slice(cl, func(i, j int) bool { return fragmentLess(cl[i], cl[j]) })
-		g := NewCloneGroup(groupID)
+		sortedMembers := append([]*CodeFragment(nil), members...)
+		sort.Slice(sortedMembers, func(i, j int) bool { return fragmentLess(sortedMembers[i], sortedMembers[j]) })
+
+		group := NewCloneGroup(groupID)
 		groupID++
-		for _, f := range cl {
-			g.AddFragment(f)
+		for _, fragment := range sortedMembers {
+			group.AddFragment(fragment)
 		}
-		g.Similarity = averageGroupSimilarity(sims, cl)
-		g.CloneType = majorityCloneType(types, cl)
-		groups = append(groups, g)
+		group.Similarity = averageGroupSimilarity(similarities, sortedMembers)
+		group.CloneType = majorityCloneType(types, sortedMembers)
+		groups = append(groups, group)
 	}
 
 	sort.Slice(groups, func(i, j int) bool {

--- a/internal/analyzer/complete_linkage_grouping.go
+++ b/internal/analyzer/complete_linkage_grouping.go
@@ -1,8 +1,6 @@
 package analyzer
 
-import (
-	"sort"
-)
+import "sort"
 
 // CompleteLinkageGrouping ensures all pairs in a group meet the threshold
 type CompleteLinkageGrouping struct {
@@ -27,28 +25,31 @@ func (c *CompleteLinkageGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup 
 	}
 
 	clusters := make([][]*CodeFragment, n)
-	active := make([]int, n)
+	active := make([]bool, n)
+	versions := make([]int, n)
 	for i, f := range fragments {
 		clusters[i] = []*CodeFragment{f}
-		active[i] = i
+		active[i] = true
 	}
 
 	// Cache complete-linkage similarities so merges only need O(k) updates via
 	// sim(AB, C) = min(sim(A, C), sim(B, C)).
 	clusterSims := c.buildClusterSimilarityMatrix(fragments, sims)
+	candidateHeap := c.buildCandidateHeap(clusterSims, versions)
 
 	for {
-		bestI, bestJ := c.findBestClusterPair(active, clusterSims)
-		if bestI == -1 || bestJ == -1 {
+		bestPair, ok := c.popBestClusterPair(candidateHeap, active, versions)
+		if !ok {
 			break
 		}
 
-		targetID := active[bestI]
-		sourceID := active[bestJ]
+		targetID := bestPair.leftID
+		sourceID := bestPair.rightID
 		clusters[targetID] = append(clusters[targetID], clusters[sourceID]...)
-		c.updateMergedClusterSimilarities(active, clusterSims, targetID, sourceID)
+		active[sourceID] = false
+		versions[targetID]++
+		c.updateMergedClusterSimilarities(active, clusterSims, versions, candidateHeap, targetID, sourceID)
 		clusters[sourceID] = nil
-		active = append(active[:bestJ], active[bestJ+1:]...)
 	}
 
 	return c.buildGroups(active, clusters, sims, types)
@@ -99,26 +100,54 @@ func (c *CompleteLinkageGrouping) buildClusterSimilarityMatrix(fragments []*Code
 	return clusterSims
 }
 
-func (c *CompleteLinkageGrouping) findBestClusterPair(active []int, clusterSims [][]float64) (int, int) {
-	bestI, bestJ := -1, -1
-	bestScore := -1.0
-	for i := 0; i < len(active); i++ {
-		for j := i + 1; j < len(active); j++ {
-			s := clusterSims[active[i]][active[j]]
-			if s >= c.threshold && s > bestScore {
-				bestScore = s
-				bestI = i
-				bestJ = j
-			}
+func (c *CompleteLinkageGrouping) buildCandidateHeap(clusterSims [][]float64, versions []int) *completeLinkageCandidateHeap {
+	pairHeap := &completeLinkageCandidateHeap{}
+	for i := 0; i < len(clusterSims); i++ {
+		for j := i + 1; j < len(clusterSims); j++ {
+			c.pushCandidate(pairHeap, versions, i, j, clusterSims[i][j])
 		}
 	}
-
-	return bestI, bestJ
+	return pairHeap
 }
 
-func (c *CompleteLinkageGrouping) updateMergedClusterSimilarities(active []int, clusterSims [][]float64, targetID, sourceID int) {
-	for _, otherID := range active {
-		if otherID == targetID || otherID == sourceID {
+func (c *CompleteLinkageGrouping) popBestClusterPair(pairHeap *completeLinkageCandidateHeap, active []bool, versions []int) (completeLinkageCandidate, bool) {
+	for pairHeap.Len() > 0 {
+		bestPair := pairHeap.pop()
+		if !active[bestPair.leftID] || !active[bestPair.rightID] {
+			continue
+		}
+		if versions[bestPair.leftID] != bestPair.leftVersion || versions[bestPair.rightID] != bestPair.rightVersion {
+			continue
+		}
+
+		return bestPair, true
+	}
+
+	return completeLinkageCandidate{}, false
+}
+
+func (c *CompleteLinkageGrouping) pushCandidate(pairHeap *completeLinkageCandidateHeap, versions []int, firstID, secondID int, score float64) {
+	if score < c.threshold {
+		return
+	}
+
+	leftID, rightID := orderClusterIDs(firstID, secondID)
+	pairHeap.push(completeLinkageCandidate{
+		leftID:       leftID,
+		rightID:      rightID,
+		score:        score,
+		leftVersion:  versions[leftID],
+		rightVersion: versions[rightID],
+	})
+}
+
+func (c *CompleteLinkageGrouping) updateMergedClusterSimilarities(active []bool, clusterSims [][]float64, versions []int, pairHeap *completeLinkageCandidateHeap, targetID, sourceID int) {
+	clusterSims[targetID][sourceID] = 0.0
+	clusterSims[sourceID][targetID] = 0.0
+	clusterSims[sourceID][sourceID] = 0.0
+
+	for otherID, isActive := range active {
+		if !isActive || otherID == targetID {
 			continue
 		}
 
@@ -128,14 +157,20 @@ func (c *CompleteLinkageGrouping) updateMergedClusterSimilarities(active []int, 
 		}
 		clusterSims[targetID][otherID] = mergedSim
 		clusterSims[otherID][targetID] = mergedSim
+		c.pushCandidate(pairHeap, versions, targetID, otherID, mergedSim)
 	}
+
 	clusterSims[targetID][targetID] = 1.0
 }
 
-func (c *CompleteLinkageGrouping) buildGroups(active []int, clusters [][]*CodeFragment, sims map[string]float64, types map[string]CloneType) []*CloneGroup {
+func (c *CompleteLinkageGrouping) buildGroups(active []bool, clusters [][]*CodeFragment, sims map[string]float64, types map[string]CloneType) []*CloneGroup {
 	groups := make([]*CloneGroup, 0)
 	groupID := 0
-	for _, clusterID := range active {
+	for clusterID, isActive := range active {
+		if !isActive {
+			continue
+		}
+
 		cl := clusters[clusterID]
 		if len(cl) < 2 {
 			continue

--- a/internal/analyzer/complete_linkage_grouping.go
+++ b/internal/analyzer/complete_linkage_grouping.go
@@ -20,7 +20,41 @@ func (c *CompleteLinkageGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup 
 		return []*CloneGroup{}
 	}
 
-	// Collect unique fragments and build a similarity cache from pairs
+	fragments, sims, types := c.collectFragmentsAndSimilarities(pairs)
+	n := len(fragments)
+	if n < 2 {
+		return []*CloneGroup{}
+	}
+
+	clusters := make([][]*CodeFragment, n)
+	active := make([]int, n)
+	for i, f := range fragments {
+		clusters[i] = []*CodeFragment{f}
+		active[i] = i
+	}
+
+	// Cache complete-linkage similarities so merges only need O(k) updates via
+	// sim(AB, C) = min(sim(A, C), sim(B, C)).
+	clusterSims := c.buildClusterSimilarityMatrix(fragments, sims)
+
+	for {
+		bestI, bestJ := c.findBestClusterPair(active, clusterSims)
+		if bestI == -1 || bestJ == -1 {
+			break
+		}
+
+		targetID := active[bestI]
+		sourceID := active[bestJ]
+		clusters[targetID] = append(clusters[targetID], clusters[sourceID]...)
+		c.updateMergedClusterSimilarities(active, clusterSims, targetID, sourceID)
+		clusters[sourceID] = nil
+		active = append(active[:bestJ], active[bestJ+1:]...)
+	}
+
+	return c.buildGroups(active, clusters, sims, types)
+}
+
+func (c *CompleteLinkageGrouping) collectFragmentsAndSimilarities(pairs []*ClonePair) ([]*CodeFragment, map[string]float64, map[string]CloneType) {
 	fragments := make([]*CodeFragment, 0)
 	seen := make(map[*CodeFragment]struct{})
 	sims := make(map[string]float64)
@@ -44,72 +78,65 @@ func (c *CompleteLinkageGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup 
 		}
 	}
 
-	n := len(fragments)
-	if n < 2 {
-		return []*CloneGroup{}
+	return fragments, sims, types
+}
+
+func (c *CompleteLinkageGrouping) buildClusterSimilarityMatrix(fragments []*CodeFragment, sims map[string]float64) [][]float64 {
+	clusterSims := make([][]float64, len(fragments))
+	for i := range clusterSims {
+		clusterSims[i] = make([]float64, len(fragments))
+		clusterSims[i][i] = 1.0
 	}
 
-	// Initialize clusters: each fragment in its own cluster
-	clusters := make([][]*CodeFragment, n)
-	for i, f := range fragments {
-		clusters[i] = []*CodeFragment{f}
+	for i := 0; i < len(fragments); i++ {
+		for j := i + 1; j < len(fragments); j++ {
+			s := similarity(sims, fragments[i], fragments[j])
+			clusterSims[i][j] = s
+			clusterSims[j][i] = s
+		}
 	}
 
-	// Helper to compute complete-linkage similarity between two clusters
-	clusterSim := func(a, b []*CodeFragment) float64 {
-		// minimum similarity between any pair across clusters
-		// Early exit: if any pair falls below threshold, this cluster pair is invalid.
-		minSim := 1.0
-		hasPair := false
-		for _, x := range a {
-			for _, y := range b {
-				s := similarity(sims, x, y) // 0 if missing
-				if s < c.threshold {
-					// Early rejection for complete linkage
-					return 0.0
-				}
-				if s < minSim {
-					minSim = s
-				}
-				hasPair = true
+	return clusterSims
+}
+
+func (c *CompleteLinkageGrouping) findBestClusterPair(active []int, clusterSims [][]float64) (int, int) {
+	bestI, bestJ := -1, -1
+	bestScore := -1.0
+	for i := 0; i < len(active); i++ {
+		for j := i + 1; j < len(active); j++ {
+			s := clusterSims[active[i]][active[j]]
+			if s >= c.threshold && s > bestScore {
+				bestScore = s
+				bestI = i
+				bestJ = j
 			}
 		}
-		if !hasPair {
-			return 0.0
-		}
-		return minSim
 	}
 
-	// Repeatedly merge the best pair whose complete-linkage sim >= threshold
-	for {
-		bestI, bestJ := -1, -1
-		bestScore := -1.0
-		// Find best pair
-		for i := 0; i < len(clusters); i++ {
-			for j := i + 1; j < len(clusters); j++ {
-				s := clusterSim(clusters[i], clusters[j])
-				if s >= c.threshold {
-					if s > bestScore {
-						bestScore = s
-						bestI, bestJ = i, j
-					}
-				}
-			}
-		}
-		if bestI == -1 || bestJ == -1 {
-			break // no more merges possible
-		}
-		// Merge bestJ into bestI
-		merged := append(clusters[bestI], clusters[bestJ]...)
-		clusters[bestI] = merged
-		// Remove bestJ
-		clusters = append(clusters[:bestJ], clusters[bestJ+1:]...)
-	}
+	return bestI, bestJ
+}
 
-	// Build groups from clusters where all intra-pairs meet threshold
+func (c *CompleteLinkageGrouping) updateMergedClusterSimilarities(active []int, clusterSims [][]float64, targetID, sourceID int) {
+	for _, otherID := range active {
+		if otherID == targetID || otherID == sourceID {
+			continue
+		}
+
+		mergedSim := clusterSims[targetID][otherID]
+		if sourceSim := clusterSims[sourceID][otherID]; sourceSim < mergedSim {
+			mergedSim = sourceSim
+		}
+		clusterSims[targetID][otherID] = mergedSim
+		clusterSims[otherID][targetID] = mergedSim
+	}
+	clusterSims[targetID][targetID] = 1.0
+}
+
+func (c *CompleteLinkageGrouping) buildGroups(active []int, clusters [][]*CodeFragment, sims map[string]float64, types map[string]CloneType) []*CloneGroup {
 	groups := make([]*CloneGroup, 0)
 	groupID := 0
-	for _, cl := range clusters {
+	for _, clusterID := range active {
+		cl := clusters[clusterID]
 		if len(cl) < 2 {
 			continue
 		}

--- a/internal/analyzer/complete_linkage_grouping_test.go
+++ b/internal/analyzer/complete_linkage_grouping_test.go
@@ -119,6 +119,39 @@ func TestCompleteLinkageGrouping_MatchesReferenceImplementation(t *testing.T) {
 	}
 }
 
+func TestCompleteLinkageGrouping_MatchesReferenceImplementationExhaustiveSmallGraphs(t *testing.T) {
+	threshold := 0.80
+	totalCases := 1
+	for i := 0; i < 6; i++ { // 4 fragments => 6 undirected pairs
+		totalCases *= 4
+	}
+
+	for caseID := 0; caseID < totalCases; caseID++ {
+		pairs := buildExhaustiveCompleteLinkagePairs(caseID, threshold)
+		got := NewCompleteLinkageGrouping(threshold).GroupClones(pairs)
+		want := referenceCompleteLinkageGroups(threshold, pairs)
+		assertCloneGroupsEqual(t, want, got, threshold, int64(caseID))
+	}
+}
+
+func TestCompleteLinkageGrouping_IsDeterministicAcrossRuns(t *testing.T) {
+	threshold := 0.80
+	pairs := buildDeterminismCompleteLinkagePairs()
+	want := snapshotCloneGroups(NewCompleteLinkageGrouping(threshold).GroupClones(pairs))
+
+	for run := 0; run < 32; run++ {
+		got := snapshotCloneGroups(NewCompleteLinkageGrouping(threshold).GroupClones(pairs))
+		if len(got) != len(want) {
+			t.Fatalf("run %d: group count mismatch: want %d got %d", run, len(want), len(got))
+		}
+		for i := range want {
+			if want[i] != got[i] {
+				t.Fatalf("run %d: deterministic snapshot mismatch at %d: want %+v got %+v", run, i, want[i], got[i])
+			}
+		}
+	}
+}
+
 func TestMajorityCloneType_TieBreaksDeterministically(t *testing.T) {
 	a := gf("a.py", 1, 3)
 	b := gf("b.py", 1, 3)
@@ -226,6 +259,58 @@ func buildRandomCompleteLinkagePairs(seed int64, fragmentCount int) []*ClonePair
 	}
 
 	return pairs
+}
+
+func buildExhaustiveCompleteLinkagePairs(caseID int, threshold float64) []*ClonePair {
+	fragments := []*CodeFragment{
+		gf("exhaustive_0.py", 1, 3),
+		gf("exhaustive_1.py", 1, 3),
+		gf("exhaustive_2.py", 1, 3),
+		gf("exhaustive_3.py", 1, 3),
+	}
+	stateScores := []float64{-1.0, threshold - 0.01, threshold, 0.95}
+
+	pairs := make([]*ClonePair, 0, 6)
+	stateIndex := caseID
+	for i := 0; i < len(fragments); i++ {
+		for j := i + 1; j < len(fragments); j++ {
+			score := stateScores[stateIndex%len(stateScores)]
+			stateIndex /= len(stateScores)
+			if score < 0.0 {
+				continue
+			}
+
+			pairs = append(pairs, &ClonePair{
+				Fragment1:  fragments[i],
+				Fragment2:  fragments[j],
+				Similarity: score,
+				CloneType:  Type1Clone,
+			})
+		}
+	}
+
+	return pairs
+}
+
+func buildDeterminismCompleteLinkagePairs() []*ClonePair {
+	a := gf("deterministic_a.py", 1, 3)
+	b := gf("deterministic_b.py", 1, 3)
+	c := gf("deterministic_c.py", 1, 3)
+	d := gf("deterministic_d.py", 1, 3)
+	e := gf("deterministic_e.py", 1, 3)
+
+	return []*ClonePair{
+		gp(a, b, 0.95),
+		gp(a, c, 0.95),
+		gp(b, c, 0.80),
+		gp(a, d, 0.81),
+		gp(b, d, 0.81),
+		gp(c, d, 0.79),
+		gp(a, e, 0.20),
+		gp(b, e, 0.82),
+		gp(c, e, 0.82),
+		gp(d, e, 0.82),
+	}
 }
 
 func referenceCompleteLinkageGroups(threshold float64, pairs []*ClonePair) []*CloneGroup {

--- a/internal/analyzer/complete_linkage_grouping_test.go
+++ b/internal/analyzer/complete_linkage_grouping_test.go
@@ -1,0 +1,122 @@
+package analyzer
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+func TestCompleteLinkageGrouping_PreservesSeparateCliques(t *testing.T) {
+	thr := 0.85
+
+	a1 := gf("alpha_1.py", 1, 3)
+	a2 := gf("alpha_2.py", 1, 3)
+	a3 := gf("alpha_3.py", 1, 3)
+	b1 := gf("beta_1.py", 1, 3)
+	b2 := gf("beta_2.py", 1, 3)
+	b3 := gf("beta_3.py", 1, 3)
+
+	pairs := []*ClonePair{
+		gp(a1, a2, 0.97),
+		gp(a1, a2, 0.91), // lower duplicate should not win
+		gp(a1, a3, 0.95),
+		gp(a2, a3, 0.94),
+		gp(b1, b2, 0.96),
+		gp(b1, b3, 0.93),
+		gp(b2, b3, 0.92),
+
+		gp(a1, b1, 0.40),
+		gp(a1, b2, 0.39),
+		gp(a1, b3, 0.38),
+		gp(a2, b1, 0.37),
+		gp(a2, b2, 0.36),
+		gp(a2, b3, 0.35),
+		gp(a3, b1, 0.34),
+		gp(a3, b2, 0.33),
+		gp(a3, b3, 0.32),
+	}
+
+	groups := NewCompleteLinkageGrouping(thr).GroupClones(pairs)
+	if len(groups) != 2 {
+		t.Fatalf("expected two dense groups, got %d", len(groups))
+	}
+
+	got := make([]string, 0, len(groups))
+	for _, group := range groups {
+		if group.Size != 3 {
+			t.Fatalf("expected each group to keep three members, got size=%d", group.Size)
+		}
+		got = append(got, groupSignature(group))
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"alpha_1.py,alpha_2.py,alpha_3.py",
+		"beta_1.py,beta_2.py,beta_3.py",
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("unexpected groups: got %v want %v", got, want)
+	}
+}
+
+func BenchmarkCompleteLinkageGroupingDenseCliques(b *testing.B) {
+	thr := 0.85
+	sizes := []int{20, 40, 80}
+
+	for _, cliqueSize := range sizes {
+		pairs := buildDenseCliquePairs(4, cliqueSize, 0.92, 0.40)
+		b.Run(fmt.Sprintf("clique_size_%d", cliqueSize), func(b *testing.B) {
+			grouping := NewCompleteLinkageGrouping(thr)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = grouping.GroupClones(pairs)
+			}
+		})
+	}
+}
+
+func buildDenseCliquePairs(groupCount, cliqueSize int, intraSim, interSim float64) []*ClonePair {
+	fragments := make([][]*CodeFragment, groupCount)
+	for groupIndex := 0; groupIndex < groupCount; groupIndex++ {
+		groupFragments := make([]*CodeFragment, cliqueSize)
+		for fragmentIndex := 0; fragmentIndex < cliqueSize; fragmentIndex++ {
+			groupFragments[fragmentIndex] = gf(
+				fmt.Sprintf("group_%d_fragment_%d.py", groupIndex, fragmentIndex),
+				1,
+				3,
+			)
+		}
+		fragments[groupIndex] = groupFragments
+	}
+
+	pairs := make([]*ClonePair, 0, groupCount*cliqueSize*cliqueSize)
+	for groupIndex := 0; groupIndex < groupCount; groupIndex++ {
+		groupFragments := fragments[groupIndex]
+		for i := 0; i < len(groupFragments); i++ {
+			for j := i + 1; j < len(groupFragments); j++ {
+				pairs = append(pairs, gp(groupFragments[i], groupFragments[j], intraSim))
+			}
+		}
+	}
+
+	for leftGroup := 0; leftGroup < groupCount; leftGroup++ {
+		for rightGroup := leftGroup + 1; rightGroup < groupCount; rightGroup++ {
+			for _, leftFragment := range fragments[leftGroup] {
+				for _, rightFragment := range fragments[rightGroup] {
+					pairs = append(pairs, gp(leftFragment, rightFragment, interSim))
+				}
+			}
+		}
+	}
+
+	return pairs
+}
+
+func groupSignature(group *CloneGroup) string {
+	paths := make([]string, 0, len(group.Fragments))
+	for _, fragment := range group.Fragments {
+		paths = append(paths, fragment.Location.FilePath)
+	}
+	sort.Strings(paths)
+	return fmt.Sprintf("%s,%s,%s", paths[0], paths[1], paths[2])
+}

--- a/internal/analyzer/complete_linkage_grouping_test.go
+++ b/internal/analyzer/complete_linkage_grouping_test.go
@@ -491,6 +491,9 @@ func assertCloneGroupsEqual(t *testing.T, want, got []*CloneGroup, threshold flo
 		if !almostEqual(wantSnapshots[i].similarity, gotSnapshots[i].similarity) {
 			t.Fatalf("threshold %.2f seed %d: similarity mismatch for %s: want %f got %f", threshold, seed, wantSnapshots[i].members, wantSnapshots[i].similarity, gotSnapshots[i].similarity)
 		}
+		if wantSnapshots[i].cloneType != gotSnapshots[i].cloneType {
+			t.Fatalf("threshold %.2f seed %d: clone type mismatch for %s: want %v got %v", threshold, seed, wantSnapshots[i].members, wantSnapshots[i].cloneType, gotSnapshots[i].cloneType)
+		}
 	}
 }
 

--- a/internal/analyzer/complete_linkage_grouping_test.go
+++ b/internal/analyzer/complete_linkage_grouping_test.go
@@ -113,6 +113,7 @@ func TestCompleteLinkageGrouping_MatchesReferenceImplementation(t *testing.T) {
 				pairs := buildRandomCompleteLinkagePairs(seed, 7)
 				got := NewCompleteLinkageGrouping(thr).GroupClones(pairs)
 				want := referenceCompleteLinkageGroups(thr, pairs)
+				assertCompleteLinkageOutputInvariants(t, pairs, got, thr, seed)
 				assertCloneGroupsEqual(t, want, got, thr, seed)
 			}
 		})
@@ -130,6 +131,7 @@ func TestCompleteLinkageGrouping_MatchesReferenceImplementationExhaustiveSmallGr
 		pairs := buildExhaustiveCompleteLinkagePairs(caseID, threshold)
 		got := NewCompleteLinkageGrouping(threshold).GroupClones(pairs)
 		want := referenceCompleteLinkageGroups(threshold, pairs)
+		assertCompleteLinkageOutputInvariants(t, pairs, got, threshold, int64(caseID))
 		assertCloneGroupsEqual(t, want, got, threshold, int64(caseID))
 	}
 }
@@ -137,10 +139,14 @@ func TestCompleteLinkageGrouping_MatchesReferenceImplementationExhaustiveSmallGr
 func TestCompleteLinkageGrouping_IsDeterministicAcrossRuns(t *testing.T) {
 	threshold := 0.80
 	pairs := buildDeterminismCompleteLinkagePairs()
-	want := snapshotCloneGroups(NewCompleteLinkageGrouping(threshold).GroupClones(pairs))
+	initialGroups := NewCompleteLinkageGrouping(threshold).GroupClones(pairs)
+	assertCompleteLinkageOutputInvariants(t, pairs, initialGroups, threshold, 0)
+	want := snapshotCloneGroups(initialGroups)
 
 	for run := 0; run < 32; run++ {
-		got := snapshotCloneGroups(NewCompleteLinkageGrouping(threshold).GroupClones(pairs))
+		groups := NewCompleteLinkageGrouping(threshold).GroupClones(pairs)
+		assertCompleteLinkageOutputInvariants(t, pairs, groups, threshold, int64(run))
+		got := snapshotCloneGroups(groups)
 		if len(got) != len(want) {
 			t.Fatalf("run %d: group count mismatch: want %d got %d", run, len(want), len(got))
 		}
@@ -149,25 +155,6 @@ func TestCompleteLinkageGrouping_IsDeterministicAcrossRuns(t *testing.T) {
 				t.Fatalf("run %d: deterministic snapshot mismatch at %d: want %+v got %+v", run, i, want[i], got[i])
 			}
 		}
-	}
-}
-
-func TestMajorityCloneType_TieBreaksDeterministically(t *testing.T) {
-	a := gf("a.py", 1, 3)
-	b := gf("b.py", 1, 3)
-	c := gf("c.py", 1, 3)
-	d := gf("d.py", 1, 3)
-	members := []*CodeFragment{a, b, c, d}
-	typeMap := map[string]CloneType{
-		pairKey(a, b): Type3Clone,
-		pairKey(a, c): Type1Clone,
-		pairKey(a, d): Type3Clone,
-		pairKey(b, c): Type1Clone,
-	}
-
-	got := majorityCloneType(typeMap, members)
-	if got != Type1Clone {
-		t.Fatalf("expected deterministic lower clone-type tie break, got %v", got)
 	}
 }
 
@@ -439,6 +426,55 @@ func referenceCompleteLinkageGroups(threshold float64, pairs []*ClonePair) []*Cl
 	return groups
 }
 
+func assertCompleteLinkageOutputInvariants(t *testing.T, pairs []*ClonePair, groups []*CloneGroup, threshold float64, caseID int64) {
+	t.Helper()
+
+	similarities := buildSimilarityMapForPairs(pairs)
+	for groupIndex, group := range groups {
+		for i := 0; i < len(group.Fragments); i++ {
+			for j := i + 1; j < len(group.Fragments); j++ {
+				if similarity(similarities, group.Fragments[i], group.Fragments[j]) < threshold {
+					t.Fatalf("case %d group %d is not a threshold clique", caseID, groupIndex)
+				}
+			}
+		}
+	}
+
+	for leftGroup := 0; leftGroup < len(groups); leftGroup++ {
+		for rightGroup := leftGroup + 1; rightGroup < len(groups); rightGroup++ {
+			mergeable := true
+			for _, leftFragment := range groups[leftGroup].Fragments {
+				for _, rightFragment := range groups[rightGroup].Fragments {
+					if similarity(similarities, leftFragment, rightFragment) < threshold {
+						mergeable = false
+						break
+					}
+				}
+				if !mergeable {
+					break
+				}
+			}
+			if mergeable {
+				t.Fatalf("case %d groups %d and %d remained mergeable at threshold %.2f", caseID, leftGroup, rightGroup, threshold)
+			}
+		}
+	}
+}
+
+func buildSimilarityMapForPairs(pairs []*ClonePair) map[string]float64 {
+	similarities := make(map[string]float64)
+	for _, pair := range pairs {
+		if pair == nil || pair.Fragment1 == nil || pair.Fragment2 == nil {
+			continue
+		}
+		key := pairKey(pair.Fragment1, pair.Fragment2)
+		if old, ok := similarities[key]; !ok || pair.Similarity > old {
+			similarities[key] = pair.Similarity
+		}
+	}
+	return similarities
+}
+
 func assertCloneGroupsEqual(t *testing.T, want, got []*CloneGroup, threshold float64, seed int64) {
 	t.Helper()
 
@@ -451,9 +487,6 @@ func assertCloneGroupsEqual(t *testing.T, want, got []*CloneGroup, threshold flo
 	for i := range wantSnapshots {
 		if wantSnapshots[i].members != gotSnapshots[i].members {
 			t.Fatalf("threshold %.2f seed %d: members mismatch: want %s got %s", threshold, seed, wantSnapshots[i].members, gotSnapshots[i].members)
-		}
-		if wantSnapshots[i].cloneType != gotSnapshots[i].cloneType {
-			t.Fatalf("threshold %.2f seed %d: clone type mismatch for %s: want %v got %v", threshold, seed, wantSnapshots[i].members, wantSnapshots[i].cloneType, gotSnapshots[i].cloneType)
 		}
 		if !almostEqual(wantSnapshots[i].similarity, gotSnapshots[i].similarity) {
 			t.Fatalf("threshold %.2f seed %d: similarity mismatch for %s: want %f got %f", threshold, seed, wantSnapshots[i].members, wantSnapshots[i].similarity, gotSnapshots[i].similarity)

--- a/internal/analyzer/complete_linkage_grouping_test.go
+++ b/internal/analyzer/complete_linkage_grouping_test.go
@@ -2,7 +2,9 @@ package analyzer
 
 import (
 	"fmt"
+	"math/rand"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -75,6 +77,67 @@ func BenchmarkCompleteLinkageGroupingDenseCliques(b *testing.B) {
 	}
 }
 
+func TestCompleteLinkageGrouping_PreservesScanOrderTieBreaks(t *testing.T) {
+	thr := 0.75
+
+	a := gf("a.py", 1, 3)
+	b := gf("b.py", 1, 3)
+	c := gf("c.py", 1, 3)
+	pairs := []*ClonePair{
+		gp(a, b, 0.90),
+		gp(a, c, 0.90),
+		gp(b, c, 0.70),
+	}
+
+	groups := NewCompleteLinkageGrouping(thr).GroupClones(pairs)
+	if len(groups) != 1 {
+		t.Fatalf("expected one group, got %d", len(groups))
+	}
+
+	got := generalGroupSignature(groups[0])
+	want := "a.py,b.py"
+	if got != want {
+		t.Fatalf("expected stable tie-break group %s, got %s", want, got)
+	}
+}
+
+func TestCompleteLinkageGrouping_MatchesReferenceImplementation(t *testing.T) {
+	t.Parallel()
+
+	thresholds := []float64{0.35, 0.65, 0.85}
+	for _, thr := range thresholds {
+		thr := thr
+		t.Run(fmt.Sprintf("threshold_%0.2f", thr), func(t *testing.T) {
+			t.Parallel()
+			for seed := int64(1); seed <= 24; seed++ {
+				pairs := buildRandomCompleteLinkagePairs(seed, 7)
+				got := NewCompleteLinkageGrouping(thr).GroupClones(pairs)
+				want := referenceCompleteLinkageGroups(thr, pairs)
+				assertCloneGroupsEqual(t, want, got, thr, seed)
+			}
+		})
+	}
+}
+
+func TestMajorityCloneType_TieBreaksDeterministically(t *testing.T) {
+	a := gf("a.py", 1, 3)
+	b := gf("b.py", 1, 3)
+	c := gf("c.py", 1, 3)
+	d := gf("d.py", 1, 3)
+	members := []*CodeFragment{a, b, c, d}
+	typeMap := map[string]CloneType{
+		pairKey(a, b): Type3Clone,
+		pairKey(a, c): Type1Clone,
+		pairKey(a, d): Type3Clone,
+		pairKey(b, c): Type1Clone,
+	}
+
+	got := majorityCloneType(typeMap, members)
+	if got != Type1Clone {
+		t.Fatalf("expected deterministic lower clone-type tie break, got %v", got)
+	}
+}
+
 func buildDenseCliquePairs(groupCount, cliqueSize int, intraSim, interSim float64) []*ClonePair {
 	fragments := make([][]*CodeFragment, groupCount)
 	for groupIndex := 0; groupIndex < groupCount; groupIndex++ {
@@ -119,4 +182,230 @@ func groupSignature(group *CloneGroup) string {
 	}
 	sort.Strings(paths)
 	return fmt.Sprintf("%s,%s,%s", paths[0], paths[1], paths[2])
+}
+
+func generalGroupSignature(group *CloneGroup) string {
+	paths := make([]string, 0, len(group.Fragments))
+	for _, fragment := range group.Fragments {
+		paths = append(paths, fragment.Location.FilePath)
+	}
+	sort.Strings(paths)
+	return strings.Join(paths, ",")
+}
+
+func buildRandomCompleteLinkagePairs(seed int64, fragmentCount int) []*ClonePair {
+	rng := rand.New(rand.NewSource(seed))
+	fragments := make([]*CodeFragment, fragmentCount)
+	for i := 0; i < fragmentCount; i++ {
+		fragments[i] = gf(fmt.Sprintf("fragment_%d.py", i), 1, 3)
+	}
+
+	pairs := make([]*ClonePair, 0, fragmentCount*fragmentCount)
+	for i := 0; i < len(fragments); i++ {
+		for j := i + 1; j < len(fragments); j++ {
+			if rng.Float64() < 0.2 {
+				continue
+			}
+
+			pairs = append(pairs, &ClonePair{
+				Fragment1:  fragments[i],
+				Fragment2:  fragments[j],
+				Similarity: rng.Float64(),
+				CloneType:  CloneType(rng.Intn(int(Type4Clone)) + 1),
+			})
+
+			if rng.Float64() < 0.35 {
+				pairs = append(pairs, &ClonePair{
+					Fragment1:  fragments[i],
+					Fragment2:  fragments[j],
+					Similarity: rng.Float64(),
+					CloneType:  CloneType(rng.Intn(int(Type4Clone)) + 1),
+				})
+			}
+		}
+	}
+
+	return pairs
+}
+
+func referenceCompleteLinkageGroups(threshold float64, pairs []*ClonePair) []*CloneGroup {
+	if len(pairs) == 0 {
+		return []*CloneGroup{}
+	}
+
+	fragments := make([]*CodeFragment, 0)
+	seen := make(map[*CodeFragment]struct{})
+	sims := make(map[string]float64)
+	types := make(map[string]CloneType)
+	for _, p := range pairs {
+		if p == nil || p.Fragment1 == nil || p.Fragment2 == nil {
+			continue
+		}
+		if _, ok := seen[p.Fragment1]; !ok {
+			seen[p.Fragment1] = struct{}{}
+			fragments = append(fragments, p.Fragment1)
+		}
+		if _, ok := seen[p.Fragment2]; !ok {
+			seen[p.Fragment2] = struct{}{}
+			fragments = append(fragments, p.Fragment2)
+		}
+		key := pairKey(p.Fragment1, p.Fragment2)
+		if old, ok := sims[key]; !ok || p.Similarity > old {
+			sims[key] = p.Similarity
+			types[key] = p.CloneType
+		}
+	}
+
+	if len(fragments) < 2 {
+		return []*CloneGroup{}
+	}
+
+	clusters := make([][]*CodeFragment, len(fragments))
+	for i, fragment := range fragments {
+		clusters[i] = []*CodeFragment{fragment}
+	}
+
+	clusterSim := func(firstCluster, secondCluster []*CodeFragment) float64 {
+		minSim := 1.0
+		hasPair := false
+		for _, firstFragment := range firstCluster {
+			for _, secondFragment := range secondCluster {
+				sim := similarity(sims, firstFragment, secondFragment)
+				if sim < threshold {
+					return 0.0
+				}
+				if sim < minSim {
+					minSim = sim
+				}
+				hasPair = true
+			}
+		}
+		if !hasPair {
+			return 0.0
+		}
+		return minSim
+	}
+
+	for {
+		bestI, bestJ := -1, -1
+		bestScore := -1.0
+		for i := 0; i < len(clusters); i++ {
+			for j := i + 1; j < len(clusters); j++ {
+				sim := clusterSim(clusters[i], clusters[j])
+				if sim >= threshold && sim > bestScore {
+					bestScore = sim
+					bestI = i
+					bestJ = j
+				}
+			}
+		}
+		if bestI == -1 || bestJ == -1 {
+			break
+		}
+
+		clusters[bestI] = append(clusters[bestI], clusters[bestJ]...)
+		clusters = append(clusters[:bestJ], clusters[bestJ+1:]...)
+	}
+
+	groups := make([]*CloneGroup, 0)
+	groupID := 0
+	for _, cluster := range clusters {
+		if len(cluster) < 2 {
+			continue
+		}
+
+		valid := true
+		for i := 0; i < len(cluster) && valid; i++ {
+			for j := i + 1; j < len(cluster); j++ {
+				if similarity(sims, cluster[i], cluster[j]) < threshold {
+					valid = false
+					break
+				}
+			}
+		}
+		if !valid {
+			continue
+		}
+
+		sort.Slice(cluster, func(i, j int) bool { return fragmentLess(cluster[i], cluster[j]) })
+		group := NewCloneGroup(groupID)
+		groupID++
+		for _, fragment := range cluster {
+			group.AddFragment(fragment)
+		}
+		group.Similarity = averageGroupSimilarity(sims, cluster)
+		group.CloneType = majorityCloneType(types, cluster)
+		groups = append(groups, group)
+	}
+
+	sort.Slice(groups, func(i, j int) bool {
+		if !almostEqual(groups[i].Similarity, groups[j].Similarity) {
+			return groups[i].Similarity > groups[j].Similarity
+		}
+		if groups[i].Size != groups[j].Size {
+			return groups[i].Size > groups[j].Size
+		}
+		if len(groups[i].Fragments) == 0 || len(groups[j].Fragments) == 0 {
+			return false
+		}
+		return fragmentLess(groups[i].Fragments[0], groups[j].Fragments[0])
+	})
+
+	return groups
+}
+
+func assertCloneGroupsEqual(t *testing.T, want, got []*CloneGroup, threshold float64, seed int64) {
+	t.Helper()
+
+	wantSnapshots := snapshotCloneGroups(want)
+	gotSnapshots := snapshotCloneGroups(got)
+	if len(wantSnapshots) != len(gotSnapshots) {
+		t.Fatalf("threshold %.2f seed %d: group count mismatch: want %d got %d", threshold, seed, len(wantSnapshots), len(gotSnapshots))
+	}
+
+	for i := range wantSnapshots {
+		if wantSnapshots[i].members != gotSnapshots[i].members {
+			t.Fatalf("threshold %.2f seed %d: members mismatch: want %s got %s", threshold, seed, wantSnapshots[i].members, gotSnapshots[i].members)
+		}
+		if wantSnapshots[i].cloneType != gotSnapshots[i].cloneType {
+			t.Fatalf("threshold %.2f seed %d: clone type mismatch for %s: want %v got %v", threshold, seed, wantSnapshots[i].members, wantSnapshots[i].cloneType, gotSnapshots[i].cloneType)
+		}
+		if !almostEqual(wantSnapshots[i].similarity, gotSnapshots[i].similarity) {
+			t.Fatalf("threshold %.2f seed %d: similarity mismatch for %s: want %f got %f", threshold, seed, wantSnapshots[i].members, wantSnapshots[i].similarity, gotSnapshots[i].similarity)
+		}
+	}
+}
+
+type cloneGroupSnapshot struct {
+	members    string
+	similarity float64
+	cloneType  CloneType
+}
+
+func snapshotCloneGroups(groups []*CloneGroup) []cloneGroupSnapshot {
+	snapshots := make([]cloneGroupSnapshot, 0, len(groups))
+	for _, group := range groups {
+		memberIDs := make([]string, 0, len(group.Fragments))
+		for _, fragment := range group.Fragments {
+			memberIDs = append(memberIDs, fragmentID(fragment))
+		}
+		sort.Strings(memberIDs)
+		snapshots = append(snapshots, cloneGroupSnapshot{
+			members:    strings.Join(memberIDs, "||"),
+			similarity: group.Similarity,
+			cloneType:  group.CloneType,
+		})
+	}
+
+	sort.Slice(snapshots, func(i, j int) bool {
+		if snapshots[i].members != snapshots[j].members {
+			return snapshots[i].members < snapshots[j].members
+		}
+		if !almostEqual(snapshots[i].similarity, snapshots[j].similarity) {
+			return snapshots[i].similarity < snapshots[j].similarity
+		}
+		return snapshots[i].cloneType < snapshots[j].cloneType
+	})
+
+	return snapshots
 }

--- a/internal/analyzer/complete_linkage_heap.go
+++ b/internal/analyzer/complete_linkage_heap.go
@@ -2,50 +2,91 @@ package analyzer
 
 import "container/heap"
 
-type completeLinkageCandidate struct {
-	leftID       int
-	rightID      int
-	score        float64
-	leftVersion  int
-	rightVersion int
+type completeLinkageBestNeighbor struct {
+	clusterID  int
+	neighborID int
+	score      float64
 }
 
-type completeLinkageCandidateHeap []completeLinkageCandidate
+type completeLinkageBestNeighborHeap struct {
+	entries   []completeLinkageBestNeighbor
+	positions []int
+}
 
-func (h completeLinkageCandidateHeap) Len() int { return len(h) }
-
-func (h completeLinkageCandidateHeap) Less(i, j int) bool {
-	if !almostEqual(h[i].score, h[j].score) {
-		return h[i].score > h[j].score
+func newCompleteLinkageBestNeighborHeap(clusterCount int) *completeLinkageBestNeighborHeap {
+	positions := make([]int, clusterCount)
+	for i := range positions {
+		positions[i] = -1
 	}
-	if h[i].leftID != h[j].leftID {
-		return h[i].leftID < h[j].leftID
+	return &completeLinkageBestNeighborHeap{positions: positions}
+}
+
+func (h *completeLinkageBestNeighborHeap) Len() int { return len(h.entries) }
+
+func (h *completeLinkageBestNeighborHeap) Less(i, j int) bool {
+	if !almostEqual(h.entries[i].score, h.entries[j].score) {
+		return h.entries[i].score > h.entries[j].score
 	}
-	return h[i].rightID < h[j].rightID
+
+	leftI, rightI := orderClusterIDs(h.entries[i].clusterID, h.entries[i].neighborID)
+	leftJ, rightJ := orderClusterIDs(h.entries[j].clusterID, h.entries[j].neighborID)
+	if leftI != leftJ {
+		return leftI < leftJ
+	}
+	if rightI != rightJ {
+		return rightI < rightJ
+	}
+	return h.entries[i].clusterID < h.entries[j].clusterID
 }
 
-func (h completeLinkageCandidateHeap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
+func (h *completeLinkageBestNeighborHeap) Swap(i, j int) {
+	h.entries[i], h.entries[j] = h.entries[j], h.entries[i]
+	h.positions[h.entries[i].clusterID] = i
+	h.positions[h.entries[j].clusterID] = j
 }
 
-func (h *completeLinkageCandidateHeap) Push(x any) {
-	*h = append(*h, x.(completeLinkageCandidate))
+func (h *completeLinkageBestNeighborHeap) Push(x any) {
+	entry := x.(completeLinkageBestNeighbor)
+	h.positions[entry.clusterID] = len(h.entries)
+	h.entries = append(h.entries, entry)
 }
 
-func (h *completeLinkageCandidateHeap) Pop() any {
-	old := *h
-	last := len(old) - 1
-	item := old[last]
-	*h = old[:last]
-	return item
+func (h *completeLinkageBestNeighborHeap) Pop() any {
+	last := len(h.entries) - 1
+	entry := h.entries[last]
+	h.entries = h.entries[:last]
+	h.positions[entry.clusterID] = -1
+	return entry
 }
 
-func (h *completeLinkageCandidateHeap) push(candidate completeLinkageCandidate) {
-	heap.Push(h, candidate)
+func (h *completeLinkageBestNeighborHeap) set(clusterID, neighborID int, score float64) {
+	if position := h.positions[clusterID]; position >= 0 {
+		h.entries[position].neighborID = neighborID
+		h.entries[position].score = score
+		heap.Fix(h, position)
+		return
+	}
+
+	heap.Push(h, completeLinkageBestNeighbor{
+		clusterID:  clusterID,
+		neighborID: neighborID,
+		score:      score,
+	})
 }
 
-func (h *completeLinkageCandidateHeap) pop() completeLinkageCandidate {
-	return heap.Pop(h).(completeLinkageCandidate)
+func (h *completeLinkageBestNeighborHeap) remove(clusterID int) {
+	position := h.positions[clusterID]
+	if position < 0 {
+		return
+	}
+	heap.Remove(h, position)
+}
+
+func (h *completeLinkageBestNeighborHeap) popBest() (completeLinkageBestNeighbor, bool) {
+	if h.Len() == 0 {
+		return completeLinkageBestNeighbor{}, false
+	}
+	return heap.Pop(h).(completeLinkageBestNeighbor), true
 }
 
 func orderClusterIDs(firstID, secondID int) (int, int) {

--- a/internal/analyzer/complete_linkage_heap.go
+++ b/internal/analyzer/complete_linkage_heap.go
@@ -1,0 +1,56 @@
+package analyzer
+
+import "container/heap"
+
+type completeLinkageCandidate struct {
+	leftID       int
+	rightID      int
+	score        float64
+	leftVersion  int
+	rightVersion int
+}
+
+type completeLinkageCandidateHeap []completeLinkageCandidate
+
+func (h completeLinkageCandidateHeap) Len() int { return len(h) }
+
+func (h completeLinkageCandidateHeap) Less(i, j int) bool {
+	if !almostEqual(h[i].score, h[j].score) {
+		return h[i].score > h[j].score
+	}
+	if h[i].leftID != h[j].leftID {
+		return h[i].leftID < h[j].leftID
+	}
+	return h[i].rightID < h[j].rightID
+}
+
+func (h completeLinkageCandidateHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *completeLinkageCandidateHeap) Push(x any) {
+	*h = append(*h, x.(completeLinkageCandidate))
+}
+
+func (h *completeLinkageCandidateHeap) Pop() any {
+	old := *h
+	last := len(old) - 1
+	item := old[last]
+	*h = old[:last]
+	return item
+}
+
+func (h *completeLinkageCandidateHeap) push(candidate completeLinkageCandidate) {
+	heap.Push(h, candidate)
+}
+
+func (h *completeLinkageCandidateHeap) pop() completeLinkageCandidate {
+	return heap.Pop(h).(completeLinkageCandidate)
+}
+
+func orderClusterIDs(firstID, secondID int) (int, int) {
+	if firstID < secondID {
+		return firstID, secondID
+	}
+	return secondID, firstID
+}

--- a/internal/analyzer/connected_grouping.go
+++ b/internal/analyzer/connected_grouping.go
@@ -152,7 +152,7 @@ func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) Cl
 	var best CloneType
 	maxC := -1
 	for t, c := range counts {
-		if c > maxC || (c == maxC && t < best) {
+		if c > maxC {
 			maxC = c
 			best = t
 		}

--- a/internal/analyzer/connected_grouping.go
+++ b/internal/analyzer/connected_grouping.go
@@ -152,7 +152,7 @@ func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) Cl
 	var best CloneType
 	maxC := -1
 	for t, c := range counts {
-		if c > maxC {
+		if c > maxC || (c == maxC && t < best) {
 			maxC = c
 			best = t
 		}


### PR DESCRIPTION
This finishes the deeper part of #86.

Complete-linkage grouping now keeps sparse threshold-qualified neighbors and uses an indexed best-neighbor heap instead of rescanning every active cluster pair after each merge.

On `BenchmarkGroupingStrategies/completelink_1000` (`main` -> this branch):

- `time`: `11,091,543,992 ns/op` -> `889,650 ns/op`
- `memory`: `5,093,308,049 B/op` -> `1,216,729 B/op`
- `allocs`: `228,070,871 allocs/op` -> `12,531 allocs/op`

I also tightened coverage around the new path with:

- parity checks against the slow reference implementation
- `4,096` exhaustive small-graph cases
- `72` randomized parity cases across `3` thresholds
- determinism checks across `32` runs
- clique and non-mergeable output invaraints
- dense benchmark coverage

This takes the complete-linkage fix all the way instead of only fixing the inner recompuation path.