### PR TITLE
fix: compute module cognitive metrics

### DIFF
--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -153,7 +153,7 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 	// Count actual conditional decisions (blocks with conditional outgoing edges)
 	conditionalDecisions := len(visitor.decisionPoints)
 
-	// Calculate nesting depth if function node is available
+	// Calculate nesting depth if the original AST node is available.
 	nestingDepth := 0
 	startLine := 0
 	startCol := 0
@@ -166,6 +166,9 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		startCol = cfg.FunctionNode.Location.StartCol
 		endLine = cfg.FunctionNode.Location.EndLine
 	} else if cfg.ModuleNode != nil {
+		nestingResult := CalculateMaxNestingDepth(cfg.ModuleNode)
+		nestingDepth = nestingResult.MaxDepth
+
 		startLine = cfg.ModuleNode.Location.StartLine
 		startCol = cfg.ModuleNode.Location.StartCol
 		endLine = cfg.ModuleNode.Location.EndLine

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -246,8 +246,11 @@ func (s *ComplexityServiceImpl) calculateFunctionComplexities(filePath string, c
 		}
 
 		cognitiveComplexity := 0
-		if cfg.FunctionNode != nil {
-			cognitiveResult := analyzer.CalculateCognitiveComplexity(cfg.FunctionNode)
+		if complexityNode := cfg.FunctionNode; complexityNode != nil {
+			cognitiveResult := analyzer.CalculateCognitiveComplexity(complexityNode)
+			cognitiveComplexity = cognitiveResult.Total
+		} else if cfg.ModuleNode != nil {
+			cognitiveResult := analyzer.CalculateCognitiveComplexity(cfg.ModuleNode)
 			cognitiveComplexity = cognitiveResult.Total
 		}
 

--- a/service/complexity_service_test.go
+++ b/service/complexity_service_test.go
@@ -119,6 +119,45 @@ func TestComplexityService_Analyze(t *testing.T) {
 		assert.Equal(t, "branch", response.Functions[0].Name)
 	})
 
+	t.Run("module-level complexity includes cognitive and nesting metrics", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := tempDir + "/module_control_flow.py"
+		content := []byte(`for i in range(10):
+    if i % 2 == 0:
+        for j in range(i):
+            if j > 0:
+                print(i, j)
+            else:
+                print("zero")
+    elif i % 3 == 0:
+        print("three")
+    else:
+        print("other")
+`)
+		err := os.WriteFile(filePath, content, 0644)
+		require.NoError(t, err)
+
+		req := newDefaultComplexityRequest(filePath)
+
+		response, err := service.Analyze(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		var module *domain.FunctionComplexity
+		for i := range response.Functions {
+			if response.Functions[i].Name == domain.ModuleFunctionName {
+				module = &response.Functions[i]
+				break
+			}
+		}
+		require.NotNil(t, module, "expected module-level complexity result")
+		assert.Greater(t, module.Metrics.Complexity, 1)
+		assert.Greater(t, module.Metrics.IfStatements, 0)
+		assert.Greater(t, module.Metrics.LoopStatements, 0)
+		assert.Greater(t, module.Metrics.CognitiveComplexity, 0)
+		assert.Greater(t, module.Metrics.NestingDepth, 0)
+	})
+
 	t.Run("enabled false suppresses complexity results", func(t *testing.T) {
 		req := newDefaultComplexityRequest("../testdata/python/simple/functions.py")
 		req.Enabled = domain.BoolPtr(false)


### PR DESCRIPTION
## Summary
Fixes #462.

Module-level CFGs already retain their original `ModuleNode`, but the complexity service only calculated cognitive complexity for `FunctionNode`, and the lower complexity analyzer only calculated nesting depth for `FunctionNode`. This leaves `<module>` reports with non-zero cyclomatic complexity and branch/loop counts but `CognitiveComplexity=0` and `NestingDepth=0`.

This reuses `ModuleNode` for those two metrics and adds a regression test covering top-level loops/branches.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Fixes #462

## Changes
- Compute nesting depth from `cfg.ModuleNode` for module-level complexity results.
- Compute cognitive complexity from `cfg.ModuleNode` in the service layer.
- Add a regression test proving `<module>` entries report non-zero cognitive and nesting metrics for nested top-level control flow.

## Testing
- [x] `make test` passes locally
- [ ] `make lint` passes locally (`go vet ./...` passed, but local `make lint` cannot complete because `golangci-lint` is not installed)
- [x] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)

Additional local checks:
- `go test ./service -run 'TestComplexityService_Analyze/module-level_complexity_includes_cognitive_and_nesting_metrics' -count=1`
- `go test ./service ./internal/analyzer -run 'TestComplexity|TestCalculateComplexity|TestCalculateCognitiveComplexity|TestCalculateMaxNestingDepth' -count=1`
- `go build -v ./cmd/pyscn`
- `go vet ./...`
- `git diff --check`
- `gofmt` check on changed files

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (if needed)

## Additional Context
I checked the earlier closed PR #463 for this issue before opening this. That PR changed `internal/analyzer/module_analyzer.go` and removed a large amount of unrelated code; this PR is a narrow metrics fix with a regression test.