### PR TITLE
fix: drop strict-subset members from clone groups (#416)

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -1070,7 +1070,7 @@ func (cd *CloneDetector) groupClonesWithStrategy(strategy GroupingStrategy) {
 		cd.cloneGroups = []*CloneGroup{}
 		return
 	}
-	cd.cloneGroups = strategy.GroupClones(cd.clonePairs)
+	cd.cloneGroups = dedupeStrictSubsetGroupMembers(strategy.GroupClones(cd.clonePairs))
 }
 
 // isSameLocation checks if two locations refer to the same code

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -1070,7 +1070,9 @@ func (cd *CloneDetector) groupClonesWithStrategy(strategy GroupingStrategy) {
 		cd.cloneGroups = []*CloneGroup{}
 		return
 	}
-	cd.cloneGroups = dedupeStrictSubsetGroupMembers(strategy.GroupClones(cd.clonePairs))
+	dedupeResult := dedupeStrictSubsetGroupMembers(strategy.GroupClones(cd.clonePairs), cd.clonePairs)
+	cd.cloneGroups = dedupeResult.groups
+	cd.clonePairs = filterClonePairsWithSuppressedMembers(cd.clonePairs, dedupeResult.suppressed)
 }
 
 // isSameLocation checks if two locations refer to the same code

--- a/internal/analyzer/group_dedup.go
+++ b/internal/analyzer/group_dedup.go
@@ -1,5 +1,12 @@
 package analyzer
 
+import "sort"
+
+type groupDedupeResult struct {
+	groups     []*CloneGroup
+	suppressed map[*CodeFragment]struct{}
+}
+
 // dedupeStrictSubsetGroupMembers removes clone-group members whose source
 // range is a strict subset of (or identical to) another member's range in the
 // same file. Groups reduced to fewer than two members are dropped.
@@ -15,34 +22,60 @@ package analyzer
 //
 // For exactly-equal ranges (which UF can produce in the same way), the first
 // occurrence is kept; later duplicates are suppressed for deterministic output.
-func dedupeStrictSubsetGroupMembers(groups []*CloneGroup) []*CloneGroup {
-	if len(groups) == 0 {
-		return groups
+func dedupeStrictSubsetGroupMembers(groups []*CloneGroup, pairs []*ClonePair) groupDedupeResult {
+	result := groupDedupeResult{
+		groups:     groups,
+		suppressed: make(map[*CodeFragment]struct{}),
 	}
+	if len(groups) == 0 {
+		return result
+	}
+
 	out := make([]*CloneGroup, 0, len(groups))
+	var similarities map[string]float64
+	var cloneTypes map[string]CloneType
+	metadataReady := false
+	anyChanged := false
 	for _, g := range groups {
 		if g == nil {
 			continue
 		}
-		kept := filterMaximalPerFile(g.Fragments)
+		kept, suppressed := filterMaximalPerFile(g.Fragments)
+		for fragment := range suppressed {
+			result.suppressed[fragment] = struct{}{}
+		}
+		groupChanged := len(suppressed) > 0
+		anyChanged = anyChanged || groupChanged
 		if len(kept) < 2 {
 			continue
 		}
 		g.Fragments = kept
 		g.Size = len(kept)
+		if groupChanged {
+			if !metadataReady {
+				similarities, cloneTypes = clonePairMetadata(pairs)
+				metadataReady = true
+			}
+			refreshGroupMetadata(g, similarities, cloneTypes)
+		}
 		out = append(out, g)
 	}
-	return out
+	if anyChanged {
+		sortCloneGroups(out)
+	}
+	result.groups = out
+	return result
 }
 
 // filterMaximalPerFile returns the subset of fragments that are maximal under
 // the same-file containment order. A fragment is suppressed if any other
 // kept fragment in the same file strictly covers it, or if it duplicates an
 // earlier fragment's range exactly.
-func filterMaximalPerFile(frags []*CodeFragment) []*CodeFragment {
+func filterMaximalPerFile(frags []*CodeFragment) ([]*CodeFragment, map[*CodeFragment]struct{}) {
+	suppressedFragments := make(map[*CodeFragment]struct{})
 	n := len(frags)
 	if n <= 1 {
-		return frags
+		return frags, suppressedFragments
 	}
 	suppressed := make([]bool, n)
 	for i := 0; i < n; i++ {
@@ -60,11 +93,15 @@ func filterMaximalPerFile(frags []*CodeFragment) []*CodeFragment {
 	}
 	out := make([]*CodeFragment, 0, n)
 	for i, f := range frags {
-		if !suppressed[i] {
-			out = append(out, f)
+		if suppressed[i] {
+			if f != nil {
+				suppressedFragments[f] = struct{}{}
+			}
+			continue
 		}
+		out = append(out, f)
 	}
-	return out
+	return out, suppressedFragments
 }
 
 // covers reports whether outer (at index iOuter) covers inner (at index
@@ -81,4 +118,60 @@ func covers(outer, inner *CodeLocation, iOuter, iInner int) bool {
 		return iOuter < iInner
 	}
 	return true
+}
+
+func clonePairMetadata(pairs []*ClonePair) (map[string]float64, map[string]CloneType) {
+	similarities := make(map[string]float64, len(pairs))
+	cloneTypes := make(map[string]CloneType, len(pairs))
+	for _, pair := range pairs {
+		if pair == nil || pair.Fragment1 == nil || pair.Fragment2 == nil {
+			continue
+		}
+		key := pairKey(pair.Fragment1, pair.Fragment2)
+		if old, ok := similarities[key]; !ok || pair.Similarity > old {
+			similarities[key] = pair.Similarity
+			cloneTypes[key] = pair.CloneType
+		}
+	}
+	return similarities, cloneTypes
+}
+
+func refreshGroupMetadata(group *CloneGroup, similarities map[string]float64, cloneTypes map[string]CloneType) {
+	group.Similarity = averageGroupSimilarity(similarities, group.Fragments)
+	group.CloneType = majorityCloneType(cloneTypes, group.Fragments)
+}
+
+func filterClonePairsWithSuppressedMembers(pairs []*ClonePair, suppressed map[*CodeFragment]struct{}) []*ClonePair {
+	if len(pairs) == 0 || len(suppressed) == 0 {
+		return pairs
+	}
+	out := make([]*ClonePair, 0, len(pairs))
+	for _, pair := range pairs {
+		if pair == nil {
+			continue
+		}
+		if _, ok := suppressed[pair.Fragment1]; ok {
+			continue
+		}
+		if _, ok := suppressed[pair.Fragment2]; ok {
+			continue
+		}
+		out = append(out, pair)
+	}
+	return out
+}
+
+func sortCloneGroups(groups []*CloneGroup) {
+	sort.Slice(groups, func(i, j int) bool {
+		if !almostEqual(groups[i].Similarity, groups[j].Similarity) {
+			return groups[i].Similarity > groups[j].Similarity
+		}
+		if groups[i].Size != groups[j].Size {
+			return groups[i].Size > groups[j].Size
+		}
+		if len(groups[i].Fragments) == 0 || len(groups[j].Fragments) == 0 {
+			return false
+		}
+		return fragmentLess(groups[i].Fragments[0], groups[j].Fragments[0])
+	})
 }

--- a/internal/analyzer/group_dedup.go
+++ b/internal/analyzer/group_dedup.go
@@ -1,0 +1,84 @@
+package analyzer
+
+// dedupeStrictSubsetGroupMembers removes clone-group members whose source
+// range is a strict subset of (or identical to) another member's range in the
+// same file. Groups reduced to fewer than two members are dropped.
+//
+// Why this exists: tryCreateClonePair / the LSH path already reject *direct*
+// pairs between overlapping same-file fragments (see isOverlappingLocation),
+// so cd.clonePairs cannot contain a same-file `(A, B)` where one strictly
+// covers the other. Union-Find grouping, however, still merges such fragments
+// into one group via a shared distinct-file neighbor — e.g., pairs
+// `(A=x.py:512-542, C=y.py:1-30)` and `(B=x.py:515-542, C=y.py:1-30)` are both
+// legal yet transitively connect A and B. This post-pass collapses those
+// overlapping windows back to the maximal one per file.
+//
+// For exactly-equal ranges (which UF can produce in the same way), the first
+// occurrence is kept; later duplicates are suppressed for deterministic output.
+func dedupeStrictSubsetGroupMembers(groups []*CloneGroup) []*CloneGroup {
+	if len(groups) == 0 {
+		return groups
+	}
+	out := make([]*CloneGroup, 0, len(groups))
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		kept := filterMaximalPerFile(g.Fragments)
+		if len(kept) < 2 {
+			continue
+		}
+		g.Fragments = kept
+		g.Size = len(kept)
+		out = append(out, g)
+	}
+	return out
+}
+
+// filterMaximalPerFile returns the subset of fragments that are maximal under
+// the same-file containment order. A fragment is suppressed if any other
+// kept fragment in the same file strictly covers it, or if it duplicates an
+// earlier fragment's range exactly.
+func filterMaximalPerFile(frags []*CodeFragment) []*CodeFragment {
+	n := len(frags)
+	if n <= 1 {
+		return frags
+	}
+	suppressed := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if suppressed[i] || frags[i] == nil || frags[i].Location == nil {
+			continue
+		}
+		for j := 0; j < n; j++ {
+			if i == j || suppressed[j] || frags[j] == nil || frags[j].Location == nil {
+				continue
+			}
+			if covers(frags[i].Location, frags[j].Location, i, j) {
+				suppressed[j] = true
+			}
+		}
+	}
+	out := make([]*CodeFragment, 0, n)
+	for i, f := range frags {
+		if !suppressed[i] {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// covers reports whether outer (at index iOuter) covers inner (at index
+// iInner) in the same file. Strict coverage suppresses inner outright;
+// identical ranges suppress only the later index so that exactly one survives.
+func covers(outer, inner *CodeLocation, iOuter, iInner int) bool {
+	if outer.FilePath != inner.FilePath {
+		return false
+	}
+	if outer.StartLine > inner.StartLine || outer.EndLine < inner.EndLine {
+		return false
+	}
+	if outer.StartLine == inner.StartLine && outer.EndLine == inner.EndLine {
+		return iOuter < iInner
+	}
+	return true
+}

--- a/internal/analyzer/group_dedup_test.go
+++ b/internal/analyzer/group_dedup_test.go
@@ -15,6 +15,14 @@ func makeGroup(id int, frags ...*CodeFragment) *CloneGroup {
 	return g
 }
 
+func dedupeGroups(groups []*CloneGroup, pairs ...*ClonePair) []*CloneGroup {
+	return dedupeStrictSubsetGroupMembers(groups, pairs).groups
+}
+
+func gpType(a, b *CodeFragment, sim float64, cloneType CloneType) *ClonePair {
+	return &ClonePair{Fragment1: a, Fragment2: b, Similarity: sim, CloneType: cloneType}
+}
+
 // rangesOf returns a sorted slice of "file:start-end" labels for a group's
 // fragments, providing order-independent comparison in assertions.
 func rangesOf(g *CloneGroup) []string {
@@ -48,7 +56,7 @@ func TestDedupe_AutofeatRepro(t *testing.T) {
 	c := gf("x.py", 548, 575)
 	g := makeGroup(1, a, b, c)
 
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+	out := dedupeGroups([]*CloneGroup{g})
 
 	if len(out) != 1 {
 		t.Fatalf("expected 1 group, got %d", len(out))
@@ -73,7 +81,7 @@ func TestDedupe_EqualRangeKeepsFirst(t *testing.T) {
 	c := gf("y.py", 1, 10)
 	g := makeGroup(1, a, aDup, c)
 
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+	out := dedupeGroups([]*CloneGroup{g})
 
 	if len(out) != 1 {
 		t.Fatalf("expected 1 group, got %d", len(out))
@@ -110,7 +118,7 @@ func TestDedupe_ChainCollapses(t *testing.T) {
 	d := gf("y.py", 1, 50)
 	g := makeGroup(1, a, b, c, d)
 
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+	out := dedupeGroups([]*CloneGroup{g})
 
 	if len(out) != 1 || out[0].Size != 2 {
 		t.Fatalf("expected 1 group of size 2, got %+v", out)
@@ -130,7 +138,7 @@ func TestDedupe_DifferentFilesUntouched(t *testing.T) {
 	c := gf("z.py", 1, 10)
 	g := makeGroup(1, a, b, c)
 
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+	out := dedupeGroups([]*CloneGroup{g})
 
 	if len(out) != 1 || out[0].Size != 3 {
 		t.Fatalf("expected 1 group of size 3, got %+v", out)
@@ -144,7 +152,7 @@ func TestDedupe_GroupShrinksToSingleton(t *testing.T) {
 	b := gf("x.py", 10, 90)
 	g := makeGroup(1, a, b)
 
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+	out := dedupeGroups([]*CloneGroup{g})
 
 	if len(out) != 0 {
 		t.Fatalf("expected 0 groups after singleton drop, got %d", len(out))
@@ -158,7 +166,7 @@ func TestDedupe_DisjointSameFileBothKept(t *testing.T) {
 	b := gf("x.py", 20, 30)
 	g := makeGroup(1, a, b)
 
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+	out := dedupeGroups([]*CloneGroup{g})
 
 	if len(out) != 1 || out[0].Size != 2 {
 		t.Fatalf("expected 1 group of size 2, got %+v", out)
@@ -168,16 +176,69 @@ func TestDedupe_DisjointSameFileBothKept(t *testing.T) {
 // TestDedupe_EmptyAndNilGroups verifies passthrough behavior for degenerate
 // inputs.
 func TestDedupe_EmptyAndNilGroups(t *testing.T) {
-	if got := dedupeStrictSubsetGroupMembers(nil); len(got) != 0 {
+	if got := dedupeGroups(nil); len(got) != 0 {
 		t.Fatalf("nil input should return empty result, got %d groups", len(got))
 	}
-	if got := dedupeStrictSubsetGroupMembers([]*CloneGroup{}); len(got) != 0 {
+	if got := dedupeGroups([]*CloneGroup{}); len(got) != 0 {
 		t.Fatalf("empty input should return empty result, got %d groups", len(got))
 	}
 	// A nil group entry should be skipped without panic.
-	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{nil})
+	out := dedupeGroups([]*CloneGroup{nil})
 	if len(out) != 0 {
 		t.Fatalf("nil group entry should be skipped, got %d groups", len(out))
+	}
+}
+
+// TestDedupe_RecomputesMetadataAfterSuppression verifies group-level metadata
+// reflects the members that remain after pruning, not the larger pre-dedup set.
+func TestDedupe_RecomputesMetadataAfterSuppression(t *testing.T) {
+	a := gf("x.py", 1, 10)
+	b := gf("x.py", 2, 10)
+	c := gf("y.py", 1, 10)
+	g := makeGroup(1, a, b, c)
+	g.Similarity = 0.99
+	g.CloneType = Type1Clone
+	pairs := []*ClonePair{
+		gpType(a, c, 0.70, Type4Clone),
+		gpType(b, c, 0.99, Type1Clone),
+	}
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g}, pairs).groups
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(out))
+	}
+	if !almostEqual(out[0].Similarity, 0.70) {
+		t.Fatalf("expected recomputed similarity 0.70, got %.3f", out[0].Similarity)
+	}
+	if out[0].CloneType != Type4Clone {
+		t.Fatalf("expected recomputed clone type Type4, got %v", out[0].CloneType)
+	}
+}
+
+// TestGroupClonesWithStrategy_FiltersSuppressedClonePairs verifies pair output
+// cannot keep reporting a strict-subset member hidden from clone groups.
+func TestGroupClonesWithStrategy_FiltersSuppressedClonePairs(t *testing.T) {
+	a := gf("x.py", 1, 10)
+	b := gf("x.py", 2, 10)
+	c := gf("y.py", 1, 10)
+	cd := &CloneDetector{
+		clonePairs: []*ClonePair{
+			gpType(a, c, 0.95, Type2Clone),
+			gpType(b, c, 0.99, Type1Clone),
+		},
+	}
+
+	cd.groupClonesWithStrategy(NewConnectedGrouping(0.85))
+
+	if len(cd.cloneGroups) != 1 || cd.cloneGroups[0].Size != 2 {
+		t.Fatalf("expected one deduped group of size 2, got %+v", cd.cloneGroups)
+	}
+	if len(cd.clonePairs) != 1 {
+		t.Fatalf("expected suppressed-member pair to be filtered, got %d pairs", len(cd.clonePairs))
+	}
+	if cd.clonePairs[0].Fragment1 == b || cd.clonePairs[0].Fragment2 == b {
+		t.Fatalf("clonePairs still contains suppressed fragment")
 	}
 }
 
@@ -195,7 +256,7 @@ func TestDedupe_E2EThroughConnectedGrouping(t *testing.T) {
 	}
 
 	groups := NewConnectedGrouping(0.85).GroupClones(pairs)
-	out := dedupeStrictSubsetGroupMembers(groups)
+	out := dedupeGroups(groups, pairs...)
 
 	if len(out) != 1 {
 		t.Fatalf("expected 1 group end-to-end, got %d", len(out))

--- a/internal/analyzer/group_dedup_test.go
+++ b/internal/analyzer/group_dedup_test.go
@@ -1,0 +1,211 @@
+package analyzer
+
+import (
+	"sort"
+	"testing"
+)
+
+// makeGroup builds a CloneGroup populated from the given fragments via the
+// public constructor + AddFragment to mirror real strategy output.
+func makeGroup(id int, frags ...*CodeFragment) *CloneGroup {
+	g := NewCloneGroup(id)
+	for _, f := range frags {
+		g.AddFragment(f)
+	}
+	return g
+}
+
+// rangesOf returns a sorted slice of "file:start-end" labels for a group's
+// fragments, providing order-independent comparison in assertions.
+func rangesOf(g *CloneGroup) []string {
+	out := make([]string, 0, len(g.Fragments))
+	for _, f := range g.Fragments {
+		out = append(out, f.Location.String())
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDedupe_AutofeatRepro reproduces the exact shape from issue #416:
+// a same-file pair {512-542, 515-542} (one a strict subset of the other) and
+// a legitimate cross-method clone {548-575}. The 515-542 member must be
+// suppressed.
+func TestDedupe_AutofeatRepro(t *testing.T) {
+	a := gf("x.py", 512, 542)
+	b := gf("x.py", 515, 542)
+	c := gf("x.py", 548, 575)
+	g := makeGroup(1, a, b, c)
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(out))
+	}
+	if out[0].Size != 2 {
+		t.Fatalf("expected Size=2 after dedup, got %d", out[0].Size)
+	}
+	got := rangesOf(out[0])
+	want := []string{a.Location.String(), c.Location.String()}
+	sort.Strings(want)
+	if !equalStringSlices(got, want) {
+		t.Fatalf("expected members %v, got %v", want, got)
+	}
+}
+
+// TestDedupe_EqualRangeKeepsFirst verifies that exactly-equal duplicates
+// (same file, same start/end) collapse to a single member with a deterministic
+// tiebreak (first occurrence wins).
+func TestDedupe_EqualRangeKeepsFirst(t *testing.T) {
+	a := gf("x.py", 1, 10)
+	aDup := gf("x.py", 1, 10)
+	c := gf("y.py", 1, 10)
+	g := makeGroup(1, a, aDup, c)
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(out))
+	}
+	if out[0].Size != 2 {
+		t.Fatalf("expected Size=2 after dedup, got %d", out[0].Size)
+	}
+	// First a (index 0) and c (different file) survive; aDup (index 1) drops.
+	for _, f := range out[0].Fragments {
+		if f == aDup {
+			t.Fatalf("duplicate-range second occurrence should have been suppressed")
+		}
+	}
+	foundA, foundC := false, false
+	for _, f := range out[0].Fragments {
+		if f == a {
+			foundA = true
+		}
+		if f == c {
+			foundC = true
+		}
+	}
+	if !foundA || !foundC {
+		t.Fatalf("expected first-occurrence a and c to remain, got fragments %+v", out[0].Fragments)
+	}
+}
+
+// TestDedupe_ChainCollapses verifies that a chain m3 ⊂ m2 ⊂ m1 in the same
+// file collapses to {m1}, plus an unrelated cross-file member.
+func TestDedupe_ChainCollapses(t *testing.T) {
+	a := gf("x.py", 1, 100)
+	b := gf("x.py", 10, 90)
+	c := gf("x.py", 20, 80)
+	d := gf("y.py", 1, 50)
+	g := makeGroup(1, a, b, c, d)
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+
+	if len(out) != 1 || out[0].Size != 2 {
+		t.Fatalf("expected 1 group of size 2, got %+v", out)
+	}
+	for _, f := range out[0].Fragments {
+		if f == b || f == c {
+			t.Fatalf("inner chain members b/c should have been suppressed, got %+v", out[0].Fragments)
+		}
+	}
+}
+
+// TestDedupe_DifferentFilesUntouched verifies that fragments in different
+// files are never suppressed regardless of line-range relationship.
+func TestDedupe_DifferentFilesUntouched(t *testing.T) {
+	a := gf("x.py", 1, 10)
+	b := gf("y.py", 1, 10) // identical range but different file
+	c := gf("z.py", 1, 10)
+	g := makeGroup(1, a, b, c)
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+
+	if len(out) != 1 || out[0].Size != 3 {
+		t.Fatalf("expected 1 group of size 3, got %+v", out)
+	}
+}
+
+// TestDedupe_GroupShrinksToSingleton verifies a group with only a covering
+// pair from one file (no cross-file neighbor) is dropped entirely.
+func TestDedupe_GroupShrinksToSingleton(t *testing.T) {
+	a := gf("x.py", 1, 100)
+	b := gf("x.py", 10, 90)
+	g := makeGroup(1, a, b)
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+
+	if len(out) != 0 {
+		t.Fatalf("expected 0 groups after singleton drop, got %d", len(out))
+	}
+}
+
+// TestDedupe_DisjointSameFileBothKept verifies that disjoint same-file
+// fragments (e.g., two methods in the same module) are not suppressed.
+func TestDedupe_DisjointSameFileBothKept(t *testing.T) {
+	a := gf("x.py", 1, 10)
+	b := gf("x.py", 20, 30)
+	g := makeGroup(1, a, b)
+
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{g})
+
+	if len(out) != 1 || out[0].Size != 2 {
+		t.Fatalf("expected 1 group of size 2, got %+v", out)
+	}
+}
+
+// TestDedupe_EmptyAndNilGroups verifies passthrough behavior for degenerate
+// inputs.
+func TestDedupe_EmptyAndNilGroups(t *testing.T) {
+	if got := dedupeStrictSubsetGroupMembers(nil); len(got) != 0 {
+		t.Fatalf("nil input should return empty result, got %d groups", len(got))
+	}
+	if got := dedupeStrictSubsetGroupMembers([]*CloneGroup{}); len(got) != 0 {
+		t.Fatalf("empty input should return empty result, got %d groups", len(got))
+	}
+	// A nil group entry should be skipped without panic.
+	out := dedupeStrictSubsetGroupMembers([]*CloneGroup{nil})
+	if len(out) != 0 {
+		t.Fatalf("nil group entry should be skipped, got %d groups", len(out))
+	}
+}
+
+// TestDedupe_E2EThroughConnectedGrouping is the end-to-end integration test:
+// pairs (A, C) and (B, C) where A and B are overlapping same-file fragments
+// — isOverlappingLocation prevents a direct (A, B) pair, but Union-Find unites
+// {A, B, C} via C. After dedup the group must contain {A, C}.
+func TestDedupe_E2EThroughConnectedGrouping(t *testing.T) {
+	A := gf("x.py", 512, 542)
+	B := gf("x.py", 515, 542)
+	C := gf("y.py", 1, 30)
+	pairs := []*ClonePair{
+		gp(A, C, 0.95),
+		gp(B, C, 0.95),
+	}
+
+	groups := NewConnectedGrouping(0.85).GroupClones(pairs)
+	out := dedupeStrictSubsetGroupMembers(groups)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 group end-to-end, got %d", len(out))
+	}
+	if out[0].Size != 2 {
+		t.Fatalf("expected Size=2 after dedup, got %d", out[0].Size)
+	}
+	for _, f := range out[0].Fragments {
+		if f == B {
+			t.Fatalf("B (strict subset of A in same file) should have been suppressed")
+		}
+	}
+}


### PR DESCRIPTION
Closes #416.

## Summary

- pyscn's clone detector emitted clone groups containing overlapping windows of the same code in the same file (e.g. `x.py:512-542` and `x.py:515-542` both representing one `__init__`).
- Root cause: `isOverlappingLocation` (`internal/analyzer/clone_detector.go:1085`) already rejects *direct* same-file overlapping pairs at pair-creation time, but Union-Find grouping (`connected_grouping.go:18`) still merges such fragments transitively via a shared distinct-file neighbor — pairs `(A=x.py:512-542, C=y.py:1-30)` and `(B=x.py:515-542, C=y.py:1-30)` are both legal yet pull `{A, B, C}` into one group.
- Added `dedupeStrictSubsetGroupMembers` as a strategy-agnostic post-pass at the single funnel `groupClonesWithStrategy`. A member is suppressed when another same-file member covers its range (strict subset, or equal-range later occurrence). Groups reduced below two members are dropped.

## Why this placement
- One funnel covers all four strategies (connected / complete-linkage / k-core / star-medoid) → DRY.
- Pair-level dedup is unnecessary: `isOverlappingLocation` already keeps `cd.clonePairs` free of same-file overlapping pairs (YAGNI).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all tests pass; analyzer suite + new `internal/analyzer/group_dedup_test.go` with 8 cases)
- [x] `go vet ./...` and `gofmt -l .` clean
- [x] End-to-end against the issue's reproducer (`cod3licious/autofeat@639793a`):
  - Group containing the `__init__` clones collapses from `{512-542, 515-542, 548-575}` (size 4) to `{512-542, 548-575}` (size 2), matching the issue's expected behavior.
  - Across all groups in the report: 0 same-file containment violations remain.

## New tests (`internal/analyzer/group_dedup_test.go`)

1. Bug repro (autofeat shape) — strict subset within group dropped.
2. Equal-range duplicates — first occurrence kept, deterministic tiebreak.
3. Chain `m3 ⊂ m2 ⊂ m1` collapses to `{m1}`.
4. Different files never deduped.
5. Group reducing to a singleton is dropped.
6. Disjoint same-file fragments both kept.
7. Nil/empty input passthrough (no panic).
8. End-to-end through `ConnectedGrouping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)