### PR TITLE
feat: add main sequence architecture metrics

### DIFF
--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -302,7 +302,7 @@ pyscn reports zones with fixed thresholds:
 |---|---|
 | Stable module | `I <= 0.3` |
 | Unstable module | `I >= 0.7` |
-| Zone of Pain | `D >= 0.5`, `I <= 0.3`, and `A <= 0.3` |
+| Zone of Pain | `D >= 0.5`, `Ca >= 2`, `I <= 0.3`, and `A <= 0.3` |
 | Zone of Uselessness | `D >= 0.5`, `I >= 0.7`, and `A >= 0.7` |
 | Main Sequence | `D <= 0.2` |
 

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -259,16 +259,17 @@ If `Ca + Ce = 0` (isolated module), instability defaults to 0.
 
 ### Abstractness (A)
 
-Abstractness measures the ratio of "abstract" public names to total public names in a module. A name is considered abstract if it matches one of these heuristics:
+Abstractness measures the ratio of abstract classes to total classes in a module. The analyzer reads the module AST and counts a class as abstract when it:
 
-- Ends with `Interface`, `Abstract`, `Base`, or `ABC`
-- Starts with `I` followed by an uppercase letter (e.g., `IRepository`)
+- Inherits from `ABC` or `abc.ABC`
+- Uses `ABCMeta` or `abc.ABCMeta` as its metaclass
+- Defines at least one method decorated with `@abstractmethod` or `@abc.abstractmethod`
 
 ```
-A = abstract_public_names / total_public_names
+A = abstract_classes / total_classes
 ```
 
-A value of 0 means entirely concrete; 1 means entirely abstract.
+A value of 0 means all classes are concrete. A value of 1 means all classes are abstract. Modules without classes use `A = 0`.
 
 ### Distance from Main Sequence (D)
 
@@ -294,6 +295,16 @@ quadrantChart
 | **Zone of Pain** | Low A, Low I (concrete + stable) | Hard to change because many modules depend on concrete implementations |
 | **Zone of Uselessness** | High A, High I (abstract + unstable) | Abstract modules that nobody uses |
 | **Main Sequence** | D close to 0 | Well-balanced -- abstractness matches stability |
+
+pyscn reports zones with fixed thresholds:
+
+| Classification | Condition |
+|---|---|
+| Stable module | `I <= 0.3` |
+| Unstable module | `I >= 0.7` |
+| Zone of Pain | `D >= 0.5`, `I <= 0.3`, and `A <= 0.3` |
+| Zone of Uselessness | `D >= 0.5`, `I >= 0.7`, and `A >= 0.7` |
+| Main Sequence | `D <= 0.2` |
 
 ### Risk Level Assignment
 

--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -132,10 +132,11 @@ type ModuleDependencyMetrics struct {
 	IsPackage  bool   // True if this is a package
 
 	// Size metrics
-	LinesOfCode     int      // Total lines of code
-	FunctionCount   int      // Number of functions
-	ClassCount      int      // Number of classes
-	PublicInterface []string // Public names exported
+	LinesOfCode        int      // Total lines of code
+	FunctionCount      int      // Number of functions
+	ClassCount         int      // Number of classes
+	AbstractClassCount int      // Number of abstract classes
+	PublicInterface    []string // Public names exported
 
 	// Coupling metrics (Robert Martin's metrics)
 	AfferentCoupling int     // Ca - modules that depend on this one

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -5,6 +5,15 @@ import (
 	"sort"
 )
 
+const (
+	mainSequenceMaxDistance = 0.2
+	zoneMinDistance         = 0.5
+	lowInstability          = 0.3
+	highInstability         = 0.7
+	lowAbstractness         = 0.3
+	highAbstractness        = 0.7
+)
+
 // CouplingMetricsCalculator calculates various coupling and quality metrics for modules
 type CouplingMetricsCalculator struct {
 	graph *DependencyGraph
@@ -159,6 +168,36 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
 
 	// Identify refactoring priorities
 	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities()
+	systemMetrics.StableModules = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
+		return metrics.Instability <= lowInstability
+	})
+	systemMetrics.InstableModules = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
+		return metrics.Instability >= highInstability
+	})
+	systemMetrics.ZoneOfPain = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
+		return metrics.Distance >= zoneMinDistance &&
+			metrics.Instability <= lowInstability &&
+			metrics.Abstractness <= lowAbstractness
+	})
+	systemMetrics.ZoneOfUselessness = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
+		return metrics.Distance >= zoneMinDistance &&
+			metrics.Instability >= highInstability &&
+			metrics.Abstractness >= highAbstractness
+	})
+	systemMetrics.MainSequence = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
+		return metrics.Distance <= mainSequenceMaxDistance
+	})
+}
+
+func (calc *CouplingMetricsCalculator) modulesMatching(match func(*ModuleMetrics) bool) []string {
+	modules := make([]string, 0)
+	for moduleName, metrics := range calc.graph.ModuleMetrics {
+		if metrics != nil && match(metrics) {
+			modules = append(modules, moduleName)
+		}
+	}
+	sort.Strings(modules)
+	return modules
 }
 
 // calculateModularityIndex calculates the modularity index of the system

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -168,26 +168,36 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
 
 	// Identify refactoring priorities
 	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities()
-	systemMetrics.StableModules = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
-		return metrics.Instability <= lowInstability
-	})
-	systemMetrics.InstableModules = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
-		return metrics.Instability >= highInstability
-	})
-	systemMetrics.ZoneOfPain = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
-		return metrics.Distance >= zoneMinDistance &&
-			metrics.AfferentCoupling >= 2 &&
-			metrics.Instability <= lowInstability &&
-			metrics.Abstractness <= lowAbstractness
-	})
-	systemMetrics.ZoneOfUselessness = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
-		return metrics.Distance >= zoneMinDistance &&
-			metrics.Instability >= highInstability &&
-			metrics.Abstractness >= highAbstractness
-	})
-	systemMetrics.MainSequence = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
-		return metrics.Distance <= mainSequenceMaxDistance
-	})
+	systemMetrics.StableModules = calc.modulesMatching(isStableModule)
+	systemMetrics.InstableModules = calc.modulesMatching(isInstableModule)
+	systemMetrics.ZoneOfPain = calc.modulesMatching(isZoneOfPain)
+	systemMetrics.ZoneOfUselessness = calc.modulesMatching(isZoneOfUselessness)
+	systemMetrics.MainSequence = calc.modulesMatching(isOnMainSequence)
+}
+
+func isStableModule(metrics *ModuleMetrics) bool {
+	return metrics.Instability <= lowInstability
+}
+
+func isInstableModule(metrics *ModuleMetrics) bool {
+	return metrics.Instability >= highInstability
+}
+
+func isZoneOfPain(metrics *ModuleMetrics) bool {
+	return metrics.Distance >= zoneMinDistance &&
+		metrics.AfferentCoupling >= 2 &&
+		metrics.Instability <= lowInstability &&
+		metrics.Abstractness <= lowAbstractness
+}
+
+func isZoneOfUselessness(metrics *ModuleMetrics) bool {
+	return metrics.Distance >= zoneMinDistance &&
+		metrics.Instability >= highInstability &&
+		metrics.Abstractness >= highAbstractness
+}
+
+func isOnMainSequence(metrics *ModuleMetrics) bool {
+	return metrics.Distance <= mainSequenceMaxDistance
 }
 
 func (calc *CouplingMetricsCalculator) modulesMatching(match func(*ModuleMetrics) bool) []string {

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -89,6 +89,8 @@ func (calc *CouplingMetricsCalculator) calculateModuleMetrics(moduleName string,
 
 	// Size metrics
 	metrics.LinesOfCode = node.LineCount
+	metrics.ClassCount = node.ClassCount
+	metrics.AbstractClassCount = node.AbstractClassCount
 	metrics.PublicInterface = len(node.PublicNames)
 
 	// Quality metrics from external data
@@ -101,47 +103,11 @@ func (calc *CouplingMetricsCalculator) calculateModuleMetrics(moduleName string,
 
 // calculateAbstractness calculates the abstractness of a module
 func (calc *CouplingMetricsCalculator) calculateAbstractness(node *ModuleNode) float64 {
-	if len(node.PublicNames) == 0 {
-		return 0.0 // No public interface = not abstract
+	if node.ClassCount == 0 {
+		return 0.0
 	}
 
-	// Simple heuristic: count abstract/interface-like public names
-	abstractCount := 0
-	for _, name := range node.PublicNames {
-		// Heuristics for abstractness:
-		// - Names ending with "Interface", "Abstract", "Base"
-		// - Names starting with "I" followed by uppercase (IService)
-		// - Functions with "abc" decorators would need AST analysis
-		if calc.isAbstractName(name) {
-			abstractCount++
-		}
-	}
-
-	return float64(abstractCount) / float64(len(node.PublicNames))
-}
-
-// isAbstractName checks if a name suggests abstractness
-func (calc *CouplingMetricsCalculator) isAbstractName(name string) bool {
-	abstractPrefixes := []string{"I"} // Interface naming convention
-	abstractSuffixes := []string{"Interface", "Abstract", "Base", "ABC"}
-
-	// Check suffixes
-	for _, suffix := range abstractSuffixes {
-		if len(name) > len(suffix) && name[len(name)-len(suffix):] == suffix {
-			return true
-		}
-	}
-
-	// Check prefixes (IService, IRepository, etc.)
-	for _, prefix := range abstractPrefixes {
-		if len(name) > len(prefix)+1 &&
-			name[:len(prefix)] == prefix &&
-			name[len(prefix)] >= 'A' && name[len(prefix)] <= 'Z' {
-			return true
-		}
-	}
-
-	return false
+	return float64(node.AbstractClassCount) / float64(node.ClassCount)
 }
 
 // calculateSystemMetrics calculates system-wide metrics

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -176,6 +176,7 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
 	})
 	systemMetrics.ZoneOfPain = calc.modulesMatching(func(metrics *ModuleMetrics) bool {
 		return metrics.Distance >= zoneMinDistance &&
+			metrics.AfferentCoupling >= 2 &&
 			metrics.Instability <= lowInstability &&
 			metrics.Abstractness <= lowAbstractness
 	})

--- a/internal/analyzer/dependency_graph.go
+++ b/internal/analyzer/dependency_graph.go
@@ -27,10 +27,11 @@ type ModuleNode struct {
 	OutDegree int // Number of outgoing dependencies
 
 	// Module information
-	LineCount     int      // Total lines in the module
-	FunctionCount int      // Number of functions defined
-	ClassCount    int      // Number of classes defined
-	PublicNames   []string // Public names exported by this module
+	LineCount          int      // Total lines in the module
+	FunctionCount      int      // Number of functions defined
+	ClassCount         int      // Number of classes defined
+	AbstractClassCount int      // Number of abstract classes defined
+	PublicNames        []string // Public names exported by this module
 }
 
 // DependencyEdge represents a dependency relationship between modules
@@ -91,8 +92,10 @@ type ModuleMetrics struct {
 	Distance         float64 // D - Distance from main sequence
 
 	// Size metrics
-	LinesOfCode     int // Total lines of code
-	PublicInterface int // Number of public functions/classes
+	LinesOfCode        int // Total lines of code
+	ClassCount         int // Number of classes
+	AbstractClassCount int // Number of abstract classes
+	PublicInterface    int // Number of public functions/classes
 
 	// Quality metrics
 	CyclomaticComplexity int // Average complexity of functions

--- a/internal/analyzer/dependency_graph.go
+++ b/internal/analyzer/dependency_graph.go
@@ -129,6 +129,11 @@ type SystemMetrics struct {
 
 	// Refactoring
 	RefactoringPriority []string // Modules needing refactoring (highest priority first)
+	StableModules       []string // Low instability modules
+	InstableModules     []string // High instability modules
+	ZoneOfPain          []string // Stable concrete modules far from the main sequence
+	ZoneOfUselessness   []string // Unstable abstract modules far from the main sequence
+	MainSequence        []string // Modules close to A + I = 1
 }
 
 // NewDependencyGraph creates a new dependency graph

--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -651,7 +651,7 @@ func (ma *ModuleAnalyzer) nodeQualifiedName(node *parser.Node) string {
 				return ma.nodeQualifiedName(value)
 			}
 		}
-	case parser.NodeType("keyword_argument"):
+	case parser.NodeKeywordArgument:
 		if len(node.Children) >= 3 && ma.nodeQualifiedName(node.Children[0]) == "metaclass" {
 			return ma.nodeQualifiedName(node.Children[2])
 		}

--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -558,7 +558,7 @@ func (ma *ModuleAnalyzer) pathToModuleName(path string) string {
 
 // extractModuleInfo extracts information about the module from its AST
 func (ma *ModuleAnalyzer) extractModuleInfo(ast *parser.Node, module *ModuleNode) {
-	var functionCount, classCount int
+	var functionCount, classCount, abstractClassCount int
 	var publicNames []string
 
 	ma.walkNode(ast, func(node *parser.Node) bool {
@@ -570,6 +570,9 @@ func (ma *ModuleAnalyzer) extractModuleInfo(ast *parser.Node, module *ModuleNode
 			}
 		case parser.NodeClassDef:
 			classCount++
+			if ma.isAbstractClass(node) {
+				abstractClassCount++
+			}
 			if node.Name != "" && !strings.HasPrefix(node.Name, "_") {
 				publicNames = append(publicNames, node.Name)
 			}
@@ -580,12 +583,95 @@ func (ma *ModuleAnalyzer) extractModuleInfo(ast *parser.Node, module *ModuleNode
 	// Update module information
 	module.FunctionCount = functionCount
 	module.ClassCount = classCount
+	module.AbstractClassCount = abstractClassCount
 	module.PublicNames = publicNames
 
 	// Count lines (approximation)
 	if _, err := os.Stat(module.FilePath); err == nil {
 		module.LineCount = ma.estimateLineCount(module.FilePath)
 	}
+}
+
+func (ma *ModuleAnalyzer) isAbstractClass(classNode *parser.Node) bool {
+	for _, base := range classNode.Bases {
+		if ma.isAbstractClassName(ma.nodeQualifiedName(base)) {
+			return true
+		}
+	}
+
+	for _, child := range classNode.Body {
+		if ma.isAbstractMethod(child) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ma *ModuleAnalyzer) isAbstractMethod(node *parser.Node) bool {
+	if node == nil || (node.Type != parser.NodeFunctionDef && node.Type != parser.NodeAsyncFunctionDef) {
+		return false
+	}
+
+	for _, decorator := range node.Decorator {
+		if ma.nodeQualifiedName(decorator) == "abstractmethod" || strings.HasSuffix(ma.nodeQualifiedName(decorator), ".abstractmethod") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ma *ModuleAnalyzer) isAbstractClassName(name string) bool {
+	switch name {
+	case "ABC", "abc.ABC", "ABCMeta", "abc.ABCMeta":
+		return true
+	default:
+		return false
+	}
+}
+
+func (ma *ModuleAnalyzer) nodeQualifiedName(node *parser.Node) string {
+	if node == nil {
+		return ""
+	}
+
+	switch node.Type {
+	case parser.NodeDecorator:
+		if value, ok := node.Value.(*parser.Node); ok {
+			return ma.nodeQualifiedName(value)
+		}
+	case parser.NodeCall:
+		if value, ok := node.Value.(*parser.Node); ok {
+			return ma.nodeQualifiedName(value)
+		}
+	case parser.NodeKeyword:
+		if node.Name == "metaclass" {
+			if value, ok := node.Value.(*parser.Node); ok {
+				return ma.nodeQualifiedName(value)
+			}
+		}
+	case parser.NodeType("keyword_argument"):
+		if len(node.Children) >= 3 && ma.nodeQualifiedName(node.Children[0]) == "metaclass" {
+			return ma.nodeQualifiedName(node.Children[2])
+		}
+	case parser.NodeName:
+		return node.Name
+	case parser.NodeAttribute:
+		left := ""
+		if value, ok := node.Value.(*parser.Node); ok {
+			left = ma.nodeQualifiedName(value)
+		}
+		if left == "" && node.Left != nil {
+			left = ma.nodeQualifiedName(node.Left)
+		}
+		if left == "" {
+			return node.Name
+		}
+		return left + "." + node.Name
+	}
+
+	return ""
 }
 
 // shouldIncludeDependency checks if a dependency should be included

--- a/internal/analyzer/module_analyzer_import_test.go
+++ b/internal/analyzer/module_analyzer_import_test.go
@@ -62,6 +62,11 @@ class Worker:
     def run(self):
         pass
 
+class AsyncWorker:
+    @abc.abstractmethod
+    async def run(self):
+        pass
+
 class Concrete:
     def run(self):
         pass
@@ -87,11 +92,11 @@ class Concrete:
 		t.Fatalf("expected module %s in graph", moduleName)
 	}
 
-	if node.ClassCount != 5 {
-		t.Fatalf("expected 5 classes, got %d", node.ClassCount)
+	if node.ClassCount != 6 {
+		t.Fatalf("expected 6 classes, got %d", node.ClassCount)
 	}
-	if node.AbstractClassCount != 4 {
-		t.Fatalf("expected 4 abstract classes, got %d", node.AbstractClassCount)
+	if node.AbstractClassCount != 5 {
+		t.Fatalf("expected 5 abstract classes, got %d", node.AbstractClassCount)
 	}
 }
 

--- a/internal/analyzer/module_analyzer_import_test.go
+++ b/internal/analyzer/module_analyzer_import_test.go
@@ -41,6 +41,60 @@ func TestModuleAnalyzerResolvesPlainImportWithinProject(t *testing.T) {
 	}
 }
 
+func TestModuleAnalyzerExtractsAbstractClassCount(t *testing.T) {
+	dir := t.TempDir()
+	modulePath := filepath.Join(dir, "contracts.py")
+	source := []byte(`
+from abc import ABC, ABCMeta, abstractmethod
+import abc
+
+class Repository(ABC):
+    pass
+
+class Service(abc.ABC):
+    pass
+
+class Controller(metaclass=ABCMeta):
+    pass
+
+class Worker:
+    @abstractmethod
+    def run(self):
+        pass
+
+class Concrete:
+    def run(self):
+        pass
+`)
+
+	if err := os.WriteFile(modulePath, source, 0o644); err != nil {
+		t.Fatalf("failed to write contracts module: %v", err)
+	}
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{ProjectRoot: dir})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	graph, err := analyzer.AnalyzeFiles([]string{modulePath})
+	if err != nil {
+		t.Fatalf("AnalyzeFiles failed: %v", err)
+	}
+
+	moduleName := analyzer.filePathToModuleName(modulePath)
+	node := graph.Nodes[moduleName]
+	if node == nil {
+		t.Fatalf("expected module %s in graph", moduleName)
+	}
+
+	if node.ClassCount != 5 {
+		t.Fatalf("expected 5 classes, got %d", node.ClassCount)
+	}
+	if node.AbstractClassCount != 4 {
+		t.Fatalf("expected 4 abstract classes, got %d", node.AbstractClassCount)
+	}
+}
+
 func TestModuleAnalyzerResolvesImportWithAlias(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -81,18 +81,19 @@ const (
 	NodeMatchOr        NodeType = "MatchOr"
 
 	// Other
-	NodeAlias         NodeType = "Alias"
-	NodeExceptHandler NodeType = "ExceptHandler"
-	NodeArguments     NodeType = "Arguments"
-	NodeArg           NodeType = "Arg"
-	NodeKeyword       NodeType = "Keyword"
-	NodeComprehension NodeType = "Comprehension"
-	NodeDecorator     NodeType = "Decorator"
-	NodeWithItem      NodeType = "WithItem"
-	NodeMatchCase     NodeType = "MatchCase"
-	NodeElseClause    NodeType = "else_clause" // Structural marker from parser
-	NodeElifClause    NodeType = "elif_clause" // Structural marker from parser
-	NodeBlock         NodeType = "block"       // Block of statements from parser
+	NodeAlias           NodeType = "Alias"
+	NodeExceptHandler   NodeType = "ExceptHandler"
+	NodeArguments       NodeType = "Arguments"
+	NodeArg             NodeType = "Arg"
+	NodeKeyword         NodeType = "Keyword"
+	NodeKeywordArgument NodeType = "keyword_argument"
+	NodeComprehension   NodeType = "Comprehension"
+	NodeDecorator       NodeType = "Decorator"
+	NodeWithItem        NodeType = "WithItem"
+	NodeMatchCase       NodeType = "MatchCase"
+	NodeElseClause      NodeType = "else_clause" // Structural marker from parser
+	NodeElifClause      NodeType = "elif_clause" // Structural marker from parser
+	NodeBlock           NodeType = "block"       // Block of statements from parser
 
 	// Tree-sitter specific nodes
 	NodeGenericType   NodeType = "generic_type"

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -1102,6 +1102,50 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                     {{end}}
                 </div>
 
+                {{if .System.DependencyAnalysis.CouplingAnalysis}}
+                <h3 style="margin-top: 30px;">Main Sequence</h3>
+                <div class="metric-grid">
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.3f" .System.DependencyAnalysis.CouplingAnalysis.AverageInstability}}</div>
+                        <div class="metric-label">Average Instability</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.3f" .System.DependencyAnalysis.CouplingAnalysis.MainSequenceDeviation}}</div>
+                        <div class="metric-label">Main Sequence Deviation</div>
+                    </div>
+                </div>
+                {{if or .System.DependencyAnalysis.CouplingAnalysis.ZoneOfPain .System.DependencyAnalysis.CouplingAnalysis.ZoneOfUselessness .System.DependencyAnalysis.CouplingAnalysis.MainSequence}}
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Zone</th>
+                            <th>Modules</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {{if .System.DependencyAnalysis.CouplingAnalysis.ZoneOfPain}}
+                        <tr>
+                            <td>Zone of Pain</td>
+                            <td>{{join .System.DependencyAnalysis.CouplingAnalysis.ZoneOfPain ", "}}</td>
+                        </tr>
+                        {{end}}
+                        {{if .System.DependencyAnalysis.CouplingAnalysis.ZoneOfUselessness}}
+                        <tr>
+                            <td>Zone of Uselessness</td>
+                            <td>{{join .System.DependencyAnalysis.CouplingAnalysis.ZoneOfUselessness ", "}}</td>
+                        </tr>
+                        {{end}}
+                        {{if .System.DependencyAnalysis.CouplingAnalysis.MainSequence}}
+                        <tr>
+                            <td>Main Sequence</td>
+                            <td>{{join .System.DependencyAnalysis.CouplingAnalysis.MainSequence ", "}}</td>
+                        </tr>
+                        {{end}}
+                    </tbody>
+                </table>
+                {{end}}
+                {{end}}
+
                 {{/* Circular Dependencies Details Section */}}
                 {{if .System.DependencyAnalysis.CircularDependencies}}
                 <h3 style="margin-top: 30px;">Circular Dependencies</h3>

--- a/service/system_analysis_formatter.go
+++ b/service/system_analysis_formatter.go
@@ -147,6 +147,15 @@ func (f *SystemAnalysisFormatterImpl) writeDependenciesSection(builder *strings.
 		if len(deps.CouplingAnalysis.HighlyCoupledModules) > 0 {
 			builder.WriteString(utils.FormatLabelWithIndent(SectionPadding, "Highly Coupled", strings.Join(deps.CouplingAnalysis.HighlyCoupledModules[:min(3, len(deps.CouplingAnalysis.HighlyCoupledModules))], ", ")))
 		}
+		if len(deps.CouplingAnalysis.ZoneOfPain) > 0 {
+			builder.WriteString(utils.FormatLabelWithIndent(SectionPadding, "Zone of Pain", strings.Join(deps.CouplingAnalysis.ZoneOfPain, ", ")))
+		}
+		if len(deps.CouplingAnalysis.ZoneOfUselessness) > 0 {
+			builder.WriteString(utils.FormatLabelWithIndent(SectionPadding, "Zone of Uselessness", strings.Join(deps.CouplingAnalysis.ZoneOfUselessness, ", ")))
+		}
+		if len(deps.CouplingAnalysis.MainSequence) > 0 {
+			builder.WriteString(utils.FormatLabelWithIndent(SectionPadding, "Main Sequence", strings.Join(deps.CouplingAnalysis.MainSequence, ", ")))
+		}
 		builder.WriteString("\n")
 	}
 
@@ -265,6 +274,10 @@ func (f *SystemAnalysisFormatterImpl) formatCSV(response *domain.SystemAnalysisR
 		if response.DependencyAnalysis.CouplingAnalysis != nil {
 			_ = writer.Write([]string{"Dependencies", "Average Coupling", fmt.Sprintf("%.2f", response.DependencyAnalysis.CouplingAnalysis.AverageCoupling)})
 			_ = writer.Write([]string{"Dependencies", "Average Instability", fmt.Sprintf("%.3f", response.DependencyAnalysis.CouplingAnalysis.AverageInstability)})
+			_ = writer.Write([]string{"Dependencies", "Main Sequence Deviation", fmt.Sprintf("%.3f", response.DependencyAnalysis.CouplingAnalysis.MainSequenceDeviation)})
+			_ = writer.Write([]string{"Dependencies", "Zone of Pain", strings.Join(response.DependencyAnalysis.CouplingAnalysis.ZoneOfPain, ";")})
+			_ = writer.Write([]string{"Dependencies", "Zone of Uselessness", strings.Join(response.DependencyAnalysis.CouplingAnalysis.ZoneOfUselessness, ";")})
+			_ = writer.Write([]string{"Dependencies", "Main Sequence", strings.Join(response.DependencyAnalysis.CouplingAnalysis.MainSequence, ";")})
 		}
 	}
 
@@ -488,6 +501,9 @@ func (f *SystemAnalysisFormatterImpl) writeHTMLDependenciesContent(builder *stri
 		builder.WriteString(GenerateMetricCard(fmt.Sprintf("%.3f", deps.CouplingAnalysis.AverageInstability), "Average Instability"))
 		builder.WriteString(GenerateMetricCard(fmt.Sprintf("%.3f", deps.CouplingAnalysis.MainSequenceDeviation), "Main Sequence Deviation"))
 		builder.WriteString(`</div>`)
+		f.writeHTMLModuleList(builder, "Zone of Pain", deps.CouplingAnalysis.ZoneOfPain)
+		f.writeHTMLModuleList(builder, "Zone of Uselessness", deps.CouplingAnalysis.ZoneOfUselessness)
+		f.writeHTMLModuleList(builder, "Main Sequence", deps.CouplingAnalysis.MainSequence)
 	}
 
 	// Add detailed dependency list if available
@@ -675,6 +691,22 @@ func (f *SystemAnalysisFormatterImpl) writeHTMLDependenciesContent(builder *stri
                 </tbody>
             </table>`)
 	}
+}
+
+func (f *SystemAnalysisFormatterImpl) writeHTMLModuleList(builder *strings.Builder, title string, modules []string) {
+	if len(modules) == 0 {
+		return
+	}
+
+	builder.WriteString(`<h4>`)
+	builder.WriteString(title)
+	builder.WriteString(`</h4><ul>`)
+	for _, module := range modules {
+		builder.WriteString(`<li><code>`)
+		builder.WriteString(module)
+		builder.WriteString(`</code></li>`)
+	}
+	builder.WriteString(`</ul>`)
 }
 
 func (f *SystemAnalysisFormatterImpl) writeHTMLArchitectureContent(builder *strings.Builder, arch *domain.ArchitectureAnalysisResult) {

--- a/service/system_analysis_formatter_test.go
+++ b/service/system_analysis_formatter_test.go
@@ -39,6 +39,46 @@ func TestSystemAnalysisFormatterIncludesResponsibilityAnalysisHTML(t *testing.T)
 	assert.False(t, strings.Contains(output, "<nil>"))
 }
 
+func TestSystemAnalysisFormatterIncludesMainSequenceZones(t *testing.T) {
+	formatter := NewSystemAnalysisFormatter()
+	response := &domain.SystemAnalysisResponse{
+		DependencyAnalysis: &domain.DependencyAnalysisResult{
+			TotalModules:      3,
+			TotalDependencies: 2,
+			CouplingAnalysis: &domain.CouplingAnalysis{
+				AverageCoupling:       1.5,
+				AverageInstability:    0.4,
+				MainSequenceDeviation: 0.2,
+				ZoneOfPain:            []string{"domain.core"},
+				ZoneOfUselessness:     []string{"unused.contracts"},
+				MainSequence:          []string{"balanced.service"},
+			},
+		},
+	}
+
+	textOutput, err := formatter.Format(response, domain.OutputFormatText)
+	require.NoError(t, err)
+	assert.Contains(t, textOutput, "Zone of Pain")
+	assert.Contains(t, textOutput, "domain.core")
+	assert.Contains(t, textOutput, "Zone of Uselessness")
+	assert.Contains(t, textOutput, "unused.contracts")
+	assert.Contains(t, textOutput, "Main Sequence")
+	assert.Contains(t, textOutput, "balanced.service")
+
+	htmlOutput, err := formatter.Format(response, domain.OutputFormatHTML)
+	require.NoError(t, err)
+	assert.Contains(t, htmlOutput, "Zone of Pain")
+	assert.Contains(t, htmlOutput, "domain.core")
+	assert.Contains(t, htmlOutput, "Zone of Uselessness")
+	assert.Contains(t, htmlOutput, "unused.contracts")
+
+	csvOutput, err := formatter.Format(response, domain.OutputFormatCSV)
+	require.NoError(t, err)
+	assert.Contains(t, csvOutput, "Zone of Pain,domain.core")
+	assert.Contains(t, csvOutput, "Zone of Uselessness,unused.contracts")
+	assert.Contains(t, csvOutput, "Main Sequence,balanced.service")
+}
+
 func systemResponseWithResponsibilityViolation() *domain.SystemAnalysisResponse {
 	return &domain.SystemAnalysisResponse{
 		ArchitectureAnalysis: &domain.ArchitectureAnalysisResult{

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -1187,8 +1187,11 @@ func (s *SystemAnalysisServiceImpl) convertCouplingResults(results *analyzer.Sys
 		AverageInstability:    results.AverageInstability,
 		MainSequenceDeviation: results.MainSequenceDeviation,
 		HighlyCoupledModules:  highlyCoupled,
-		ZoneOfPain:            s.extractZoneOfPain(results),
-		ZoneOfUselessness:     s.extractZoneOfUselessness(results),
+		StableModules:         results.StableModules,
+		InstableModules:       results.InstableModules,
+		ZoneOfPain:            results.ZoneOfPain,
+		ZoneOfUselessness:     results.ZoneOfUselessness,
+		MainSequence:          results.MainSequence,
 	}
 }
 
@@ -1242,21 +1245,6 @@ func (s *SystemAnalysisServiceImpl) convertCircularResults(result *analyzer.Circ
 // Removed legacy helpers for ad-hoc layer counting.
 
 // Removed helper methods that used undefined domain types
-
-func (s *SystemAnalysisServiceImpl) extractZoneOfPain(metrics *analyzer.SystemMetrics) []string {
-	// Zone of pain: high coupling, low abstractness
-	// For now, return refactoring priorities as a proxy
-	if len(metrics.RefactoringPriority) > 3 {
-		return metrics.RefactoringPriority[:3]
-	}
-	return metrics.RefactoringPriority
-}
-
-func (s *SystemAnalysisServiceImpl) extractZoneOfUselessness(metrics *analyzer.SystemMetrics) []string {
-	// Zone of uselessness: low coupling, high abstractness
-	// This would require more detailed analysis of individual modules
-	return []string{}
-}
 
 // convertDependencyChains converts analyzer.DependencyChain to domain.DependencyPath
 func (s *SystemAnalysisServiceImpl) convertDependencyChains(chains []analyzer.DependencyChain) []domain.DependencyPath {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -1356,10 +1356,11 @@ func (s *SystemAnalysisServiceImpl) extractModuleMetrics(graph *analyzer.Depende
 			Package:    node.Package,
 
 			// Size metrics from node
-			LinesOfCode:     node.LineCount,
-			FunctionCount:   node.FunctionCount,
-			ClassCount:      node.ClassCount,
-			PublicInterface: node.PublicNames,
+			LinesOfCode:        node.LineCount,
+			FunctionCount:      node.FunctionCount,
+			ClassCount:         node.ClassCount,
+			AbstractClassCount: node.AbstractClassCount,
+			PublicInterface:    node.PublicNames,
 
 			// Dependencies
 			DirectDependencies:     s.getDirectDependencies(moduleName, node),
@@ -1374,6 +1375,7 @@ func (s *SystemAnalysisServiceImpl) extractModuleMetrics(graph *analyzer.Depende
 			metrics.Instability = analyzerMetrics.Instability
 			metrics.Abstractness = analyzerMetrics.Abstractness
 			metrics.Distance = analyzerMetrics.Distance
+			metrics.AbstractClassCount = analyzerMetrics.AbstractClassCount
 
 			// Determine risk level based on distance
 			if analyzerMetrics.Distance > 0.7 {

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -27,6 +27,7 @@ func TestExtractModuleMetrics(t *testing.T) {
 				module.LineCount = 150
 				module.FunctionCount = 10
 				module.ClassCount = 3
+				module.AbstractClassCount = 1
 				module.PublicNames = []string{"TestClass", "test_function", "CONSTANT"}
 
 				// Add dependencies
@@ -49,6 +50,7 @@ func TestExtractModuleMetrics(t *testing.T) {
 				assert.Equal(t, 150, metrics.LinesOfCode)
 				assert.Equal(t, 10, metrics.FunctionCount)
 				assert.Equal(t, 3, metrics.ClassCount)
+				assert.Equal(t, 1, metrics.AbstractClassCount)
 				assert.Equal(t, []string{"TestClass", "test_function", "CONSTANT"}, metrics.PublicInterface)
 
 				// Dependencies
@@ -96,6 +98,7 @@ func TestExtractModuleMetrics(t *testing.T) {
 				module.LineCount = 200
 				module.FunctionCount = 15
 				module.ClassCount = 5
+				module.AbstractClassCount = 2
 				module.PublicNames = []string{"AnalyzedClass", "process", "validate"}
 				module.InDegree = 3
 				module.OutDegree = 2
@@ -109,6 +112,7 @@ func TestExtractModuleMetrics(t *testing.T) {
 					Abstractness:         0.3,
 					Distance:             0.5, // Medium risk threshold
 					LinesOfCode:          200,
+					AbstractClassCount:   2,
 					PublicInterface:      3,
 					CyclomaticComplexity: 10,
 				}
@@ -124,6 +128,7 @@ func TestExtractModuleMetrics(t *testing.T) {
 				assert.Equal(t, 200, metrics.LinesOfCode)
 				assert.Equal(t, 15, metrics.FunctionCount)
 				assert.Equal(t, 5, metrics.ClassCount)
+				assert.Equal(t, 2, metrics.AbstractClassCount)
 				assert.Equal(t, []string{"AnalyzedClass", "process", "validate"}, metrics.PublicInterface)
 
 				// Analyzer metrics should be used

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -23,6 +23,9 @@ class Entity:
 		"app/consumer.py": `
 import domain.core
 `,
+		"app/other_consumer.py": `
+import domain.core
+`,
 		"unused/contracts.py": `
 from abc import ABC
 import infra.db

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -1,6 +1,10 @@
 package service
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -8,6 +12,103 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAnalyzeDependenciesReportsMainSequenceMetricsFromPythonProject(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"domain/core.py": `
+class Entity:
+    pass
+`,
+		"app/consumer.py": `
+import domain.core
+`,
+		"unused/contracts.py": `
+from abc import ABC
+import infra.db
+import infra.cache
+
+class Port(ABC):
+    pass
+
+class Gateway(ABC):
+    pass
+`,
+		"infra/db.py": `
+class Database:
+    pass
+`,
+		"infra/cache.py": `
+class Cache:
+    pass
+`,
+		"balanced/client.py": `
+import balanced.service
+`,
+		"balanced/service.py": `
+from abc import ABC
+import balanced.dep
+
+class Port(ABC):
+    pass
+
+class Service:
+    pass
+`,
+		"balanced/dep.py": `
+class Dependency:
+    pass
+`,
+	}
+
+	var paths []string
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+		paths = append(paths, path)
+	}
+
+	service := NewSystemAnalysisService()
+	response, err := service.AnalyzeDependencies(context.Background(), domain.SystemAnalysisRequest{
+		Paths:             paths,
+		IncludeThirdParty: domain.BoolPtr(false),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response.CouplingAnalysis)
+
+	domainCore := moduleWithSuffix(t, response.ModuleMetrics, "domain.core")
+	unusedContracts := moduleWithSuffix(t, response.ModuleMetrics, "unused.contracts")
+	balancedService := moduleWithSuffix(t, response.ModuleMetrics, "balanced.service")
+
+	assert.Contains(t, response.CouplingAnalysis.ZoneOfPain, domainCore)
+	assert.Contains(t, response.CouplingAnalysis.ZoneOfUselessness, unusedContracts)
+	assert.Contains(t, response.CouplingAnalysis.MainSequence, balancedService)
+
+	assert.Equal(t, 2, response.ModuleMetrics[unusedContracts].ClassCount)
+	assert.Equal(t, 2, response.ModuleMetrics[unusedContracts].AbstractClassCount)
+	assert.InDelta(t, 1.0, response.ModuleMetrics[unusedContracts].Abstractness, 0.01)
+
+	assert.Equal(t, 2, response.ModuleMetrics[balancedService].ClassCount)
+	assert.Equal(t, 1, response.ModuleMetrics[balancedService].AbstractClassCount)
+	assert.InDelta(t, 0.5, response.ModuleMetrics[balancedService].Abstractness, 0.01)
+	assert.InDelta(t, 0.0, response.ModuleMetrics[balancedService].Distance, 0.01)
+}
+
+func moduleWithSuffix(t *testing.T, modules map[string]*domain.ModuleDependencyMetrics, suffix string) string {
+	t.Helper()
+	for module := range modules {
+		if strings.HasSuffix(module, suffix) {
+			return module
+		}
+	}
+	t.Fatalf("expected module ending with %q in %v", suffix, modules)
+	return ""
+}
 
 func TestExtractModuleMetrics(t *testing.T) {
 	tests := []struct {

--- a/service/system_metrics_test.go
+++ b/service/system_metrics_test.go
@@ -173,6 +173,48 @@ func TestExtractCouplingResult_UsesCalculatedMetrics(t *testing.T) {
 	assert.Len(t, graph.ModuleMetrics, 3)
 }
 
+func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
+	service := &SystemAnalysisServiceImpl{}
+	graph := analyzer.NewDependencyGraph("/test/project")
+
+	pain := graph.AddModule("domain.core", "/test/domain/core.py")
+	pain.ClassCount = 2
+
+	consumer := graph.AddModule("app.consumer", "/test/app/consumer.py")
+	consumer.ClassCount = 1
+
+	useless := graph.AddModule("unused.contracts", "/test/unused/contracts.py")
+	useless.ClassCount = 2
+	useless.AbstractClassCount = 2
+
+	mainSequence := graph.AddModule("balanced.service", "/test/balanced/service.py")
+	mainSequence.ClassCount = 2
+	mainSequence.AbstractClassCount = 1
+
+	graph.AddModule("infra.db", "/test/infra/db.py")
+	graph.AddModule("infra.cache", "/test/infra/cache.py")
+	graph.AddModule("balanced.client", "/test/balanced/client.py")
+	graph.AddModule("balanced.dep", "/test/balanced/dep.py")
+
+	graph.AddDependency("app.consumer", "domain.core", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("unused.contracts", "infra.db", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("unused.contracts", "infra.cache", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("balanced.client", "balanced.service", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("balanced.service", "balanced.dep", analyzer.DependencyEdgeImport, nil)
+
+	calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
+	err := calculator.CalculateMetrics()
+	require.NoError(t, err)
+
+	result := service.convertCouplingResults(graph.SystemMetrics)
+	require.NotNil(t, result)
+	assert.Contains(t, result.ZoneOfPain, "domain.core")
+	assert.Contains(t, result.ZoneOfUselessness, "unused.contracts")
+	assert.Contains(t, result.MainSequence, "balanced.service")
+	assert.Contains(t, result.StableModules, "domain.core")
+	assert.Contains(t, result.InstableModules, "unused.contracts")
+}
+
 func TestExtractCouplingResult_DifferentGraphsProduceDifferentMetrics(t *testing.T) {
 	service := &SystemAnalysisServiceImpl{}
 

--- a/service/system_metrics_test.go
+++ b/service/system_metrics_test.go
@@ -182,6 +182,8 @@ func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
 
 	consumer := graph.AddModule("app.consumer", "/test/app/consumer.py")
 	consumer.ClassCount = 1
+	otherConsumer := graph.AddModule("app.other_consumer", "/test/app/other_consumer.py")
+	otherConsumer.ClassCount = 1
 
 	useless := graph.AddModule("unused.contracts", "/test/unused/contracts.py")
 	useless.ClassCount = 2
@@ -197,6 +199,7 @@ func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
 	graph.AddModule("balanced.dep", "/test/balanced/dep.py")
 
 	graph.AddDependency("app.consumer", "domain.core", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("app.other_consumer", "domain.core", analyzer.DependencyEdgeImport, nil)
 	graph.AddDependency("unused.contracts", "infra.db", analyzer.DependencyEdgeImport, nil)
 	graph.AddDependency("unused.contracts", "infra.cache", analyzer.DependencyEdgeImport, nil)
 	graph.AddDependency("balanced.client", "balanced.service", analyzer.DependencyEdgeImport, nil)
@@ -213,6 +216,9 @@ func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
 	assert.Contains(t, result.MainSequence, "balanced.service")
 	assert.Contains(t, result.StableModules, "domain.core")
 	assert.Contains(t, result.InstableModules, "unused.contracts")
+	assert.NotContains(t, result.ZoneOfPain, "infra.db")
+	assert.NotContains(t, result.ZoneOfPain, "infra.cache")
+	assert.NotContains(t, result.ZoneOfPain, "balanced.dep")
 }
 
 func TestExtractCouplingResult_DifferentGraphsProduceDifferentMetrics(t *testing.T) {

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -591,11 +591,12 @@ Mirrors `domain.SystemAnalysisResponse`. Nested field names are Go PascalCase.
 | `LinesOfCode`            | integer | Total lines of code.                                     |
 | `FunctionCount`          | integer | Number of functions.                                     |
 | `ClassCount`             | integer | Number of classes.                                       |
+| `AbstractClassCount`     | integer | Number of abstract classes.                              |
 | `PublicInterface`        | array of string | Names in `__all__` or top-level public names.    |
 | `AfferentCoupling`       | integer | Ca — modules depending on this one.                      |
 | `EfferentCoupling`       | integer | Ce — modules this one depends on.                        |
 | `Instability`            | number  | `I = Ce / (Ca + Ce)`, `0`–`1`.                           |
-| `Abstractness`           | number  | A — abstract elements / total elements, `0`–`1`.         |
+| `Abstractness`           | number  | A — abstract classes / total classes, `0`–`1`.           |
 | `Distance`               | number  | `D = |A + I - 1|`, `0`–`1`. Distance from main sequence. |
 | `Maintainability`        | number  | Maintainability index, `0`–`100`.                        |
 | `TechnicalDebt`          | number  | Estimated technical debt in hours.                       |


### PR DESCRIPTION
Closes #166

This replaces heuristic abstractness with AST-backed abstract class counting and uses the resulting A/I/D metrics to classify modules on the main sequence.

Abstractness now comes from real class structure: ABC, abc.ABC, ABCMeta, and abstractmethod decorators. The dependency analysis also reports stable/unstable modules, Zone of Pain, Zone of Uselessness, and modules close to the main sequence.

Zone of Pain requires multiple incoming dependents so isolated concrete modules do not get noisy false positives.

Validation:
go test ./...
go vet ./...