### PR TITLE
fix: require text match for type1 clones

### DIFF
--- a/internal/analyzer/clone_classifier_test.go
+++ b/internal/analyzer/clone_classifier_test.go
@@ -644,7 +644,7 @@ def goodbye():
 		}
 	})
 
-	t.Run("ExtractWithoutContent", func(t *testing.T) {
+	t.Run("ExtractWithContentWhenTextualAnalysisDisabled", func(t *testing.T) {
 		config := DefaultCloneDetectorConfig()
 		config.EnableTextualAnalysis = false
 		config.MinLines = 1
@@ -662,12 +662,11 @@ def goodbye():
 		result, err := p.Parse(ctx, []byte(source))
 		require.NoError(t, err)
 
-		// Even with source provided, content should not be populated when disabled
 		fragments := detector.ExtractFragmentsWithSource([]*parser.Node{result.AST}, "test.py", []byte(source))
 		require.NotEmpty(t, fragments)
 
 		for _, f := range fragments {
-			assert.Empty(t, f.Content, "Fragment content should be empty when textual analysis is disabled")
+			assert.NotEmpty(t, f.Content, "Source-aware extraction should populate fragment content")
 		}
 	})
 }

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -954,7 +954,7 @@ func (cd *CloneDetector) compareFragmentsWithClassifier(fragment1, fragment2 *Co
 	distance := cd.analyzer.ComputeDistance(fragment1.TreeNode, fragment2.TreeNode)
 	similarity := cd.analyzer.ComputeSimilarity(fragment1.TreeNode, fragment2.TreeNode)
 
-	cloneType := cd.classifyClonePair(fragment1, fragment2, similarity, distance)
+	cloneType, similarity := cd.classifyClonePair(fragment1, fragment2, similarity)
 	if cloneType == 0 {
 		return nil
 	}
@@ -980,7 +980,7 @@ func (cd *CloneDetector) compareWithAPTED(fragment1, fragment2 *CodeFragment) *C
 	distance := cd.analyzer.ComputeDistance(fragment1.TreeNode, fragment2.TreeNode)
 	similarity := cd.analyzer.ComputeSimilarity(fragment1.TreeNode, fragment2.TreeNode)
 
-	cloneType := cd.classifyClonePair(fragment1, fragment2, similarity, distance)
+	cloneType, similarity := cd.classifyClonePair(fragment1, fragment2, similarity)
 	if cloneType == 0 {
 		return nil
 	}
@@ -997,21 +997,34 @@ func (cd *CloneDetector) compareWithAPTED(fragment1, fragment2 *CodeFragment) *C
 	}
 }
 
-func (cd *CloneDetector) classifyClonePair(fragment1, fragment2 *CodeFragment, similarity, distance float64) CloneType {
+func (cd *CloneDetector) classifyClonePair(fragment1, fragment2 *CodeFragment, similarity float64) (CloneType, float64) {
 	if similarity >= cd.cloneDetectorConfig.Type1Threshold && cd.textualAnalyzer.IsExactMatch(fragment1, fragment2) {
-		return Type1Clone
+		return Type1Clone, similarity
 	}
+	similarity = cd.capNonTextualSimilarity(similarity)
 	if similarity >= cd.cloneDetectorConfig.Type2Threshold {
-		return Type2Clone
+		return Type2Clone, similarity
 	}
 	if similarity >= cd.cloneDetectorConfig.Type3Threshold {
-		return Type3Clone
+		return Type3Clone, similarity
 	}
 	if similarity >= cd.cloneDetectorConfig.Type4Threshold {
-		return Type4Clone
+		return Type4Clone, similarity
 	}
 
-	return 0
+	return 0, similarity
+}
+
+func (cd *CloneDetector) capNonTextualSimilarity(similarity float64) float64 {
+	if similarity < cd.cloneDetectorConfig.Type1Threshold {
+		return similarity
+	}
+
+	capped := math.Nextafter(cd.cloneDetectorConfig.Type1Threshold, 0)
+	if capped < cd.cloneDetectorConfig.Type2Threshold {
+		return cd.cloneDetectorConfig.Type2Threshold
+	}
+	return capped
 }
 
 // calculateConfidence calculates confidence in clone detection

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -260,7 +260,8 @@ type CloneDetector struct {
 
 	analyzer         *APTEDAnalyzer
 	converter        *TreeConverter
-	classifier       *CloneClassifier     // Multi-dimensional classifier (optional)
+	classifier       *CloneClassifier // Multi-dimensional classifier (optional)
+	textualAnalyzer  *TextualSimilarityAnalyzer
 	featureExtractor *ASTFeatureExtractor // Pre-filter feature extractor
 	fragments        []*CodeFragment
 	clonePairs       []*ClonePair
@@ -322,6 +323,7 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 		analyzer:            analyzer,
 		converter:           NewTreeConverterWithConfig(config.SkipDocstrings),
 		classifier:          classifier,
+		textualAnalyzer:     NewTextualSimilarityAnalyzer(),
 		featureExtractor:    NewASTFeatureExtractor(),
 		fragments:           []*CodeFragment{},
 		clonePairs:          []*ClonePair{},
@@ -351,7 +353,7 @@ func (cd *CloneDetector) ExtractFragments(astNodes []*parser.Node, filePath stri
 }
 
 // ExtractFragmentsWithSource extracts code fragments from AST nodes with source content.
-// Use this method when EnableTextualAnalysis is true to populate CodeFragment.Content.
+// Source content is needed for Type-1 clone classification and optional report output.
 func (cd *CloneDetector) ExtractFragmentsWithSource(astNodes []*parser.Node, filePath string, sourceCode []byte) []*CodeFragment {
 	var fragments []*CodeFragment
 
@@ -380,7 +382,7 @@ func (cd *CloneDetector) extractFragmentsRecursiveWithSource(node *parser.Node, 
 
 		// Extract content from source code if textual analysis is enabled
 		content := ""
-		if cd.cloneDetectorConfig.EnableTextualAnalysis && len(sourceCode) > 0 {
+		if len(sourceCode) > 0 {
 			content = cd.extractSourceContent(sourceCode, &node.Location)
 		}
 
@@ -952,7 +954,7 @@ func (cd *CloneDetector) compareFragmentsWithClassifier(fragment1, fragment2 *Co
 	distance := cd.analyzer.ComputeDistance(fragment1.TreeNode, fragment2.TreeNode)
 	similarity := cd.analyzer.ComputeSimilarity(fragment1.TreeNode, fragment2.TreeNode)
 
-	cloneType := cd.classifyCloneType(similarity, distance)
+	cloneType := cd.classifyClonePair(fragment1, fragment2, similarity, distance)
 	if cloneType == 0 {
 		return nil
 	}
@@ -978,7 +980,7 @@ func (cd *CloneDetector) compareWithAPTED(fragment1, fragment2 *CodeFragment) *C
 	distance := cd.analyzer.ComputeDistance(fragment1.TreeNode, fragment2.TreeNode)
 	similarity := cd.analyzer.ComputeSimilarity(fragment1.TreeNode, fragment2.TreeNode)
 
-	cloneType := cd.classifyCloneType(similarity, distance)
+	cloneType := cd.classifyClonePair(fragment1, fragment2, similarity, distance)
 	if cloneType == 0 {
 		return nil
 	}
@@ -995,19 +997,21 @@ func (cd *CloneDetector) compareWithAPTED(fragment1, fragment2 *CodeFragment) *C
 	}
 }
 
-// classifyCloneType classifies the type of clone based on similarity
-func (cd *CloneDetector) classifyCloneType(similarity, distance float64) CloneType {
-	if similarity >= cd.cloneDetectorConfig.Type1Threshold {
+func (cd *CloneDetector) classifyClonePair(fragment1, fragment2 *CodeFragment, similarity, distance float64) CloneType {
+	if similarity >= cd.cloneDetectorConfig.Type1Threshold && cd.textualAnalyzer.IsExactMatch(fragment1, fragment2) {
 		return Type1Clone
-	} else if similarity >= cd.cloneDetectorConfig.Type2Threshold {
+	}
+	if similarity >= cd.cloneDetectorConfig.Type2Threshold {
 		return Type2Clone
-	} else if similarity >= cd.cloneDetectorConfig.Type3Threshold {
+	}
+	if similarity >= cd.cloneDetectorConfig.Type3Threshold {
 		return Type3Clone
-	} else if similarity >= cd.cloneDetectorConfig.Type4Threshold {
+	}
+	if similarity >= cd.cloneDetectorConfig.Type4Threshold {
 		return Type4Clone
 	}
 
-	return 0 // Not a clone
+	return 0
 }
 
 // calculateConfidence calculates confidence in clone detection

--- a/internal/analyzer/clone_detector_benchmark_fixture_test.go
+++ b/internal/analyzer/clone_detector_benchmark_fixture_test.go
@@ -38,7 +38,7 @@ func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) 
 					StartCol:  1,
 					EndCol:    80,
 				},
-				Content:    fmt.Sprintf("family_%02d_copy_%02d", family, copyIndex),
+				Content:    fmt.Sprintf("family_%02d", family),
 				Hash:       fmt.Sprintf("family_%02d_copy_%02d_hash", family, copyIndex),
 				Size:       benchmarkTreeSize(tree),
 				LineCount:  8,

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloneDetector_Creation(t *testing.T) {
@@ -233,29 +234,69 @@ func TestCloneDetector_ShouldIncludeFragment(t *testing.T) {
 	}
 }
 
-func TestCloneDetector_ClassifyCloneType(t *testing.T) {
+func TestCloneDetector_ClassifyClonePair(t *testing.T) {
 	config := DefaultCloneDetectorConfig()
 	detector := NewCloneDetector(config)
+	exact := &CodeFragment{Content: "def same():\n    return 1\n"}
+	different := &CodeFragment{Content: "def different():\n    return 2\n"}
 
 	tests := []struct {
 		name       string
 		similarity float64
+		fragment1  *CodeFragment
+		fragment2  *CodeFragment
 		expected   CloneType
 	}{
-		{"very high similarity", 0.99, Type1Clone},  // 0.99 >= 0.85 (Type1 threshold)
-		{"high similarity", 0.86, Type1Clone},       // 0.86 >= 0.85 (Type1 threshold)
-		{"medium similarity", 0.80, Type2Clone},     // 0.80 >= 0.75 (Type2 threshold)
-		{"type3 range", 0.72, Type3Clone},           // 0.72 >= 0.70 (Type3 threshold)
-		{"type4 range", 0.65, Type4Clone},           // 0.65 >= 0.60 (Type4 threshold)
-		{"very low similarity", 0.50, CloneType(0)}, // Not a clone
+		{"exact text at type1 threshold", 0.99, exact, exact, Type1Clone},
+		{"text mismatch at type1 threshold", 0.99, exact, different, Type2Clone},
+		{"medium similarity", 0.80, exact, different, Type2Clone},
+		{"type3 range", 0.72, exact, different, Type3Clone},
+		{"type4 range", 0.65, exact, different, Type4Clone},
+		{"very low similarity", 0.50, exact, different, CloneType(0)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := detector.classifyCloneType(tt.similarity, 0.0)
+			result := detector.classifyClonePair(tt.fragment1, tt.fragment2, tt.similarity, 0.0)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestCloneDetector_Type1RequiresTextualMatch(t *testing.T) {
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 1
+	config.MinNodes = 1
+	detector := NewCloneDetector(config)
+
+	newFragment := func(content string) *CodeFragment {
+		root := NewTreeNode(1, "If")
+		root.AddChild(NewTreeNode(2, "Assign"))
+		root.AddChild(NewTreeNode(3, "Assign"))
+		PrepareTreeForAPTED(root)
+
+		return &CodeFragment{
+			Location:  &CodeLocation{FilePath: "test.py", StartLine: 1, EndLine: 4},
+			TreeNode:  root,
+			Content:   content,
+			Size:      3,
+			LineCount: 4,
+		}
+	}
+
+	clone := detector.compareWithAPTED(
+		newFragment("if enabled:\n    value = 1\nelse:\n    value = 2\n"),
+		newFragment("if enabled:\n value = 1 # same logic\nelse:\n value = 2\n"),
+	)
+	require.NotNil(t, clone)
+	assert.Equal(t, Type1Clone, clone.CloneType)
+
+	textMismatch := detector.compareWithAPTED(
+		newFragment("if path.endswith('.py'):\n    count += 1\nelse:\n    count -= 1\n"),
+		newFragment("if radius > 0:\n    area = radius * radius\nelse:\n    area = 0\n"),
+	)
+	require.NotNil(t, textMismatch)
+	assert.Equal(t, Type2Clone, textMismatch.CloneType)
 }
 
 func TestCloneDetector_IsSignificantClone(t *testing.T) {

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -257,7 +257,7 @@ func TestCloneDetector_ClassifyClonePair(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := detector.classifyClonePair(tt.fragment1, tt.fragment2, tt.similarity, 0.0)
+			result, _ := detector.classifyClonePair(tt.fragment1, tt.fragment2, tt.similarity)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -297,6 +297,9 @@ func TestCloneDetector_Type1RequiresTextualMatch(t *testing.T) {
 	)
 	require.NotNil(t, textMismatch)
 	assert.Equal(t, Type2Clone, textMismatch.CloneType)
+	assert.Less(t, textMismatch.Similarity, 1.0)
+	assert.Less(t, textMismatch.Similarity, config.Type1Threshold)
+	assert.GreaterOrEqual(t, textMismatch.Similarity, config.Type2Threshold)
 }
 
 func TestCloneDetector_IsSignificantClone(t *testing.T) {

--- a/internal/analyzer/textual_similarity.go
+++ b/internal/analyzer/textual_similarity.go
@@ -71,6 +71,22 @@ func (t *TextualSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) floa
 	return t.computeLevenshteinSimilarity(content1, content2)
 }
 
+// IsExactMatch reports whether two fragments have identical source text after
+// Type-1 normalization. Near matches are deliberately not treated as Type-1.
+func (t *TextualSimilarityAnalyzer) IsExactMatch(f1, f2 *CodeFragment) bool {
+	if f1 == nil || f2 == nil {
+		return false
+	}
+
+	content1 := t.normalizeContent(f1.Content)
+	content2 := t.normalizeContent(f2.Content)
+	if content1 == "" || content2 == "" {
+		return false
+	}
+
+	return content1 == content2
+}
+
 // normalizeContent normalizes source code content for comparison.
 // This removes comments and normalizes whitespace based on configuration.
 func (t *TextualSimilarityAnalyzer) normalizeContent(content string) string {

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -123,7 +123,7 @@ func (s *CloneService) DetectClonesInFiles(ctx context.Context, filePaths []stri
 
 			// Convert single AST node to slice for ExtractFragments
 			astNodes := []*parser.Node{parseResult.AST}
-			fragments := detector.ExtractFragments(astNodes, filePath)
+			fragments := detector.ExtractFragmentsWithSource(astNodes, filePath, content)
 			allFragments = append(allFragments, fragments...)
 		}
 	}

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -303,6 +303,49 @@ func TestCloneService_DetectClonesInFiles(t *testing.T) {
 		require.NotNil(t, response)
 		assert.Contains(t, clonePairTypes(response.ClonePairs), domain.Type1Clone)
 	})
+
+	t.Run("structural matches with different text are not type1", func(t *testing.T) {
+		tmp := t.TempDir()
+		f1 := filepath.Join(tmp, "a.py")
+		f2 := filepath.Join(tmp, "b.py")
+
+		source1 := `def scan_paths(items):
+    if items:
+        total = len(items)
+    else:
+        total = 0
+    return total
+`
+		source2 := `def measure_radius(values):
+    if values:
+        area = len(values)
+    else:
+        area = 0
+    return area
+`
+		require.NoError(t, os.WriteFile(f1, []byte(source1), 0o644))
+		require.NoError(t, os.WriteFile(f2, []byte(source2), 0o644))
+
+		req := newDefaultCloneRequest(f1, f2)
+		req.MinLines = 3
+		req.MinNodes = 1
+		req.SimilarityThreshold = domain.DefaultType4CloneThreshold
+		req.Type1Threshold = domain.DefaultType1CloneThreshold
+		req.Type2Threshold = domain.DefaultType2CloneThreshold
+		req.Type3Threshold = domain.DefaultType3CloneThreshold
+		req.Type4Threshold = domain.DefaultType4CloneThreshold
+		req.CloneTypes = []domain.CloneType{domain.Type1Clone, domain.Type2Clone, domain.Type3Clone, domain.Type4Clone}
+
+		response, err := service.DetectClonesInFiles(ctx, req.Paths, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		require.NotEmpty(t, response.ClonePairs)
+		for _, pair := range response.ClonePairs {
+			assert.NotEqual(t, domain.Type1Clone, pair.Type)
+			assert.Less(t, pair.Similarity, 1.0)
+		}
+	})
 }
 
 func TestCloneService_ComputeSimilarity(t *testing.T) {

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -36,6 +36,14 @@ func newDefaultCloneRequest(paths ...string) *domain.CloneRequest {
 	}
 }
 
+func clonePairTypes(pairs []*domain.ClonePair) []domain.CloneType {
+	types := make([]domain.CloneType, 0, len(pairs))
+	for _, pair := range pairs {
+		types = append(types, pair.Type)
+	}
+	return types
+}
+
 func TestNewCloneService(t *testing.T) {
 	service := NewCloneService()
 
@@ -262,6 +270,38 @@ func TestCloneService_DetectClonesInFiles(t *testing.T) {
 		assert.NotNil(t, response)
 		assert.NotNil(t, response.Statistics)
 		assert.Equal(t, 2, response.Statistics.FilesAnalyzed) // skips missing; counts only processed files
+	})
+
+	t.Run("identical source fragments are reported as type1", func(t *testing.T) {
+		tmp := t.TempDir()
+		f1 := filepath.Join(tmp, "a.py")
+		f2 := filepath.Join(tmp, "b.py")
+
+		source := `def calculate(value):
+    if value > 10:
+        result = value * 2
+    else:
+        result = value + 2
+    return result
+`
+		require.NoError(t, os.WriteFile(f1, []byte(source), 0o644))
+		require.NoError(t, os.WriteFile(f2, []byte(source), 0o644))
+
+		req := newDefaultCloneRequest(f1, f2)
+		req.MinLines = 3
+		req.MinNodes = 1
+		req.SimilarityThreshold = domain.DefaultType4CloneThreshold
+		req.Type1Threshold = domain.DefaultType1CloneThreshold
+		req.Type2Threshold = domain.DefaultType2CloneThreshold
+		req.Type3Threshold = domain.DefaultType3CloneThreshold
+		req.Type4Threshold = domain.DefaultType4CloneThreshold
+		req.CloneTypes = []domain.CloneType{domain.Type1Clone, domain.Type2Clone, domain.Type3Clone, domain.Type4Clone}
+
+		response, err := service.DetectClonesInFiles(ctx, req.Paths, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		assert.Contains(t, clonePairTypes(response.ClonePairs), domain.Type1Clone)
 	})
 }
 


### PR DESCRIPTION
Closes #395

This fixes Type-1 clone classification so structurally identical fragments are not reported as text-identical unless their normalized source text actually matches.

The clone detector now keeps source text during fragment extraction and uses a single pair-aware classifier for both the standard APTED path and the optional multi-dimensional path. High structural similarity with different text now falls through below Type-1, and its reported similarity is capped below the Type-1 threshold instead of showing as 1.0.

Added regression coverage for the detector-level false positive, LSH parity, and the service path that extracts fragments from real files.

Tests:
go test ./...
go vet ./...
