### PR TITLE
docs: update CHANGELOG for v1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## [1.18.1] - 2026-05-01
+## [1.18.1] - 2026-05-02
 
 ### Fixed
 - Emit real line range for synthetic `__main__` complexity record (#403)
+
+### Documentation
+- Sync rule catalog and config reference with v1.13–v1.18 releases (#406)
 
 ## [1.18.0] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.18.1] - 2026-05-01
+
+### Fixed
+- Emit real line range for synthetic `__main__` complexity record (#403)
+
 ## [1.18.0] - 2026-04-30
 
 ### Added


### PR DESCRIPTION
Update CHANGELOG for v1.18.1 release.

### Fixed
- Emit real line range for synthetic `__main__` complexity record (#403)