### PR TITLE
Fix Type-4 semantic clone detection

### DIFF
--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -175,7 +175,7 @@ func (tc *TreeConverter) ConvertAST(astNode *parser.Node) *TreeNode {
 	// Store reference to original AST node
 	treeNode.OriginalNode = astNode
 
-	for _, child := range orderedASTChildren(astNode, tc.shouldSkipBodyNode) {
+	for _, child := range parser.OrderedChildren(astNode, tc.shouldSkipBodyNode) {
 		if childNode := tc.ConvertAST(child); childNode != nil {
 			treeNode.AddChild(childNode)
 		}
@@ -186,89 +186,6 @@ func (tc *TreeConverter) ConvertAST(astNode *parser.Node) *TreeNode {
 
 func (tc *TreeConverter) shouldSkipBodyNode(parent *parser.Node, bodyNode *parser.Node, bodyIndex int) bool {
 	return tc.canNodeHaveDocstring(parent.Type) && tc.isDocstring(bodyNode, bodyIndex)
-}
-
-func orderedASTChildren(node *parser.Node, skipBodyNode func(parent, bodyNode *parser.Node, bodyIndex int) bool) []*parser.Node {
-	if node == nil {
-		return nil
-	}
-
-	children := make([]*parser.Node, 0, astChildCapacity(node))
-	seen := make(map[*parser.Node]struct{}, astChildCapacity(node))
-
-	appendNode := func(child *parser.Node) {
-		if child == nil {
-			return
-		}
-		if _, ok := seen[child]; ok {
-			return
-		}
-		seen[child] = struct{}{}
-		children = append(children, child)
-	}
-	appendNodes := func(nodes []*parser.Node) {
-		for _, child := range nodes {
-			appendNode(child)
-		}
-	}
-	appendValueNode := func(value interface{}) {
-		if child, ok := value.(*parser.Node); ok {
-			appendNode(child)
-		}
-	}
-
-	appendNodes(node.Children)
-	appendNodes(node.Decorator)
-	appendNodes(node.Bases)
-	appendNodes(node.Args)
-	appendNodes(node.Targets)
-	appendNode(node.Test)
-	appendNode(node.Iter)
-	appendNode(node.Left)
-	appendNode(node.Right)
-	appendNode(node.Target)
-	appendValueNode(node.Value)
-	appendNodes(node.Keywords)
-	for i, bodyNode := range node.Body {
-		if skipBodyNode != nil && skipBodyNode(node, bodyNode, i) {
-			continue
-		}
-		appendNode(bodyNode)
-	}
-	appendNodes(node.Handlers)
-	appendNodes(node.Orelse)
-	appendNodes(node.Finalbody)
-
-	return children
-}
-
-func astChildCapacity(node *parser.Node) int {
-	if node == nil {
-		return 0
-	}
-
-	capacity := len(node.Children) + len(node.Decorator) + len(node.Bases) + len(node.Args) +
-		len(node.Targets) + len(node.Keywords) + len(node.Body) + len(node.Handlers) +
-		len(node.Orelse) + len(node.Finalbody)
-	if node.Test != nil {
-		capacity++
-	}
-	if node.Iter != nil {
-		capacity++
-	}
-	if node.Left != nil {
-		capacity++
-	}
-	if node.Right != nil {
-		capacity++
-	}
-	if node.Target != nil {
-		capacity++
-	}
-	if _, ok := node.Value.(*parser.Node); ok {
-		capacity++
-	}
-	return capacity
 }
 
 // canNodeHaveDocstring checks if a node type can have a docstring

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -901,6 +901,10 @@ func (cd *CloneDetector) compareFragments(fragment1, fragment2 *CodeFragment) *C
 		return nil
 	}
 
+	if cd.usesSemanticClassifier() {
+		return cd.compareFragmentsWithClassifier(fragment1, fragment2)
+	}
+
 	// Early filtering check
 	if !cd.shouldCompareFragments(fragment1, fragment2) {
 		return nil
@@ -924,6 +928,12 @@ func (cd *CloneDetector) compareFragments(fragment1, fragment2 *CodeFragment) *C
 	return cd.compareFragmentsSingleMetric(fragment1, fragment2)
 }
 
+func (cd *CloneDetector) usesSemanticClassifier() bool {
+	return cd.classifier != nil &&
+		cd.cloneDetectorConfig.EnableMultiDimensionalAnalysis &&
+		cd.cloneDetectorConfig.EnableSemanticAnalysis
+}
+
 // compareFragmentsWithClassifier uses the classifier as a gate and APTED for
 // final similarity/distance scoring and clone-type classification.
 func (cd *CloneDetector) compareFragmentsWithClassifier(fragment1, fragment2 *CodeFragment) *ClonePair {
@@ -936,6 +946,17 @@ func (cd *CloneDetector) compareFragmentsWithClassifier(fragment1, fragment2 *Co
 	// Distance is populated and clone type is derived from a consistent metric.
 	distance := cd.analyzer.ComputeDistance(fragment1.TreeNode, fragment2.TreeNode)
 	similarity := cd.analyzer.ComputeSimilarity(fragment1.TreeNode, fragment2.TreeNode)
+
+	if result.CloneType == Type4Clone && result.Analyzer == "semantic" {
+		return &ClonePair{
+			Fragment1:  fragment1,
+			Fragment2:  fragment2,
+			Similarity: result.Similarity,
+			Distance:   distance,
+			CloneType:  result.CloneType,
+			Confidence: result.Confidence,
+		}
+	}
 
 	cloneType, similarity := cd.classifyClonePair(fragment1, fragment2, similarity)
 	if cloneType == 0 {
@@ -1052,7 +1073,7 @@ func (cd *CloneDetector) isSignificantClone(pair *ClonePair) bool {
 	}
 
 	// Check maximum distance threshold (0 means no limit)
-	if cd.cloneDetectorConfig.MaxEditDistance > 0 && pair.Distance > cd.cloneDetectorConfig.MaxEditDistance {
+	if pair.CloneType != Type4Clone && cd.cloneDetectorConfig.MaxEditDistance > 0 && pair.Distance > cd.cloneDetectorConfig.MaxEditDistance {
 		return false
 	}
 

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -86,7 +86,7 @@ func calculateASTSize(node *parser.Node) int {
 	}
 
 	size := 1
-	for _, child := range orderedASTChildren(node, nil) {
+	for _, child := range parser.OrderedChildren(node, nil) {
 		size += calculateASTSize(child)
 	}
 
@@ -393,7 +393,7 @@ func (cd *CloneDetector) extractFragmentsRecursiveWithSource(node *parser.Node, 
 	}
 
 	// Recursively process children
-	for _, child := range orderedASTChildren(node, nil) {
+	for _, child := range parser.OrderedChildren(node, nil) {
 		cd.extractFragmentsRecursiveWithSource(child, filePath, sourceCode, fragments)
 	}
 }
@@ -468,7 +468,7 @@ func (cd *CloneDetector) extractFragmentsRecursive(node *parser.Node, filePath s
 	}
 
 	// Recursively process children
-	for _, child := range orderedASTChildren(node, nil) {
+	for _, child := range parser.OrderedChildren(node, nil) {
 		cd.extractFragmentsRecursive(child, filePath, fragments)
 	}
 }

--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -27,16 +27,28 @@ func (b *DFABuilder) Build(cfg *CFG) (*DFAInfo, error) {
 	b.cfg = cfg
 	b.info = NewDFAInfo(cfg)
 
-	// Step 1: Collect all definitions
+	// Step 1: Seed function parameter definitions.
+	b.collectFunctionParameters()
+
+	// Step 2: Collect all definitions
 	b.collectDefinitions()
 
-	// Step 2: Collect all uses
+	// Step 3: Collect all uses
 	b.collectUses()
 
-	// Step 3: Link definitions to uses
+	// Step 4: Link definitions to uses
 	b.linkDefUse()
 
 	return b.info, nil
+}
+
+func (b *DFABuilder) collectFunctionParameters() {
+	if b.cfg == nil || b.cfg.FunctionNode == nil || b.cfg.Entry == nil {
+		return
+	}
+	for _, def := range b.extractParameterDefs(b.cfg.FunctionNode, b.cfg.Entry, -1) {
+		b.info.AddDef(def)
+	}
 }
 
 // collectDefinitions walks the CFG to find all variable definitions
@@ -238,8 +250,7 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 
 	var uses []*VarReference
 
-	// For assignment statements, we need to extract uses from the Value field
-	// since Walk doesn't include it
+	// For assignment statements, only the right-hand side is a read.
 	if stmt.Type == parser.NodeAssign || stmt.Type == parser.NodeAnnAssign {
 		if valueNode, ok := stmt.Value.(*parser.Node); ok {
 			uses = append(uses, b.extractUsesFromExpression(valueNode, block, stmt, pos)...)
@@ -303,28 +314,25 @@ func (b *DFABuilder) extractUsesFromExpression(expr *parser.Node, block *BasicBl
 
 	case parser.NodeSubscript:
 		// x[i] - the base (x) is a use, and the index might contain uses too
-		if len(expr.Children) > 0 {
-			base := expr.Children[0]
-			if base != nil && base.Type == parser.NodeName {
+		if base := nodeValue(expr); base != nil {
+			if base.Type == parser.NodeName {
 				ref := NewVarReference(base.Name, UseKindSubscript, block, stmt, pos)
 				uses = append(uses, ref)
-			} else if base != nil {
+			} else {
 				uses = append(uses, b.extractUsesFromExpression(base, block, stmt, pos)...)
 			}
 		}
-		// Also check the subscript index
-		if len(expr.Children) > 1 {
-			uses = append(uses, b.extractUsesFromExpression(expr.Children[1], block, stmt, pos)...)
+		for _, child := range expr.Children {
+			uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
 		}
 
 	case parser.NodeCall:
 		// f(x) - the function and arguments are uses
-		if len(expr.Children) > 0 {
-			funcNode := expr.Children[0]
-			if funcNode != nil && funcNode.Type == parser.NodeName {
+		if funcNode := nodeValue(expr); funcNode != nil {
+			if funcNode.Type == parser.NodeName {
 				ref := NewVarReference(funcNode.Name, UseKindCall, block, stmt, pos)
 				uses = append(uses, ref)
-			} else if funcNode != nil {
+			} else {
 				uses = append(uses, b.extractUsesFromExpression(funcNode, block, stmt, pos)...)
 			}
 		}
@@ -334,8 +342,8 @@ func (b *DFABuilder) extractUsesFromExpression(expr *parser.Node, block *BasicBl
 		}
 		// Process keyword arguments
 		for _, kw := range expr.Keywords {
-			if len(kw.Children) > 0 {
-				uses = append(uses, b.extractUsesFromExpression(kw.Children[0], block, stmt, pos)...)
+			for _, child := range kw.GetChildren() {
+				uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
 			}
 		}
 
@@ -346,8 +354,8 @@ func (b *DFABuilder) extractUsesFromExpression(expr *parser.Node, block *BasicBl
 
 	case parser.NodeUnaryOp:
 		// -x, not x - the operand is a use
-		if len(expr.Children) > 0 {
-			uses = append(uses, b.extractUsesFromExpression(expr.Children[0], block, stmt, pos)...)
+		if value := nodeValue(expr); value != nil {
+			uses = append(uses, b.extractUsesFromExpression(value, block, stmt, pos)...)
 		}
 
 	case parser.NodeCompare:
@@ -359,36 +367,41 @@ func (b *DFABuilder) extractUsesFromExpression(expr *parser.Node, block *BasicBl
 
 	case parser.NodeTuple, parser.NodeList, parser.NodeSet:
 		// Collection literals - elements are uses
-		for _, child := range expr.Children {
+		for _, child := range expr.GetChildren() {
 			uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
 		}
 
 	case parser.NodeDict:
 		// Dict literal - keys and values are uses
-		for _, child := range expr.Children {
+		for _, child := range expr.GetChildren() {
 			uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
 		}
 
 	case parser.NodeIfExp:
 		// Ternary expression: a if b else c
-		uses = append(uses, b.extractUsesFromExpression(expr.Test, block, stmt, pos)...)
-		for _, child := range expr.Children {
+		for _, child := range expr.GetChildren() {
 			uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
 		}
 
 	case parser.NodeLambda:
-		// Lambda: lambda x: x + 1 - body contains uses, but parameters are local
-		// For simplicity, we skip lambda internals for now
+		// Lambda internals have local parameter scope.
+		return uses
 
 	case parser.NodeBoolOp:
 		// and/or - operands are uses
-		for _, child := range expr.Children {
+		for _, child := range expr.GetChildren() {
 			uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
+		}
+
+	case parser.NodeNamedExpr:
+		// x := value defines x and reads only the value side.
+		if value := nodeValue(expr); value != nil {
+			uses = append(uses, b.extractUsesFromExpression(value, block, stmt, pos)...)
 		}
 
 	default:
 		// For other expression types, recursively process children
-		for _, child := range expr.Children {
+		for _, child := range expr.GetChildren() {
 			uses = append(uses, b.extractUsesFromExpression(child, block, stmt, pos)...)
 		}
 	}
@@ -454,21 +467,22 @@ func (b *DFABuilder) extractForTargetDefs(stmt *parser.Node, block *BasicBlock, 
 func (b *DFABuilder) extractParameterDefs(stmt *parser.Node, block *BasicBlock, pos int) []*VarReference {
 	var defs []*VarReference
 
-	// Find Arguments node in children
-	for _, child := range stmt.Children {
-		if child != nil && child.Type == parser.NodeArguments {
-			// Extract parameter names from arguments
-			for _, arg := range child.Children {
-				if arg != nil && arg.Type == parser.NodeArg && arg.Name != "" {
-					ref := NewVarReference(arg.Name, DefKindParameter, block, stmt, pos)
-					defs = append(defs, ref)
-				}
-			}
-			break
+	for _, arg := range stmt.Args {
+		if arg != nil && arg.Type == parser.NodeArg && arg.Name != "" {
+			ref := NewVarReference(arg.Name, DefKindParameter, block, stmt, pos)
+			defs = append(defs, ref)
 		}
 	}
 
 	return defs
+}
+
+func nodeValue(node *parser.Node) *parser.Node {
+	if node == nil {
+		return nil
+	}
+	value, _ := node.Value.(*parser.Node)
+	return value
 }
 
 // extractImportDefs extracts definitions from an import statement

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -33,6 +33,17 @@ func buildCFGForDFA(t *testing.T, source string) *CFG {
 	return cfg
 }
 
+func assertChainHasUseKind(t *testing.T, chain *DefUseChain, kind DefUseKind) {
+	t.Helper()
+
+	for _, use := range chain.Uses {
+		if use.Kind == kind {
+			return
+		}
+	}
+	t.Fatalf("Expected %s to have use kind %s, got %v", chain.Variable, kind, chain.Uses)
+}
+
 func TestDFABuilder(t *testing.T) {
 	t.Run("Build_NilCFG", func(t *testing.T) {
 		builder := NewDFABuilder()
@@ -189,15 +200,13 @@ def add(a, b):
 		chainA := info.Chains["a"]
 		chainB := info.Chains["b"]
 
-		if chainA != nil {
-			assert.Len(t, chainA.Defs, 1)
-			assert.Equal(t, DefKindParameter, chainA.Defs[0].Kind)
-		}
+		require.NotNil(t, chainA)
+		assert.Len(t, chainA.Defs, 1)
+		assert.Equal(t, DefKindParameter, chainA.Defs[0].Kind)
 
-		if chainB != nil {
-			assert.Len(t, chainB.Defs, 1)
-			assert.Equal(t, DefKindParameter, chainB.Defs[0].Kind)
-		}
+		require.NotNil(t, chainB)
+		assert.Len(t, chainB.Defs, 1)
+		assert.Equal(t, DefKindParameter, chainB.Defs[0].Kind)
 	})
 
 	t.Run("Build_Import", func(t *testing.T) {
@@ -230,17 +239,8 @@ value = obj.attr
 		require.NoError(t, err)
 
 		chainObj := info.Chains["obj"]
-		if chainObj != nil {
-			// obj.attr should create a UseKindAttribute
-			hasAttrUse := false
-			for _, use := range chainObj.Uses {
-				if use.Kind == UseKindAttribute {
-					hasAttrUse = true
-					break
-				}
-			}
-			assert.True(t, hasAttrUse, "Should have attribute access use")
-		}
+		require.NotNil(t, chainObj)
+		assertChainHasUseKind(t, chainObj, UseKindAttribute)
 	})
 
 	t.Run("Build_FunctionCall", func(t *testing.T) {
@@ -257,17 +257,29 @@ result = f(10)
 		require.NoError(t, err)
 
 		chainF := info.Chains["f"]
-		if chainF != nil {
-			// f(10) should create a UseKindCall
-			hasCallUse := false
-			for _, use := range chainF.Uses {
-				if use.Kind == UseKindCall {
-					hasCallUse = true
-					break
-				}
-			}
-			assert.True(t, hasCallUse, "Should have function call use")
-		}
+		require.NotNil(t, chainF)
+		assertChainHasUseKind(t, chainF, UseKindCall)
+	})
+
+	t.Run("Build_SubscriptExpression", func(t *testing.T) {
+		source := `
+items = [1, 2, 3]
+idx = 1
+value = items[idx]
+`
+		cfg := buildCFGForDFA(t, source)
+		builder := NewDFABuilder()
+		info, err := builder.Build(cfg)
+
+		require.NoError(t, err)
+
+		chainItems := info.Chains["items"]
+		require.NotNil(t, chainItems)
+		assertChainHasUseKind(t, chainItems, UseKindSubscript)
+
+		chainIdx := info.Chains["idx"]
+		require.NotNil(t, chainIdx)
+		assertChainHasUseKind(t, chainIdx, UseKindRead)
 	})
 
 	t.Run("Build_ControlFlowCrossBlock", func(t *testing.T) {

--- a/internal/analyzer/semantic_similarity.go
+++ b/internal/analyzer/semantic_similarity.go
@@ -80,7 +80,7 @@ func (s *SemanticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) flo
 
 	// If DFA is not enabled, return CFG similarity only
 	if !s.enableDFA {
-		return cfgSimilarity
+		return s.applySemanticEvidence(cfgSimilarity, f1, f2)
 	}
 
 	// Build DFA info for both CFGs
@@ -95,8 +95,134 @@ func (s *SemanticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) flo
 	// Compare DFA features
 	dfaSimilarity := s.compareDFAFeatures(dfaFeatures1, dfaFeatures2)
 
-	// Combine CFG and DFA similarities with configured weights
-	return s.cfgFeatureWeight*cfgSimilarity + s.dfaFeatureWeight*dfaSimilarity
+	// Combine CFG and DFA similarities with configured weights.
+	baseSimilarity := s.cfgFeatureWeight*cfgSimilarity + s.dfaFeatureWeight*dfaSimilarity
+	return s.applySemanticEvidence(baseSimilarity, f1, f2)
+}
+
+const semanticMismatchPenalty = 0.75
+
+type semanticSignals struct {
+	strongSignals    map[string]struct{}
+	returnCategories map[string]struct{}
+}
+
+func (s *SemanticSimilarityAnalyzer) applySemanticEvidence(baseSimilarity float64, f1, f2 *CodeFragment) float64 {
+	if baseSimilarity == 0.0 {
+		return 0.0
+	}
+
+	signals1 := extractSemanticSignals(f1.ASTNode)
+	signals2 := extractSemanticSignals(f2.ASTNode)
+	if !hasSharedSemanticSignal(signals1.strongSignals, signals2.strongSignals) {
+		return baseSimilarity * semanticMismatchPenalty
+	}
+	if !hasCompatibleReturnCategories(signals1.returnCategories, signals2.returnCategories) {
+		return baseSimilarity * semanticMismatchPenalty
+	}
+	return baseSimilarity
+}
+
+func extractSemanticSignals(node *parser.Node) semanticSignals {
+	signals := semanticSignals{
+		strongSignals:    make(map[string]struct{}),
+		returnCategories: make(map[string]struct{}),
+	}
+	if node == nil {
+		return signals
+	}
+
+	node.Walk(func(current *parser.Node) bool {
+		switch current.Type {
+		case parser.NodeBinOp, parser.NodeAugAssign:
+			addSignal(signals.strongSignals, "binop", current.Op)
+		case parser.NodeCompare:
+			addSignal(signals.strongSignals, "compare", current.Op)
+		case parser.NodeUnaryOp:
+			addSignal(signals.strongSignals, "unary", current.Op)
+		case parser.NodeBoolOp:
+			addSignal(signals.strongSignals, "bool", current.Op)
+		case parser.NodeCall:
+			if signal := callSemanticSignal(current); signal != "" {
+				signals.strongSignals[signal] = struct{}{}
+			}
+		case parser.NodeReturn:
+			signals.returnCategories[returnCategory(current)] = struct{}{}
+		}
+		return true
+	})
+
+	return signals
+}
+
+func addSignal(signals map[string]struct{}, kind, value string) {
+	if value == "" {
+		return
+	}
+	signals[kind+":"+value] = struct{}{}
+}
+
+func callSemanticSignal(node *parser.Node) string {
+	callee := nodeValue(node)
+	if callee == nil {
+		return ""
+	}
+
+	switch callee.Type {
+	case parser.NodeAttribute:
+		if callee.Name != "" {
+			return "method:" + callee.Name
+		}
+	case parser.NodeName:
+		if callee.Name != "" && !isWeakSemanticCall(callee.Name) {
+			return "call:" + callee.Name
+		}
+	}
+	return ""
+}
+
+func isWeakSemanticCall(name string) bool {
+	switch name {
+	case "len", "range", "enumerate", "list", "dict", "set", "tuple", "int", "str", "float", "bool":
+		return true
+	default:
+		return false
+	}
+}
+
+func returnCategory(node *parser.Node) string {
+	value := nodeValue(node)
+	if value == nil {
+		return "none"
+	}
+	if value.Type == parser.NodeTuple || value.Type == parser.NodeType("expression_list") {
+		return "tuple"
+	}
+	return "scalar"
+}
+
+func hasSharedSemanticSignal(signals1, signals2 map[string]struct{}) bool {
+	if len(signals1) == 0 || len(signals2) == 0 {
+		return true
+	}
+	for signal := range signals1 {
+		if _, ok := signals2[signal]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCompatibleReturnCategories(categories1, categories2 map[string]struct{}) bool {
+	if len(categories1) == 0 || len(categories2) == 0 {
+		return true
+	}
+	for category := range categories1 {
+		if _, ok := categories2[category]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // buildCFGFromFragment builds a CFG from a code fragment

--- a/internal/analyzer/similarity_analyzer.go
+++ b/internal/analyzer/similarity_analyzer.go
@@ -148,9 +148,10 @@ func (c *CloneClassifier) ClassifyClone(f1, f2 *CodeFragment) *ClassificationRes
 		}
 	}
 
-	// Fallback: check if cached structural similarity meets Type-4 threshold
-	// This maintains backward compatibility with single-metric classification
-	if c.structuralAnalyzer != nil && structuralSim >= c.type4Threshold {
+	// Fallback: check if cached structural similarity meets Type-4 threshold.
+	// This is only for classifier setups without semantic analysis; when semantic
+	// analysis is enabled, Type-4 must come from the semantic analyzer.
+	if !c.enableSemanticAnalysis && c.structuralAnalyzer != nil && structuralSim >= c.type4Threshold {
 		return &ClassificationResult{
 			CloneType:  Type4Clone,
 			Similarity: structuralSim,

--- a/internal/analyzer/type4_detector_test.go
+++ b/internal/analyzer/type4_detector_test.go
@@ -4,87 +4,111 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestType4CloneDetection(t *testing.T) {
-	testDir := "../../testdata/python/clones/type4"
-
-	// Read all Python files
-	files, err := filepath.Glob(filepath.Join(testDir, "*.py"))
-	if err != nil {
-		t.Fatalf("Failed to glob files: %v", err)
-	}
-
-	// Create config with DFA enabled
 	config := DefaultCloneDetectorConfig()
 	config.EnableDFAAnalysis = true
 	config.Type4Threshold = 0.70
 
 	detector := NewCloneDetector(config)
+	allFragments, functionFragments := loadType4FunctionFragments(t, detector)
 
-	t.Logf("EnableMultiDimensionalAnalysis: %v", detector.cloneDetectorConfig.EnableMultiDimensionalAnalysis)
-	t.Logf("EnableSemanticAnalysis: %v", detector.cloneDetectorConfig.EnableSemanticAnalysis)
-	t.Logf("EnableDFAAnalysis: %v", detector.cloneDetectorConfig.EnableDFAAnalysis)
-	t.Logf("Classifier is set: %v", detector.classifier != nil)
+	pairs, groups := detector.DetectClones(allFragments)
+	require.NotEmpty(t, pairs)
+	require.NotEmpty(t, groups)
+
+	pairByID := make(map[string]*ClonePair, len(pairs))
+	for _, pair := range pairs {
+		pairByID[type4PairID(type4FragmentID(pair.Fragment1), type4FragmentID(pair.Fragment2))] = pair
+	}
+
+	expectedPairs := [][2]string{
+		{"sum_iterative.py::sum_numbers", "sum_recursive.py::sum_numbers"},
+		{"sum_iterative.py::sum_range", "sum_recursive.py::sum_range"},
+		{"find_max_a.py::find_maximum", "find_max_b.py::find_maximum"},
+		{"find_max_a.py::find_min_max", "find_max_b.py::find_min_max"},
+		{"filter_transform_a.py::filter_and_double", "filter_transform_b.py::filter_and_double"},
+		{"filter_transform_a.py::process_data", "filter_transform_b.py::process_data"},
+		{"filter_transform_a.py::count_matching", "filter_transform_b.py::count_matching"},
+	}
+	for _, expected := range expectedPairs {
+		pair := pairByID[type4PairID(expected[0], expected[1])]
+		require.NotNil(t, pair, "missing Type-4 pair %s <-> %s", expected[0], expected[1])
+		assert.Equal(t, Type4Clone, pair.CloneType)
+		assert.GreaterOrEqual(t, pair.Similarity, config.Type4Threshold)
+	}
+
+	negativePairs := [][2]string{
+		{"sum_iterative.py::sum_numbers", "find_max_b.py::find_maximum"},
+		{"sum_iterative.py::sum_range", "find_max_b.py::find_min_max"},
+		{"find_max_a.py::find_maximum", "find_max_b.py::find_min_max"},
+	}
+	for _, negative := range negativePairs {
+		assert.Nil(t, pairByID[type4PairID(negative[0], negative[1])], "unexpected Type-4 pair %s <-> %s", negative[0], negative[1])
+	}
+
+	for _, expected := range expectedPairs {
+		first := functionFragments[expected[0]]
+		second := functionFragments[expected[1]]
+		require.NotNil(t, first, "missing fixture function %s", expected[0])
+		require.NotNil(t, second, "missing fixture function %s", expected[1])
+
+		pair := detector.compareFragments(first, second)
+		require.NotNil(t, pair, "direct comparison missed %s <-> %s", expected[0], expected[1])
+		assert.Equal(t, Type4Clone, pair.CloneType)
+	}
+}
+
+func loadType4FunctionFragments(t *testing.T, detector *CloneDetector) ([]*CodeFragment, map[string]*CodeFragment) {
+	t.Helper()
+
+	testDir := "../../testdata/python/clones/type4"
+	files, err := filepath.Glob(filepath.Join(testDir, "*.py"))
+	require.NoError(t, err)
+	sort.Strings(files)
 
 	p := parser.New()
 	ctx := context.Background()
-
-	// Extract fragments from all files
+	functionFragments := make(map[string]*CodeFragment)
 	var allFragments []*CodeFragment
+
 	for _, file := range files {
 		content, err := os.ReadFile(file)
-		if err != nil {
-			t.Logf("Failed to read %s: %v", file, err)
-			continue
-		}
+		require.NoError(t, err)
 
 		result, err := p.Parse(ctx, content)
-		if err != nil {
-			t.Logf("Failed to parse %s: %v", file, err)
-			continue
-		}
+		require.NoError(t, err)
 
 		fragments := detector.ExtractFragmentsWithSource([]*parser.Node{result.AST}, file, content)
 		allFragments = append(allFragments, fragments...)
-	}
-
-	t.Logf("\nExtracted %d fragments:", len(allFragments))
-	for i, f := range allFragments {
-		t.Logf("  [%d] %s:%d-%d (nodes:%d, lines:%d)",
-			i,
-			filepath.Base(f.Location.FilePath),
-			f.Location.StartLine,
-			f.Location.EndLine,
-			f.Size,
-			f.LineCount)
-	}
-
-	// Run detection
-	pairs, groups := detector.DetectClones(allFragments)
-
-	t.Logf("\nDetected %d clone pairs, %d groups:", len(pairs), len(groups))
-	for _, pair := range pairs {
-		t.Logf("  %s:%d vs %s:%d = %.3f (Type-%d)",
-			filepath.Base(pair.Fragment1.Location.FilePath),
-			pair.Fragment1.Location.StartLine,
-			filepath.Base(pair.Fragment2.Location.FilePath),
-			pair.Fragment2.Location.StartLine,
-			pair.Similarity,
-			pair.CloneType)
-	}
-
-	// Test manual comparison of specific fragments
-	if len(allFragments) >= 2 {
-		t.Logf("\nManual comparison of first two fragments:")
-		pair := detector.compareFragments(allFragments[0], allFragments[1])
-		if pair != nil {
-			t.Logf("  Result: sim=%.3f, type=%d", pair.Similarity, pair.CloneType)
-		} else {
-			t.Logf("  Result: nil (not a clone)")
+		for _, fragment := range fragments {
+			if fragment.ASTNode != nil && fragment.ASTNode.Type == parser.NodeFunctionDef {
+				functionFragments[type4FragmentID(fragment)] = fragment
+			}
 		}
 	}
+
+	require.NotEmpty(t, allFragments)
+	return allFragments, functionFragments
+}
+
+func type4FragmentID(fragment *CodeFragment) string {
+	if fragment == nil || fragment.Location == nil || fragment.ASTNode == nil {
+		return ""
+	}
+	return filepath.Base(fragment.Location.FilePath) + "::" + fragment.ASTNode.Name
+}
+
+func type4PairID(first, second string) string {
+	if first > second {
+		first, second = second, first
+	}
+	return first + "|" + second
 }

--- a/internal/analyzer/type4_similarity_test.go
+++ b/internal/analyzer/type4_similarity_test.go
@@ -1,95 +1,51 @@
 package analyzer
 
 import (
-	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/ludo-technologies/pyscn/internal/parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestType4SimilarityScores(t *testing.T) {
-	// Read test files
-	testDir := "../../testdata/python/clones/type4"
-
-	files := []string{
-		"sum_iterative.py",
-		"sum_recursive.py",
-		"find_max_a.py",
-		"find_max_b.py",
-	}
-
-	p := parser.New()
-	ctx := context.Background()
-
-	// Parse all files and extract functions
-	type funcInfo struct {
-		file string
-		name string
-		ast  *parser.Node
-	}
-	var functions []funcInfo
-
-	for _, file := range files {
-		path := filepath.Join(testDir, file)
-		content, err := os.ReadFile(path)
-		if err != nil {
-			t.Logf("Skipping %s: %v", file, err)
-			continue
-		}
-
-		result, err := p.Parse(ctx, content)
-		if err != nil {
-			t.Logf("Skipping %s: parse error: %v", file, err)
-			continue
-		}
-
-		// Extract function definitions
-		for _, node := range result.AST.Body {
-			if node.Type == parser.NodeFunctionDef {
-				functions = append(functions, funcInfo{
-					file: file,
-					name: node.Name,
-					ast:  node,
-				})
-			}
-		}
-	}
-
-	t.Logf("Found %d functions", len(functions))
-
-	// Create semantic analyzer with DFA
+	config := DefaultCloneDetectorConfig()
+	config.EnableDFAAnalysis = true
+	config.Type4Threshold = 0.70
+	detector := NewCloneDetector(config)
+	_, functions := loadType4FunctionFragments(t, detector)
 	analyzer := NewSemanticSimilarityAnalyzerWithDFA()
 
-	// Compare all pairs
-	t.Logf("\nSimilarity Matrix (with DFA):")
-	for i := 0; i < len(functions); i++ {
-		for j := i + 1; j < len(functions); j++ {
-			f1 := &CodeFragment{ASTNode: functions[i].ast}
-			f2 := &CodeFragment{ASTNode: functions[j].ast}
+	expectedPairs := [][2]string{
+		{"sum_iterative.py::sum_numbers", "sum_recursive.py::sum_numbers"},
+		{"sum_iterative.py::sum_range", "sum_recursive.py::sum_range"},
+		{"find_max_a.py::find_maximum", "find_max_b.py::find_maximum"},
+		{"find_max_a.py::find_min_max", "find_max_b.py::find_min_max"},
+		{"filter_transform_a.py::filter_and_double", "filter_transform_b.py::filter_and_double"},
+		{"filter_transform_a.py::process_data", "filter_transform_b.py::process_data"},
+		{"filter_transform_a.py::count_matching", "filter_transform_b.py::count_matching"},
+	}
+	for _, expected := range expectedPairs {
+		first := functions[expected[0]]
+		second := functions[expected[1]]
+		require.NotNil(t, first, "missing fixture function %s", expected[0])
+		require.NotNil(t, second, "missing fixture function %s", expected[1])
 
-			sim := analyzer.ComputeSimilarity(f1, f2)
-			t.Logf("  %s:%s vs %s:%s = %.3f",
-				functions[i].file, functions[i].name,
-				functions[j].file, functions[j].name,
-				sim)
-		}
+		similarity := analyzer.ComputeSimilarity(first, second)
+		assert.GreaterOrEqual(t, similarity, config.Type4Threshold, "%s <-> %s", expected[0], expected[1])
 	}
 
-	// Also test without DFA
-	analyzerNoDFA := NewSemanticSimilarityAnalyzer()
-	t.Logf("\nSimilarity Matrix (CFG only):")
-	for i := 0; i < len(functions); i++ {
-		for j := i + 1; j < len(functions); j++ {
-			f1 := &CodeFragment{ASTNode: functions[i].ast}
-			f2 := &CodeFragment{ASTNode: functions[j].ast}
+	negativePairs := [][2]string{
+		{"sum_iterative.py::sum_numbers", "find_max_b.py::find_maximum"},
+		{"sum_iterative.py::sum_range", "find_max_b.py::find_min_max"},
+		{"find_max_a.py::find_maximum", "find_max_b.py::find_min_max"},
+	}
+	for _, negative := range negativePairs {
+		first := functions[negative[0]]
+		second := functions[negative[1]]
+		require.NotNil(t, first, "missing fixture function %s", negative[0])
+		require.NotNil(t, second, "missing fixture function %s", negative[1])
 
-			sim := analyzerNoDFA.ComputeSimilarity(f1, f2)
-			t.Logf("  %s:%s vs %s:%s = %.3f",
-				functions[i].file, functions[i].name,
-				functions[j].file, functions[j].name,
-				sim)
-		}
+		similarity := analyzer.ComputeSimilarity(first, second)
+		assert.Less(t, similarity, config.Type4Threshold, "%s <-> %s", negative[0], negative[1])
 	}
 }

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -169,38 +169,96 @@ func (n *Node) AddToBody(node *Node) {
 	}
 }
 
-// GetChildren returns all child nodes
+// BodyChildFilter decides whether a body child should be skipped while walking
+// a node's canonical children.
+type BodyChildFilter func(parent, bodyNode *Node, bodyIndex int) bool
+
+// GetChildren returns all child nodes in the parser's canonical order.
 func (n *Node) GetChildren() []*Node {
-	allChildren := []*Node{}
-	allChildren = append(allChildren, n.Children...)
-	allChildren = append(allChildren, n.Body...)
-	allChildren = append(allChildren, n.Orelse...)
-	allChildren = append(allChildren, n.Finalbody...)
-	allChildren = append(allChildren, n.Handlers...)
+	return OrderedChildren(n, nil)
+}
 
-	if n.Test != nil {
-		allChildren = append(allChildren, n.Test)
-	}
-	if n.Iter != nil {
-		allChildren = append(allChildren, n.Iter)
-	}
-	if n.Left != nil {
-		allChildren = append(allChildren, n.Left)
-	}
-	if n.Right != nil {
-		allChildren = append(allChildren, n.Right)
-	}
-	if n.Target != nil {
-		allChildren = append(allChildren, n.Target)
+// OrderedChildren returns every structural child exactly once in a stable order.
+// Value is included when it holds a *Node because many builders store core
+// expression children there.
+func OrderedChildren(node *Node, skipBodyNode BodyChildFilter) []*Node {
+	if node == nil {
+		return nil
 	}
 
-	allChildren = append(allChildren, n.Targets...)
-	allChildren = append(allChildren, n.Args...)
-	allChildren = append(allChildren, n.Keywords...)
-	allChildren = append(allChildren, n.Decorator...)
-	allChildren = append(allChildren, n.Bases...)
+	children := make([]*Node, 0, childCapacity(node))
+	seen := make(map[*Node]struct{}, childCapacity(node))
 
-	return allChildren
+	appendNode := func(child *Node) {
+		if child == nil {
+			return
+		}
+		if _, ok := seen[child]; ok {
+			return
+		}
+		seen[child] = struct{}{}
+		children = append(children, child)
+	}
+	appendNodes := func(nodes []*Node) {
+		for _, child := range nodes {
+			appendNode(child)
+		}
+	}
+
+	appendNodes(node.Children)
+	appendNodes(node.Decorator)
+	appendNodes(node.Bases)
+	appendNodes(node.Args)
+	appendNodes(node.Targets)
+	appendNode(node.Test)
+	appendNode(node.Iter)
+	appendNode(node.Left)
+	appendNode(node.Right)
+	appendNode(node.Target)
+	if valueNode, ok := node.Value.(*Node); ok {
+		appendNode(valueNode)
+	}
+	appendNodes(node.Keywords)
+	for i, bodyNode := range node.Body {
+		if skipBodyNode != nil && skipBodyNode(node, bodyNode, i) {
+			continue
+		}
+		appendNode(bodyNode)
+	}
+	appendNodes(node.Handlers)
+	appendNodes(node.Orelse)
+	appendNodes(node.Finalbody)
+
+	return children
+}
+
+func childCapacity(node *Node) int {
+	if node == nil {
+		return 0
+	}
+
+	capacity := len(node.Children) + len(node.Decorator) + len(node.Bases) + len(node.Args) +
+		len(node.Targets) + len(node.Keywords) + len(node.Body) + len(node.Handlers) +
+		len(node.Orelse) + len(node.Finalbody)
+	if node.Test != nil {
+		capacity++
+	}
+	if node.Iter != nil {
+		capacity++
+	}
+	if node.Left != nil {
+		capacity++
+	}
+	if node.Right != nil {
+		capacity++
+	}
+	if node.Target != nil {
+		capacity++
+	}
+	if _, ok := node.Value.(*Node); ok {
+		capacity++
+	}
+	return capacity
 }
 
 // IsStatement returns true if the node is a statement
@@ -267,53 +325,10 @@ func (n *Node) Walk(visitor func(*Node) bool) {
 	}
 }
 
-// WalkDeep traverses the AST including the Value field when it contains a *Node.
-// This is necessary because tree-sitter stores some child nodes in the Value field
-// (e.g., Call nodes store the callee in Value, Assign nodes store the RHS in Value).
+// WalkDeep is kept for callers that used the old explicit deep walk. Walk now
+// uses the same canonical child contract.
 func (n *Node) WalkDeep(visitor func(*Node) bool) {
-	if n == nil || !visitor(n) {
-		return
-	}
-
-	walkNodeList(n.Children, visitor)
-	walkNodeList(n.Body, visitor)
-	walkNodeList(n.Orelse, visitor)
-	walkNodeList(n.Finalbody, visitor)
-	walkNodeList(n.Handlers, visitor)
-
-	if n.Test != nil {
-		n.Test.WalkDeep(visitor)
-	}
-	if n.Iter != nil {
-		n.Iter.WalkDeep(visitor)
-	}
-	if n.Left != nil {
-		n.Left.WalkDeep(visitor)
-	}
-	if n.Right != nil {
-		n.Right.WalkDeep(visitor)
-	}
-	if n.Target != nil {
-		n.Target.WalkDeep(visitor)
-	}
-
-	walkNodeList(n.Targets, visitor)
-	walkNodeList(n.Args, visitor)
-	walkNodeList(n.Keywords, visitor)
-	walkNodeList(n.Decorator, visitor)
-	walkNodeList(n.Bases, visitor)
-
-	if valueNode, ok := n.Value.(*Node); ok {
-		valueNode.WalkDeep(visitor)
-	}
-}
-
-func walkNodeList(nodes []*Node, visitor func(*Node) bool) {
-	for _, child := range nodes {
-		if child != nil {
-			child.WalkDeep(visitor)
-		}
-	}
+	n.Walk(visitor)
 }
 
 // Find finds all nodes matching a predicate
@@ -355,13 +370,18 @@ func (n *Node) Copy() *Node {
 
 	copied := &Node{
 		Type:     n.Type,
-		Value:    n.Value,
 		Location: n.Location,
 		Name:     n.Name,
 		Op:       n.Op,
 		Module:   n.Module,
 		Names:    append([]string{}, n.Names...),
 		Level:    n.Level,
+	}
+	copied.Value = n.Value
+	if valueNode, ok := n.Value.(*Node); ok {
+		copiedValue := valueNode.Copy()
+		copiedValue.Parent = copied
+		copied.Value = copiedValue
 	}
 
 	// Copy children
@@ -473,4 +493,23 @@ func (n *Node) Copy() *Node {
 	}
 
 	return copied
+}
+
+// RefreshParentLinks rebuilds Parent pointers from the canonical child graph.
+func (n *Node) RefreshParentLinks() {
+	refreshParentLinks(n, nil, make(map[*Node]struct{}))
+}
+
+func refreshParentLinks(node, parent *Node, seen map[*Node]struct{}) {
+	if node == nil {
+		return
+	}
+	if _, ok := seen[node]; ok {
+		return
+	}
+	seen[node] = struct{}{}
+	node.Parent = parent
+	for _, child := range node.GetChildren() {
+		refreshParentLinks(child, node, seen)
+	}
 }

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -51,6 +51,9 @@ func (b *ASTBuilder) Build(tree *sitter.Tree) (*Node, error) {
 	}
 
 	ast := b.buildNode(rootNode)
+	if ast != nil {
+		ast.RefreshParentLinks()
+	}
 	return ast, nil
 }
 
@@ -934,6 +937,23 @@ func (b *ASTBuilder) buildUnaryOp(tsNode *sitter.Node) *Node {
 	if operand := b.getChildByFieldName(tsNode, "operand"); operand != nil {
 		node.Value = b.buildNode(operand)
 	}
+	if node.Value == nil {
+		childCount := int(tsNode.ChildCount())
+		for i := 0; i < childCount; i++ {
+			child := tsNode.Child(i)
+			if child == nil || b.isTrivia(child) {
+				continue
+			}
+			if b.isUnaryOperatorToken(child) {
+				if node.Op == "" {
+					node.Op = b.getNodeText(child)
+				}
+				continue
+			}
+			node.Value = b.buildNode(child)
+			break
+		}
+	}
 
 	return node
 }
@@ -1086,12 +1106,26 @@ func (b *ASTBuilder) buildSubscript(tsNode *sitter.Node) *Node {
 	if value := b.getChildByFieldName(tsNode, "object"); value != nil {
 		node.Value = b.buildNode(value)
 	}
+	if node.Value == nil {
+		if value := b.getChildByFieldName(tsNode, "value"); value != nil {
+			node.Value = b.buildNode(value)
+		}
+	}
 
 	if subscript := b.getChildByFieldName(tsNode, "subscript"); subscript != nil {
 		node.AddChild(b.buildNode(subscript))
 	}
 
 	return node
+}
+
+func (b *ASTBuilder) isUnaryOperatorToken(tsNode *sitter.Node) bool {
+	switch tsNode.Type() {
+	case "+", "-", "~", "not":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildSlice builds a slice node

--- a/internal/parser/ast_test.go
+++ b/internal/parser/ast_test.go
@@ -239,6 +239,110 @@ func TestNodeMethods(t *testing.T) {
 	}
 }
 
+func TestCanonicalTraversalIncludesValueNodes(t *testing.T) {
+	source := `
+async def load(client, items, idx):
+    result = client.fetch(items[idx])
+    await client.commit(result)
+    yield result
+    return client.done(result)
+`
+
+	result, err := New().Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	calls := result.AST.FindByType(NodeCall)
+	callByAttr := make(map[string]*Node)
+	for _, call := range calls {
+		callee, ok := call.Value.(*Node)
+		if ok && callee.Type == NodeAttribute {
+			callByAttr[callee.Name] = call
+			if callee.Parent != call {
+				t.Fatalf("Callee %s parent = %v, want call", callee.Name, callee.Parent)
+			}
+		}
+	}
+	for _, name := range []string{"fetch", "commit", "done"} {
+		if callByAttr[name] == nil {
+			t.Fatalf("FindByType(NodeCall) did not find call to client.%s", name)
+		}
+	}
+
+	if returnNode := callByAttr["done"].GetParentOfType(NodeReturn); returnNode == nil {
+		t.Fatal("Call stored in Return.Value should resolve its return parent")
+	}
+
+	subscripts := result.AST.FindByType(NodeSubscript)
+	if len(subscripts) != 1 {
+		t.Fatalf("Expected 1 subscript, got %d", len(subscripts))
+	}
+	base, ok := subscripts[0].Value.(*Node)
+	if !ok || base.Type != NodeName || base.Name != "items" {
+		t.Fatalf("Subscript base = %T %v, want Name(items)", subscripts[0].Value, subscripts[0].Value)
+	}
+	if base.Parent != subscripts[0] {
+		t.Fatal("Subscript base parent should point to the subscript node")
+	}
+
+	awaits := result.AST.FindByType(NodeAwait)
+	if len(awaits) != 1 {
+		t.Fatalf("Expected 1 await node, got %d", len(awaits))
+	}
+	if valueNode, ok := awaits[0].Value.(*Node); !ok || valueNode.Parent != awaits[0] {
+		t.Fatal("Await value should be traversable and parented")
+	}
+
+	yields := result.AST.FindByType(NodeYield)
+	if len(yields) != 1 {
+		t.Fatalf("Expected 1 yield node, got %d", len(yields))
+	}
+	if valueNode, ok := yields[0].Value.(*Node); !ok || valueNode.Parent != yields[0] {
+		t.Fatal("Yield value should be traversable and parented")
+	}
+}
+
+func TestCopyDeepCopiesValueNodes(t *testing.T) {
+	source := `
+def call():
+    return foo()
+`
+
+	result, err := New().Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	copied := result.AST.Copy()
+	originalCall := firstCallWithName(t, result.AST, "foo")
+	copiedCall := firstCallWithName(t, copied, "foo")
+
+	copiedCallee := copiedCall.Value.(*Node)
+	copiedCallee.Name = "bar"
+
+	originalCallee := originalCall.Value.(*Node)
+	if originalCallee.Name != "foo" {
+		t.Fatalf("Original callee mutated to %q", originalCallee.Name)
+	}
+	if copiedCallee.Parent != copiedCall {
+		t.Fatal("Copied value node should point to copied parent")
+	}
+}
+
+func firstCallWithName(t *testing.T, ast *Node, name string) *Node {
+	t.Helper()
+
+	for _, call := range ast.FindByType(NodeCall) {
+		callee, ok := call.Value.(*Node)
+		if ok && callee.Type == NodeName && callee.Name == name {
+			return call
+		}
+	}
+	t.Fatalf("Call %s() not found", name)
+	return nil
+}
+
 func TestASTBuilderComplexCode(t *testing.T) {
 	source := `
 import sys


### PR DESCRIPTION
What changed
- Unified parser child traversal so typed fields like Value participate consistently in traversal and APTED sizing.
- Updated DFA extraction to read parser field contracts for parameters, calls, subscripts, unary/named expressions, and keyword args.
- Preserved semantic Type-4 classifier results in detector reporting and added fixture-backed positive/negative coverage.

Why
Type-4 semantic scores could pass the classifier, then get dropped when the detector reclassified the pair with structural APTED. A few parser/DFA paths also missed expression nodes stored outside raw Children.

Validation
- go test ./internal/parser ./internal/analyzer -count=1
- go test ./... -count=1