### PR TITLE
fix(dfa): structurally model with-statement aliases (issue #428)

### DIFF
--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -226,6 +226,7 @@ func orderedASTChildren(node *parser.Node, skipBodyNode func(parent, bodyNode *p
 	appendNode(node.Iter)
 	appendNode(node.Left)
 	appendNode(node.Right)
+	appendNode(node.Target)
 	appendValueNode(node.Value)
 	appendNodes(node.Keywords)
 	for i, bodyNode := range node.Body {
@@ -259,6 +260,9 @@ func astChildCapacity(node *parser.Node) int {
 		capacity++
 	}
 	if node.Right != nil {
+		capacity++
+	}
+	if node.Target != nil {
 		capacity++
 	}
 	if _, ok := node.Value.(*parser.Node); ok {

--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -1,8 +1,6 @@
 package analyzer
 
 import (
-	"strings"
-
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
@@ -533,14 +531,14 @@ func (b *DFABuilder) extractWithTargetDefs(stmt *parser.Node, block *BasicBlock,
 
 	// Look for WithItem children
 	for _, child := range stmt.Children {
-		if child != nil && child.Type == parser.NodeWithItem {
-			// WithItem stores the alias in Name, not in Children[1]
-			// The parser populates node.Name with the alias from the "as" pattern
-			// Skip non-identifier names (e.g., tuple unpacking like `(a, b)`)
-			if child.Name != "" && !strings.ContainsAny(child.Name, "(),[]*") {
-				ref := NewVarReference(child.Name, DefKindWithTarget, block, stmt, pos)
-				defs = append(defs, ref)
-			}
+		if child == nil || child.Type != parser.NodeWithItem {
+			continue
+		}
+		if child.Target != nil {
+			defs = append(defs, b.extractNamesFromTarget(child.Target, DefKindWithTarget, block, stmt, pos)...)
+		} else if child.Name != "" {
+			ref := NewVarReference(child.Name, DefKindWithTarget, block, stmt, pos)
+			defs = append(defs, ref)
 		}
 	}
 
@@ -602,12 +600,21 @@ func (b *DFABuilder) extractNamesFromTarget(target *parser.Node, kind DefUseKind
 		}
 
 	default:
-		// Handle pattern_list and other tree-sitter specific types
-		// pattern_list is used for tuple unpacking like: a, b = 1, 2
-		if string(target.Type) == "pattern_list" {
+		// Handle tree-sitter pattern node types that buildNode falls through as generic nodes:
+		//   - pattern_list:        a, b = 1, 2
+		//   - tuple_pattern:       with cm() as (a, b):
+		//   - list_pattern:        with cm() as [a, b]:
+		//   - list_splat_pattern:  *rest inside the above patterns
+		switch string(target.Type) {
+		case "pattern_list", "tuple_pattern", "list_pattern":
 			for _, elem := range target.Children {
-				// Skip comma separators
 				if elem != nil && elem.Type != "," && string(elem.Type) != "," {
+					defs = append(defs, b.extractNamesFromTarget(elem, kind, block, stmt, pos)...)
+				}
+			}
+		case "list_splat_pattern", "list_splat":
+			for _, elem := range target.Children {
+				if elem != nil && elem.Type != "*" && string(elem.Type) != "*" {
 					defs = append(defs, b.extractNamesFromTarget(elem, kind, block, stmt, pos)...)
 				}
 			}

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -341,6 +341,66 @@ with open(src) as inp, open(dst) as out:
 		assert.Len(t, chainOut.Defs, 1)
 		assert.Equal(t, DefKindWithTarget, chainOut.Defs[0].Kind)
 	})
+
+	t.Run("Build_AsyncWithStatement_ExtractsAliasTarget", func(t *testing.T) {
+		source := `
+async def fetch(session, url):
+    async with session.get(url) as response:
+        return response
+`
+		ast := parseSourceForDFA(t, source)
+		cfgs, err := NewCFGBuilder().BuildAll(ast)
+		require.NoError(t, err)
+
+		cfg, ok := cfgs["fetch"]
+		require.True(t, ok, "expected CFG for async function 'fetch'")
+
+		info, err := NewDFABuilder().Build(cfg)
+		require.NoError(t, err)
+
+		chainResponse := info.Chains["response"]
+		require.NotNil(t, chainResponse, "'response' should be in variable chains")
+		assert.Len(t, chainResponse.Defs, 1)
+		assert.Equal(t, DefKindWithTarget, chainResponse.Defs[0].Kind)
+	})
+
+	t.Run("Build_WithStatement_TupleAliasUnpacks", func(t *testing.T) {
+		source := `
+with cm() as (a, b):
+    use(a, b)
+`
+		cfg := buildCFGForDFA(t, source)
+		builder := NewDFABuilder()
+		info, err := builder.Build(cfg)
+
+		require.NoError(t, err)
+
+		for _, name := range []string{"a", "b"} {
+			chain := info.Chains[name]
+			require.NotNil(t, chain, "%q should be in variable chains", name)
+			assert.Len(t, chain.Defs, 1)
+			assert.Equal(t, DefKindWithTarget, chain.Defs[0].Kind)
+		}
+	})
+
+	t.Run("Build_WithStatement_ListAliasWithStarredUnpacks", func(t *testing.T) {
+		source := `
+with cm() as [a, *rest]:
+    use(a, rest)
+`
+		cfg := buildCFGForDFA(t, source)
+		builder := NewDFABuilder()
+		info, err := builder.Build(cfg)
+
+		require.NoError(t, err)
+
+		for _, name := range []string{"a", "rest"} {
+			chain := info.Chains[name]
+			require.NotNil(t, chain, "%q should be in variable chains", name)
+			assert.Len(t, chain.Defs, 1)
+			assert.Equal(t, DefKindWithTarget, chain.Defs[0].Kind)
+		}
+	})
 }
 
 func TestDFAFeatureComparison(t *testing.T) {

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -120,6 +120,7 @@ type Node struct {
 
 	// Additional fields for specific node types
 	Name      string   // For function/class definitions, variables
+	Target    *Node    // For with-item `as` alias (may be a name, tuple, list, or starred pattern)
 	Targets   []*Node  // For assignments
 	Body      []*Node  // For compound statements
 	Orelse    []*Node  // For if/for/while/try statements
@@ -188,6 +189,9 @@ func (n *Node) GetChildren() []*Node {
 	}
 	if n.Right != nil {
 		allChildren = append(allChildren, n.Right)
+	}
+	if n.Target != nil {
+		allChildren = append(allChildren, n.Target)
 	}
 
 	allChildren = append(allChildren, n.Targets...)
@@ -288,6 +292,9 @@ func (n *Node) WalkDeep(visitor func(*Node) bool) {
 	}
 	if n.Right != nil {
 		n.Right.WalkDeep(visitor)
+	}
+	if n.Target != nil {
+		n.Target.WalkDeep(visitor)
 	}
 
 	walkNodeList(n.Targets, visitor)
@@ -418,6 +425,11 @@ func (n *Node) Copy() *Node {
 	if n.Right != nil {
 		copied.Right = n.Right.Copy()
 		copied.Right.Parent = copied
+	}
+
+	if n.Target != nil {
+		copied.Target = n.Target.Copy()
+		copied.Target.Parent = copied
 	}
 
 	for _, node := range n.Targets {

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -1862,7 +1862,30 @@ func (b *ASTBuilder) populateWithItemFromAsPattern(node *Node, tsNode *sitter.No
 	}
 
 	if alias := b.getChildByFieldName(tsNode, "alias"); alias != nil {
-		node.Name = b.getNodeText(alias)
+		// tree-sitter-python wraps the actual target in an `as_pattern_target` node;
+		// unwrap it so we build the inner identifier/tuple/list directly.
+		aliasTarget := alias
+		if alias.Type() == "as_pattern_target" {
+			for i := 0; i < int(alias.ChildCount()); i++ {
+				child := alias.Child(i)
+				if child == nil || b.isTrivia(child) || !child.IsNamed() {
+					continue
+				}
+				aliasTarget = child
+				break
+			}
+		}
+		if target := b.buildNode(aliasTarget); target != nil {
+			// Simple identifier aliases live in Name (apted/label fast path, generic
+			// traversal already covers them via the WithItem label). Compound aliases
+			// (tuple/list/starred) live in Target so generic AST traversal can reach
+			// the contained names instead of dropping them as a flattened string.
+			if target.Type == NodeName {
+				node.Name = target.Name
+			} else {
+				node.Target = target
+			}
+		}
 	}
 	return node
 }

--- a/internal/parser/ast_test.go
+++ b/internal/parser/ast_test.go
@@ -555,6 +555,92 @@ async def async_acquire(resource):
 	}
 }
 
+func TestASTBuilderWithItemTargetField(t *testing.T) {
+	source := `
+def unpack(cm):
+    with cm() as f:
+        pass
+    with cm() as (a, b):
+        pass
+    with cm() as [c, *rest]:
+        pass
+`
+
+	result, err := New().Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	withStmts := result.AST.FindByType(NodeWith)
+	if len(withStmts) != 3 {
+		t.Fatalf("Expected 3 with statements, got %d", len(withStmts))
+	}
+
+	// 1) simple identifier alias → Name is populated, Target stays nil
+	// (the alias is already represented by Name and the apted label; setting Target
+	// would duplicate it in generic AST traversal and inflate clone fingerprints).
+	itemSimple := withStmts[0].Children[0]
+	if itemSimple.Name != "f" {
+		t.Fatalf("Simple alias Name = %q, want %q", itemSimple.Name, "f")
+	}
+	if itemSimple.Target != nil {
+		t.Fatalf("Simple alias should not populate Target, got %s(%s)", itemSimple.Target.Type, itemSimple.Target.Name)
+	}
+
+	// 2) tuple alias → Target is a Tuple node containing two Name children
+	itemTuple := withStmts[1].Children[0]
+	if itemTuple.Target == nil {
+		t.Fatalf("Expected Target on tuple alias")
+	}
+	if itemTuple.Target.Type != NodeTuple {
+		t.Fatalf("Tuple alias Target type = %s, want %s", itemTuple.Target.Type, NodeTuple)
+	}
+	tupleNames := collectNameLeaves(itemTuple.Target)
+	if got, want := tupleNames, []string{"a", "b"}; !equalStringSlices(got, want) {
+		t.Fatalf("Tuple alias names = %v, want %v", got, want)
+	}
+	// Name should NOT be populated for compound aliases — that was the silent-drop case.
+	if itemTuple.Name != "" {
+		t.Fatalf("Compound alias should not populate Name, got %q", itemTuple.Name)
+	}
+
+	// 3) list alias with starred → Target is a List node; *rest is captured
+	itemList := withStmts[2].Children[0]
+	if itemList.Target == nil {
+		t.Fatalf("Expected Target on list alias")
+	}
+	if itemList.Target.Type != NodeList {
+		t.Fatalf("List alias Target type = %s, want %s", itemList.Target.Type, NodeList)
+	}
+	listNames := collectNameLeaves(itemList.Target)
+	if got, want := listNames, []string{"c", "rest"}; !equalStringSlices(got, want) {
+		t.Fatalf("List alias names = %v, want %v", got, want)
+	}
+}
+
+func collectNameLeaves(n *Node) []string {
+	var out []string
+	n.WalkDeep(func(child *Node) bool {
+		if child.Type == NodeName {
+			out = append(out, child.Name)
+		}
+		return true
+	})
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func countStringConstants(node *Node, value string) int {
 	count := 0
 	node.WalkDeep(func(child *Node) bool {


### PR DESCRIPTION
## Summary

Closes the three follow-ups from #428 (DFA `with ... as` alias handling, after #424 / #420):

- **Compound alias targets are no longer dropped.** `populateWithItemFromAsPattern` now unwraps the tree-sitter `as_pattern_target` wrapper and builds the alias as a `*Node` into a new `Target` field on `NodeWithItem`, so `with cm() as (a, b):` and `with cm() as [a, *rest]:` keep their structure instead of being flattened to a string.
- **`extractWithTargetDefs` consumes the structured target** via `extractNamesFromTarget`, emitting DFA definitions for every contained name. The `strings.ContainsAny` text filter and the `strings` import are gone.
- **Generic AST traversal sees the new target.** `GetChildren`, `WalkDeep`, `Copy`, and the APTED tree converter (`orderedASTChildren` / `astChildCapacity`) all visit/copy `Target`, so consumers other than the DFA path (clone detection, generic walks, deep copies) reach the contained names too.

To preserve clone-detection fingerprints for the common simple-alias case, `Name` and `Target` are mutually exclusive:
- simple identifier alias (`with X as y:`) → `Name = "y"`, `Target = nil` (unchanged tree shape; apted label stays `WithItem(y)`).
- compound alias (tuple / list / starred) → `Name = ""`, `Target = Tuple|List|...` (previously silently dropped, now reachable).

DFA falls back to `Name` when `Target` is nil so simple aliases still produce a `DefKindWithTarget`.


Closes #428.