### PR TITLE
[codex] fix clones LSH auto threshold for high pair counts

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -670,8 +670,13 @@ func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUs
 		// Estimate fragment count (empirical average: ~5.0 fragments per file)
 		estimatedFragments := n * 5.0
 
-		// Determine LSH usage using centralized logic
-		useLSH := domain.ShouldUseLSH(executionCfg.CloneLSHEnabled, int(estimatedFragments), executionCfg.CloneLSHAutoThreshold)
+		// Determine LSH usage using centralized logic.
+		useLSH := domain.ShouldUseLSHWithPairEstimate(
+			executionCfg.CloneLSHEnabled,
+			int(estimatedFragments),
+			executionCfg.CloneLSHAutoThreshold,
+			domain.DefaultLSHAutoPairThreshold,
+		)
 
 		if useLSH {
 			// LSH enabled: Near-linear O(n^1.1) complexity

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -280,7 +280,7 @@ type CostModel interface {
 }
 ```
 
-**LSH Acceleration (for large projects):**
+**LSH Acceleration (for many fragments or high pair counts):**
 
 ```go
 // LSH (Locality-Sensitive Hashing) for candidate filtering
@@ -301,7 +301,7 @@ type FeatureExtractor struct {
 
 **Two-Stage Detection Process:**
 
-**Stage 1: LSH Candidate Generation (for large projects)**
+**Stage 1: LSH Candidate Generation (for many fragments or high pair counts)**
 1. Extract AST features (subtree hashes, k-grams, patterns)
 2. Apply MinHash + LSH banding to find candidate pairs
 3. Filter candidates by similarity threshold
@@ -554,7 +554,7 @@ type BatchProcessor struct {
 
 ### 2. LSH Acceleration
 
-- Automatic LSH activation for large projects (>500 files)
+- Automatic LSH activation for >=500 fragments or >10,000 estimated pairs
 - Two-stage detection: LSH candidates + APTED verification
 - Configurable hash functions and banding parameters
 - Early termination for dissimilar pairs
@@ -946,7 +946,7 @@ All tests run automatically on:
 
 **Recently Completed:**
 - ✅ TOML-only configuration system (.pyscn.toml, pyproject.toml)
-- ✅ LSH-based clone detection acceleration for large projects
+- ✅ LSH-based clone detection acceleration for high fragment or pair counts
 - ✅ Multiple grouping modes (connected, star, complete linkage, k-core)
 - ✅ Performance optimizations and batch processing
 
@@ -1031,7 +1031,7 @@ type3_threshold = 0.85
 type4_threshold = 0.70
 max_results = 1000
 
-# LSH acceleration for large projects
+# LSH acceleration for large or high-pair-count projects
 [clones.lsh]
 enabled = "auto"
 auto_threshold = 500

--- a/docs/algorithms/clone-detection.md
+++ b/docs/algorithms/clone-detection.md
@@ -335,7 +335,7 @@ LSH activation is controlled by the `LSHEnabled` setting:
 |-------|----------|
 | `"true"` | Always use LSH |
 | `"false"` | Never use LSH |
-| `"auto"` (default) | Enable LSH when fragment count >= `LSHAutoThreshold` (default: 500) |
+| `"auto"` (default) | Enable LSH when fragment count >= `LSHAutoThreshold` (default: 500), or when estimated exact pairwise comparisons exceed 10,000 |
 
 ## Grouping Algorithms
 

--- a/domain/clone.go
+++ b/domain/clone.go
@@ -378,8 +378,8 @@ func NewCloneStatistics() *CloneStatistics {
 	}
 }
 
-// ShouldUseLSH determines whether to use LSH based on configuration and fragment count
-// This centralizes the LSH decision logic used by both clone detection and progress estimation
+// ShouldUseLSH determines whether to use LSH based on configuration and fragment count.
+// This centralizes the legacy LSH decision logic used by callers that only know fragment count.
 func ShouldUseLSH(lshEnabled string, fragmentCount int, autoThreshold int) bool {
 	if lshEnabled == "true" {
 		return true
@@ -393,4 +393,33 @@ func ShouldUseLSH(lshEnabled string, fragmentCount int, autoThreshold int) bool 
 		threshold = 500 // Default threshold
 	}
 	return fragmentCount >= threshold
+}
+
+// ShouldUseLSHWithPairEstimate determines whether to use LSH based on explicit
+// configuration, fragment count, and the estimated number of pairwise comparisons.
+func ShouldUseLSHWithPairEstimate(lshEnabled string, fragmentCount int, autoThreshold int, pairThreshold int) bool {
+	if lshEnabled == "true" {
+		return true
+	}
+	if lshEnabled == "false" {
+		return false
+	}
+	if ShouldUseLSH(lshEnabled, fragmentCount, autoThreshold) {
+		return true
+	}
+
+	threshold := pairThreshold
+	if threshold <= 0 {
+		threshold = DefaultLSHAutoPairThreshold
+	}
+
+	return estimatedClonePairs(fragmentCount) > int64(threshold)
+}
+
+func estimatedClonePairs(fragmentCount int) int64 {
+	if fragmentCount <= 1 {
+		return 0
+	}
+	n := int64(fragmentCount)
+	return n * (n - 1) / 2
 }

--- a/domain/clone_test.go
+++ b/domain/clone_test.go
@@ -600,3 +600,70 @@ func TestShouldUseLSH(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldUseLSHWithPairEstimate(t *testing.T) {
+	tests := []struct {
+		name          string
+		lshEnabled    string
+		fragmentCount int
+		autoThreshold int
+		pairThreshold int
+		want          bool
+	}{
+		{
+			name:          "explicit true ignores thresholds",
+			lshEnabled:    "true",
+			fragmentCount: 10,
+			autoThreshold: 500,
+			pairThreshold: 10000,
+			want:          true,
+		},
+		{
+			name:          "explicit false ignores pair explosion",
+			lshEnabled:    "false",
+			fragmentCount: 259,
+			autoThreshold: 500,
+			pairThreshold: 10000,
+			want:          false,
+		},
+		{
+			name:          "auto below fragment threshold but above pair threshold",
+			lshEnabled:    "auto",
+			fragmentCount: 259,
+			autoThreshold: 500,
+			pairThreshold: 10000,
+			want:          true,
+		},
+		{
+			name:          "auto below both thresholds",
+			lshEnabled:    "auto",
+			fragmentCount: 100,
+			autoThreshold: 500,
+			pairThreshold: 10000,
+			want:          false,
+		},
+		{
+			name:          "auto at fragment threshold",
+			lshEnabled:    "auto",
+			fragmentCount: 500,
+			autoThreshold: 500,
+			pairThreshold: 10000,
+			want:          true,
+		},
+		{
+			name:          "zero pair threshold uses default",
+			lshEnabled:    "auto",
+			fragmentCount: 259,
+			autoThreshold: 500,
+			pairThreshold: 0,
+			want:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldUseLSHWithPairEstimate(tt.lshEnabled, tt.fragmentCount, tt.autoThreshold, tt.pairThreshold)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/domain/defaults.go
+++ b/domain/defaults.go
@@ -194,9 +194,14 @@ const (
 // ============================================================================
 
 const (
-	// DefaultLSHAutoThreshold is the file count threshold for automatic LSH activation.
-	// When file count exceeds this, LSH acceleration is automatically enabled.
+	// DefaultLSHAutoThreshold is the fragment count threshold for automatic LSH activation.
+	// When fragment count exceeds this, LSH acceleration is automatically enabled.
 	DefaultLSHAutoThreshold = 500
+
+	// DefaultLSHAutoPairThreshold is the estimated pair count threshold for
+	// automatic LSH activation. This catches small repos with enough fragments
+	// to make exact pairwise APTED comparisons too expensive.
+	DefaultLSHAutoPairThreshold = 10000
 
 	// DefaultLSHSimilarityThreshold is the minimum similarity for LSH candidate filtering.
 	DefaultLSHSimilarityThreshold = 0.50

--- a/domain/defaults_test.go
+++ b/domain/defaults_test.go
@@ -96,6 +96,9 @@ func TestDefaultValueConsistency(t *testing.T) {
 		if DefaultLSHAutoThreshold <= 0 {
 			t.Errorf("LSHAutoThreshold (%d) should be > 0", DefaultLSHAutoThreshold)
 		}
+		if DefaultLSHAutoPairThreshold <= 0 {
+			t.Errorf("LSHAutoPairThreshold (%d) should be > 0", DefaultLSHAutoPairThreshold)
+		}
 		if DefaultLSHBands <= 0 {
 			t.Errorf("LSHBands (%d) should be > 0", DefaultLSHBands)
 		}

--- a/internal/config/default_config.toml.tmpl
+++ b/internal/config/default_config.toml.tmpl
@@ -78,8 +78,8 @@ grouping_threshold = {{ .GroupingThreshold }}        # Threshold for grouping
 k_core_k = 2                     # K-core parameter
 
 # LSH acceleration settings
-lsh_enabled = "auto"             # Enable LSH: true, false, auto (based on project size)
-lsh_auto_threshold = {{ .LSHAutoThreshold }}         # Auto-enable LSH for projects with >{{ .LSHAutoThreshold }} fragments
+lsh_enabled = "auto"             # Enable LSH: true, false, auto (based on fragment or pair count)
+lsh_auto_threshold = {{ .LSHAutoThreshold }}         # Auto-enable LSH at >= {{ .LSHAutoThreshold }} fragments, or >10,000 estimated pairs
 lsh_similarity_threshold = {{ .LSHSimilarityThreshold }}  # LSH similarity threshold
 lsh_bands = {{ .LSHBands }}                   # Number of LSH bands
 lsh_rows = {{ .LSHRows }}                     # Number of rows per band

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -322,7 +322,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 			KCoreK:    2,
 		},
 		LSH: LSHConfig{
-			Enabled:             "auto", // Auto-enable based on project size
+			Enabled:             "auto", // Auto-enable based on fragment or estimated pair count
 			AutoThreshold:       domain.DefaultLSHAutoThreshold,
 			SimilarityThreshold: domain.DefaultLSHSimilarityThreshold,
 			Bands:               domain.DefaultLSHBands,

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -147,8 +147,13 @@ func (s *CloneService) DetectClonesInFiles(ctx context.Context, filePaths []stri
 
 	// Starting actual clone detection (this is the slow part)
 
-	// Determine whether to use LSH based on configuration
-	useLSH := domain.ShouldUseLSH(req.LSHEnabled, len(allFragments), req.LSHAutoThreshold)
+	// Determine whether to use LSH based on configuration and estimated exact-pair cost.
+	useLSH := domain.ShouldUseLSHWithPairEstimate(
+		req.LSHEnabled,
+		len(allFragments),
+		req.LSHAutoThreshold,
+		detectorConfig.MaxClonePairs,
+	)
 
 	// Update detector with LSH decision
 	detector.SetUseLSH(useLSH)

--- a/website/docs/configuration/reference.md
+++ b/website/docs/configuration/reference.md
@@ -92,8 +92,8 @@ Clone detection (the most configurable analyzer).
 
 | Key                        | Type           | Default  | Description |
 | -------------------------- | -------------- | -------- | --- |
-| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | Enable LSH (`auto` = based on fragment count). |
-| `lsh_auto_threshold`       | int            | `500`    | Fragment count threshold for auto-enable. |
+| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | Enable LSH (`auto` = based on fragment count or estimated pair count). |
+| `lsh_auto_threshold`       | int            | `500`    | Fragment count threshold for auto-enable; auto also enables above 10,000 estimated pairs. |
 | `lsh_similarity_threshold` | float          | `0.50`   | LSH candidate pre-filter. |
 | `lsh_bands`                | int            | `32`     | LSH bands. |
 | `lsh_rows`                 | int            | `4`      | Rows per band. |

--- a/website/docs/ja/configuration/reference.md
+++ b/website/docs/ja/configuration/reference.md
@@ -92,8 +92,8 @@
 
 | キー                        | 型           | デフォルト  | 説明 |
 | -------------------------- | -------------- | -------- | --- |
-| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | LSH を有効にします（`auto` = フラグメント数に基づく）。 |
-| `lsh_auto_threshold`       | int            | `500`    | 自動有効化のフラグメント数閾値。 |
+| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | LSH を有効にします（`auto` = フラグメント数または推定ペア数に基づく）。 |
+| `lsh_auto_threshold`       | int            | `500`    | 自動有効化のフラグメント数閾値。推定ペア数が 10,000 を超える場合も自動有効化されます。 |
 | `lsh_similarity_threshold` | float          | `0.50`   | LSH 候補のプレフィルター。 |
 | `lsh_bands`                | int            | `32`     | LSH バンド数。 |
 | `lsh_rows`                 | int            | `4`      | バンドあたりの行数。 |

--- a/website/docs/zh/configuration/reference.md
+++ b/website/docs/zh/configuration/reference.md
@@ -92,8 +92,8 @@
 
 | 键                         | 类型           | 默认值   | 说明 |
 | -------------------------- | -------------- | -------- | --- |
-| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | 启用 LSH（`auto` = 根据片段数量决定）。 |
-| `lsh_auto_threshold`       | int            | `500`    | 自动启用的片段数量阈值。 |
+| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | 启用 LSH（`auto` = 根据片段数量或估算配对数量决定）。 |
+| `lsh_auto_threshold`       | int            | `500`    | 自动启用的片段数量阈值；估算配对数量超过 10,000 时也会自动启用。 |
 | `lsh_similarity_threshold` | float          | `0.50`   | LSH 候选预过滤阈值。 |
 | `lsh_bands`                | int            | `32`     | LSH 分段数。 |
 | `lsh_rows`                 | int            | `4`      | 每段的行数。 |


### PR DESCRIPTION
## Summary

- Add pair-count-aware LSH auto selection for clone detection.
- Keep the existing fragment-count threshold behavior while also enabling LSH when estimated exact comparisons exceed the clone-pair cap.
- Reuse the same decision in analyze progress estimation.

## Root Cause

Issue #427 reproduces on a small repo with only 259 clone fragments, below the existing 500-fragment LSH auto threshold. That still creates more than 33k possible fragment pairs and thousands of APTED candidates, causing clone detection to run for minutes with no output.

## Validation

- `go test ./...`
- Reproduced against `prompt-toolkit/ptpython@dfe9dae32df17f6695aad6168ec271d02eb1232e` with `pyscn analyze --json --no-open --select clones`, which completed in 446ms after this change.

Fixes #427