### PR TITLE
fix: surface module-scope code as "<module>" not "__main__" (#394)

### DIFF
--- a/domain/complexity.go
+++ b/domain/complexity.go
@@ -41,6 +41,12 @@ const (
 	RiskLevelHigh   RiskLevel = "high"
 )
 
+// ModuleFunctionName is the user-facing label used for module-scope (top-level) code
+// in places that key/display per-function results. The angle brackets follow Python's
+// own convention (e.g. tracebacks and `dis` output) and signal that this is not a real
+// function defined in the source.
+const ModuleFunctionName = "<module>"
+
 // ComplexityRequest represents a request for complexity analysis
 type ComplexityRequest struct {
 	// Input files or directories to analyze

--- a/domain/suggestion.go
+++ b/domain/suggestion.go
@@ -93,7 +93,7 @@ func generateComplexitySuggestions(resp *ComplexityResponse) []Suggestion {
 
 		var title, desc string
 		var steps []string
-		isTopLevel := f.Name == "__main__"
+		isTopLevel := f.Name == ModuleFunctionName
 		basename := filepath.Base(f.FilePath)
 
 		if isTopLevel {

--- a/domain/suggestion_test.go
+++ b/domain/suggestion_test.go
@@ -166,7 +166,7 @@ func TestGenerateSuggestions_ComplexityTopLevel(t *testing.T) {
 		Complexity: &ComplexityResponse{
 			Functions: []FunctionComplexity{
 				{
-					Name:     "__main__",
+					Name:     ModuleFunctionName,
 					FilePath: "src/comprehensions.py",
 					Metrics:  ComplexityMetrics{Complexity: 15},
 				},
@@ -182,14 +182,14 @@ func TestGenerateSuggestions_ComplexityTopLevel(t *testing.T) {
 	if !strings.Contains(s.Title, "comprehensions.py") {
 		t.Errorf("expected title to contain filename, got: %s", s.Title)
 	}
-	if strings.Contains(s.Title, "__main__") {
-		t.Errorf("title should not contain '__main__', got: %s", s.Title)
+	if strings.Contains(s.Title, ModuleFunctionName) {
+		t.Errorf("title should not contain %q, got: %s", ModuleFunctionName, s.Title)
 	}
 	if !strings.Contains(s.Description, "Top-level code") {
 		t.Errorf("expected description to mention top-level code, got: %s", s.Description)
 	}
-	if s.Function != "__main__" {
-		t.Errorf("expected Function field to remain '__main__', got: %s", s.Function)
+	if s.Function != ModuleFunctionName {
+		t.Errorf("expected Function field to remain %q, got: %s", ModuleFunctionName, s.Function)
 	}
 	if !strings.Contains(s.Steps[0], "Extract top-level logic") {
 		t.Errorf("expected top-level specific steps, got: %v", s.Steps)

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
@@ -14,7 +15,6 @@ const (
 	LabelFunctionBody = "func_body"
 	LabelClassBody    = "class_body"
 	LabelUnreachable  = "unreachable"
-	LabelMainModule   = "main"
 	LabelEntry        = "ENTRY"
 	LabelExit         = "EXIT"
 
@@ -113,7 +113,7 @@ func (b *CFGBuilder) Build(node *parser.Node) (*CFG, error) {
 	}
 
 	// Initialize CFG based on node type
-	cfgName := LabelMainModule
+	cfgName := domain.ModuleFunctionName
 	if node.Type == parser.NodeFunctionDef || node.Type == parser.NodeAsyncFunctionDef {
 		cfgName = node.Name
 	} else if node.Type == parser.NodeClassDef {
@@ -164,7 +164,7 @@ func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 	if err != nil {
 		return nil, err
 	}
-	allCFGs["__main__"] = mainCFG
+	allCFGs[domain.ModuleFunctionName] = mainCFG
 
 	// Add all function CFGs (including nested ones)
 	for name, cfg := range b.functionCFGs {

--- a/internal/analyzer/cfg_builder_test.go
+++ b/internal/analyzer/cfg_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
@@ -41,8 +42,8 @@ print(z)
 		if cfg == nil {
 			t.Fatal("CFG is nil")
 		}
-		if cfg.Name != "main" {
-			t.Errorf("Expected CFG name 'main', got %s", cfg.Name)
+		if cfg.Name != domain.ModuleFunctionName {
+			t.Errorf("Expected CFG name %q, got %s", domain.ModuleFunctionName, cfg.Name)
 		}
 
 		// Check that entry is connected to exit
@@ -197,8 +198,8 @@ def outer():
 		}
 
 		// Check for main CFG
-		if _, ok := allCFGs["__main__"]; !ok {
-			t.Error("Missing __main__ CFG")
+		if _, ok := allCFGs[domain.ModuleFunctionName]; !ok {
+			t.Errorf("Missing %q CFG", domain.ModuleFunctionName)
 		}
 
 		// Check for outer function
@@ -368,7 +369,7 @@ if __name__ == "__main__":
 	}
 
 	// Check main CFG exists
-	mainCFG, ok := allCFGs["__main__"]
+	mainCFG, ok := allCFGs[domain.ModuleFunctionName]
 	if !ok {
 		t.Fatal("Main CFG not found")
 	}
@@ -659,10 +660,10 @@ def elif_with_return(x):
 				t.Fatalf("Failed to build CFGs: %v", err)
 			}
 
-			// Get the function CFG (not __main__)
+			// Get the function CFG (not the module CFG)
 			var cfg *CFG
 			for name, c := range cfgs {
-				if name != "__main__" {
+				if name != domain.ModuleFunctionName {
 					cfg = c
 					break
 				}

--- a/internal/analyzer/cfg_edge_cases_test.go
+++ b/internal/analyzer/cfg_edge_cases_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -505,7 +506,7 @@ def nested_returns():
 			if tc.name == "OnlyReturns" || tc.name == "NestedReturns" {
 				// These tests define functions, get the function CFG
 				for name, c := range cfgs {
-					if name != "__main__" {
+					if name != domain.ModuleFunctionName {
 						cfg = c
 						break
 					}
@@ -513,7 +514,7 @@ def nested_returns():
 				require.NotNil(t, cfg, "Failed to find function CFG")
 			} else {
 				// Module-level tests
-				cfg = cfgs["__main__"]
+				cfg = cfgs[domain.ModuleFunctionName]
 				require.NotNil(t, cfg, "Failed to find main CFG")
 			}
 

--- a/internal/analyzer/cfg_integration_test.go
+++ b/internal/analyzer/cfg_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,7 +114,7 @@ func TestCFGIntegrationWithRealFiles(t *testing.T) {
 			}
 
 			// Get the main module CFG for validation
-			cfg := cfgs["__main__"]
+			cfg := cfgs[domain.ModuleFunctionName]
 			require.NotNil(t, cfg, "Failed to find main CFG for %s", tc.file)
 
 			// Validate basic CFG properties
@@ -366,7 +367,7 @@ def exception_handler():
 			if tc.name == "SimpleFunction" || tc.name == "IfElseStatement" || tc.name == "ForLoop" || tc.name == "TryExcept" {
 				// These are function definitions, get the function CFG
 				for name, c := range cfgs {
-					if name != "__main__" {
+					if name != domain.ModuleFunctionName {
 						cfg = c
 						break
 					}
@@ -374,7 +375,7 @@ def exception_handler():
 				require.NotNil(t, cfg, "Failed to find function CFG")
 			} else {
 				// Module-level code
-				cfg = cfgs["__main__"]
+				cfg = cfgs[domain.ModuleFunctionName]
 				require.NotNil(t, cfg, "Failed to find module CFG")
 			}
 

--- a/internal/analyzer/complexity_test.go
+++ b/internal/analyzer/complexity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/config"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
@@ -271,12 +272,12 @@ print(count)
 		t.Fatalf("Failed to build CFGs: %v", err)
 	}
 
-	mainCFG, ok := cfgs["__main__"]
+	mainCFG, ok := cfgs[domain.ModuleFunctionName]
 	if !ok {
-		t.Fatal("Expected __main__ CFG to be present")
+		t.Fatalf("Expected %q CFG to be present", domain.ModuleFunctionName)
 	}
 	if mainCFG.ModuleNode == nil {
-		t.Fatal("Expected ModuleNode to be set on the __main__ CFG")
+		t.Fatalf("Expected ModuleNode to be set on the %q CFG", domain.ModuleFunctionName)
 	}
 
 	res := CalculateComplexity(mainCFG)
@@ -285,6 +286,44 @@ print(count)
 	}
 	if res.EndLine < res.StartLine {
 		t.Errorf("EndLine (%d) should be >= StartLine (%d)", res.EndLine, res.StartLine)
+	}
+}
+
+// Regression test for issue #394: the user-facing name for module-scope code
+// must be the Python-conventional "<module>" label, not the internal "__main__"
+// sentinel that surfaces as a fictitious function in reports.
+func TestCalculateComplexity_ModuleLevelName(t *testing.T) {
+	source := `import os
+for path in os.listdir("."):
+    if path.endswith(".py"):
+        print(path)
+`
+
+	p := parser.New()
+	result, err := p.Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+
+	cfgs, err := NewCFGBuilder().BuildAll(result.AST)
+	if err != nil {
+		t.Fatalf("Failed to build CFGs: %v", err)
+	}
+
+	if _, ok := cfgs["__main__"]; ok {
+		t.Errorf("Module CFG must not be keyed as %q (user-facing leak); expected %q", "__main__", domain.ModuleFunctionName)
+	}
+	mainCFG, ok := cfgs[domain.ModuleFunctionName]
+	if !ok {
+		t.Fatalf("Expected module CFG keyed as %q", domain.ModuleFunctionName)
+	}
+	if mainCFG.Name != domain.ModuleFunctionName {
+		t.Errorf("CFG.Name = %q, want %q", mainCFG.Name, domain.ModuleFunctionName)
+	}
+
+	res := CalculateComplexity(mainCFG)
+	if res.FunctionName != domain.ModuleFunctionName {
+		t.Errorf("ComplexityResult.FunctionName = %q, want %q", res.FunctionName, domain.ModuleFunctionName)
 	}
 }
 

--- a/internal/analyzer/dead_code.go
+++ b/internal/analyzer/dead_code.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
@@ -166,7 +167,7 @@ func DetectInFile(cfgs map[string]*CFG, filePath string) []*DeadCodeResult {
 
 	for functionName, cfg := range cfgs {
 		// Skip the main module CFG for now, focus on functions
-		if functionName == "__main__" {
+		if functionName == domain.ModuleFunctionName {
 			continue
 		}
 

--- a/internal/analyzer/dead_code_test.go
+++ b/internal/analyzer/dead_code_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -281,10 +282,10 @@ def foo():
 			require.NoError(t, err, "Failed to build CFGs")
 
 			// For these tests, we're testing function-level dead code
-			// Find the first function CFG (not __main__)
+			// Find the first function CFG (not the module CFG)
 			var cfg *CFG
 			for name, c := range cfgs {
-				if name != "__main__" {
+				if name != domain.ModuleFunctionName {
 					cfg = c
 					break
 				}
@@ -480,10 +481,10 @@ def foo():
 			require.NoError(t, err, "Failed to build CFGs")
 
 			// For these tests, we're testing function-level dead code
-			// Find the first function CFG (not __main__)
+			// Find the first function CFG (not the module CFG)
 			var cfg *CFG
 			for name, c := range cfgs {
-				if name != "__main__" {
+				if name != domain.ModuleFunctionName {
 					cfg = c
 					break
 				}
@@ -594,10 +595,10 @@ class MyClass:
 			require.NoError(t, err, "Failed to build CFGs")
 
 			// For these tests, we're testing function-level dead code
-			// Find the first function CFG (not __main__)
+			// Find the first function CFG (not the module CFG)
 			var cfg *CFG
 			for name, c := range cfgs {
-				if name != "__main__" {
+				if name != domain.ModuleFunctionName {
 					cfg = c
 					break
 				}
@@ -605,7 +606,7 @@ class MyClass:
 
 			// If no function CFG found, use the module CFG (for empty/comments-only tests)
 			if cfg == nil {
-				cfg = cfgs["__main__"]
+				cfg = cfgs[domain.ModuleFunctionName]
 				require.NotNil(t, cfg, "No CFG found at all")
 			}
 

--- a/service/dead_code_service.go
+++ b/service/dead_code_service.go
@@ -149,7 +149,7 @@ func (s *DeadCodeServiceImpl) analyzeFile(ctx context.Context, filePath string, 
 
 	for functionName, cfg := range cfgs {
 		// Skip the main module CFG for now, focus on functions
-		if functionName == "__main__" {
+		if functionName == domain.ModuleFunctionName {
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- Module-scope (top-level) Python code surfaced in complexity reports as a fictitious function literally named `__main__` — the internal CFG sentinel from `cfg_builder.go` leaked into user-facing JSON/HTML output.
- Switch the label to Python's conventional `<module>` (as used by `dis` and tracebacks) via a new `domain.ModuleFunctionName` constant; route every sentinel comparison (`dead_code`, `dead_code_service`, `suggestion`) through it.
- Line-range part of #394 was already fixed by the #396 patch; this PR closes the remaining label issue.

Fixes #394

## Behavior change

Before:
```json
{ "Name": "__main__", "StartLine": 1, "EndLine": 12, ... }
```
After:
```json
{ "Name": "<module>", "StartLine": 1, "EndLine": 12, ... }
```

The existing top-level suggestion path (`Reduce top-level code complexity in 'filename.py'`) continues to fire — it now keys on `domain.ModuleFunctionName` instead of the literal.

## Notes / out-of-scope
- For mixed files (module-scope code + `def` blocks) the module CFG's line range still spans the whole file, including function bodies — observed but **not** addressed here, as it falls outside #394. Worth a follow-up issue.
- JSON consumers keying on `Functions[].Name == "__main__"` will need to migrate to `"<module>"`. This is a deliberate breaking change to fix the misleading output.