### PR TITLE
docs: update CHANGELOG for v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.21.0] - 2026-05-19
+
+### Performance
+- Speed up the full `analyze` pipeline by reusing parsed files and the system dependency graph, scoring APTED pairs once, and using integer LSH candidates (#438)
+
+### Fixed
+- Count rule invocations (not violations) in architecture `ComplianceScore` denominator (#448, #426)
+- Exit non-zero when output generation fails in the `analyze` command (#437, #249)
+
 ## [1.20.0] - 2026-05-16
 
 ### Added


### PR DESCRIPTION
Update CHANGELOG for v1.21.0 release.

## Highlights
- **Performance**: Major speedup for the `analyze` pipeline (#438)
- **Fixed**: Architecture `ComplianceScore` denominator (#448, #426)
- **Fixed**: `analyze` now exits non-zero when output generation fails (#437, #249)