### PR TITLE
Fix DFA extraction for with statement alias targets (Issue #420)

### DIFF
--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -532,10 +532,11 @@ func (b *DFABuilder) extractWithTargetDefs(stmt *parser.Node, block *BasicBlock,
 	// Look for WithItem children
 	for _, child := range stmt.Children {
 		if child != nil && child.Type == parser.NodeWithItem {
-			// The second child of WithItem is the optional target (as x)
-			if len(child.Children) > 1 && child.Children[1] != nil {
-				target := child.Children[1]
-				defs = append(defs, b.extractNamesFromTarget(target, DefKindWithTarget, block, stmt, pos)...)
+			// WithItem stores the alias in Name, not in Children[1]
+			// The parser populates node.Name with the alias from the "as" pattern
+			if child.Name != "" {
+				ref := NewVarReference(child.Name, DefKindWithTarget, block, stmt, pos)
+				defs = append(defs, ref)
 			}
 		}
 	}

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -296,6 +296,50 @@ z = y
 			assert.GreaterOrEqual(t, len(chainY.Defs), 1)
 		}
 	})
+
+	t.Run("Build_WithStatement_ExtractsAliasTarget", func(t *testing.T) {
+		source := `
+with open(path) as f:
+    data = f.read()
+`
+		cfg := buildCFGForDFA(t, source)
+		builder := NewDFABuilder()
+		info, err := builder.Build(cfg)
+
+		require.NoError(t, err)
+
+		// 'f' should be extracted as a DefKindWithTarget definition
+		chainF := info.Chains["f"]
+		require.NotNil(t, chainF, "'f' should be in variable chains")
+		assert.Len(t, chainF.Defs, 1)
+		assert.Equal(t, DefKindWithTarget, chainF.Defs[0].Kind)
+
+		// f is correctly extracted as DefKindWithTarget
+		// Note: uses in attribute access may not be linked due to base identifier recognition in extractUsesFromExpression
+	})
+
+	t.Run("Build_WithStatement_MultipleItems", func(t *testing.T) {
+		source := `
+with open(src) as inp, open(dst) as out:
+    out.write(inp.read())
+`
+		cfg := buildCFGForDFA(t, source)
+		builder := NewDFABuilder()
+		info, err := builder.Build(cfg)
+
+		require.NoError(t, err)
+
+		// Both 'inp' and 'out' should be extracted as DefKindWithTarget
+		chainInp := info.Chains["inp"]
+		require.NotNil(t, chainInp, "'inp' should be in variable chains")
+		assert.Len(t, chainInp.Defs, 1)
+		assert.Equal(t, DefKindWithTarget, chainInp.Defs[0].Kind)
+
+		chainOut := info.Chains["out"]
+		require.NotNil(t, chainOut, "'out' should be in variable chains")
+		assert.Len(t, chainOut.Defs, 1)
+		assert.Equal(t, DefKindWithTarget, chainOut.Defs[0].Kind)
+	})
 }
 
 func TestDFAFeatureComparison(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes issue #420: DFA builder incorrectly extracts with ... as alias targets.

### Root Cause
In dfa_builder.go, xtractWithTargetDefs was accessing child.Children[1] to get the alias name from with ... as x: statements. However, NodeWithItem actually stores the alias in child.Name, not child.Children[1] (confirmed via st_builder.go's populateWithItemFromAsPattern).

### Fix
Changed the extraction to use child.Name directly, matching how the parser actually stores the alias from the s pattern.

### Changes
- **dfa_builder.go**: Replaced child.Children[1] access with direct child.Name access
- **dfa_builder_test.go**: Added two test cases:
  - Build_WithStatement_ExtractsAliasTarget - single alias extraction
  - Build_WithStatement_MultipleItems - multiple with items extraction

### Testing
All 500+ tests pass. New tests verify that aliases from with statements are correctly extracted as DefKindWithTarget definitions.

---
Fixes #420