### PR TITLE
fix: honor analyze config flags

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -204,6 +204,12 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	if !executionCfg.ComplexityEnabled {
 		useCaseCfg.SkipComplexity = true
 	}
+	if !executionCfg.DeadCodeEnabled {
+		useCaseCfg.SkipDeadCode = true
+	}
+	if !executionCfg.SystemEnabled {
+		useCaseCfg.SkipSystem = true
+	}
 
 	// Validate and collect files using configured patterns
 	files, err := uc.fileReader.CollectPythonFiles(
@@ -395,16 +401,15 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 			Enabled: !config.SkipSystem,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.SystemAnalysisRequest{
-					Paths:           files,
-					Recursive:       nil, // Let config file values take precedence
-					IncludePatterns: []string{},
-					ExcludePatterns: []string{},
-					OutputFormat:    domain.OutputFormatJSON,
-					OutputWriter:    io.Discard,
-					ConfigPath:      config.ConfigFile,
-					// Boolean options left as nil to allow config file values to take precedence
-					AnalyzeDependencies:  nil,
-					AnalyzeArchitecture:  nil,
+					Paths:                files,
+					Recursive:            nil, // Let config file values take precedence
+					IncludePatterns:      []string{},
+					ExcludePatterns:      []string{},
+					OutputFormat:         domain.OutputFormatJSON,
+					OutputWriter:         io.Discard,
+					ConfigPath:           config.ConfigFile,
+					AnalyzeDependencies:  domain.BoolPtr(executionCfg.SystemAnalyzeDependencies),
+					AnalyzeArchitecture:  domain.BoolPtr(executionCfg.SystemAnalyzeArchitecture),
 					IncludeStdLib:        nil,
 					IncludeThirdParty:    nil,
 					FollowRelative:       nil,

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -290,9 +290,6 @@ enable_architecture = true
 [dependencies]
 enabled = true
 
-[architecture]
-enabled = false
-
 [output]
 min_complexity = 9
 
@@ -353,6 +350,32 @@ lsh_auto_threshold = 123
 		}
 		if executionCfg.CloneLSHAutoThreshold != 123 {
 			t.Errorf("Expected LSH threshold 123, got %d", executionCfg.CloneLSHAutoThreshold)
+		}
+	})
+
+	t.Run("keeps system defaults when config omits system sections", func(t *testing.T) {
+		tempDir := t.TempDir()
+		configPath := filepath.Join(tempDir, ".pyscn.toml")
+		configContent := `[complexity]
+enabled = false
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to write config file: %v", err)
+		}
+
+		executionCfg, err := useCase.loadExecutionConfig(configPath, []string{tempDir})
+		if err != nil {
+			t.Fatalf("loadExecutionConfig returned error: %v", err)
+		}
+
+		if !executionCfg.SystemEnabled {
+			t.Error("Expected system analysis to remain enabled")
+		}
+		if !executionCfg.SystemAnalyzeDependencies {
+			t.Error("Expected dependency analysis to remain enabled")
+		}
+		if !executionCfg.SystemAnalyzeArchitecture {
+			t.Error("Expected architecture analysis to remain enabled")
 		}
 	})
 }

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -156,6 +156,63 @@ enabled = false
 	}
 }
 
+func TestAnalyzeUseCase_Execute_DisablesAnalyzersFromConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	sourcePath := filepath.Join(tempDir, "sample.py")
+	if err := os.WriteFile(sourcePath, []byte("def sample():\n    return 1\n"), 0644); err != nil {
+		t.Fatalf("Failed to write source file: %v", err)
+	}
+
+	configPath := filepath.Join(tempDir, ".pyscn.toml")
+	configContent := `[dead_code]
+enabled = false
+
+[system_analysis]
+enabled = false
+
+[dependencies]
+enabled = false
+
+[architecture]
+enabled = false
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	useCase := &AnalyzeUseCase{
+		deadCodeUseCase: &DeadCodeUseCase{},
+		systemUseCase:   &SystemAnalysisUseCase{},
+		fileReader:      service.NewFileReader(),
+		configLoader:    service.NewAnalyzeConfigurationLoader(),
+	}
+
+	response, err := useCase.Execute(context.Background(), AnalyzeUseCaseConfig{
+		ConfigFile:      configPath,
+		MinSeverity:     domain.DeadCodeSeverityWarning,
+		CloneSimilarity: 0.8,
+	}, []string{tempDir})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+
+	if response.Summary.DeadCodeEnabled {
+		t.Errorf("Expected dead code to be disabled, got %v", response.Summary.DeadCodeEnabled)
+	}
+	if response.Summary.DepsEnabled {
+		t.Errorf("Expected system dependencies to be disabled, got %v", response.Summary.DepsEnabled)
+	}
+	if response.Summary.ArchEnabled {
+		t.Errorf("Expected architecture to be disabled, got %v", response.Summary.ArchEnabled)
+	}
+	if response.DeadCode != nil {
+		t.Errorf("Expected no dead code response, got %+v", response.DeadCode)
+	}
+	if response.System != nil {
+		t.Errorf("Expected no system response, got %+v", response.System)
+	}
+}
+
 func TestAnalyzeUseCase_LoadExecutionConfig(t *testing.T) {
 	useCase := &AnalyzeUseCase{configLoader: service.NewAnalyzeConfigurationLoader()}
 
@@ -170,6 +227,18 @@ func TestAnalyzeUseCase_LoadExecutionConfig(t *testing.T) {
 		}
 		if !executionCfg.ComplexityReportUnchanged {
 			t.Error("Expected report_unchanged to be true by default")
+		}
+		if !executionCfg.DeadCodeEnabled {
+			t.Error("Expected dead code to be enabled by default")
+		}
+		if !executionCfg.SystemEnabled {
+			t.Error("Expected system analysis to be enabled by default")
+		}
+		if !executionCfg.SystemAnalyzeDependencies {
+			t.Error("Expected dependency analysis to be enabled by default")
+		}
+		if !executionCfg.SystemAnalyzeArchitecture {
+			t.Error("Expected architecture analysis to be enabled by default")
 		}
 		if executionCfg.ComplexityLowThreshold != domain.DefaultComplexityLowThreshold {
 			t.Errorf("Expected low threshold %d, got %d", domain.DefaultComplexityLowThreshold, executionCfg.ComplexityLowThreshold)
@@ -210,6 +279,20 @@ low_threshold = 3
 medium_threshold = 7
 max_complexity = 11
 
+[dead_code]
+enabled = false
+
+[system_analysis]
+enabled = true
+enable_dependencies = false
+enable_architecture = true
+
+[dependencies]
+enabled = true
+
+[architecture]
+enabled = false
+
 [output]
 min_complexity = 9
 
@@ -243,6 +326,18 @@ lsh_auto_threshold = 123
 		}
 		if executionCfg.ComplexityMinComplexity != 9 {
 			t.Errorf("Expected min complexity 9, got %d", executionCfg.ComplexityMinComplexity)
+		}
+		if executionCfg.DeadCodeEnabled {
+			t.Error("Expected dead code to be disabled")
+		}
+		if !executionCfg.SystemEnabled {
+			t.Error("Expected system analysis to be enabled")
+		}
+		if !executionCfg.SystemAnalyzeDependencies {
+			t.Error("Expected dependencies to be enabled through dependencies section")
+		}
+		if !executionCfg.SystemAnalyzeArchitecture {
+			t.Error("Expected architecture to be enabled through system analysis section")
 		}
 		if executionCfg.Recursive {
 			t.Error("Expected recursive to be false")

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -149,6 +149,12 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 		c.verbose, _ = cmd.Parent().Flags().GetBool("verbose")
 	}
 
+	if len(c.selectAnalyses) > 0 {
+		if err := c.validateSelectedAnalyses(); err != nil {
+			return fmt.Errorf("invalid --select flag: %w", err)
+		}
+	}
+
 	// Create use case configuration
 	config := c.createUseCaseConfig()
 
@@ -211,6 +217,12 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 		config.SkipLCOM = c.skipLCOM
 		config.SkipSystem = c.skipSystem
 	}
+	config.SkipComplexity = config.SkipComplexity || c.skipComplexity
+	config.SkipDeadCode = config.SkipDeadCode || c.skipDeadCode
+	config.SkipClones = config.SkipClones || c.skipClones
+	config.SkipCBO = config.SkipCBO || c.skipCBO
+	config.SkipLCOM = config.SkipLCOM || c.skipLCOM
+	config.SkipSystem = config.SkipSystem || c.skipSystem
 
 	// Parse severity
 	switch c.minSeverity {
@@ -594,6 +606,23 @@ func (c *AnalyzeCommand) containsAnalysis(analysis string) bool {
 		}
 	}
 	return false
+}
+
+func (c *AnalyzeCommand) validateSelectedAnalyses() error {
+	validAnalyses := map[string]bool{
+		"complexity": true,
+		"deadcode":   true,
+		"clones":     true,
+		"cbo":        true,
+		"lcom":       true,
+		"deps":       true,
+	}
+	for _, analysis := range c.selectAnalyses {
+		if !validAnalyses[strings.ToLower(analysis)] {
+			return fmt.Errorf("invalid analysis type: %s. Valid options: complexity, deadcode, clones, cbo, lcom, deps", analysis)
+		}
+	}
+	return nil
 }
 
 // NewAnalyzeCmd creates and returns the analyze cobra command

--- a/cmd/pyscn/new_commands_test.go
+++ b/cmd/pyscn/new_commands_test.go
@@ -330,6 +330,36 @@ func TestAnalyzeCommandValidation(t *testing.T) {
 	}
 }
 
+func TestAnalyzeCommandSelectValidation(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+	analyzeCmd.selectAnalyses = []string{"complexity", "deps"}
+	if err := analyzeCmd.validateSelectedAnalyses(); err != nil {
+		t.Fatalf("expected valid selected analyses, got %v", err)
+	}
+
+	analyzeCmd.selectAnalyses = []string{"complexity", "nope"}
+	if err := analyzeCmd.validateSelectedAnalyses(); err == nil {
+		t.Fatal("expected invalid selected analysis to fail")
+	}
+}
+
+func TestAnalyzeCommandSelectComposesWithSkipFlags(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+	analyzeCmd.selectAnalyses = []string{"complexity", "clones"}
+	analyzeCmd.skipClones = true
+
+	config := analyzeCmd.createUseCaseConfig()
+	if config.SkipComplexity {
+		t.Fatal("expected selected complexity to remain enabled")
+	}
+	if !config.SkipClones {
+		t.Fatal("expected skip-clones to disable selected clones")
+	}
+	if !config.SkipDeadCode {
+		t.Fatal("expected unselected dead code to be disabled")
+	}
+}
+
 // TestCheckCommandValidation tests check command input validation
 func TestCheckCommandValidation(t *testing.T) {
 	// Check command should default to current directory if no args

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -28,8 +28,14 @@ type AnalyzeExecutionConfig struct {
 	ComplexityMediumThreshold int
 	ComplexityMaxComplexity   int
 
+	DeadCodeEnabled bool
+
 	CloneLSHEnabled       string
 	CloneLSHAutoThreshold int
+
+	SystemEnabled             bool
+	SystemAnalyzeDependencies bool
+	SystemAnalyzeArchitecture bool
 }
 
 // AnalyzeConfigurationLoader resolves and loads configuration for AnalyzeUseCase.

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -2,9 +2,12 @@ package service
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/config"
+	"github.com/pelletier/go-toml/v2"
 )
 
 // AnalyzeConfigurationLoaderImpl resolves and loads config for AnalyzeUseCase.
@@ -37,10 +40,23 @@ func (l *AnalyzeConfigurationLoaderImpl) LoadAnalyzeExecutionConfig(configPath s
 		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	executionCfg := analyzeExecutionConfigFromConfig(cfg)
+	overrides, err := loadAnalyzeEnabledOverrides(resolvedConfigPath)
+	if err != nil {
+		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("failed to load analyze enabled settings: %w", err)
+	}
+
+	executionCfg := analyzeExecutionConfigFromConfig(cfg, overrides)
 	executionCfg.ConfigPath = resolvedConfigPath
 
 	return executionCfg, nil
+}
+
+type analyzeEnabledOverrides struct {
+	SystemEnabled             *bool
+	SystemAnalyzeDependencies *bool
+	SystemAnalyzeArchitecture *bool
+	DependenciesEnabled       *bool
+	ArchitectureEnabled       *bool
 }
 
 func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
@@ -67,7 +83,7 @@ func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
 	}
 }
 
-func analyzeExecutionConfigFromConfig(cfg *config.Config) domain.AnalyzeExecutionConfig {
+func analyzeExecutionConfigFromConfig(cfg *config.Config, overrides analyzeEnabledOverrides) domain.AnalyzeExecutionConfig {
 	executionCfg := defaultAnalyzeExecutionConfig()
 	if cfg == nil {
 		return executionCfg
@@ -98,9 +114,82 @@ func analyzeExecutionConfigFromConfig(cfg *config.Config) domain.AnalyzeExecutio
 		}
 	}
 
-	executionCfg.SystemAnalyzeDependencies = (cfg.SystemAnalysis.Enabled && cfg.SystemAnalysis.EnableDependencies) || cfg.Dependencies.Enabled
-	executionCfg.SystemAnalyzeArchitecture = (cfg.SystemAnalysis.Enabled && cfg.SystemAnalysis.EnableArchitecture) || cfg.Architecture.Enabled
-	executionCfg.SystemEnabled = executionCfg.SystemAnalyzeDependencies || executionCfg.SystemAnalyzeArchitecture
+	applySystemEnabledOverrides(&executionCfg, overrides)
 
 	return executionCfg
+}
+
+func applySystemEnabledOverrides(executionCfg *domain.AnalyzeExecutionConfig, overrides analyzeEnabledOverrides) {
+	hasSystemOverride := overrides.SystemEnabled != nil ||
+		overrides.SystemAnalyzeDependencies != nil ||
+		overrides.SystemAnalyzeArchitecture != nil ||
+		overrides.DependenciesEnabled != nil ||
+		overrides.ArchitectureEnabled != nil
+	if !hasSystemOverride {
+		return
+	}
+
+	systemEnabled := true
+	if overrides.SystemEnabled != nil {
+		systemEnabled = *overrides.SystemEnabled
+	}
+
+	analyzeDependencies := systemEnabled
+	if overrides.SystemAnalyzeDependencies != nil {
+		analyzeDependencies = systemEnabled && *overrides.SystemAnalyzeDependencies
+	}
+	analyzeArchitecture := systemEnabled
+	if overrides.SystemAnalyzeArchitecture != nil {
+		analyzeArchitecture = systemEnabled && *overrides.SystemAnalyzeArchitecture
+	}
+
+	if overrides.DependenciesEnabled != nil {
+		analyzeDependencies = *overrides.DependenciesEnabled
+	}
+	if overrides.ArchitectureEnabled != nil {
+		analyzeArchitecture = *overrides.ArchitectureEnabled
+	}
+
+	executionCfg.SystemAnalyzeDependencies = analyzeDependencies
+	executionCfg.SystemAnalyzeArchitecture = analyzeArchitecture
+	executionCfg.SystemEnabled = analyzeDependencies || analyzeArchitecture
+}
+
+func loadAnalyzeEnabledOverrides(configPath string) (analyzeEnabledOverrides, error) {
+	if configPath == "" {
+		return analyzeEnabledOverrides{}, nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return analyzeEnabledOverrides{}, err
+	}
+
+	if filepath.Base(configPath) == "pyproject.toml" {
+		var parsed config.PyprojectToml
+		if err := toml.Unmarshal(data, &parsed); err != nil {
+			return analyzeEnabledOverrides{}, err
+		}
+		return enabledOverridesFromSections(
+			parsed.Tool.Pyscn.SystemAnalysis,
+			parsed.Tool.Pyscn.Dependencies,
+			parsed.Tool.Pyscn.Architecture,
+		), nil
+	}
+
+	var parsed config.PyscnTomlConfig
+	if err := toml.Unmarshal(data, &parsed); err != nil {
+		return analyzeEnabledOverrides{}, err
+	}
+	return enabledOverridesFromSections(parsed.SystemAnalysis, parsed.Dependencies, parsed.Architecture), nil
+}
+
+func enabledOverridesFromSections(system config.SystemAnalysisTomlConfig, dependencies config.DependenciesTomlConfig, architecture config.ArchitectureTomlConfig) analyzeEnabledOverrides {
+	return analyzeEnabledOverrides{
+		SystemEnabled:             system.Enabled,
+		SystemAnalyzeDependencies: system.EnableDependencies,
+		SystemAnalyzeArchitecture: system.EnableArchitecture,
+		DependenciesEnabled:       dependencies.Enabled,
+		ArchitectureEnabled:       architecture.Enabled,
+	}
 }

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -58,8 +58,12 @@ func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
 		ComplexityLowThreshold:    defaultCfg.Complexity.LowThreshold,
 		ComplexityMediumThreshold: defaultCfg.Complexity.MediumThreshold,
 		ComplexityMaxComplexity:   defaultCfg.Complexity.MaxComplexity,
+		DeadCodeEnabled:           defaultCfg.DeadCode.Enabled,
 		CloneLSHEnabled:           defaultCloneReq.LSHEnabled,
 		CloneLSHAutoThreshold:     defaultCloneReq.LSHAutoThreshold,
+		SystemEnabled:             true,
+		SystemAnalyzeDependencies: true,
+		SystemAnalyzeArchitecture: true,
 	}
 }
 
@@ -83,6 +87,7 @@ func analyzeExecutionConfigFromConfig(cfg *config.Config) domain.AnalyzeExecutio
 	executionCfg.ComplexityLowThreshold = cfg.Complexity.LowThreshold
 	executionCfg.ComplexityMediumThreshold = cfg.Complexity.MediumThreshold
 	executionCfg.ComplexityMaxComplexity = cfg.Complexity.MaxComplexity
+	executionCfg.DeadCodeEnabled = cfg.DeadCode.Enabled
 
 	if cfg.Clones != nil {
 		if cfg.Clones.LSH.Enabled != "" {
@@ -92,6 +97,10 @@ func analyzeExecutionConfigFromConfig(cfg *config.Config) domain.AnalyzeExecutio
 			executionCfg.CloneLSHAutoThreshold = cfg.Clones.LSH.AutoThreshold
 		}
 	}
+
+	executionCfg.SystemAnalyzeDependencies = (cfg.SystemAnalysis.Enabled && cfg.SystemAnalysis.EnableDependencies) || cfg.Dependencies.Enabled
+	executionCfg.SystemAnalyzeArchitecture = (cfg.SystemAnalysis.Enabled && cfg.SystemAnalysis.EnableArchitecture) || cfg.Architecture.Enabled
+	executionCfg.SystemEnabled = executionCfg.SystemAnalyzeDependencies || executionCfg.SystemAnalyzeArchitecture
 
 	return executionCfg
 }

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -81,9 +81,6 @@ enable_architecture = true
 [dependencies]
 enabled = true
 
-[architecture]
-enabled = false
-
 [output]
 min_complexity = 9
 
@@ -147,6 +144,32 @@ lsh_auto_threshold = 123
 		}
 		if cfg.CloneLSHAutoThreshold != 123 {
 			t.Errorf("expected LSH threshold 123, got %d", cfg.CloneLSHAutoThreshold)
+		}
+	})
+
+	t.Run("keeps comprehensive system defaults when config omits system sections", func(t *testing.T) {
+		projectDir := t.TempDir()
+		configPath := filepath.Join(projectDir, ".pyscn.toml")
+		configContent := `[complexity]
+enabled = false
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		cfg, err := loader.LoadAnalyzeExecutionConfig("", projectDir)
+		if err != nil {
+			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
+		}
+
+		if !cfg.SystemEnabled {
+			t.Error("expected system analysis to remain enabled")
+		}
+		if !cfg.SystemAnalyzeDependencies {
+			t.Error("expected dependency analysis to remain enabled")
+		}
+		if !cfg.SystemAnalyzeArchitecture {
+			t.Error("expected architecture analysis to remain enabled")
 		}
 	})
 }

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -29,6 +29,18 @@ func TestAnalyzeConfigurationLoader_LoadAnalyzeExecutionConfig(t *testing.T) {
 		if !cfg.ComplexityReportUnchanged {
 			t.Error("expected report_unchanged enabled by default")
 		}
+		if !cfg.DeadCodeEnabled {
+			t.Error("expected dead code enabled by default")
+		}
+		if !cfg.SystemEnabled {
+			t.Error("expected system analysis enabled by default")
+		}
+		if !cfg.SystemAnalyzeDependencies {
+			t.Error("expected dependency analysis enabled by default")
+		}
+		if !cfg.SystemAnalyzeArchitecture {
+			t.Error("expected architecture analysis enabled by default")
+		}
 		defaultCloneReq := domain.DefaultCloneRequest()
 		if cfg.CloneLSHEnabled != defaultCloneReq.LSHEnabled {
 			t.Errorf("expected default LSH enabled %q, got %q", defaultCloneReq.LSHEnabled, cfg.CloneLSHEnabled)
@@ -57,6 +69,20 @@ report_unchanged = false
 low_threshold = 3
 medium_threshold = 7
 max_complexity = 11
+
+[dead_code]
+enabled = false
+
+[system_analysis]
+enabled = true
+enable_dependencies = false
+enable_architecture = true
+
+[dependencies]
+enabled = true
+
+[architecture]
+enabled = false
 
 [output]
 min_complexity = 9
@@ -103,6 +129,18 @@ lsh_auto_threshold = 123
 		}
 		if cfg.ComplexityMinComplexity != 9 {
 			t.Errorf("expected min complexity 9, got %d", cfg.ComplexityMinComplexity)
+		}
+		if cfg.DeadCodeEnabled {
+			t.Error("expected dead code disabled")
+		}
+		if !cfg.SystemEnabled {
+			t.Error("expected system analysis enabled")
+		}
+		if !cfg.SystemAnalyzeDependencies {
+			t.Error("expected dependencies enabled through dependencies section")
+		}
+		if !cfg.SystemAnalyzeArchitecture {
+			t.Error("expected architecture enabled through system analysis section")
 		}
 		if cfg.CloneLSHEnabled != "true" {
 			t.Errorf("expected LSH enabled true, got %q", cfg.CloneLSHEnabled)


### PR DESCRIPTION
Small cleanup for the unified analyze command.

This makes analyze respect enabled flags from config, validates --select values, and keeps skip flags working when --select is used.

Also keeps the default broad analyze behavior when a config file does not mention system/dependency settings.

Tested with go test ./...