### PR TITLE
fix(architecture): count rule invocations in ComplianceScore (#426)

### DIFF
--- a/service/responsibility_analysis.go
+++ b/service/responsibility_analysis.go
@@ -82,25 +82,30 @@ func parseViolationSeverity(value string) domain.ViolationSeverity {
 func (s *SystemAnalysisServiceImpl) analyzeResponsibilityForRequest(
 	graph *analyzer.DependencyGraph,
 	req domain.SystemAnalysisRequest,
-) (*domain.ResponsibilityAnalysis, *domain.CohesionAnalysis, []domain.ArchitectureViolation) {
+) (*domain.ResponsibilityAnalysis, *domain.CohesionAnalysis, []domain.ArchitectureViolation, int) {
 	if !domain.BoolValue(req.ValidateResponsibility, true) && !domain.BoolValue(req.ValidateCohesion, true) {
-		return nil, nil, nil
+		return nil, nil, nil, 0
 	}
 
 	options := responsibilityOptionsFromRequest(req)
 	responsibility, cohesion, responsibilityViolations := s.analyzeResponsibility(graph, options)
 	violations := make([]domain.ArchitectureViolation, 0, len(responsibilityViolations)+len(cohesion.LowCohesionPackages))
+	checks := 0
 	if !domain.BoolValue(req.ValidateResponsibility, true) {
 		responsibility = nil
 	} else {
 		violations = append(violations, responsibilityViolations...)
+		// Every module in the graph is evaluated against the SRP rule once.
+		checks += len(graph.GetModuleNames())
 	}
 	if !domain.BoolValue(req.ValidateCohesion, true) {
 		cohesion = nil
 	} else {
 		violations = append(violations, cohesionArchitectureViolations(cohesion, options.cohesionSeverity)...)
+		// Every package whose cohesion was computed counts as one invocation.
+		checks += len(cohesion.PackageCohesion)
 	}
-	return responsibility, cohesion, violations
+	return responsibility, cohesion, violations, checks
 }
 
 func responsibilitySeverityCounts(violations []domain.ArchitectureViolation) map[domain.ViolationSeverity]int {

--- a/service/responsibility_analysis_test.go
+++ b/service/responsibility_analysis_test.go
@@ -125,7 +125,7 @@ func TestAnalyzeResponsibilityForRequestKeepsCohesionIndependent(t *testing.T) {
 
 	validateResponsibility := false
 	validateCohesion := true
-	responsibility, cohesion, violations := service.analyzeResponsibilityForRequest(graph, domain.SystemAnalysisRequest{
+	responsibility, cohesion, violations, checks := service.analyzeResponsibilityForRequest(graph, domain.SystemAnalysisRequest{
 		ValidateResponsibility:    &validateResponsibility,
 		ValidateCohesion:          &validateCohesion,
 		CohesionViolationSeverity: domain.ViolationSeverityError,
@@ -134,6 +134,8 @@ func TestAnalyzeResponsibilityForRequestKeepsCohesionIndependent(t *testing.T) {
 	assert.Nil(t, responsibility)
 	require.NotNil(t, cohesion)
 	require.Len(t, violations, 1)
+	assert.Equal(t, len(cohesion.PackageCohesion), checks,
+		"checks should equal the number of packages whose cohesion was evaluated")
 	assert.Equal(t, domain.ViolationTypeCohesion, violations[0].Type)
 	assert.Equal(t, domain.ViolationSeverityError, violations[0].Severity)
 	assert.Equal(t, "app.orders", violations[0].Module)
@@ -208,4 +210,12 @@ func TestAnalyzeArchitectureRunsResponsibilityWithoutLayerRules(t *testing.T) {
 	assert.Equal(t, "app.red.hub", result.ResponsibilityAnalysis.SRPViolations[0].Module)
 	assert.Equal(t, 1, result.TotalViolations)
 	assert.Zero(t, result.LayerAnalysis.LayersAnalyzed)
+
+	// The repo has many modules and only one SRP violation, so TotalRules
+	// (rule invocations) must exceed TotalViolations and ComplianceScore must
+	// not collapse to zero. Regression test for #426.
+	assert.Greater(t, result.TotalRules, result.TotalViolations,
+		"TotalRules should count every module checked against the SRP rule, not just the violations")
+	assert.Greater(t, result.ComplianceScore, 0.0,
+		"ComplianceScore should not be zero when most modules pass the responsibility rule")
 }

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -193,7 +193,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 		return nil, fmt.Errorf("architecture analysis cancelled: %w", err)
 	}
 
-	responsibilityAnalysis, cohesionAnalysis, responsibilityViolations := s.analyzeResponsibilityForRequest(graph, req)
+	responsibilityAnalysis, cohesionAnalysis, responsibilityViolations, responsibilityChecks := s.analyzeResponsibilityForRequest(graph, req)
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("architecture analysis cancelled: %w", err)
 	}
@@ -206,7 +206,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 			return s.emptyArchitectureResult(), nil
 		}
 		severityCounts := responsibilitySeverityCounts(responsibilityViolations)
-		checked := len(responsibilityViolations)
+		checked := responsibilityChecks
 		errorCount := severityCounts[domain.ViolationSeverityError]
 		warningCount := severityCounts[domain.ViolationSeverityWarning]
 		compliance := s.calculateComplianceWeighted(errorCount, warningCount, checked)
@@ -252,7 +252,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 		violations = append(violations, violation)
 		severityCounts[violation.Severity]++
 	}
-	checked += len(responsibilityViolations)
+	checked += responsibilityChecks
 	errorCount := severityCounts[domain.ViolationSeverityError]
 	warningCount := severityCounts[domain.ViolationSeverityWarning]
 	compliance := s.calculateComplianceWeighted(errorCount, warningCount, checked)


### PR DESCRIPTION
## Summary

Fixes #426.

`system.ArchitectureAnalysis.ComplianceScore` collapsed to 0 whenever any SRP / cohesion violation fired, because `TotalRules` was set to `len(responsibilityViolations)` — i.e. the same number as `TotalViolations`. A repo with 3 SRP warnings across 32 modules scored `0/100` even though 29 modules were clean.

The fix changes `analyzeResponsibilityForRequest` to also return the number of rule **invocations** performed:

- SRP rule: one invocation per module (`len(graph.GetModuleNames())`)
- Cohesion rule: one invocation per package whose cohesion was computed (`len(cohesion.PackageCohesion)`)

Both branches of `analyzeArchitectureGraph` (layer-rules and no-layer-rules) now add this to the denominator instead of the violation count.

## Behavior change

`TotalRules` and `ComplianceScore` in JSON / HTML / CSV / text output will both shift upward. Example from the original repro:

- Before: 32 modules, 3 SRP warnings → `TotalRules=3`, `ComplianceScore=0`
- After: → `TotalRules≈32`, `ComplianceScore≈0.91`

The detection logic itself is unchanged — `TotalViolations`, `SeverityBreakdown`, `Violations[]`, `LayerAnalysis`, `ResponsibilityAnalysis`, and `CohesionAnalysis` are identical to before. Only the compliance percentage moves. Worth calling out in release notes for anyone gating CI on `arch_compliance`.

## Test plan

- [x] Reproduces in `TestAnalyzeArchitectureRunsResponsibilityWithoutLayerRules` (added regression assertions: `TotalRules > TotalViolations`, `ComplianceScore > 0`)
- [x] `go test ./...` passes
- [x] `make lint` passes