### PR TITLE
fix: preserve f-string ivar access

### DIFF
--- a/internal/analyzer/apted_tree_test.go
+++ b/internal/analyzer/apted_tree_test.go
@@ -561,6 +561,33 @@ except Error as right:
     value = f"{right}"
 `,
 		},
+		{
+			name: "formatted string static format spec",
+			left: `if cond:
+    value = f"{item:>5}"
+`,
+			right: `if cond:
+    value = f"{item:<5}"
+`,
+		},
+		{
+			name: "formatted string conversion marker",
+			left: `if cond:
+    value = f"{item!r}"
+`,
+			right: `if cond:
+    value = f"{item!s}"
+`,
+		},
+		{
+			name: "formatted string debug marker",
+			left: `if cond:
+    value = f"{item}"
+`,
+			right: `if cond:
+    value = f"{item=}"
+`,
+		},
 	}
 
 	analyzer := NewAPTEDAnalyzer(NewPythonCostModel())

--- a/internal/analyzer/lcom.go
+++ b/internal/analyzer/lcom.go
@@ -294,7 +294,7 @@ func (a *LCOMAnalyzer) getDecoratorName(decorator *parser.Node) string {
 
 // extractMethodCalls walks a method's AST to find all self.xxx() method call targets
 func (a *LCOMAnalyzer) extractMethodCalls(methodNode *parser.Node, calls map[string]bool) {
-	a.walkNode(methodNode, func(node *parser.Node) bool {
+	methodNode.WalkDeep(func(node *parser.Node) bool {
 		if node.Type == parser.NodeCall && node.Value != nil {
 			if attrNode, ok := node.Value.(*parser.Node); ok {
 				if attrNode.Type == parser.NodeAttribute && a.isSelfAccess(attrNode) && attrNode.Name != "" {
@@ -308,7 +308,7 @@ func (a *LCOMAnalyzer) extractMethodCalls(methodNode *parser.Node, calls map[str
 
 // extractInstanceVars walks a method's AST to find all self.xxx attribute accesses
 func (a *LCOMAnalyzer) extractInstanceVars(methodNode *parser.Node, vars map[string]bool) {
-	a.walkNode(methodNode, func(node *parser.Node) bool {
+	methodNode.WalkDeep(func(node *parser.Node) bool {
 		if node.Type == parser.NodeAttribute {
 			// Check if this is self.xxx
 			if a.isSelfAccess(node) && node.Name != "" {
@@ -352,55 +352,13 @@ func (a *LCOMAnalyzer) assessRiskLevel(lcom4 int) string {
 // collectClasses collects all class definition nodes from the AST
 func (a *LCOMAnalyzer) collectClasses(ast *parser.Node) []*parser.Node {
 	var classes []*parser.Node
-	a.walkNode(ast, func(node *parser.Node) bool {
+	ast.WalkDeep(func(node *parser.Node) bool {
 		if node.Type == parser.NodeClassDef && node.Name != "" {
 			classes = append(classes, node)
 		}
 		return true
 	})
 	return classes
-}
-
-// walkNode performs a depth-first traversal of the AST
-func (a *LCOMAnalyzer) walkNode(node *parser.Node, visitor func(*parser.Node) bool) {
-	if node == nil || !visitor(node) {
-		return
-	}
-
-	for _, child := range node.Children {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Body {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Targets {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Args {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Keywords {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Orelse {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Finalbody {
-		a.walkNode(child, visitor)
-	}
-	for _, child := range node.Handlers {
-		a.walkNode(child, visitor)
-	}
-
-	if node.Value != nil {
-		if valueNode, ok := node.Value.(*parser.Node); ok {
-			a.walkNode(valueNode, visitor)
-		}
-	}
-	a.walkNode(node.Left, visitor)
-	a.walkNode(node.Right, visitor)
-	a.walkNode(node.Test, visitor)
-	a.walkNode(node.Iter, visitor)
 }
 
 // CalculateLCOM is a convenience function that creates an analyzer with defaults and runs it

--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -442,3 +442,70 @@ class TwoGroupClass:
 	assert.Contains(t, r.MethodGroups[1], "get_b")
 	assert.Contains(t, r.MethodGroups[1], "set_b")
 }
+
+func TestLCOMAnalyzer_FStringInstanceVariableAccesses(t *testing.T) {
+	p := parser.New()
+	code := `
+class A:
+    def __init__(self):
+        self._sep = '/'
+    def render(self):
+        return f"x{self._sep}y"
+
+class B:
+    def __init__(self):
+        self._sep = '/'
+    def render(self):
+        return f"x{1:{self._sep}>5}y"
+
+class C:
+    def __init__(self):
+        self._sep = '/'
+    def render(self):
+        return "x" + self._sep + "y"
+
+class D:
+    def __init__(self):
+        self._x = 1
+    def m1(self):
+        return self._x
+    def m2(self):
+        return f"{self._x}"
+
+class E:
+    def __init__(self):
+        self._x = 1
+    def render(self):
+        return f"{f'{self._x}'}"
+`
+	result, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	analyzer := NewLCOMAnalyzer(nil)
+	results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+	require.NoError(t, err)
+	require.Len(t, results, 5)
+
+	byName := make(map[string]*LCOMResult, len(results))
+	for _, result := range results {
+		byName[result.ClassName] = result
+	}
+
+	expectedGroups := map[string][][]string{
+		"A": {{"__init__", "render"}},
+		"B": {{"__init__", "render"}},
+		"C": {{"__init__", "render"}},
+		"D": {{"__init__", "m1", "m2"}},
+		"E": {{"__init__", "render"}},
+	}
+
+	for className, groups := range expectedGroups {
+		t.Run(className, func(t *testing.T) {
+			result, ok := byName[className]
+			require.True(t, ok, "missing class %s", className)
+			assert.Equal(t, 1, result.LCOM4)
+			assert.Equal(t, 1, result.InstanceVariables)
+			assert.Equal(t, groups, result.MethodGroups)
+		})
+	}
+}

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -267,31 +267,45 @@ func (n *Node) Walk(visitor func(*Node) bool) {
 // This is necessary because tree-sitter stores some child nodes in the Value field
 // (e.g., Call nodes store the callee in Value, Assign nodes store the RHS in Value).
 func (n *Node) WalkDeep(visitor func(*Node) bool) {
-	visited := make(map[*Node]bool)
-	n.walkDeep(visitor, visited)
+	if n == nil || !visitor(n) {
+		return
+	}
+
+	walkNodeList(n.Children, visitor)
+	walkNodeList(n.Body, visitor)
+	walkNodeList(n.Orelse, visitor)
+	walkNodeList(n.Finalbody, visitor)
+	walkNodeList(n.Handlers, visitor)
+
+	if n.Test != nil {
+		n.Test.WalkDeep(visitor)
+	}
+	if n.Iter != nil {
+		n.Iter.WalkDeep(visitor)
+	}
+	if n.Left != nil {
+		n.Left.WalkDeep(visitor)
+	}
+	if n.Right != nil {
+		n.Right.WalkDeep(visitor)
+	}
+
+	walkNodeList(n.Targets, visitor)
+	walkNodeList(n.Args, visitor)
+	walkNodeList(n.Keywords, visitor)
+	walkNodeList(n.Decorator, visitor)
+	walkNodeList(n.Bases, visitor)
+
+	if valueNode, ok := n.Value.(*Node); ok {
+		valueNode.WalkDeep(visitor)
+	}
 }
 
-func (n *Node) walkDeep(visitor func(*Node) bool, visited map[*Node]bool) {
-	if n == nil {
-		return
-	}
-	if visited[n] {
-		return
-	}
-	visited[n] = true
-
-	if !visitor(n) {
-		return
-	}
-
-	// Traverse all standard AST children (Body/Orelse/Handlers/etc.).
-	for _, child := range n.GetChildren() {
-		child.walkDeep(visitor, visited)
-	}
-
-	// Traverse Value field if it contains a Node (tree-sitter-specific storage).
-	if valueNode, ok := n.Value.(*Node); ok {
-		valueNode.walkDeep(visitor, visited)
+func walkNodeList(nodes []*Node, visitor func(*Node) bool) {
+	for _, child := range nodes {
+		if child != nil {
+			child.WalkDeep(visitor)
+		}
 	}
 }
 

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -166,7 +166,12 @@ func (b *ASTBuilder) buildNode(tsNode *sitter.Node) *Node {
 		return b.buildName(tsNode)
 	case "integer", "float", "true", "false", "none":
 		return b.buildConstant(tsNode)
-	case "string", "concatenated_string":
+	case "string":
+		if b.stringHasInterpolation(tsNode) {
+			return b.buildFormattedString(tsNode)
+		}
+		return b.buildConstant(tsNode)
+	case "concatenated_string":
 		if b.hasStringInterpolation(tsNode) {
 			return b.buildFormattedString(tsNode)
 		}
@@ -1554,14 +1559,56 @@ func (b *ASTBuilder) hasStringInterpolation(tsNode *sitter.Node) bool {
 	if tsNode == nil {
 		return false
 	}
-	if tsNode.Type() == "interpolation" {
+	switch tsNode.Type() {
+	case "interpolation":
 		return true
+	case "string":
+		return b.stringHasInterpolation(tsNode)
 	}
 
 	childCount := int(tsNode.ChildCount())
 	for i := 0; i < childCount; i++ {
 		if b.hasStringInterpolation(tsNode.Child(i)) {
 			return true
+		}
+	}
+	return false
+}
+
+func (b *ASTBuilder) stringHasInterpolation(tsNode *sitter.Node) bool {
+	if !b.hasFormattedStringPrefix(tsNode) {
+		return false
+	}
+
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		if b.hasStringInterpolation(tsNode.Child(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *ASTBuilder) hasFormattedStringPrefix(tsNode *sitter.Node) bool {
+	start := int(tsNode.StartByte())
+	end := int(tsNode.EndByte())
+	if start < 0 || start >= len(b.source) {
+		return false
+	}
+	if end > len(b.source) {
+		end = len(b.source)
+	}
+
+	for i := start; i < end; i++ {
+		switch b.source[i] {
+		case 'f', 'F':
+			return true
+		case 'r', 'R', 'u', 'U', 'b', 'B':
+			continue
+		case '\'', '"':
+			return false
+		default:
+			return false
 		}
 	}
 	return false

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -1480,12 +1480,12 @@ func (b *ASTBuilder) buildFormattedValue(tsNode *sitter.Node) *Node {
 		if expr == nil {
 			continue
 		}
+		cursor = child.EndByte()
 		if node.Value == nil {
 			node.Value = expr
 			continue
 		}
 		node.AddChild(expr)
-		cursor = child.EndByte()
 	}
 	b.addFormattedLiteral(node, cursor, tsNode.EndByte(), tsNode, true)
 

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -164,10 +164,17 @@ func (b *ASTBuilder) buildNode(tsNode *sitter.Node) *Node {
 		return b.buildAwait(tsNode)
 	case "identifier":
 		return b.buildName(tsNode)
-	case "integer", "float", "string", "concatenated_string", "true", "false", "none":
+	case "integer", "float", "true", "false", "none":
 		return b.buildConstant(tsNode)
-	case "formatted_string", "interpolation":
+	case "string", "concatenated_string":
+		if b.hasStringInterpolation(tsNode) {
+			return b.buildFormattedString(tsNode)
+		}
+		return b.buildConstant(tsNode)
+	case "formatted_string":
 		return b.buildFormattedString(tsNode)
+	case "interpolation":
+		return b.buildFormattedValue(tsNode)
 
 	// Handle compound statements
 	case "block":
@@ -1399,33 +1406,181 @@ func (b *ASTBuilder) buildConstant(tsNode *sitter.Node) *Node {
 func (b *ASTBuilder) buildFormattedString(tsNode *sitter.Node) *Node {
 	node := NewNode(NodeJoinedStr)
 	node.Location = b.getLocation(tsNode)
+	b.addFormattedStringChildren(node, tsNode)
+	return node
+}
 
+func (b *ASTBuilder) addFormattedStringChildren(node *Node, tsNode *sitter.Node) {
 	childCount := int(tsNode.ChildCount())
 	for i := 0; i < childCount; i++ {
 		child := tsNode.Child(i)
-		if child != nil {
-			switch child.Type() {
-			case "interpolation":
-				// Extract the expression inside the interpolation
-				exprCount := int(child.ChildCount())
-				for j := 0; j < exprCount; j++ {
-					exprChild := child.Child(j)
-					if exprChild != nil && exprChild.Type() != "{" && exprChild.Type() != "}" {
-						fmtValue := NewNode(NodeFormattedValue)
-						fmtValue.Value = b.buildNode(exprChild)
-						node.AddChild(fmtValue)
-					}
-				}
-			case "string_content":
-				// Regular string content
-				strNode := NewNode(NodeConstant)
-				strNode.Value = b.getNodeText(child)
-				node.AddChild(strNode)
+		if child == nil {
+			continue
+		}
+
+		switch child.Type() {
+		case "interpolation":
+			node.AddChild(b.buildFormattedValue(child))
+		case "string_content":
+			strNode := NewNode(NodeConstant)
+			strNode.Location = b.getLocation(child)
+			strNode.Value = b.getNodeText(child)
+			node.AddChild(strNode)
+		case "string", "concatenated_string", "formatted_string":
+			if b.hasStringInterpolation(child) {
+				b.addFormattedStringChildren(node, child)
+			} else {
+				node.AddChild(b.buildConstant(child))
 			}
 		}
 	}
+}
+
+func (b *ASTBuilder) buildFormattedValue(tsNode *sitter.Node) *Node {
+	node := NewNode(NodeFormattedValue)
+	node.Location = b.getLocation(tsNode)
+
+	cursor := tsNode.StartByte()
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child == nil {
+			continue
+		}
+		if b.isFormattedStringSyntax(child) {
+			if !child.IsNamed() {
+				b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, true)
+				b.addFormattedLiteral(node, child.StartByte(), child.EndByte(), tsNode, true)
+				cursor = child.EndByte()
+			}
+			continue
+		}
+
+		if child.Type() == "format_specifier" {
+			b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, true)
+			b.addFormatSpecifierParts(node, child)
+			cursor = child.EndByte()
+			continue
+		}
+		if child.Type() == "type_conversion" {
+			b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, true)
+			b.addFormattedLiteral(node, child.StartByte(), child.EndByte(), child, true)
+			cursor = child.EndByte()
+			continue
+		}
+
+		b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, true)
+
+		expr := b.buildNode(child)
+		if expr == nil {
+			continue
+		}
+		if node.Value == nil {
+			node.Value = expr
+			continue
+		}
+		node.AddChild(expr)
+		cursor = child.EndByte()
+	}
+	b.addFormattedLiteral(node, cursor, tsNode.EndByte(), tsNode, true)
 
 	return node
+}
+
+func (b *ASTBuilder) addFormatSpecifierParts(node *Node, tsNode *sitter.Node) {
+	cursor := tsNode.StartByte()
+	end := tsNode.EndByte()
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child == nil || b.isFormattedStringSyntax(child) {
+			continue
+		}
+
+		switch child.Type() {
+		case "format_expression":
+			b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, false)
+			b.addFormatExpression(node, child)
+			cursor = child.EndByte()
+		case "format_specifier":
+			b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, false)
+			b.addFormatSpecifierParts(node, child)
+			cursor = child.EndByte()
+		case "interpolation":
+			b.addFormattedLiteral(node, cursor, child.StartByte(), tsNode, false)
+			node.AddChild(b.buildFormattedValue(child))
+			cursor = child.EndByte()
+		}
+	}
+	b.addFormattedLiteral(node, cursor, end, tsNode, false)
+}
+
+func (b *ASTBuilder) addFormatExpression(node *Node, tsNode *sitter.Node) {
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child == nil || b.isFormattedStringSyntax(child) {
+			continue
+		}
+		if child.Type() == "format_specifier" {
+			b.addFormatSpecifierParts(node, child)
+			continue
+		}
+
+		expr := b.buildNode(child)
+		if expr != nil {
+			node.AddChild(expr)
+		}
+	}
+}
+
+func (b *ASTBuilder) addFormattedLiteral(node *Node, start, end uint32, locationNode *sitter.Node, skipBraces bool) {
+	if start >= end {
+		return
+	}
+
+	literal := string(b.source[start:end])
+	if literal == "" || (skipBraces && (literal == "{" || literal == "}")) {
+		return
+	}
+
+	strNode := NewNode(NodeConstant)
+	strNode.Location = b.getLocation(locationNode)
+	strNode.Value = literal
+	node.AddChild(strNode)
+}
+
+func (b *ASTBuilder) hasStringInterpolation(tsNode *sitter.Node) bool {
+	if tsNode == nil {
+		return false
+	}
+	if tsNode.Type() == "interpolation" {
+		return true
+	}
+
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		if b.hasStringInterpolation(tsNode.Child(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *ASTBuilder) isFormattedStringSyntax(tsNode *sitter.Node) bool {
+	if tsNode == nil {
+		return true
+	}
+	if !tsNode.IsNamed() {
+		return true
+	}
+
+	switch tsNode.Type() {
+	case "string_start", "string_end", "string_content":
+		return true
+	default:
+		return b.isTrivia(tsNode)
+	}
 }
 
 // buildBlock builds a block of statements

--- a/internal/parser/ast_test.go
+++ b/internal/parser/ast_test.go
@@ -332,3 +332,126 @@ if __name__ == "__main__":
 		t.Errorf("Expected at least 1 for loop, found %d", len(forLoops))
 	}
 }
+
+func TestASTBuilderFStringInterpolationsPreserveExpressions(t *testing.T) {
+	source := `
+class FStringExamples:
+    def embedded(self):
+        return f"x{self._sep}y"
+
+    def format_spec(self):
+        return f"x{1:{self._width}>5}y"
+
+    def right_aligned(self):
+        return f"{self._value:>5}"
+
+    def left_aligned(self):
+        return f"{self._value:<5}"
+
+    def conversion(self):
+        return f"{self._value!r}"
+
+    def debug_value(self):
+        return f"{self._value=}"
+
+    def nested(self):
+        return f"{f'{self._nested}'}"
+
+    def plain_string(self):
+        return "x{self._plain}y"
+`
+
+	result, err := New().Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	returns := result.AST.FindByType(NodeReturn)
+	if len(returns) != 8 {
+		t.Fatalf("Expected 8 return statements, got %d", len(returns))
+	}
+
+	tests := []struct {
+		name string
+		idx  int
+		attr string
+	}{
+		{name: "embedded interpolation", idx: 0, attr: "_sep"},
+		{name: "format spec expression", idx: 1, attr: "_width"},
+		{name: "right aligned static format spec", idx: 2, attr: "_value"},
+		{name: "left aligned static format spec", idx: 3, attr: "_value"},
+		{name: "conversion marker", idx: 4, attr: "_value"},
+		{name: "debug marker", idx: 5, attr: "_value"},
+		{name: "nested f-string expression", idx: 6, attr: "_nested"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := returns[tt.idx].Value.(*Node)
+			if !ok {
+				t.Fatalf("Return value is %T, want *Node", returns[tt.idx].Value)
+			}
+			if value.Type != NodeJoinedStr {
+				t.Fatalf("Return value type = %s, want %s", value.Type, NodeJoinedStr)
+			}
+
+			formattedValues := 0
+			foundAttr := false
+			value.WalkDeep(func(node *Node) bool {
+				if node.Type == NodeFormattedValue {
+					formattedValues++
+				}
+				if node.Type == NodeAttribute && node.Name == tt.attr {
+					foundAttr = true
+				}
+				return true
+			})
+
+			if formattedValues == 0 {
+				t.Fatal("Expected at least one formatted value")
+			}
+			if !foundAttr {
+				t.Fatalf("Expected deep traversal to find self.%s", tt.attr)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name string
+		idx  int
+		want string
+	}{
+		{name: "dynamic format spec keeps static suffix", idx: 1, want: ">5"},
+		{name: "right aligned static format spec", idx: 2, want: ":>5"},
+		{name: "left aligned static format spec", idx: 3, want: ":<5"},
+		{name: "conversion marker", idx: 4, want: "!r"},
+		{name: "debug marker", idx: 5, want: "="},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := returns[tt.idx].Value.(*Node)
+			if !ok {
+				t.Fatalf("Return value is %T, want *Node", returns[tt.idx].Value)
+			}
+
+			foundLiteral := false
+			value.WalkDeep(func(node *Node) bool {
+				if node.Type == NodeConstant && node.Value == tt.want {
+					foundLiteral = true
+				}
+				return true
+			})
+
+			if !foundLiteral {
+				t.Fatalf("Expected deep traversal to find format spec literal %q", tt.want)
+			}
+		})
+	}
+
+	plainValue, ok := returns[7].Value.(*Node)
+	if !ok {
+		t.Fatalf("Plain string return value is %T, want *Node", returns[7].Value)
+	}
+	if plainValue.Type != NodeConstant {
+		t.Fatalf("Plain string type = %s, want %s", plainValue.Type, NodeConstant)
+	}
+}

--- a/internal/parser/ast_test.go
+++ b/internal/parser/ast_test.go
@@ -339,6 +339,9 @@ class FStringExamples:
     def embedded(self):
         return f"x{self._sep}y"
 
+    def simple(self):
+        return f"{self._value}"
+
     def format_spec(self):
         return f"x{1:{self._width}>5}y"
 
@@ -367,8 +370,8 @@ class FStringExamples:
 	}
 
 	returns := result.AST.FindByType(NodeReturn)
-	if len(returns) != 8 {
-		t.Fatalf("Expected 8 return statements, got %d", len(returns))
+	if len(returns) != 9 {
+		t.Fatalf("Expected 9 return statements, got %d", len(returns))
 	}
 
 	tests := []struct {
@@ -377,12 +380,13 @@ class FStringExamples:
 		attr string
 	}{
 		{name: "embedded interpolation", idx: 0, attr: "_sep"},
-		{name: "format spec expression", idx: 1, attr: "_width"},
-		{name: "right aligned static format spec", idx: 2, attr: "_value"},
-		{name: "left aligned static format spec", idx: 3, attr: "_value"},
-		{name: "conversion marker", idx: 4, attr: "_value"},
-		{name: "debug marker", idx: 5, attr: "_value"},
-		{name: "nested f-string expression", idx: 6, attr: "_nested"},
+		{name: "simple interpolation", idx: 1, attr: "_value"},
+		{name: "format spec expression", idx: 2, attr: "_width"},
+		{name: "right aligned static format spec", idx: 3, attr: "_value"},
+		{name: "left aligned static format spec", idx: 4, attr: "_value"},
+		{name: "conversion marker", idx: 5, attr: "_value"},
+		{name: "debug marker", idx: 6, attr: "_value"},
+		{name: "nested f-string expression", idx: 7, attr: "_nested"},
 	}
 
 	for _, tt := range tests {
@@ -421,11 +425,11 @@ class FStringExamples:
 		idx  int
 		want string
 	}{
-		{name: "dynamic format spec keeps static suffix", idx: 1, want: ">5"},
-		{name: "right aligned static format spec", idx: 2, want: ":>5"},
-		{name: "left aligned static format spec", idx: 3, want: ":<5"},
-		{name: "conversion marker", idx: 4, want: "!r"},
-		{name: "debug marker", idx: 5, want: "="},
+		{name: "dynamic format spec keeps static suffix", idx: 2, want: ">5"},
+		{name: "right aligned static format spec", idx: 3, want: ":>5"},
+		{name: "left aligned static format spec", idx: 4, want: ":<5"},
+		{name: "conversion marker", idx: 5, want: "!r"},
+		{name: "debug marker", idx: 6, want: "="},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			value, ok := returns[tt.idx].Value.(*Node)
@@ -447,11 +451,43 @@ class FStringExamples:
 		})
 	}
 
-	plainValue, ok := returns[7].Value.(*Node)
+	for _, tt := range []struct {
+		name string
+		idx  int
+		dup  string
+	}{
+		{name: "simple interpolation expression is not duplicated", idx: 1, dup: "self._value"},
+		{name: "static format spec expression is not duplicated", idx: 3, dup: "self._value"},
+		{name: "dynamic format spec outer expression is not duplicated", idx: 2, dup: "1"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			value, ok := returns[tt.idx].Value.(*Node)
+			if !ok {
+				t.Fatalf("Return value is %T, want *Node", returns[tt.idx].Value)
+			}
+
+			if countStringConstants(value, tt.dup) != 0 {
+				t.Fatalf("Expression literal %q was duplicated as a string constant", tt.dup)
+			}
+		})
+	}
+
+	plainValue, ok := returns[8].Value.(*Node)
 	if !ok {
-		t.Fatalf("Plain string return value is %T, want *Node", returns[7].Value)
+		t.Fatalf("Plain string return value is %T, want *Node", returns[8].Value)
 	}
 	if plainValue.Type != NodeConstant {
 		t.Fatalf("Plain string type = %s, want %s", plainValue.Type, NodeConstant)
 	}
+}
+
+func countStringConstants(node *Node, value string) int {
+	count := 0
+	node.WalkDeep(func(child *Node) bool {
+		if child.Type == NodeConstant && child.Value == value {
+			count++
+		}
+		return true
+	})
+	return count
 }


### PR DESCRIPTION
## What:
- Preserve f-string interpolation expressions in the parser AST
- Keep format specs, conversions, and debug markers visible to AST consumers
- Use shared deep traversal for LCOM instance-variable collection
- Add parser, LCOM, and APTED regression coverage

## Why:
LCOM4 missed self.<ivar> accesses inside f-strings because tree-sitter string nodes with interpolations were collapsed to constants before analyzers could visit their expressions.

Closes #413