### PR TITLE
fix: tighten Type-2 clone classification

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -254,14 +254,15 @@ type CloneDetector struct {
 	// Embed config fields (private to maintain encapsulation)
 	cloneDetectorConfig CloneDetectorConfig
 
-	analyzer         *APTEDAnalyzer
-	converter        *TreeConverter
-	classifier       *CloneClassifier // Multi-dimensional classifier (optional)
-	textualAnalyzer  *TextualSimilarityAnalyzer
-	featureExtractor *ASTFeatureExtractor // Pre-filter feature extractor
-	fragments        []*CodeFragment
-	clonePairs       []*ClonePair
-	cloneGroups      []*CloneGroup
+	analyzer          *APTEDAnalyzer
+	converter         *TreeConverter
+	classifier        *CloneClassifier // Multi-dimensional classifier (optional)
+	textualAnalyzer   *TextualSimilarityAnalyzer
+	syntacticAnalyzer *SyntacticSimilarityAnalyzer
+	featureExtractor  *ASTFeatureExtractor // Pre-filter feature extractor
+	fragments         []*CodeFragment
+	clonePairs        []*ClonePair
+	cloneGroups       []*CloneGroup
 }
 
 // NewCloneDetector creates a new clone detector with the given configuration
@@ -320,6 +321,7 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 		converter:           NewTreeConverterWithConfig(config.SkipDocstrings),
 		classifier:          classifier,
 		textualAnalyzer:     NewTextualSimilarityAnalyzer(),
+		syntacticAnalyzer:   NewSyntacticSimilarityAnalyzer(),
 		featureExtractor:    NewASTFeatureExtractor(),
 		fragments:           []*CodeFragment{},
 		clonePairs:          []*ClonePair{},
@@ -982,18 +984,21 @@ func (cd *CloneDetector) classifyClonePair(fragment1, fragment2 *CodeFragment, s
 	if similarity >= cd.cloneDetectorConfig.Type1Threshold && cd.textualAnalyzer.IsExactMatch(fragment1, fragment2) {
 		return Type1Clone, similarity
 	}
-	similarity = cd.capNonTextualSimilarity(similarity)
-	if similarity >= cd.cloneDetectorConfig.Type2Threshold {
-		return Type2Clone, similarity
+
+	structuralSimilarity := cd.capNonTextualSimilarity(similarity)
+	syntacticSimilarity := cd.syntacticAnalyzer.ComputeSimilarity(fragment1, fragment2)
+	if structuralSimilarity >= cd.cloneDetectorConfig.Type2Threshold &&
+		syntacticSimilarity >= cd.cloneDetectorConfig.Type2Threshold {
+		return Type2Clone, math.Min(structuralSimilarity, syntacticSimilarity)
 	}
-	if similarity >= cd.cloneDetectorConfig.Type3Threshold {
-		return Type3Clone, similarity
+	if structuralSimilarity >= cd.cloneDetectorConfig.Type3Threshold {
+		return Type3Clone, structuralSimilarity
 	}
-	if similarity >= cd.cloneDetectorConfig.Type4Threshold {
-		return Type4Clone, similarity
+	if structuralSimilarity >= cd.cloneDetectorConfig.Type4Threshold {
+		return Type4Clone, structuralSimilarity
 	}
 
-	return 0, similarity
+	return 0, structuralSimilarity
 }
 
 func (cd *CloneDetector) capNonTextualSimilarity(similarity float64) float64 {

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -986,10 +986,11 @@ func (cd *CloneDetector) classifyClonePair(fragment1, fragment2 *CodeFragment, s
 	}
 
 	structuralSimilarity := cd.capNonTextualSimilarity(similarity)
-	syntacticSimilarity := cd.syntacticAnalyzer.ComputeSimilarity(fragment1, fragment2)
-	if structuralSimilarity >= cd.cloneDetectorConfig.Type2Threshold &&
-		syntacticSimilarity >= cd.cloneDetectorConfig.Type2Threshold {
-		return Type2Clone, math.Min(structuralSimilarity, syntacticSimilarity)
+	if structuralSimilarity >= cd.cloneDetectorConfig.Type2Threshold {
+		syntacticSimilarity := cd.syntacticAnalyzer.ComputeSimilarity(fragment1, fragment2)
+		if syntacticSimilarity >= cd.cloneDetectorConfig.Type2Threshold {
+			return Type2Clone, math.Min(structuralSimilarity, syntacticSimilarity)
+		}
 	}
 	if structuralSimilarity >= cd.cloneDetectorConfig.Type3Threshold {
 		return Type3Clone, structuralSimilarity

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -2,6 +2,8 @@ package analyzer
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -190,6 +192,21 @@ func TestCompareWithAPTEDExpressionOnlyDifferenceReportsDistance(t *testing.T) {
 	assert.Equal(t, Type2Clone, pair.CloneType)
 }
 
+func TestCompareWithAPTEDDoesNotReportUnrelatedClassBodiesAsType2(t *testing.T) {
+	leftFragment := parseFirstFragmentFromFile(t, "parsera_page.py")
+	rightFragment := parseFirstFragmentFromFile(t, "parsera_parsera.py")
+
+	config := DefaultCloneDetectorConfig()
+	config.MinLines = 1
+	config.MinNodes = 1
+	detector := NewCloneDetector(config)
+
+	pair := detector.compareWithAPTED(leftFragment, rightFragment)
+	if pair != nil && pair.CloneType == Type2Clone {
+		t.Fatalf("unrelated class bodies should not be Type-2 clones, got similarity %.3f", pair.Similarity)
+	}
+}
+
 func TestClonePair_String(t *testing.T) {
 	fragment1 := &CodeFragment{
 		Location: &CodeLocation{
@@ -217,6 +234,44 @@ func TestClonePair_String(t *testing.T) {
 	result := pair.String()
 	expected := "Type-2 (Renamed) clone: /test1.py:1:0-5:0 <-> /test2.py:10:0-14:0 (similarity: 0.850)"
 	assert.Equal(t, expected, result)
+}
+
+func parseFirstFragmentWithContent(t *testing.T, filePath, source string) *CodeFragment {
+	t.Helper()
+
+	p := parser.New()
+	result, err := p.Parse(t.Context(), []byte(source))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.AST)
+	require.NotEmpty(t, result.AST.Body)
+
+	classNode := result.AST.Body[0]
+	location := &CodeLocation{
+		FilePath:  filePath,
+		StartLine: classNode.Location.StartLine,
+		EndLine:   classNode.Location.EndLine,
+		StartCol:  classNode.Location.StartCol,
+		EndCol:    classNode.Location.EndCol,
+	}
+	fragment := NewCodeFragment(location, classNode, source)
+	converter := NewTreeConverterWithConfig(true)
+	fragment.TreeNode = converter.ConvertAST(classNode)
+	require.NotNil(t, fragment.TreeNode)
+	PrepareTreeForAPTED(fragment.TreeNode)
+	fragment.Size = fragment.TreeNode.Size()
+
+	return fragment
+}
+
+func parseFirstFragmentFromFile(t *testing.T, name string) *CodeFragment {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "testdata", "python", "clones", "type2_false_positive", name)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return parseFirstFragmentWithContent(t, path, string(content))
 }
 
 func TestCloneGroup_Operations(t *testing.T) {
@@ -305,8 +360,8 @@ func TestCloneDetector_ShouldIncludeFragment(t *testing.T) {
 func TestCloneDetector_ClassifyClonePair(t *testing.T) {
 	config := DefaultCloneDetectorConfig()
 	detector := NewCloneDetector(config)
-	exact := &CodeFragment{Content: "def same():\n    return 1\n"}
-	different := &CodeFragment{Content: "def different():\n    return 2\n"}
+	exact := parseFirstFragmentWithContent(t, "same.py", "def same():\n    return 1\n")
+	different := parseFirstFragmentWithContent(t, "different.py", "def different():\n    return 2\n")
 
 	tests := []struct {
 		name       string

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -369,21 +369,26 @@ func TestCloneService_DetectClonesInFiles(t *testing.T) {
 			if pair.Type != domain.Type2Clone {
 				continue
 			}
-			assert.False(t, isCrossFileLargeClonePair(pair), "unexpected cross-file class-body Type-2 clone: %s and %s",
+			assert.False(t, isParseraClassBodyPair(pair, page, parsera), "unexpected cross-file class-body Type-2 clone: %s and %s",
 				pair.Clone1.Location.FilePath, pair.Clone2.Location.FilePath)
 		}
 	})
 }
 
-func isCrossFileLargeClonePair(pair *domain.ClonePair) bool {
+func isParseraClassBodyPair(pair *domain.ClonePair, pagePath, parseraPath string) bool {
 	if pair == nil || pair.Clone1 == nil || pair.Clone2 == nil ||
 		pair.Clone1.Location == nil || pair.Clone2.Location == nil {
 		return false
 	}
-	if pair.Clone1.Location.FilePath == pair.Clone2.Location.FilePath {
-		return false
-	}
-	return pair.Clone1.LineCount >= 50 && pair.Clone2.LineCount >= 50
+
+	return (isWholeFileClass(pair.Clone1, pagePath, 168) && isWholeFileClass(pair.Clone2, parseraPath, 90)) ||
+		(isWholeFileClass(pair.Clone1, parseraPath, 90) && isWholeFileClass(pair.Clone2, pagePath, 168))
+}
+
+func isWholeFileClass(clone *domain.Clone, filePath string, endLine int) bool {
+	return clone.Location.FilePath == filePath &&
+		clone.Location.StartLine == 1 &&
+		clone.Location.EndLine == endLine
 }
 
 func TestCloneService_ComputeSimilarity(t *testing.T) {

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -346,6 +346,44 @@ func TestCloneService_DetectClonesInFiles(t *testing.T) {
 			assert.Less(t, pair.Similarity, 1.0)
 		}
 	})
+
+	t.Run("unrelated cross-file class bodies are not reported as type2", func(t *testing.T) {
+		page := filepath.Join("..", "testdata", "python", "clones", "type2_false_positive", "parsera_page.py")
+		parsera := filepath.Join("..", "testdata", "python", "clones", "type2_false_positive", "parsera_parsera.py")
+
+		req := newDefaultCloneRequest(page, parsera)
+		req.MinLines = 5
+		req.MinNodes = 10
+		req.SimilarityThreshold = domain.DefaultType4CloneThreshold
+		req.Type1Threshold = domain.DefaultType1CloneThreshold
+		req.Type2Threshold = domain.DefaultType2CloneThreshold
+		req.Type3Threshold = domain.DefaultType3CloneThreshold
+		req.Type4Threshold = domain.DefaultType4CloneThreshold
+		req.CloneTypes = []domain.CloneType{domain.Type1Clone, domain.Type2Clone, domain.Type3Clone, domain.Type4Clone}
+
+		response, err := service.DetectClonesInFiles(ctx, req.Paths, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		for _, pair := range response.ClonePairs {
+			if pair.Type != domain.Type2Clone {
+				continue
+			}
+			assert.False(t, isCrossFileLargeClonePair(pair), "unexpected cross-file class-body Type-2 clone: %s and %s",
+				pair.Clone1.Location.FilePath, pair.Clone2.Location.FilePath)
+		}
+	})
+}
+
+func isCrossFileLargeClonePair(pair *domain.ClonePair) bool {
+	if pair == nil || pair.Clone1 == nil || pair.Clone2 == nil ||
+		pair.Clone1.Location == nil || pair.Clone2.Location == nil {
+		return false
+	}
+	if pair.Clone1.Location.FilePath == pair.Clone2.Location.FilePath {
+		return false
+	}
+	return pair.Clone1.LineCount >= 50 && pair.Clone2.LineCount >= 50
 }
 
 func TestCloneService_ComputeSimilarity(t *testing.T) {

--- a/testdata/python/clones/type2_false_positive/parsera_page.py
+++ b/testdata/python/clones/type2_false_positive/parsera_page.py
@@ -1,0 +1,168 @@
+class PageLoader:
+    def __init__(
+        self, browser: Browser | None = None, custom_cookies: list[dict] | None = None
+    ):
+        self.playwright: Playwright | None = None
+        self.browser: Browser | None = browser
+        self.custom_cookies: list[dict] | None = custom_cookies
+        self.context: BrowserContext | None = None
+        self.page: Page | None = None
+
+    async def new_browser(self) -> None:
+        if not self.playwright:
+            self.playwright = await async_playwright().start()
+
+        if self.browser:
+            await self.browser.close()
+
+        self.browser = await self.playwright.firefox.launch(headless=True)
+
+    async def stealth(
+        self,
+        page: Page,
+        proxy_settings: ProxySettings | None,
+    ) -> Page:
+        user_agent = await page.evaluate("navigator.userAgent")
+        user_agent = user_agent.replace("HeadlessChrome/", "Chrome/")
+        await self.context.close()
+
+        self.context = await self.browser.new_context(
+            user_agent=user_agent, proxy=proxy_settings
+        )
+        if self.custom_cookies is not None:
+            try:
+                await self.context.add_cookies(self.custom_cookies)
+            except Exception as exc:
+                raise CookiesValidationException(str(exc)) from exc
+        page = await self.context.new_page()
+        await stealth_async(
+            page,
+            config=StealthConfig(
+                navigator_user_agent=False,
+                navigator_plugins=False,
+                navigator_vendor=False,
+            ),
+        )
+
+        return page
+
+    async def create_session(
+        self,
+        proxy_settings: ProxySettings | None = None,
+        playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
+        stealth: bool = True,
+    ) -> None:
+        if not self.browser:
+            await self.new_browser()
+        self.context = await self.browser.new_context(proxy=proxy_settings)
+
+        if self.custom_cookies is not None:
+            try:
+                await self.context.add_cookies(self.custom_cookies)
+            except Exception as exc:
+                raise CookiesValidationException(str(exc)) from exc
+        self.page = await self.context.new_page()
+        if stealth:
+            self.page = await self.stealth(
+                page=self.page, proxy_settings=proxy_settings
+            )
+
+        if playwright_script:
+            self.page = await playwright_script(self.page)
+
+    async def scroll_page(self, scrolls_limit: int = 0):
+        await self.page.evaluate(
+            """
+            window.removedContent = [];
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach(mutation => {
+                    if (mutation.removedNodes.length > 0) {
+                        mutation.removedNodes.forEach(node => {
+                            if (node.nodeType === 1) {
+                                window.removedContent.push(node.outerHTML);
+                            }
+                        });
+                    }
+                });
+            });
+            observer.observe(document.body, { childList: true, subtree: true });
+        """
+        )
+
+        scrolls = 0
+        last_height = 0
+        captured_content = []
+
+        while scrolls < scrolls_limit:
+            await self.page.evaluate("window.scrollTo(0, document.body.scrollHeight);")
+            await asyncio.sleep(2)
+            current_content = await self.page.content()
+            captured_content.append(current_content)
+            new_height = await self.page.evaluate("document.body.scrollHeight")
+
+            if new_height == last_height:
+                break
+
+            last_height = new_height
+            scrolls += 1
+
+        removed_content = await self.page.evaluate("window.removedContent.join('')")
+        final_content = "".join(captured_content) + removed_content
+
+        return final_content
+
+    async def get_iframe_html(self, frame):
+        try:
+            if frame.is_detached():
+                return None
+            return await frame.evaluate("document.documentElement.outerHTML")
+        except Exception as e:
+            print(f"Could not access iframe: {e}")
+            return None
+
+    async def get_full_html(self):
+        main_html = await self.page.evaluate("document.documentElement.outerHTML")
+
+        iframe_html_tasks = [
+            self.get_iframe_html(frame) for frame in self.page.frames[1:]
+        ]
+        iframes_html = await asyncio.gather(*iframe_html_tasks)
+        iframes_html = [html for html in iframes_html if html is not None]
+
+        combined_html = f"<!-- Main Page HTML -->\n{main_html}\n"
+        for idx, iframe_html in enumerate(iframes_html):
+            combined_html += f"\n<!-- Iframe {idx + 1} HTML -->\n{iframe_html}\n"
+
+        return combined_html
+
+    async def fetch_page(
+        self,
+        url: str,
+        scrolls_limit: int = 0,
+        load_state: Literal["domcontentloaded", "load", "networkidle"] = "networkidle",
+        playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
+    ) -> None:
+        try:
+            await self.page.goto(url)
+        except Exception as exc:
+            raise PageGotoError(str(exc)) from exc
+        try:
+            await self.page.wait_for_load_state(load_state)
+        except PlaywrightTimeoutError:
+            pass
+
+        if playwright_script:
+            self.page = await playwright_script(self.page)
+
+        if scrolls_limit > 0:
+            result = await self.scroll_page(scrolls_limit)
+        else:
+            result = await self.get_full_html()
+
+        return result
+
+    async def close(self) -> None:
+        if self.playwright:
+            await self.context.close()
+            await self.browser.close()
+            await self.playwright.stop()

--- a/testdata/python/clones/type2_false_positive/parsera_parsera.py
+++ b/testdata/python/clones/type2_false_positive/parsera_parsera.py
@@ -1,0 +1,90 @@
+class Parsera:
+    def __init__(
+        self,
+        model: BaseChatModel | None = None,
+        extractor: Extractor | None = None,
+        initial_script: Callable[[Page], Awaitable[Page]] | None = None,
+        stealth: bool = True,
+        custom_cookies: list[dict] | None = None,
+        typed: bool = False,
+    ):
+        if model is None and extractor is None:
+            self.extractor = APIExtractor()
+        elif model and extractor is None:
+            self.model = model
+            if typed:
+                self.extractor = StructuredExtractor(model=self.model)
+            else:
+                self.extractor = ChunksTabularExtractor(model=self.model)
+        elif model is None and extractor:
+            self.extractor = extractor
+        else:
+            raise ValueError(
+                "Either model or extractor should be provided, but not both"
+            )
+        self.initial_script = initial_script
+        self.stealth = stealth
+        self.loader = PageLoader(custom_cookies=custom_cookies)
+
+    async def _run(
+        self,
+        url: str,
+        elements: dict | None,
+        prompt: str,
+        proxy_settings: dict | None,
+        scrolls_limit: int = 0,
+        playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
+    ) -> dict:
+        if self.loader.context is None:
+            await self.loader.create_session(
+                proxy_settings=proxy_settings,
+                playwright_script=self.initial_script,
+                stealth=self.stealth,
+            )
+
+        content = await self.loader.fetch_page(
+            url=url, scrolls_limit=scrolls_limit, playwright_script=playwright_script
+        )
+
+        result = await self.extractor.run(
+            content=content, prompt=prompt, attributes=elements
+        )
+        return result
+
+    def run(
+        self,
+        url: str,
+        elements: dict | None = None,
+        prompt: str = "",
+        proxy_settings: dict | None = None,
+        scrolls_limit: int = 0,
+        playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
+    ) -> dict:
+        return asyncio.run(
+            self._run(
+                url=url,
+                elements=elements,
+                prompt=prompt,
+                scrolls_limit=scrolls_limit,
+                proxy_settings=proxy_settings,
+                playwright_script=playwright_script,
+            )
+        )
+
+    async def arun(
+        self,
+        url: str,
+        elements: dict | None = None,
+        prompt: str = "",
+        proxy_settings: dict | None = None,
+        scrolls_limit: int = 0,
+        playwright_script: Callable[[Page], Awaitable[Page]] | None = None,
+    ) -> dict:
+        return await self._run(
+            url=url,
+            elements=elements,
+            prompt=prompt,
+            scrolls_limit=scrolls_limit,
+            proxy_settings=proxy_settings,
+            playwright_script=playwright_script,
+        )


### PR DESCRIPTION
Closes #408

This makes Type-2 detection require both structural similarity and normalized syntactic overlap, so whole class bodies with similar skeletons do not get reported as renamed clones.

The regression uses the parsera false-positive pair from the issue and also covers the public file-analysis path. Smaller legitimate Type-2 matches are still allowed.

Validation:
go test ./... -count=1
go test ./internal/analyzer -run '^$' -bench 'BenchmarkCloneDetector_CompareFragments$' -benchmem -count=3\n\nChecked the reported repros:\nparsera full repro: type2_count=0\nemunium full repro: reported_type2=0\ntwscrape reported-file slice: no large cross-class Type-2 pair