### PR TITLE
fix: exit non-zero when output generation fails in analyze command (refs #249)

### DIFF
--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -170,10 +170,12 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 	response, analysisErr := useCase.Execute(ctx, config, args)
 
 	// Generate output even if there were partial failures
+	var outputErr error
 	if response != nil {
 		// Generate output
 		if err := c.generateOutput(cmd, response, args); err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to generate output: %v\n", err)
+			outputErr = err
 		}
 
 		// Print summary
@@ -183,6 +185,11 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 	// Return the analysis error so CLI exits with non-zero status
 	if analysisErr != nil {
 		return analysisErr
+	}
+
+	// Return output error if analysis succeeded but output generation failed
+	if outputErr != nil {
+		return outputErr
 	}
 
 	return nil

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -174,7 +174,6 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 	if response != nil {
 		// Generate output
 		if err := c.generateOutput(cmd, response, args); err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Failed to generate output: %v\n", err)
 			outputErr = err
 		}
 

--- a/cmd/pyscn/utils_test.go
+++ b/cmd/pyscn/utils_test.go
@@ -7,8 +7,13 @@ import (
 )
 
 func TestGenerateOutputFilePath_CreatesDefaultDirectory(t *testing.T) {
-	// Create a temporary directory to work in
+	// macOS: t.TempDir() returns /var/folders/... but os.Getwd() after Chdir
+	// returns /private/var/folders/... — normalise with EvalSymlinks
 	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(tempDir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks on tempDir: %v", err)
+	}
 
 	// Change to the temp directory
 	oldCwd, err := os.Getwd()
@@ -50,8 +55,13 @@ func TestGenerateOutputFilePath_CreatesDefaultDirectory(t *testing.T) {
 }
 
 func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
-	// Create a temporary directory to work in
+	// macOS: t.TempDir() returns /var/folders/... but os.Getwd() after Chdir
+	// returns /private/var/folders/... — normalise with EvalSymlinks
 	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(tempDir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks on tempDir: %v", err)
+	}
 
 	// Change to the temp directory
 	oldCwd, err := os.Getwd()
@@ -78,7 +88,13 @@ func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
 }
 
 func TestGenerateOutputFilePath_DifferentExtensions(t *testing.T) {
+	// macOS: t.TempDir() returns /var/folders/... but os.Getwd() after Chdir
+	// returns /private/var/folders/... — normalise with EvalSymlinks
 	tempDir := t.TempDir()
+	tempDir, err := filepath.EvalSymlinks(tempDir)
+	if err != nil {
+		t.Fatalf("failed to eval symlinks on tempDir: %v", err)
+	}
 
 	oldCwd, err := os.Getwd()
 	if err != nil {

--- a/cmd/pyscn/utils_test.go
+++ b/cmd/pyscn/utils_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateOutputFilePath_CreatesDefaultDirectory(t *testing.T) {
+	// Create a temporary directory to work in
+	tempDir := t.TempDir()
+
+	// Change to the temp directory
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	defer os.Chdir(oldCwd)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+
+	// Generate output file path
+	path, err := generateOutputFilePath("analyze", "html", ".")
+	if err != nil {
+		t.Fatalf("generateOutputFilePath returned error: %v", err)
+	}
+
+	// Verify the path contains the expected directory structure
+	expectedDir := filepath.Join(tempDir, ".pyscn", "reports")
+	if filepath.Dir(path) != expectedDir {
+		t.Errorf("expected directory %q, got %q", expectedDir, filepath.Dir(path))
+	}
+
+	// Verify the directory was actually created
+	if _, err := os.Stat(expectedDir); os.IsNotExist(err) {
+		t.Errorf("expected directory %q to be created, but it does not exist", expectedDir)
+	}
+
+	// Verify the filename has the expected format
+	filename := filepath.Base(path)
+	expectedPrefix := "analyze_"
+	if len(filename) < len(expectedPrefix)+10 || filename[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("expected filename to start with %q and have timestamp, got %q", expectedPrefix, filename)
+	}
+	if filepath.Ext(path) != ".html" {
+		t.Errorf("expected extension .html, got %q", filepath.Ext(path))
+	}
+}
+
+func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
+	// Create a temporary directory to work in
+	tempDir := t.TempDir()
+
+	// Change to the temp directory
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	defer os.Chdir(oldCwd)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+
+	// Resolve output directory with no config file
+	outputDir, err := resolveOutputDirectory(".")
+	if err != nil {
+		t.Fatalf("resolveOutputDirectory returned error: %v", err)
+	}
+
+	// Verify it defaults to .pyscn/reports under CWD
+	expectedDir := filepath.Join(tempDir, ".pyscn", "reports")
+	if outputDir != expectedDir {
+		t.Errorf("expected directory %q, got %q", expectedDir, outputDir)
+	}
+}
+
+func TestResolveOutputDirectory_FallbackToRelative(t *testing.T) {
+	// This tests the fallback when os.Getwd() fails
+	// We can't easily simulate this, but we can verify the function handles it
+	outputDir, err := resolveOutputDirectory(".")
+	if err != nil {
+		t.Fatalf("resolveOutputDirectory returned error: %v", err)
+	}
+
+	// Should return an absolute path or a valid relative path
+	if outputDir == "" {
+		t.Error("expected non-empty output directory")
+	}
+
+	// Should end with .pyscn/reports
+	expectedSuffix := filepath.Join(".pyscn", "reports")
+	if outputDir != expectedSuffix && !filepath.IsAbs(outputDir) {
+		t.Errorf("expected absolute path or %q, got %q", expectedSuffix, outputDir)
+	}
+}
+
+func TestGenerateOutputFilePath_AllowsCustomDirectoryViaConfig(t *testing.T) {
+	// NOTE: Testing custom output directory via config file requires the config
+	// loader to resolve relative directory paths to absolute paths. This is a
+	// separate concern from the generateOutputFilePath function itself, which
+	// correctly uses whatever directory is returned by the config loader.
+	// This test is disabled pending a config loader fix for relative paths.
+	t.Skip("Skipping - config loader returns relative paths for custom output.directory")
+
+	// This test would verify that when a user sets:
+	//   [output]
+	//   directory = "custom_reports"
+	// in their .pyscn.toml, the output path uses that directory.
+	// The config loader currently doesn't convert relative paths to absolute,
+	// which is a separate bug from #249.
+}
+
+func TestGenerateOutputFilePath_DifferentExtensions(t *testing.T) {
+	tempDir := t.TempDir()
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current directory: %v", err)
+	}
+	defer os.Chdir(oldCwd)
+
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+
+	testCases := []struct {
+		command   string
+		extension string
+	}{
+		{"complexity", "json"},
+		{"deadcode", "yaml"},
+		{"clone", "csv"},
+		{"analyze", "html"},
+	}
+
+	for _, tc := range testCases {
+		path, err := generateOutputFilePath(tc.command, tc.extension, ".")
+		if err != nil {
+			t.Errorf("[%s.%s] generateOutputFilePath returned error: %v", tc.command, tc.extension, err)
+			continue
+		}
+
+		if filepath.Ext(path) != "."+tc.extension {
+			t.Errorf("[%s.%s] expected extension .%s, got %q", tc.command, tc.extension, tc.extension, filepath.Ext(path))
+		}
+	}
+}

--- a/cmd/pyscn/utils_test.go
+++ b/cmd/pyscn/utils_test.go
@@ -15,7 +15,7 @@ func TestGenerateOutputFilePath_CreatesDefaultDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd)
+	defer os.Chdir(oldCwd) //nolint:errcheck
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)
@@ -58,7 +58,7 @@ func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd)
+	defer os.Chdir(oldCwd) //nolint:errcheck
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)
@@ -77,42 +77,6 @@ func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
 	}
 }
 
-func TestResolveOutputDirectory_FallbackToRelative(t *testing.T) {
-	// This tests the fallback when os.Getwd() fails
-	// We can't easily simulate this, but we can verify the function handles it
-	outputDir, err := resolveOutputDirectory(".")
-	if err != nil {
-		t.Fatalf("resolveOutputDirectory returned error: %v", err)
-	}
-
-	// Should return an absolute path or a valid relative path
-	if outputDir == "" {
-		t.Error("expected non-empty output directory")
-	}
-
-	// Should end with .pyscn/reports
-	expectedSuffix := filepath.Join(".pyscn", "reports")
-	if outputDir != expectedSuffix && !filepath.IsAbs(outputDir) {
-		t.Errorf("expected absolute path or %q, got %q", expectedSuffix, outputDir)
-	}
-}
-
-func TestGenerateOutputFilePath_AllowsCustomDirectoryViaConfig(t *testing.T) {
-	// NOTE: Testing custom output directory via config file requires the config
-	// loader to resolve relative directory paths to absolute paths. This is a
-	// separate concern from the generateOutputFilePath function itself, which
-	// correctly uses whatever directory is returned by the config loader.
-	// This test is disabled pending a config loader fix for relative paths.
-	t.Skip("Skipping - config loader returns relative paths for custom output.directory")
-
-	// This test would verify that when a user sets:
-	//   [output]
-	//   directory = "custom_reports"
-	// in their .pyscn.toml, the output path uses that directory.
-	// The config loader currently doesn't convert relative paths to absolute,
-	// which is a separate bug from #249.
-}
-
 func TestGenerateOutputFilePath_DifferentExtensions(t *testing.T) {
 	tempDir := t.TempDir()
 
@@ -120,7 +84,7 @@ func TestGenerateOutputFilePath_DifferentExtensions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd)
+	defer os.Chdir(oldCwd) //nolint:errcheck
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)


### PR DESCRIPTION
## Summary

When `generateOutput` fails (e.g., cannot create output directory or write the report file), the error was printed to stderr but swallowed — the CLI still exited 0. Now the output error is returned so the exit status correctly reflects failure.

## Changes

- **cmd/pyscn/analyze.go**: Track `outputErr` from `generateOutput`. If analysis succeeds but output generation fails, return the output error (non-zero exit).
- **cmd/pyscn/utils_test.go**: New unit tests for `generateOutputFilePath` and `resolveOutputDirectory` covering:
  - Default directory (CWD/.pyscn/reports) creation and path resolution
  - Filename format (`analyze_<timestamp>.html`)
  - Different command/extension combinations

## Root cause

`runAnalyze()` called `generateOutput()` which could fail, but only printed a warning and returned `nil` → exit 0. Users in non-interactive environments (WSL, CI) never saw the warning.

Refs #249