### PR TITLE
docs(i18n): sync ja/zh schemas with AbstractClassCount field

### DIFF
--- a/website/docs/ja/output/schemas.md
+++ b/website/docs/ja/output/schemas.md
@@ -591,11 +591,12 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `LinesOfCode`            | integer | コードの合計行数。                                       |
 | `FunctionCount`          | integer | 関数の数。                                               |
 | `ClassCount`             | integer | クラスの数。                                             |
+| `AbstractClassCount`     | integer | 抽象クラスの数。                                         |
 | `PublicInterface`        | array of string | `__all__` またはトップレベルのパブリック名。      |
 | `AfferentCoupling`       | integer | Ca — このモジュールに依存するモジュール。                |
 | `EfferentCoupling`       | integer | Ce — このモジュールが依存するモジュール。                |
 | `Instability`            | number  | `I = Ce / (Ca + Ce)`、`0`–`1`。                          |
-| `Abstractness`           | number  | A — 抽象要素 / 全要素、`0`–`1`。                         |
+| `Abstractness`           | number  | A — 抽象クラス / 全クラス、`0`–`1`。                     |
 | `Distance`               | number  | `D = |A + I - 1|`、`0`–`1`。メインシーケンスからの距離。 |
 | `Maintainability`        | number  | 保守性インデックス、`0`–`100`。                          |
 | `TechnicalDebt`          | number  | 推定技術的負債（時間単位）。                             |

--- a/website/docs/zh/output/schemas.md
+++ b/website/docs/zh/output/schemas.md
@@ -591,11 +591,12 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `LinesOfCode`            | integer | 代码总行数。                                     |
 | `FunctionCount`          | integer | 函数数量。                                       |
 | `ClassCount`             | integer | 类数量。                                         |
+| `AbstractClassCount`     | integer | 抽象类数量。                                     |
 | `PublicInterface`        | array of string | `__all__` 中或顶级公共名称。             |
 | `AfferentCoupling`       | integer | Ca — 依赖此模块的模块数。                        |
 | `EfferentCoupling`       | integer | Ce — 此模块依赖的模块数。                        |
 | `Instability`            | number  | `I = Ce / (Ca + Ce)`，`0`–`1`。                  |
-| `Abstractness`           | number  | A — 抽象元素 / 总元素，`0`–`1`。                 |
+| `Abstractness`           | number  | A — 抽象类 / 总类数，`0`–`1`。                   |
 | `Distance`               | number  | `D = |A + I - 1|`，`0`–`1`。与主序列的距离。     |
 | `Maintainability`        | number  | 可维护性指数，`0`–`100`。                        |
 | `TechnicalDebt`          | number  | 估计的技术债务（小时）。                         |


### PR DESCRIPTION
## Summary
- Follow-up to #407, which added `AbstractClassCount` to the English `ModuleDependencyMetrics` schema doc and redefined `Abstractness` as `abstract classes / total classes`.
- The Japanese and Simplified Chinese translations of `website/docs/output/schemas.md` were not updated in that PR, so the localized JSON schemas drifted from the English source.
- This PR adds the missing `AbstractClassCount` row and updates the `Abstractness` description in both `ja/` and `zh/` schemas docs.

## Test plan
- [x] `git diff` confirms only the two translated `schemas.md` files change, mirroring the English wording from #407.
- [x] Spot-check the rendered MkDocs site in `ja` and `zh` locales (no build step changes required).