### PR TITLE
test(cmd/pyscn): handle deferred os.Chdir error properly

### DIFF
--- a/cmd/pyscn/utils_test.go
+++ b/cmd/pyscn/utils_test.go
@@ -20,7 +20,7 @@ func TestGenerateOutputFilePath_CreatesDefaultDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd) //nolint:errcheck
+	defer os.Chdir(oldCwd)
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)
@@ -68,7 +68,7 @@ func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd) //nolint:errcheck
+	defer os.Chdir(oldCwd)
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)
@@ -100,7 +100,7 @@ func TestGenerateOutputFilePath_DifferentExtensions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd) //nolint:errcheck
+	defer os.Chdir(oldCwd)
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)

--- a/cmd/pyscn/utils_test.go
+++ b/cmd/pyscn/utils_test.go
@@ -20,7 +20,11 @@ func TestGenerateOutputFilePath_CreatesDefaultDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd)
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Errorf("failed to restore working directory: %v", err)
+		}
+	})
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)
@@ -68,7 +72,11 @@ func TestResolveOutputDirectory_DefaultToCWD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd)
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Errorf("failed to restore working directory: %v", err)
+		}
+	})
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)
@@ -100,7 +108,11 @@ func TestGenerateOutputFilePath_DifferentExtensions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get current directory: %v", err)
 	}
-	defer os.Chdir(oldCwd)
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Errorf("failed to restore working directory: %v", err)
+		}
+	})
 
 	if err := os.Chdir(tempDir); err != nil {
 		t.Fatalf("failed to change directory: %v", err)


### PR DESCRIPTION
## Summary
- Follow-up to #437. The original suffix `//nolint:errcheck` was actually load-bearing — `errcheck` is enabled by default in golangci-lint (the `enable:` block in `.golangci.yml` only adds to the defaults, it does not replace them), so dropping the suffix made CI fail.
- Rather than restore the suppression, switch from `defer os.Chdir(oldCwd)` to `t.Cleanup` and actually report restoration failure via `t.Errorf`. If CWD can't be restored, later tests would otherwise silently run from the wrong directory.

## Test plan
- [x] `go vet ./cmd/pyscn/...` passes
- [x] `go test ./cmd/pyscn/ -run 'TestGenerateOutputFilePath|TestResolveOutputDirectory'` passes locally
- [x] `golangci-lint run ./cmd/pyscn/...` clean locally