### PR TITLE
fix: make clone trees expression-aware

### DIFF
--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -2,6 +2,8 @@ package analyzer
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
@@ -191,18 +193,78 @@ func orderedASTChildren(node *parser.Node, skipBodyNode func(parent, bodyNode *p
 		return nil
 	}
 
-	children := make([]*parser.Node, 0, len(node.Children)+len(node.Body)+len(node.Orelse)+len(node.Finalbody)+len(node.Handlers))
-	children = append(children, node.Children...)
+	children := make([]*parser.Node, 0, astChildCapacity(node))
+	seen := make(map[*parser.Node]struct{}, astChildCapacity(node))
+
+	appendNode := func(child *parser.Node) {
+		if child == nil {
+			return
+		}
+		if _, ok := seen[child]; ok {
+			return
+		}
+		seen[child] = struct{}{}
+		children = append(children, child)
+	}
+	appendNodes := func(nodes []*parser.Node) {
+		for _, child := range nodes {
+			appendNode(child)
+		}
+	}
+	appendValueNode := func(value interface{}) {
+		if child, ok := value.(*parser.Node); ok {
+			appendNode(child)
+		}
+	}
+
+	appendNodes(node.Children)
+	appendNodes(node.Decorator)
+	appendNodes(node.Bases)
+	appendNodes(node.Args)
+	appendNodes(node.Targets)
+	appendNode(node.Test)
+	appendNode(node.Iter)
+	appendNode(node.Left)
+	appendNode(node.Right)
+	appendValueNode(node.Value)
+	appendNodes(node.Keywords)
 	for i, bodyNode := range node.Body {
 		if skipBodyNode != nil && skipBodyNode(node, bodyNode, i) {
 			continue
 		}
-		children = append(children, bodyNode)
+		appendNode(bodyNode)
 	}
-	children = append(children, node.Orelse...)
-	children = append(children, node.Finalbody...)
-	children = append(children, node.Handlers...)
+	appendNodes(node.Handlers)
+	appendNodes(node.Orelse)
+	appendNodes(node.Finalbody)
+
 	return children
+}
+
+func astChildCapacity(node *parser.Node) int {
+	if node == nil {
+		return 0
+	}
+
+	capacity := len(node.Children) + len(node.Decorator) + len(node.Bases) + len(node.Args) +
+		len(node.Targets) + len(node.Keywords) + len(node.Body) + len(node.Handlers) +
+		len(node.Orelse) + len(node.Finalbody)
+	if node.Test != nil {
+		capacity++
+	}
+	if node.Iter != nil {
+		capacity++
+	}
+	if node.Left != nil {
+		capacity++
+	}
+	if node.Right != nil {
+		capacity++
+	}
+	if _, ok := node.Value.(*parser.Node); ok {
+		capacity++
+	}
+	return capacity
 }
 
 // canNodeHaveDocstring checks if a node type can have a docstring
@@ -237,6 +299,42 @@ func (tc *TreeConverter) getNodeLabel(astNode *parser.Node) string {
 	case parser.NodeClassDef:
 		if astNode.Name != "" {
 			label = fmt.Sprintf("ClassDef(%s)", astNode.Name)
+		}
+	case parser.NodeAttribute:
+		if astNode.Name != "" {
+			label = fmt.Sprintf("Attribute(%s)", astNode.Name)
+		}
+	case parser.NodeKeyword:
+		if astNode.Name != "" {
+			label = fmt.Sprintf("Keyword(%s)", astNode.Name)
+		}
+	case parser.NodeArg:
+		if astNode.Name != "" {
+			label = fmt.Sprintf("Arg(%s)", astNode.Name)
+		}
+	case parser.NodeAlias:
+		if astNode.Name != "" {
+			if alias, ok := astNode.Value.(string); ok && alias != "" {
+				label = fmt.Sprintf("Alias(%s as %s)", astNode.Name, alias)
+			} else {
+				label = fmt.Sprintf("Alias(%s)", astNode.Name)
+			}
+		}
+	case parser.NodeWithItem, parser.NodeExceptHandler:
+		if astNode.Name != "" {
+			label = fmt.Sprintf("%s(%s)", astNode.Type, astNode.Name)
+		}
+	case parser.NodeImport:
+		if len(astNode.Names) > 0 {
+			label = fmt.Sprintf("Import(%s)", strings.Join(astNode.Names, ","))
+		}
+	case parser.NodeImportFrom:
+		module := astNode.Module
+		if astNode.Level > 0 {
+			module = strings.Repeat(".", astNode.Level) + module
+		}
+		if module != "" || len(astNode.Names) > 0 {
+			label = fmt.Sprintf("ImportFrom(%s:%s)", module, strings.Join(astNode.Names, ","))
 		}
 	case parser.NodeBinOp, parser.NodeUnaryOp, parser.NodeBoolOp:
 		if astNode.Op != "" {

--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -173,44 +173,36 @@ func (tc *TreeConverter) ConvertAST(astNode *parser.Node) *TreeNode {
 	// Store reference to original AST node
 	treeNode.OriginalNode = astNode
 
-	// Convert children recursively
-	for _, child := range astNode.Children {
+	for _, child := range orderedASTChildren(astNode, tc.shouldSkipBodyNode) {
 		if childNode := tc.ConvertAST(child); childNode != nil {
 			treeNode.AddChild(childNode)
 		}
 	}
 
-	// Also convert body, orelse, and other AST-specific children
-	// Skip docstrings if configured (first Expr(Constant(str)) in body)
-	canHaveDocstring := tc.canNodeHaveDocstring(astNode.Type)
-	for i, bodyNode := range astNode.Body {
-		if canHaveDocstring && tc.isDocstring(bodyNode, i) {
+	return treeNode
+}
+
+func (tc *TreeConverter) shouldSkipBodyNode(parent *parser.Node, bodyNode *parser.Node, bodyIndex int) bool {
+	return tc.canNodeHaveDocstring(parent.Type) && tc.isDocstring(bodyNode, bodyIndex)
+}
+
+func orderedASTChildren(node *parser.Node, skipBodyNode func(parent, bodyNode *parser.Node, bodyIndex int) bool) []*parser.Node {
+	if node == nil {
+		return nil
+	}
+
+	children := make([]*parser.Node, 0, len(node.Children)+len(node.Body)+len(node.Orelse)+len(node.Finalbody)+len(node.Handlers))
+	children = append(children, node.Children...)
+	for i, bodyNode := range node.Body {
+		if skipBodyNode != nil && skipBodyNode(node, bodyNode, i) {
 			continue
 		}
-		if childNode := tc.ConvertAST(bodyNode); childNode != nil {
-			treeNode.AddChild(childNode)
-		}
+		children = append(children, bodyNode)
 	}
-
-	for _, orelseNode := range astNode.Orelse {
-		if childNode := tc.ConvertAST(orelseNode); childNode != nil {
-			treeNode.AddChild(childNode)
-		}
-	}
-
-	for _, finalbodyNode := range astNode.Finalbody {
-		if childNode := tc.ConvertAST(finalbodyNode); childNode != nil {
-			treeNode.AddChild(childNode)
-		}
-	}
-
-	for _, handlerNode := range astNode.Handlers {
-		if childNode := tc.ConvertAST(handlerNode); childNode != nil {
-			treeNode.AddChild(childNode)
-		}
-	}
-
-	return treeNode
+	children = append(children, node.Orelse...)
+	children = append(children, node.Finalbody...)
+	children = append(children, node.Handlers...)
+	return children
 }
 
 // canNodeHaveDocstring checks if a node type can have a docstring

--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -324,6 +324,10 @@ func (tc *TreeConverter) getNodeLabel(astNode *parser.Node) string {
 		if astNode.Name != "" {
 			label = fmt.Sprintf("%s(%s)", astNode.Type, astNode.Name)
 		}
+	case parser.NodeGlobal, parser.NodeNonlocal:
+		if len(astNode.Names) > 0 {
+			label = fmt.Sprintf("%s(%s)", astNode.Type, strings.Join(astNode.Names, ","))
+		}
 	case parser.NodeImport:
 		if len(astNode.Names) > 0 {
 			label = fmt.Sprintf("Import(%s)", strings.Join(astNode.Names, ","))
@@ -336,7 +340,7 @@ func (tc *TreeConverter) getNodeLabel(astNode *parser.Node) string {
 		if module != "" || len(astNode.Names) > 0 {
 			label = fmt.Sprintf("ImportFrom(%s:%s)", module, strings.Join(astNode.Names, ","))
 		}
-	case parser.NodeBinOp, parser.NodeUnaryOp, parser.NodeBoolOp:
+	case parser.NodeBinOp, parser.NodeUnaryOp, parser.NodeBoolOp, parser.NodeCompare, parser.NodeAugAssign:
 		if astNode.Op != "" {
 			label = fmt.Sprintf("%s(%s)", astNode.Type, astNode.Op)
 		}

--- a/internal/analyzer/apted_tree_test.go
+++ b/internal/analyzer/apted_tree_test.go
@@ -251,6 +251,51 @@ func TestConvertASTIncludesExpressionFieldsInAPTEDDistance(t *testing.T) {
 		right string
 	}{
 		{
+			name: "assignment target",
+			left: `if cond:
+    left = value
+`,
+			right: `if cond:
+    right = value
+`,
+		},
+		{
+			name: "literal value",
+			left: `if cond:
+    value = 1
+`,
+			right: `if cond:
+    value = 2
+`,
+		},
+		{
+			name: "call callee",
+			left: `if cond:
+    value = left(arg)
+`,
+			right: `if cond:
+    value = right(arg)
+`,
+		},
+		{
+			name: "call positional argument",
+			left: `if cond:
+    value = build(left)
+`,
+			right: `if cond:
+    value = build(right)
+`,
+		},
+		{
+			name: "keyword value",
+			left: `if cond:
+    value = build(flag=left)
+`,
+			right: `if cond:
+    value = build(flag=right)
+`,
+		},
+		{
 			name: "subscript index",
 			left: `if cond:
     value = items[i]
@@ -296,6 +341,120 @@ func TestConvertASTIncludesExpressionFieldsInAPTEDDistance(t *testing.T) {
 `,
 		},
 		{
+			name: "function parameter name default and annotation",
+			left: `def update(left: int = 1):
+    return left
+`,
+			right: `def update(right: str = 2):
+    return right
+`,
+		},
+		{
+			name: "function return annotation",
+			left: `def update() -> Left:
+    return value
+`,
+			right: `def update() -> Right:
+    return value
+`,
+		},
+		{
+			name: "decorator expression",
+			left: `@left.decorator
+def update():
+    pass
+`,
+			right: `@right.decorator
+def update():
+    pass
+`,
+		},
+		{
+			name: "class base",
+			left: `class Model(LeftBase):
+    pass
+`,
+			right: `class Model(RightBase):
+    pass
+`,
+		},
+		{
+			name: "return value",
+			left: `def update():
+    return left
+`,
+			right: `def update():
+    return right
+`,
+		},
+		{
+			name: "delete target",
+			left: `if cond:
+    del left
+`,
+			right: `if cond:
+    del right
+`,
+		},
+		{
+			name: "raise value",
+			left: `if cond:
+    raise LeftError
+`,
+			right: `if cond:
+    raise RightError
+`,
+		},
+		{
+			name: "assert test",
+			left: `if cond:
+    assert left, "same"
+`,
+			right: `if cond:
+    assert right, "same"
+`,
+		},
+		{
+			name: "for target and iterator",
+			left: `for left in values:
+    total = left
+`,
+			right: `for right in items:
+    total = right
+`,
+		},
+		{
+			name: "while test",
+			left: `while left:
+    break
+`,
+			right: `while right:
+    break
+`,
+		},
+		{
+			name: "with item alias",
+			left: `with open(path) as left:
+    value = left.read()
+`,
+			right: `with open(path) as right:
+    value = right.read()
+`,
+		},
+		{
+			name: "except handler alias",
+			left: `try:
+    risky()
+except Error as left:
+    handle(left)
+`,
+			right: `try:
+    risky()
+except Error as right:
+    handle(right)
+`,
+		},
+		{
 			name: "global names",
 			left: `def update():
     global left
@@ -319,6 +478,87 @@ func TestConvertASTIncludesExpressionFieldsInAPTEDDistance(t *testing.T) {
     def update():
         nonlocal other
         other = 1
+`,
+		},
+		{
+			name: "import names",
+			left: `if cond:
+    import left_module
+`,
+			right: `if cond:
+    import right_module
+`,
+		},
+		{
+			name: "import alias",
+			left: `if cond:
+    import package as left
+`,
+			right: `if cond:
+    import package as right
+`,
+		},
+		{
+			name: "from import module and names",
+			left: `if cond:
+    from left_package import thing
+`,
+			right: `if cond:
+    from right_package import other
+`,
+		},
+		{
+			name: "lambda args and body",
+			left: `if cond:
+    value = lambda left: left + 1
+`,
+			right: `if cond:
+    value = lambda right: right + 1
+`,
+		},
+		{
+			name: "conditional expression branches",
+			left: `if cond:
+    value = left if check else fallback
+`,
+			right: `if cond:
+    value = right if check else fallback
+`,
+		},
+		{
+			name: "collection element",
+			left: `if cond:
+    value = [left, shared]
+`,
+			right: `if cond:
+    value = [right, shared]
+`,
+		},
+		{
+			name: "dict key and value",
+			left: `if cond:
+    value = {"left": left}
+`,
+			right: `if cond:
+    value = {"right": right}
+`,
+		},
+		{
+			name: "comprehension target iterator and filter",
+			left: `if cond:
+    value = [left for left in values if left]
+`,
+			right: `if cond:
+    value = [right for right in items if right]
+`,
+		},
+		{
+			name: "formatted string interpolation",
+			left: `if cond:
+    value = f"{left}"
+`,
+			right: `if cond:
+    value = f"{right}"
 `,
 		},
 	}

--- a/internal/analyzer/apted_tree_test.go
+++ b/internal/analyzer/apted_tree_test.go
@@ -277,6 +277,50 @@ func TestConvertASTIncludesExpressionFieldsInAPTEDDistance(t *testing.T) {
     value = build(y=1)
 `,
 		},
+		{
+			name: "comparison operator",
+			left: `if left < right:
+    value = 1
+`,
+			right: `if left > right:
+    value = 1
+`,
+		},
+		{
+			name: "augmented assignment operator",
+			left: `if cond:
+    value += step
+`,
+			right: `if cond:
+    value -= step
+`,
+		},
+		{
+			name: "global names",
+			left: `def update():
+    global left
+    left = 1
+`,
+			right: `def update():
+    global right
+    right = 1
+`,
+		},
+		{
+			name: "nonlocal names",
+			left: `def outer():
+    value = 0
+    def update():
+        nonlocal value
+        value = 1
+`,
+			right: `def outer():
+    other = 0
+    def update():
+        nonlocal other
+        other = 1
+`,
+		},
 	}
 
 	analyzer := NewAPTEDAnalyzer(NewPythonCostModel())

--- a/internal/analyzer/apted_tree_test.go
+++ b/internal/analyzer/apted_tree_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ludo-technologies/pyscn/internal/parser"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTreeNode(t *testing.T) {
@@ -241,6 +242,67 @@ func TestConvertAST(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertASTIncludesExpressionFieldsInAPTEDDistance(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+	}{
+		{
+			name: "subscript index",
+			left: `if cond:
+    value = items[i]
+`,
+			right: `if cond:
+    value = items[j]
+`,
+		},
+		{
+			name: "attribute name",
+			left: `if cond:
+    value = obj.left
+`,
+			right: `if cond:
+    value = obj.right
+`,
+		},
+		{
+			name: "keyword name",
+			left: `if cond:
+    value = build(x=1)
+`,
+			right: `if cond:
+    value = build(y=1)
+`,
+		},
+	}
+
+	analyzer := NewAPTEDAnalyzer(NewPythonCostModel())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			leftTree := parseFirstStatementTree(t, tt.left)
+			rightTree := parseFirstStatementTree(t, tt.right)
+			PrepareTreeForAPTED(leftTree)
+			PrepareTreeForAPTED(rightTree)
+
+			distance := analyzer.ComputeDistance(leftTree, rightTree)
+			assert.Greater(t, distance, 0.0, "expression-only differences must affect APTED distance")
+		})
+	}
+}
+
+func parseFirstStatementTree(t *testing.T, source string) *TreeNode {
+	t.Helper()
+
+	result, err := parser.New().Parse(context.Background(), []byte(source))
+	require.NoError(t, err)
+	require.NotEmpty(t, result.AST.Body)
+
+	tree := NewTreeConverter().ConvertAST(result.AST.Body[0])
+	require.NotNil(t, tree)
+	return tree
 }
 
 func TestPostOrderTraversal(t *testing.T) {

--- a/internal/analyzer/ast_features.go
+++ b/internal/analyzer/ast_features.go
@@ -72,6 +72,9 @@ func (a *ASTFeatureExtractor) ExtractFeatures(ast *TreeNode) ([]string, error) {
 	typeCounts := make(map[string]int)
 	preorder := a.preorderLabels(ast)
 	for _, lbl := range preorder {
+		if !a.shouldEmitLabelFeature(lbl) {
+			continue
+		}
 		base := a.baseType(lbl)
 		if a.includeTypes && base != "" {
 			typeCounts[base]++
@@ -132,7 +135,7 @@ func (a *ASTFeatureExtractor) ExtractSubtreeHashes(ast *TreeNode, maxHeight int)
 			_, _ = h.Write(b[:])
 		}
 		hv := h.Sum64()
-		if height <= maxHeight {
+		if height <= maxHeight && a.shouldEmitLabelFeature(n.Label) {
 			feats = append(feats, fmt.Sprintf("sub:%d:%016x", height, hv))
 		}
 		return hv, height
@@ -146,7 +149,7 @@ func (a *ASTFeatureExtractor) ExtractNodeSequences(ast *TreeNode, k int) []strin
 	if ast == nil || k <= 1 {
 		return []string{}
 	}
-	labels := a.preorderLabels(ast)
+	labels := a.preorderFeatureLabels(ast)
 	if len(labels) < k {
 		return []string{}
 	}
@@ -176,6 +179,38 @@ func (a *ASTFeatureExtractor) baseType(lbl string) string {
 	s := a.canonicalLabel(lbl)
 	// If canonical label is empty, skip
 	return s
+}
+
+func (a *ASTFeatureExtractor) shouldEmitLabelFeature(lbl string) bool {
+	if a.includeLiterals {
+		return true
+	}
+
+	switch a.baseType(lbl) {
+	case "Name", "Constant", "Arg", "Keyword":
+		return false
+	default:
+		return true
+	}
+}
+
+func (a *ASTFeatureExtractor) preorderFeatureLabels(ast *TreeNode) []string {
+	labels := []string{}
+	var walk func(n *TreeNode)
+	walk = func(n *TreeNode) {
+		if n == nil {
+			return
+		}
+		label := a.canonicalLabel(n.Label)
+		if a.shouldEmitLabelFeature(label) {
+			labels = append(labels, label)
+		}
+		for _, ch := range n.Children {
+			walk(ch)
+		}
+	}
+	walk(ast)
+	return labels
 }
 
 func (a *ASTFeatureExtractor) preorderLabels(ast *TreeNode) []string {

--- a/internal/analyzer/ast_features_test.go
+++ b/internal/analyzer/ast_features_test.go
@@ -120,6 +120,44 @@ func TestExtractFeatures_Config(t *testing.T) {
 	})
 }
 
+func TestExtractFeatures_SkipsLowEntropyExpressionLeaves(t *testing.T) {
+	extractor := NewASTFeatureExtractor()
+
+	root := NewTreeNode(1, "Assign")
+	root.AddChild(NewTreeNode(2, "Name(value)"))
+	call := NewTreeNode(3, "Call")
+	call.AddChild(NewTreeNode(4, "Name(build)"))
+	keyword := NewTreeNode(5, "Keyword(flag)")
+	keyword.AddChild(NewTreeNode(6, "Constant(true)"))
+	call.AddChild(keyword)
+	root.AddChild(call)
+
+	features, err := extractor.ExtractFeatures(root)
+	assert.NoError(t, err)
+
+	assert.NotContains(t, features, "type:Name")
+	assert.NotContains(t, features, "type:Constant")
+	assert.NotContains(t, features, "type:Keyword")
+	assert.NotContains(t, features, "typedist:Name:2-3")
+	assert.NotContains(t, features, "typedist:Constant:1")
+	assert.Contains(t, features, "type:Assign")
+	assert.Contains(t, features, "type:Call")
+}
+
+func TestExtractNodeSequences_SkipsLowEntropyExpressionLeaves(t *testing.T) {
+	extractor := NewASTFeatureExtractor()
+
+	root := NewTreeNode(1, "If")
+	root.AddChild(NewTreeNode(2, "Name(cond)"))
+	assign := NewTreeNode(3, "Assign")
+	assign.AddChild(NewTreeNode(4, "Name(value)"))
+	assign.AddChild(NewTreeNode(5, "Constant(1)"))
+	root.AddChild(assign)
+
+	seqs := extractor.ExtractNodeSequences(root, 2)
+	assert.Equal(t, []string{"If:Assign"}, seqs)
+}
+
 func TestExtractFeatures_Comprehensive(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -186,7 +186,7 @@ type CloneDetectorConfig struct {
 	LSHBands               int     // Number of LSH bands (default: 32)
 	LSHRows                int     // Rows per band (default: 4)
 	LSHMinHashCount        int     // Number of MinHash functions (default: 128)
-	LSHMaxBucketSize       int     // Maximum bucket size before treating it as non-selective
+	LSHMaxCandidates       int     // Maximum candidates returned per LSH query
 
 	// Multi-dimensional classification (optional, opt-in)
 	EnableMultiDimensionalAnalysis bool // Enable multi-dimensional clone type classification
@@ -231,7 +231,7 @@ func DefaultCloneDetectorConfig() *CloneDetectorConfig {
 		LSHBands:               32,
 		LSHRows:                4,
 		LSHMinHashCount:        128,
-		LSHMaxBucketSize:       defaultLSHMaxBucketSize,
+		LSHMaxCandidates:       defaultLSHMaxCandidates,
 
 		// Multi-dimensional classification defaults (opt-in)
 		EnableMultiDimensionalAnalysis: false,
@@ -640,7 +640,7 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 
 	// Stage 2: LSH indexing
 	lsh := NewLSHIndex(cd.cloneDetectorConfig.LSHBands, cd.cloneDetectorConfig.LSHRows).
-		WithMaxBucketSize(cd.cloneDetectorConfig.LSHMaxBucketSize)
+		WithMaxCandidates(cd.cloneDetectorConfig.LSHMaxCandidates)
 	for _, r := range records {
 		_ = lsh.AddFragment(r.id, r.sig)
 	}

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -389,16 +389,8 @@ func (cd *CloneDetector) extractFragmentsRecursiveWithSource(node *parser.Node, 
 	}
 
 	// Recursively process children
-	for _, child := range node.Children {
+	for _, child := range orderedASTChildren(node, nil) {
 		cd.extractFragmentsRecursiveWithSource(child, filePath, sourceCode, fragments)
-	}
-
-	for _, bodyNode := range node.Body {
-		cd.extractFragmentsRecursiveWithSource(bodyNode, filePath, sourceCode, fragments)
-	}
-
-	for _, orelseNode := range node.Orelse {
-		cd.extractFragmentsRecursiveWithSource(orelseNode, filePath, sourceCode, fragments)
 	}
 }
 
@@ -472,16 +464,8 @@ func (cd *CloneDetector) extractFragmentsRecursive(node *parser.Node, filePath s
 	}
 
 	// Recursively process children
-	for _, child := range node.Children {
+	for _, child := range orderedASTChildren(node, nil) {
 		cd.extractFragmentsRecursive(child, filePath, fragments)
-	}
-
-	for _, bodyNode := range node.Body {
-		cd.extractFragmentsRecursive(bodyNode, filePath, fragments)
-	}
-
-	for _, orelseNode := range node.Orelse {
-		cd.extractFragmentsRecursive(orelseNode, filePath, fragments)
 	}
 }
 

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -186,6 +186,7 @@ type CloneDetectorConfig struct {
 	LSHBands               int     // Number of LSH bands (default: 32)
 	LSHRows                int     // Rows per band (default: 4)
 	LSHMinHashCount        int     // Number of MinHash functions (default: 128)
+	LSHMaxBucketSize       int     // Maximum bucket size before treating it as non-selective
 
 	// Multi-dimensional classification (optional, opt-in)
 	EnableMultiDimensionalAnalysis bool // Enable multi-dimensional clone type classification
@@ -230,6 +231,7 @@ func DefaultCloneDetectorConfig() *CloneDetectorConfig {
 		LSHBands:               32,
 		LSHRows:                4,
 		LSHMinHashCount:        128,
+		LSHMaxBucketSize:       defaultLSHMaxBucketSize,
 
 		// Multi-dimensional classification defaults (opt-in)
 		EnableMultiDimensionalAnalysis: false,
@@ -637,7 +639,8 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 	}
 
 	// Stage 2: LSH indexing
-	lsh := NewLSHIndex(cd.cloneDetectorConfig.LSHBands, cd.cloneDetectorConfig.LSHRows)
+	lsh := NewLSHIndex(cd.cloneDetectorConfig.LSHBands, cd.cloneDetectorConfig.LSHRows).
+		WithMaxBucketSize(cd.cloneDetectorConfig.LSHMaxBucketSize)
 	for _, r := range records {
 		_ = lsh.AddFragment(r.id, r.sig)
 	}

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -86,14 +86,8 @@ func calculateASTSize(node *parser.Node) int {
 	}
 
 	size := 1
-	for _, child := range node.Children {
+	for _, child := range orderedASTChildren(node, nil) {
 		size += calculateASTSize(child)
-	}
-	for _, bodyNode := range node.Body {
-		size += calculateASTSize(bodyNode)
-	}
-	for _, orelseNode := range node.Orelse {
-		size += calculateASTSize(orelseNode)
 	}
 
 	return size

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -150,6 +150,46 @@ func TestCalculateASTSize(t *testing.T) {
 	assert.Equal(t, 2, size, "Duplicate child references should not inflate AST size")
 }
 
+func TestCompareWithAPTEDExpressionOnlyDifferenceReportsDistance(t *testing.T) {
+	left := `if cond:
+    value = items[i]
+`
+	right := `if cond:
+    value = items[j]
+`
+
+	leftTree := parseFirstStatementTree(t, left)
+	rightTree := parseFirstStatementTree(t, right)
+	PrepareTreeForAPTED(leftTree)
+	PrepareTreeForAPTED(rightTree)
+
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 1
+	config.MinNodes = 1
+	detector := NewCloneDetector(config)
+
+	pair := detector.compareWithAPTED(
+		&CodeFragment{
+			Location:  &CodeLocation{FilePath: "left.py", StartLine: 1, EndLine: 2},
+			TreeNode:  leftTree,
+			Content:   left,
+			Size:      leftTree.Size(),
+			LineCount: 2,
+		},
+		&CodeFragment{
+			Location:  &CodeLocation{FilePath: "right.py", StartLine: 1, EndLine: 2},
+			TreeNode:  rightTree,
+			Content:   right,
+			Size:      rightTree.Size(),
+			LineCount: 2,
+		},
+	)
+
+	require.NotNil(t, pair)
+	assert.Greater(t, pair.Distance, 0.0)
+	assert.Equal(t, Type2Clone, pair.CloneType)
+}
+
 func TestClonePair_String(t *testing.T) {
 	fragment1 := &CodeFragment{
 		Location: &CodeLocation{

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -30,7 +30,7 @@ func TestCloneDetectorConfig_Defaults(t *testing.T) {
 	assert.Equal(t, domain.DefaultType3CloneThreshold, config.Type3Threshold, "Default Type-3 threshold should match constant")
 	assert.Equal(t, domain.DefaultType4CloneThreshold, config.Type4Threshold, "Default Type-4 threshold should match constant")
 	assert.Equal(t, 50.0, config.MaxEditDistance, "Default max edit distance should be 50.0")
-	assert.Equal(t, defaultLSHMaxBucketSize, config.LSHMaxBucketSize, "Default LSH bucket cap should be set")
+	assert.Equal(t, defaultLSHMaxCandidates, config.LSHMaxCandidates, "Default LSH candidate cap should be set")
 	assert.False(t, config.IgnoreLiterals, "Default ignore literals should be false")
 	assert.False(t, config.IgnoreIdentifiers, "Default ignore identifiers should be false")
 	assert.True(t, config.SkipDocstrings, "Default skip docstrings should be true")

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -120,6 +120,33 @@ func TestCalculateASTSize(t *testing.T) {
 	}
 	size = calculateASTSize(parent)
 	assert.Equal(t, 3, size, "Node with 2 children should have size 3")
+
+	// Expression fields count as real AST size.
+	expressionNode := &parser.Node{
+		Type: parser.NodeAssign,
+		Targets: []*parser.Node{
+			{Type: parser.NodeName, Name: "value"},
+		},
+		Value: &parser.Node{
+			Type:  parser.NodeSubscript,
+			Value: &parser.Node{Type: parser.NodeName, Name: "items"},
+			Children: []*parser.Node{
+				{Type: parser.NodeName, Name: "index"},
+			},
+		},
+	}
+	size = calculateASTSize(expressionNode)
+	assert.Equal(t, 5, size, "Expression fields should be included in AST size")
+
+	// Shared nodes are counted once per parent, matching tree conversion.
+	shared := &parser.Node{Type: parser.NodeName, Name: "condition"}
+	duplicateReference := &parser.Node{
+		Type:     parser.NodeIf,
+		Children: []*parser.Node{shared},
+		Test:     shared,
+	}
+	size = calculateASTSize(duplicateReference)
+	assert.Equal(t, 2, size, "Duplicate child references should not inflate AST size")
 }
 
 func TestClonePair_String(t *testing.T) {

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -30,6 +30,7 @@ func TestCloneDetectorConfig_Defaults(t *testing.T) {
 	assert.Equal(t, domain.DefaultType3CloneThreshold, config.Type3Threshold, "Default Type-3 threshold should match constant")
 	assert.Equal(t, domain.DefaultType4CloneThreshold, config.Type4Threshold, "Default Type-4 threshold should match constant")
 	assert.Equal(t, 50.0, config.MaxEditDistance, "Default max edit distance should be 50.0")
+	assert.Equal(t, defaultLSHMaxBucketSize, config.LSHMaxBucketSize, "Default LSH bucket cap should be set")
 	assert.False(t, config.IgnoreLiterals, "Default ignore literals should be false")
 	assert.False(t, config.IgnoreIdentifiers, "Default ignore identifiers should be false")
 	assert.True(t, config.SkipDocstrings, "Default skip docstrings should be true")

--- a/internal/analyzer/lsh_index.go
+++ b/internal/analyzer/lsh_index.go
@@ -6,12 +6,15 @@ import (
 	"hash/fnv"
 )
 
+const defaultLSHMaxBucketSize = 1024
+
 // LSHIndex implements MinHash LSH with banding
 type LSHIndex struct {
-	bands      int
-	rows       int
-	buckets    map[string][]string // band_hash -> fragment_ids
-	signatures map[string]*MinHashSignature
+	bands         int
+	rows          int
+	maxBucketSize int
+	buckets       map[string][]string // band_hash -> fragment_ids
+	signatures    map[string]*MinHashSignature
 }
 
 // NewLSHIndex creates an index with banding parameters
@@ -23,11 +26,21 @@ func NewLSHIndex(bands, rows int) *LSHIndex {
 		rows = 4
 	}
 	return &LSHIndex{
-		bands:      bands,
-		rows:       rows,
-		buckets:    make(map[string][]string),
-		signatures: make(map[string]*MinHashSignature),
+		bands:         bands,
+		rows:          rows,
+		maxBucketSize: defaultLSHMaxBucketSize,
+		buckets:       make(map[string][]string),
+		signatures:    make(map[string]*MinHashSignature),
 	}
+}
+
+// WithMaxBucketSize sets the maximum bucket size used for candidate lookup.
+// Buckets above the cap are treated as non-selective and skipped.
+func (idx *LSHIndex) WithMaxBucketSize(maxBucketSize int) *LSHIndex {
+	if maxBucketSize > 0 {
+		idx.maxBucketSize = maxBucketSize
+	}
+	return idx
 }
 
 // AddFragment inserts a fragment signature into the index
@@ -55,6 +68,9 @@ func (idx *LSHIndex) FindCandidates(signature *MinHashSignature) []string {
 	bands := idx.computeBandKeys(signature)
 	for _, key := range bands {
 		if bucket, ok := idx.buckets[key]; ok {
+			if idx.maxBucketSize > 0 && len(bucket) > idx.maxBucketSize {
+				continue
+			}
 			for _, id := range bucket {
 				ids[id] = struct{}{}
 			}

--- a/internal/analyzer/lsh_index.go
+++ b/internal/analyzer/lsh_index.go
@@ -72,8 +72,14 @@ func (idx *LSHIndex) FindCandidates(signature *MinHashSignature) []string {
 				continue
 			}
 			for _, id := range bucket {
+				if idx.maxBucketSize > 0 && len(ids) >= idx.maxBucketSize {
+					break
+				}
 				ids[id] = struct{}{}
 			}
+		}
+		if idx.maxBucketSize > 0 && len(ids) >= idx.maxBucketSize {
+			break
 		}
 	}
 	out := make([]string, 0, len(ids))

--- a/internal/analyzer/lsh_index.go
+++ b/internal/analyzer/lsh_index.go
@@ -6,13 +6,13 @@ import (
 	"hash/fnv"
 )
 
-const defaultLSHMaxBucketSize = 1024
+const defaultLSHMaxCandidates = 1024
 
 // LSHIndex implements MinHash LSH with banding
 type LSHIndex struct {
 	bands         int
 	rows          int
-	maxBucketSize int
+	maxCandidates int
 	buckets       map[string][]string // band_hash -> fragment_ids
 	signatures    map[string]*MinHashSignature
 }
@@ -28,17 +28,16 @@ func NewLSHIndex(bands, rows int) *LSHIndex {
 	return &LSHIndex{
 		bands:         bands,
 		rows:          rows,
-		maxBucketSize: defaultLSHMaxBucketSize,
+		maxCandidates: defaultLSHMaxCandidates,
 		buckets:       make(map[string][]string),
 		signatures:    make(map[string]*MinHashSignature),
 	}
 }
 
-// WithMaxBucketSize sets the maximum bucket size used for candidate lookup.
-// Buckets above the cap are treated as non-selective and skipped.
-func (idx *LSHIndex) WithMaxBucketSize(maxBucketSize int) *LSHIndex {
-	if maxBucketSize > 0 {
-		idx.maxBucketSize = maxBucketSize
+// WithMaxCandidates caps the number of candidates returned for a query.
+func (idx *LSHIndex) WithMaxCandidates(maxCandidates int) *LSHIndex {
+	if maxCandidates > 0 {
+		idx.maxCandidates = maxCandidates
 	}
 	return idx
 }
@@ -68,17 +67,14 @@ func (idx *LSHIndex) FindCandidates(signature *MinHashSignature) []string {
 	bands := idx.computeBandKeys(signature)
 	for _, key := range bands {
 		if bucket, ok := idx.buckets[key]; ok {
-			if idx.maxBucketSize > 0 && len(bucket) > idx.maxBucketSize {
-				continue
-			}
 			for _, id := range bucket {
-				if idx.maxBucketSize > 0 && len(ids) >= idx.maxBucketSize {
+				if idx.maxCandidates > 0 && len(ids) >= idx.maxCandidates {
 					break
 				}
 				ids[id] = struct{}{}
 			}
 		}
-		if idx.maxBucketSize > 0 && len(ids) >= idx.maxBucketSize {
+		if idx.maxCandidates > 0 && len(ids) >= idx.maxCandidates {
 			break
 		}
 	}

--- a/internal/analyzer/lsh_index_test.go
+++ b/internal/analyzer/lsh_index_test.go
@@ -40,11 +40,11 @@ func TestLSHIndex_FindCandidates(t *testing.T) {
 	}
 }
 
-func TestLSHIndex_FindCandidatesSkipsOversizedBuckets(t *testing.T) {
+func TestLSHIndex_FindCandidatesKeepsOversizedBucketCandidates(t *testing.T) {
 	mh := NewMinHasher(128)
 	sig := mh.ComputeSignature([]string{"same", "feature", "set"})
 
-	lsh := NewLSHIndex(32, 4).WithMaxBucketSize(2)
+	lsh := NewLSHIndex(32, 4).WithMaxCandidates(2)
 	for _, id := range []string{"A", "B", "C"} {
 		if err := lsh.AddFragment(id, sig); err != nil {
 			t.Fatalf("add %s: %v", id, err)
@@ -52,8 +52,8 @@ func TestLSHIndex_FindCandidatesSkipsOversizedBuckets(t *testing.T) {
 	}
 
 	cands := lsh.FindCandidates(sig)
-	if len(cands) != 0 {
-		t.Fatalf("expected oversized buckets to be skipped; got %v", cands)
+	if len(cands) != 2 {
+		t.Fatalf("expected oversized bucket candidates capped at 2; got %v", cands)
 	}
 }
 
@@ -61,7 +61,7 @@ func TestLSHIndex_FindCandidatesCapsTotalCandidates(t *testing.T) {
 	mh := NewMinHasher(128)
 	query := mh.ComputeSignature([]string{"shared", "query", "features"})
 
-	lsh := NewLSHIndex(32, 4).WithMaxBucketSize(2)
+	lsh := NewLSHIndex(32, 4).WithMaxCandidates(2)
 	keys := lsh.computeBandKeys(query)
 	lsh.buckets[keys[0]] = []string{"A"}
 	lsh.buckets[keys[1]] = []string{"B"}

--- a/internal/analyzer/lsh_index_test.go
+++ b/internal/analyzer/lsh_index_test.go
@@ -56,3 +56,19 @@ func TestLSHIndex_FindCandidatesSkipsOversizedBuckets(t *testing.T) {
 		t.Fatalf("expected oversized buckets to be skipped; got %v", cands)
 	}
 }
+
+func TestLSHIndex_FindCandidatesCapsTotalCandidates(t *testing.T) {
+	mh := NewMinHasher(128)
+	query := mh.ComputeSignature([]string{"shared", "query", "features"})
+
+	lsh := NewLSHIndex(32, 4).WithMaxBucketSize(2)
+	keys := lsh.computeBandKeys(query)
+	lsh.buckets[keys[0]] = []string{"A"}
+	lsh.buckets[keys[1]] = []string{"B"}
+	lsh.buckets[keys[2]] = []string{"C"}
+
+	cands := lsh.FindCandidates(query)
+	if len(cands) > 2 {
+		t.Fatalf("expected candidates to be capped at 2; got %v", cands)
+	}
+}

--- a/internal/analyzer/lsh_index_test.go
+++ b/internal/analyzer/lsh_index_test.go
@@ -39,3 +39,20 @@ func TestLSHIndex_FindCandidates(t *testing.T) {
 		t.Fatalf("expected Y to be a candidate for X; got %v", cands)
 	}
 }
+
+func TestLSHIndex_FindCandidatesSkipsOversizedBuckets(t *testing.T) {
+	mh := NewMinHasher(128)
+	sig := mh.ComputeSignature([]string{"same", "feature", "set"})
+
+	lsh := NewLSHIndex(32, 4).WithMaxBucketSize(2)
+	for _, id := range []string{"A", "B", "C"} {
+		if err := lsh.AddFragment(id, sig); err != nil {
+			t.Fatalf("add %s: %v", id, err)
+		}
+	}
+
+	cands := lsh.FindCandidates(sig)
+	if len(cands) != 0 {
+		t.Fatalf("expected oversized buckets to be skipped; got %v", cands)
+	}
+}

--- a/internal/analyzer/lsh_integration_test.go
+++ b/internal/analyzer/lsh_integration_test.go
@@ -61,6 +61,29 @@ func TestCloneDetector_DetectClonesWithLSH_Simple(t *testing.T) {
 	}
 }
 
+func TestCloneDetector_DetectClonesWithLSH_CandidateCapDoesNotDropExactFamily(t *testing.T) {
+	fragments := make([]*CodeFragment, 0, 9)
+	for i := 0; i < 9; i++ {
+		fragments = append(fragments, &CodeFragment{
+			Location:  &CodeLocation{FilePath: "exact.py", StartLine: i*10 + 1, EndLine: i*10 + 5},
+			TreeNode:  buildSimpleTree("FunctionDef", "If", "Return"),
+			Size:      5,
+			LineCount: 5,
+		})
+	}
+
+	cfg := DefaultCloneDetectorConfig()
+	cfg.UseLSH = true
+	cfg.MinNodes = 1
+	cfg.LSHSimilarityThreshold = 0.5
+	cfg.LSHMaxCandidates = 8
+
+	pairs, groups := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
+	if len(pairs) == 0 || len(groups) == 0 {
+		t.Fatalf("candidate cap dropped every exact clone candidate")
+	}
+}
+
 func TestCloneDetector_DetectClonesWithLSH_MatchesStandardOnBenchmarkFixture(t *testing.T) {
 	fragments := buildCloneBenchmarkFragments(4, 4, 8)
 


### PR DESCRIPTION
Closes #400

Convert clone APTED trees with expression-level AST fields instead of only the statement skeleton.

This makes identifier, literal, attribute, keyword, operator, import, alias, annotation, decorator, and comprehension differences affect the reported distance.

It also keeps LSH bounded by filtering low-entropy feature leaves and capping per-query candidates without dropping large exact-clone families.

Validation: go test ./...; go vet ./...; expression edge matrix 33/33 non-zero vs upstream 0/33; LSH exact-family cap regression test.
