### PR TITLE
fix: change default output directory from .pyscn/reports to reports

### DIFF
--- a/cmd/pyscn/utils.go
+++ b/cmd/pyscn/utils.go
@@ -31,14 +31,13 @@ func resolveOutputDirectory(targetPath string) (string, error) {
 	}
 
 	// Default output directory when not specified in config
-	// Use a tool-specific hidden directory under the current working directory
-	// (avoids writing into analyzed source directories by default)
+	// Uses a visible reports/ directory under the current working directory.
 	cwd, err := os.Getwd()
 	if err != nil {
 		// Fallback to relative path if CWD not available
-		return filepath.Join(".pyscn", "reports"), nil
+		return filepath.Join("reports"), nil
 	}
-	return filepath.Join(cwd, ".pyscn", "reports"), nil
+	return filepath.Join(cwd, "reports"), nil
 }
 
 // generateOutputFilePath combines filename generation and directory resolution
@@ -53,7 +52,7 @@ func generateOutputFilePath(command, extension, targetPath string) (string, erro
 
 	// Ensure the directory exists before returning the path. At this point,
 	// outputDir is always non-empty because resolveOutputDirectory provides
-	// a default (e.g., .pyscn/reports under CWD) when config is unset.
+	// a default (e.g., reports/ under CWD) when config is unset.
 	if mkErr := os.MkdirAll(outputDir, 0o755); mkErr != nil {
 		return "", fmt.Errorf("failed to create output directory %s: %w", outputDir, mkErr)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ type OutputConfig struct {
 	// MinComplexity is the minimum complexity to report (filters low values)
 	MinComplexity int `mapstructure:"min_complexity" yaml:"min_complexity"`
 
-	// Directory specifies the output directory for reports (empty = tool default, e.g., ".pyscn/reports" under current working directory)
+	// Directory specifies the output directory for reports (empty = tool default, e.g., "reports" under current working directory)
 	Directory string `mapstructure:"directory" yaml:"directory"`
 }
 

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -356,7 +356,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 		OutputShowDetails:   domain.BoolPtr(false),
 		OutputSortBy:        "complexity",
 		OutputMinComplexity: DefaultMinComplexityFilter,
-		OutputDirectory:     "", // empty = tool default (.pyscn/reports)
+		OutputDirectory:     "", // empty = tool default (reports)
 
 		// Analysis defaults (from [analysis] section - general analysis settings)
 		AnalysisIncludePatterns: []string{"**/*.py"},


### PR DESCRIPTION
## Summary

The HTML report was being generated to a hidden directory (`.pyscn/reports/`), which caused first-time users to think no report was being created at all. The report path is printed in the output, and `reports/` is now a visible directory that users can actually spot.

## Changes

- **cmd/pyscn/utils.go**: Changed default output dir from `.pyscn/reports` to `reports`
- **internal/config/config.go**: Updated comment to reflect new default
- **internal/config/pyscn_config.go**: Updated comment to reflect new default

## Testing

Built and tested on WSL2 Ubuntu. Verified that the HTML report is now generated in a visible `reports/` directory instead of the hidden `.pyscn/reports/`.

## Fixes

Fixes #249