### PR TITLE
fix: avoid resolving stdlib imports to shadowing project modules

### DIFF
--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -447,7 +447,7 @@ func (ma *ModuleAnalyzer) resolveAbsoluteImportWithProject(imp *ImportInfo, from
 		if moduleFile := modulePath + ".py"; ma.fileExists(moduleFile) {
 			// Calculate the module name based on project structure
 			resolvedName := ma.filePathToModuleName(moduleFile)
-			if resolvedName != "" {
+			if ma.importMatchesResolvedModule(moduleName, resolvedName) {
 				ma.resolvedModules[moduleName] = resolvedName
 				return resolvedName
 			}
@@ -459,14 +459,33 @@ func (ma *ModuleAnalyzer) resolveAbsoluteImportWithProject(imp *ImportInfo, from
 			if resolvedName != "" {
 				// For __init__.py files, use the package name (without __init__)
 				resolvedName = strings.TrimSuffix(resolvedName, ".__init__")
-				ma.resolvedModules[moduleName] = resolvedName
-				return resolvedName
+				if ma.importMatchesResolvedModule(moduleName, resolvedName) {
+					ma.resolvedModules[moduleName] = resolvedName
+					return resolvedName
+				}
 			}
 		}
 	}
 
 	// Fall back to the original resolveAbsoluteImport logic
 	return ma.resolveAbsoluteImport(imp)
+}
+
+// importMatchesResolvedModule verifies that an absolute import maps by
+// qualified module path, while still supporting script-style local imports for
+// non-stdlib modules. Bare stdlib imports must not bind to same-basename
+// project modules discovered under the current file's directory.
+func (ma *ModuleAnalyzer) importMatchesResolvedModule(importName, resolvedName string) bool {
+	if importName == "" || resolvedName == "" {
+		return false
+	}
+	if resolvedName == importName {
+		return true
+	}
+	if !strings.Contains(importName, ".") {
+		return !ma.isStandardLibrary(importName) && strings.HasSuffix(resolvedName, "."+importName)
+	}
+	return strings.HasSuffix(resolvedName, "."+importName)
 }
 
 // moduleNameFromImport normalizes the module name from an import statement
@@ -782,6 +801,7 @@ func (ma *ModuleAnalyzer) isStandardLibrary(moduleName string) bool {
 		"urllib": true, "http": true, "typing": true, "abc": true, "asyncio": true,
 		"contextlib": true, "dataclasses": true, "enum": true, "pickle": true,
 		"sqlite3": true, "csv": true, "xml": true, "html": true, "email": true,
+		"time": true, "socket": true, "subprocess": true, "multiprocessing": true,
 	}
 
 	// Check direct match

--- a/internal/analyzer/module_analyzer_import_test.go
+++ b/internal/analyzer/module_analyzer_import_test.go
@@ -134,3 +134,50 @@ func TestModuleAnalyzerResolvesImportWithAlias(t *testing.T) {
 		t.Fatalf("expected dependency from %s to %s, got %v", fromModule, toModule, node.Dependencies)
 	}
 }
+
+func TestModuleAnalyzerDoesNotResolveStdlibImportToShadowingProjectModule(t *testing.T) {
+	dir := t.TempDir()
+
+	shadowModule := filepath.Join(dir, "src", "mypkg", "time.py")
+	samePackageUser := filepath.Join(dir, "src", "mypkg", "widget.py")
+	otherPackageUser := filepath.Join(dir, "utils", "serve.py")
+
+	for _, path := range []string{shadowModule, samePackageUser, otherPackageUser} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(shadowModule, []byte(`"""Project-local time picker module."""`), 0o644); err != nil {
+		t.Fatalf("failed to write shadow module: %v", err)
+	}
+	// Python 3 absolute imports should treat this as stdlib time, not
+	// src.mypkg.time, even though a same-basename project module exists.
+	if err := os.WriteFile(samePackageUser, []byte("import time\n"), 0o644); err != nil {
+		t.Fatalf("failed to write same-package user: %v", err)
+	}
+	if err := os.WriteFile(otherPackageUser, []byte("import time\n"), 0o644); err != nil {
+		t.Fatalf("failed to write other-package user: %v", err)
+	}
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{ProjectRoot: dir})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	graph, err := analyzer.AnalyzeFiles([]string{samePackageUser, shadowModule, otherPackageUser})
+	if err != nil {
+		t.Fatalf("AnalyzeFiles failed: %v", err)
+	}
+
+	shadowName := analyzer.filePathToModuleName(shadowModule)
+	for _, path := range []string{samePackageUser, otherPackageUser} {
+		moduleName := analyzer.filePathToModuleName(path)
+		node := graph.Nodes[moduleName]
+		if node == nil {
+			t.Fatalf("expected module %s in graph", moduleName)
+		}
+		if node.Dependencies[shadowName] {
+			t.Fatalf("did not expect %s to depend on stdlib-shadowing module %s; dependencies: %v", moduleName, shadowName, node.Dependencies)
+		}
+	}
+}

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -102,6 +102,44 @@ class Dependency:
 	assert.InDelta(t, 0.0, response.ModuleMetrics[balancedService].Distance, 0.01)
 }
 
+func TestAnalyzeArchitectureDoesNotReportStdlibShadowImport(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"pyproject.toml":      "[project]\nname = \"stdlib-shadow-repro\"\n",
+		"src/mypkg/time.py":   `"""Project-local time picker module."""`,
+		"src/mypkg/widget.py": "import time\n",
+		"utils/serve.py":      "import time\nprint(time.time())\n",
+	}
+
+	var paths []string
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", name, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+		if strings.HasSuffix(name, ".py") {
+			paths = append(paths, path)
+		}
+	}
+
+	service := NewSystemAnalysisService()
+	response, err := service.AnalyzeArchitecture(context.Background(), domain.SystemAnalysisRequest{
+		Paths:             paths,
+		IncludeThirdParty: domain.BoolPtr(false),
+		ArchitectureRules: &domain.ArchitectureRules{
+			Layers: []domain.Layer{
+				{Name: "tools", Packages: []string{"utils"}},
+			},
+			StrictMode: true,
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, response.Violations)
+}
+
 func moduleWithSuffix(t *testing.T, modules map[string]*domain.ModuleDependencyMetrics, suffix string) string {
 	t.Helper()
 	for module := range modules {


### PR DESCRIPTION
## Summary
- Bare absolute imports (e.g. `import time`) no longer bind to same-basename project modules discovered under the importing file's directory.
- New helper `importMatchesResolvedModule` verifies the candidate resolution matches the qualified import path; well-known stdlib basenames are never shadowed.

Closes #423
