### PR TITLE
fix: emit real line range for synthetic __main__ record (#396)

### DIFF
--- a/internal/analyzer/cfg.go
+++ b/internal/analyzer/cfg.go
@@ -172,6 +172,9 @@ type CFG struct {
 	// FunctionNode is the original AST node for the function
 	FunctionNode *parser.Node
 
+	// ModuleNode is the original AST node for the module (set only on the synthetic __main__ CFG)
+	ModuleNode *parser.Node
+
 	// nextBlockID is used to generate unique block IDs
 	nextBlockID int
 }

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -126,6 +126,8 @@ func (b *CFGBuilder) Build(node *parser.Node) (*CFG, error) {
 	// Store the function node for later use (nesting depth calculation)
 	if node.Type == parser.NodeFunctionDef || node.Type == parser.NodeAsyncFunctionDef {
 		b.cfg.FunctionNode = node
+	} else if node.Type == parser.NodeModule {
+		b.cfg.ModuleNode = node
 	}
 
 	// Build CFG based on node type

--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -165,6 +165,10 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		startLine = cfg.FunctionNode.Location.StartLine
 		startCol = cfg.FunctionNode.Location.StartCol
 		endLine = cfg.FunctionNode.Location.EndLine
+	} else if cfg.ModuleNode != nil {
+		startLine = cfg.ModuleNode.Location.StartLine
+		startCol = cfg.ModuleNode.Location.StartCol
+		endLine = cfg.ModuleNode.Location.EndLine
 	}
 
 	result := &ComplexityResult{

--- a/internal/analyzer/complexity_test.go
+++ b/internal/analyzer/complexity_test.go
@@ -1,8 +1,11 @@
 package analyzer
 
 import (
-	"github.com/ludo-technologies/pyscn/internal/config"
+	"context"
 	"testing"
+
+	"github.com/ludo-technologies/pyscn/internal/config"
+	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
 func TestComplexityResult(t *testing.T) {
@@ -240,6 +243,48 @@ func TestCalculateComplexity(t *testing.T) {
 				t.Errorf("Expected %d edges, got %d", tc.expectedEdges, result.Edges)
 			}
 		})
+	}
+}
+
+// Regression test for issue #396: module-level CFGs (the synthetic __main__)
+// must report a real source span instead of 0-0.
+func TestCalculateComplexity_ModuleLevelHasRealLineRange(t *testing.T) {
+	source := `import sys
+
+count = 0
+for arg in sys.argv[1:]:
+    if arg.startswith("--"):
+        count += 1
+    else:
+        count -= 1
+print(count)
+`
+
+	p := parser.New()
+	result, err := p.Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+
+	cfgs, err := NewCFGBuilder().BuildAll(result.AST)
+	if err != nil {
+		t.Fatalf("Failed to build CFGs: %v", err)
+	}
+
+	mainCFG, ok := cfgs["__main__"]
+	if !ok {
+		t.Fatal("Expected __main__ CFG to be present")
+	}
+	if mainCFG.ModuleNode == nil {
+		t.Fatal("Expected ModuleNode to be set on the __main__ CFG")
+	}
+
+	res := CalculateComplexity(mainCFG)
+	if res.StartLine < 1 {
+		t.Errorf("StartLine should be >= 1 for non-empty module, got %d", res.StartLine)
+	}
+	if res.EndLine < res.StartLine {
+		t.Errorf("EndLine (%d) should be >= StartLine (%d)", res.EndLine, res.StartLine)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #396: `pyscn analyze` was emitting a `__main__` complexity record with `StartLine=0, EndLine=0` for any Python file containing module-level executable code, breaking consumers that try to open the cited range.
- Root cause: the module-level CFG is registered as `__main__`, but `cfg_builder.go` only stored `FunctionNode` for `def` / `async def`. The complexity calculator gated `StartLine` / `EndLine` on `FunctionNode != nil`, so module CFGs fell through to zero-initialized values.
- Adds a `ModuleNode` field on `CFG`, populates it for `NodeModule`, and uses it as a fallback in `CalculateComplexityWithConfig`. Nesting/cognitive complexity remain function-only — no behavioral change for existing function records.

## Verification

Repro from the issue (`/tmp/scriptlike.py`):

Before:
```json
{ "Name": "__main__", "StartLine": 0, "StartColumn": 0, "EndLine": 0, ... }
```

After:
```json
{ "Name": "__main__", "StartLine": 1, "StartColumn": 0, "EndLine": 10, ... }
```

## Test plan

- [x] New regression test `TestCalculateComplexity_ModuleLevelHasRealLineRange` in `internal/analyzer/complexity_test.go`
- [x] `go test ./...` — all pass
- [x] `make lint` / `make fmt` — clean
- [x] Manual repro on the minimal script from the issue