### PR TITLE
[codex] Fix LCOM4 with-context instance variable access

### DIFF
--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -509,3 +509,76 @@ class E:
 		})
 	}
 }
+
+func TestLCOMAnalyzer_WithContextInstanceVariableAccesses(t *testing.T) {
+	p := parser.New()
+	code := `
+class B:
+    def __init__(self):
+        self._fname = 'x'
+    def write(self, t):
+        with open(self._fname, 'w') as f:
+            f.write(t)
+    def __del__(self):
+        with open(self._fname, 'w') as f:
+            f.write('done')
+
+class K:
+    def __init__(self):
+        self._x = 1
+    def m1(self):
+        with open(self._x, 'r') as f:
+            return f.read()
+    def m2(self):
+        return self._x
+
+class AsyncContext:
+    def __init__(self):
+        self._resource = None
+    async def acquire(self):
+        async with self._resource as ctx:
+            return ctx
+    def current(self):
+        return self._resource
+
+class MultipleItems:
+    def __init__(self):
+        self._a = 'a'
+        self._b = 'b'
+    def copy(self):
+        with open(self._a, 'r') as src, open(self._b, 'w') as dst:
+            dst.write(src.read())
+    def read_a(self):
+        return self._a
+    def read_b(self):
+        return self._b
+`
+	result, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	analyzer := NewLCOMAnalyzer(nil)
+	results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+
+	byName := make(map[string]*LCOMResult, len(results))
+	for _, result := range results {
+		byName[result.ClassName] = result
+	}
+
+	expectedGroups := map[string][][]string{
+		"B":             {{"__del__", "__init__", "write"}},
+		"K":             {{"__init__", "m1", "m2"}},
+		"AsyncContext":  {{"__init__", "acquire", "current"}},
+		"MultipleItems": {{"__init__", "copy", "read_a", "read_b"}},
+	}
+
+	for className, groups := range expectedGroups {
+		t.Run(className, func(t *testing.T) {
+			result, ok := byName[className]
+			require.True(t, ok, "missing class %s", className)
+			assert.Equal(t, 1, result.LCOM4)
+			assert.Equal(t, groups, result.MethodGroups)
+		})
+	}
+}

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -1820,31 +1820,12 @@ func (b *ASTBuilder) buildWithItem(tsNode *sitter.Node) *Node {
 	node.Location = b.getLocation(tsNode)
 
 	if tsNode.Type() == "as_pattern" {
-		if expr := b.getChildByFieldName(tsNode, "value"); expr != nil {
-			node.Value = b.buildNode(expr)
-		} else if expr := b.getChildByFieldName(tsNode, "expression"); expr != nil {
-			node.Value = b.buildNode(expr)
-		}
-		if node.Value == nil {
-			childCount := int(tsNode.ChildCount())
-			for i := 0; i < childCount; i++ {
-				child := tsNode.Child(i)
-				if child == nil || b.isTrivia(child) || !child.IsNamed() || tsNode.FieldNameForChild(i) == "alias" {
-					continue
-				}
-				node.Value = b.buildNode(child)
-				break
-			}
-		}
-		if alias := b.getChildByFieldName(tsNode, "alias"); alias != nil {
-			node.Name = b.getNodeText(alias)
-		}
-		return node
+		return b.populateWithItemFromAsPattern(node, tsNode)
 	}
 
 	if value := b.getChildByFieldName(tsNode, "value"); value != nil {
 		if value.Type() == "as_pattern" {
-			return b.buildWithItem(value)
+			return b.populateWithItemFromAsPattern(node, value)
 		}
 		node.Value = b.buildNode(value)
 		return node
@@ -1858,7 +1839,31 @@ func (b *ASTBuilder) buildWithItem(tsNode *sitter.Node) *Node {
 		return node
 	}
 
-	node.Value = b.buildNode(tsNode)
+	return nil
+}
+
+func (b *ASTBuilder) populateWithItemFromAsPattern(node *Node, tsNode *sitter.Node) *Node {
+	if node == nil || tsNode == nil {
+		return nil
+	}
+
+	// tree-sitter-python leaves the context expression unnamed; only the alias has a field name.
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child == nil || b.isTrivia(child) || !child.IsNamed() || tsNode.FieldNameForChild(i) == "alias" {
+			continue
+		}
+		node.Value = b.buildNode(child)
+		break
+	}
+	if node.Value == nil {
+		return nil
+	}
+
+	if alias := b.getChildByFieldName(tsNode, "alias"); alias != nil {
+		node.Name = b.getNodeText(alias)
+	}
 	return node
 }
 

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -477,7 +477,7 @@ func (b *ASTBuilder) buildWithStatement(tsNode *sitter.Node) *Node {
 	for i := 0; i < childCount; i++ {
 		child := tsNode.Child(i)
 		if child != nil && child.Type() == "with_clause" {
-			if withItem := b.buildWithItem(child); withItem != nil {
+			for _, withItem := range b.buildWithItems(child) {
 				node.AddChild(withItem)
 			}
 		}
@@ -1776,25 +1776,89 @@ func (b *ASTBuilder) buildCallArguments(tsNode *sitter.Node) ([]*Node, []*Node) 
 	return args, keywords
 }
 
+// buildWithItems builds each context manager item from a with clause.
+func (b *ASTBuilder) buildWithItems(tsNode *sitter.Node) []*Node {
+	if tsNode == nil {
+		return nil
+	}
+
+	if tsNode.Type() != "with_clause" && tsNode.Type() != "parenthesized_expression" {
+		if item := b.buildWithItem(tsNode); item != nil {
+			return []*Node{item}
+		}
+		return nil
+	}
+
+	items := []*Node{}
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child == nil || b.isTrivia(child) || !child.IsNamed() {
+			continue
+		}
+
+		switch child.Type() {
+		case "as_pattern":
+			if item := b.buildWithItem(child); item != nil {
+				items = append(items, item)
+			}
+		case "parenthesized_expression":
+			items = append(items, b.buildWithItems(child)...)
+		default:
+			if item := b.buildWithItem(child); item != nil {
+				items = append(items, item)
+			}
+		}
+	}
+
+	return items
+}
+
 // buildWithItem builds a with item node
 func (b *ASTBuilder) buildWithItem(tsNode *sitter.Node) *Node {
 	node := NewNode(NodeWithItem)
 	node.Location = b.getLocation(tsNode)
 
-	if item := b.getChildByFieldName(tsNode, "item"); item != nil {
-		node.Value = b.buildNode(item)
-	}
-
-	childCount := int(tsNode.ChildCount())
-	for i := 0; i < childCount; i++ {
-		child := tsNode.Child(i)
-		if child != nil && child.Type() == "as_pattern" {
-			if alias := b.getChildByFieldName(child, "alias"); alias != nil {
-				node.Name = b.getNodeText(alias)
+	if tsNode.Type() == "as_pattern" {
+		if expr := b.getChildByFieldName(tsNode, "value"); expr != nil {
+			node.Value = b.buildNode(expr)
+		} else if expr := b.getChildByFieldName(tsNode, "expression"); expr != nil {
+			node.Value = b.buildNode(expr)
+		}
+		if node.Value == nil {
+			childCount := int(tsNode.ChildCount())
+			for i := 0; i < childCount; i++ {
+				child := tsNode.Child(i)
+				if child == nil || b.isTrivia(child) || !child.IsNamed() || tsNode.FieldNameForChild(i) == "alias" {
+					continue
+				}
+				node.Value = b.buildNode(child)
+				break
 			}
 		}
+		if alias := b.getChildByFieldName(tsNode, "alias"); alias != nil {
+			node.Name = b.getNodeText(alias)
+		}
+		return node
 	}
 
+	if value := b.getChildByFieldName(tsNode, "value"); value != nil {
+		if value.Type() == "as_pattern" {
+			return b.buildWithItem(value)
+		}
+		node.Value = b.buildNode(value)
+		return node
+	}
+	if item := b.getChildByFieldName(tsNode, "item"); item != nil {
+		node.Value = b.buildNode(item)
+		return node
+	}
+	if expr := b.getChildByFieldName(tsNode, "expression"); expr != nil {
+		node.Value = b.buildNode(expr)
+		return node
+	}
+
+	node.Value = b.buildNode(tsNode)
 	return node
 }
 

--- a/internal/parser/ast_test.go
+++ b/internal/parser/ast_test.go
@@ -481,6 +481,80 @@ class FStringExamples:
 	}
 }
 
+func TestASTBuilderWithItemsPreserveContextExpressions(t *testing.T) {
+	source := `
+def sync_copy(path_a, path_b, lock):
+    with open(path_a) as src, open(path_b, "w") as dst:
+        return dst.write(src.read())
+    with lock:
+        return None
+
+async def async_acquire(resource):
+    async with resource as ctx:
+        return ctx
+`
+
+	result, err := New().Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	withStmts := result.AST.FindByType(NodeWith)
+	if len(withStmts) != 2 {
+		t.Fatalf("Expected 2 with statements, got %d", len(withStmts))
+	}
+
+	if len(withStmts[0].Children) != 2 {
+		t.Fatalf("Expected first with statement to have 2 items, got %d", len(withStmts[0].Children))
+	}
+	for i, wantName := range []string{"src", "dst"} {
+		item := withStmts[0].Children[i]
+		if item.Type != NodeWithItem {
+			t.Fatalf("With child %d type = %s, want %s", i, item.Type, NodeWithItem)
+		}
+		if item.Name != wantName {
+			t.Fatalf("With item %d alias = %q, want %q", i, item.Name, wantName)
+		}
+		value, ok := item.Value.(*Node)
+		if !ok {
+			t.Fatalf("With item %d value is %T, want *Node", i, item.Value)
+		}
+		if value.Type != NodeCall {
+			t.Fatalf("With item %d value type = %s, want %s", i, value.Type, NodeCall)
+		}
+	}
+
+	if len(withStmts[1].Children) != 1 {
+		t.Fatalf("Expected second with statement to have 1 item, got %d", len(withStmts[1].Children))
+	}
+	lockValue, ok := withStmts[1].Children[0].Value.(*Node)
+	if !ok {
+		t.Fatalf("Direct with item value is %T, want *Node", withStmts[1].Children[0].Value)
+	}
+	if lockValue.Type != NodeName || lockValue.Name != "lock" {
+		t.Fatalf("Direct with item value = %s(%s), want Name(lock)", lockValue.Type, lockValue.Name)
+	}
+
+	asyncWithStmts := result.AST.FindByType(NodeAsyncWith)
+	if len(asyncWithStmts) != 1 {
+		t.Fatalf("Expected 1 async with statement, got %d", len(asyncWithStmts))
+	}
+	if len(asyncWithStmts[0].Children) != 1 {
+		t.Fatalf("Expected async with statement to have 1 item, got %d", len(asyncWithStmts[0].Children))
+	}
+	asyncItem := asyncWithStmts[0].Children[0]
+	if asyncItem.Name != "ctx" {
+		t.Fatalf("Async with item alias = %q, want %q", asyncItem.Name, "ctx")
+	}
+	asyncValue, ok := asyncItem.Value.(*Node)
+	if !ok {
+		t.Fatalf("Async with item value is %T, want *Node", asyncItem.Value)
+	}
+	if asyncValue.Type != NodeName || asyncValue.Name != "resource" {
+		t.Fatalf("Async with item value = %s(%s), want Name(resource)", asyncValue.Type, asyncValue.Name)
+	}
+}
+
 func countStringConstants(node *Node, value string) int {
 	count := 0
 	node.WalkDeep(func(child *Node) bool {


### PR DESCRIPTION
## Summary
- Preserve each `with` / `async with` context expression in the parser's `WithItem` AST nodes.
- Add parser coverage for single, multiple, and async context-manager items.
- Add LCOM4 regression coverage for `self.<ivar>` accesses that appear only in context expressions.

## Root Cause
LCOM4 walks the internal AST and already includes `Value` nodes, but the parser was not storing the context expression from tree-sitter `with_item` nodes in `NodeWithItem.Value`. As a result, accesses such as `with open(self._fname) as f:` were absent from the LCOM4 method-variable graph.

## Validation
- `go test ./...`
- `make lint`

Fixes #412