### PR TITLE
Fix complexity metric source consistency

### DIFF
--- a/docs/algorithms/complexity.md
+++ b/docs/algorithms/complexity.md
@@ -200,16 +200,31 @@ A decision point is any CFG node that produces a branching choice. This is equiv
 | Counter | What it tracks |
 |---|---|
 | `decisionPoints` map | Unique blocks with `EdgeCondTrue`/`EdgeCondFalse` outgoing edges |
-| `loopStatements` | Edges of type `EdgeLoop` |
-| `exceptionHandlers` | Edges of type `EdgeException` |
-| `switchCases` | Match/switch case edges |
+| `loopStatements` | Edges of type `EdgeLoop` for CFG-only callers |
+| `exceptionHandlers` | Edges of type `EdgeException` for CFG-only callers |
+| `switchCases` | Match/switch case edges for CFG-only callers |
+
+When the CFG has its original AST node, user-facing statement counters are derived from the AST instead of CFG edge types:
+
+| Public field | AST source |
+|---|---|
+| `IfStatements` | `if` / `elif` syntax nodes |
+| `LoopStatements` | `for`, `async for`, and `while` syntax nodes |
+| `ExceptionHandlers` | `except` clauses |
+| `SwitchCases` | `match` cases |
 
 The total decision points are computed by `countDecisionPoints`:
 
 ```go
-func countDecisionPoints(visitor *complexityVisitor) int {
+func countDecisionPoints(visitor *complexityVisitor, astMetrics astComplexityMetrics, hasASTMetrics bool) int {
     conditionalDecisions := len(visitor.decisionPoints)
-    return conditionalDecisions + visitor.exceptionHandlers + visitor.switchCases
+    exceptionHandlers := visitor.exceptionHandlers
+    switchCases := visitor.switchCases
+    if hasASTMetrics {
+        exceptionHandlers = astMetrics.ExceptionHandlers
+        switchCases = astMetrics.SwitchCases
+    }
+    return conditionalDecisions + exceptionHandlers + switchCases
 }
 ```
 
@@ -308,10 +323,11 @@ Each analyzed function produces a `ComplexityResult` (`internal/analyzer/complex
 | `FunctionName` | Fully qualified function name |
 | `StartLine`, `StartCol`, `EndLine` | Source location |
 | `NestingDepth` | Maximum nesting depth |
-| `IfStatements` | Count of conditional decision points |
-| `LoopStatements` | Count of loop back-edges |
-| `ExceptionHandlers` | Count of exception handler edges |
-| `SwitchCases` | Count of match/case edges |
+| `CognitiveComplexity` | SonarQube-style cognitive complexity |
+| `IfStatements` | Count of `if` / `elif` syntax nodes |
+| `LoopStatements` | Count of `for`, `async for`, and `while` syntax nodes |
+| `ExceptionHandlers` | Count of `except` clauses |
+| `SwitchCases` | Count of `match` cases |
 | `RiskLevel` | `"low"`, `"medium"`, or `"high"` |
 
 ### Aggregate Metrics

--- a/docs/algorithms/complexity.md
+++ b/docs/algorithms/complexity.md
@@ -216,17 +216,19 @@ When the CFG has its original AST node, user-facing statement counters are deriv
 The total decision points are computed by `countDecisionPoints`:
 
 ```go
-func countDecisionPoints(visitor *complexityVisitor, astMetrics astComplexityMetrics, hasASTMetrics bool) int {
+func countDecisionPoints(visitor *complexityVisitor, metrics astComplexityMetrics, hasASTMetrics bool) int {
     conditionalDecisions := len(visitor.decisionPoints)
-    exceptionHandlers := visitor.exceptionHandlers
-    switchCases := visitor.switchCases
-    if hasASTMetrics {
-        exceptionHandlers = astMetrics.ExceptionHandlers
-        switchCases = astMetrics.SwitchCases
+    if hasASTMetrics && metrics.MatchStatements > 0 {
+        conditionalDecisions -= metrics.MatchStatements
+        if conditionalDecisions < 0 {
+            conditionalDecisions = 0
+        }
     }
-    return conditionalDecisions + exceptionHandlers + switchCases
+    return conditionalDecisions + metrics.ExceptionHandlers + metrics.SwitchCases
 }
 ```
+
+For parser-backed CFGs, `metrics` replaces the synthetic single match decision with the actual number of `case` clauses. CFG-only callers keep the older edge-based fallback.
 
 The final complexity is then:
 

--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/ludo-technologies/pyscn/internal/config"
+	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
 // ComplexityResult holds cyclomatic complexity metrics for a function or method
@@ -23,7 +24,8 @@ type ComplexityResult struct {
 	EndLine      int
 
 	// Nesting depth
-	NestingDepth int
+	NestingDepth        int
+	CognitiveComplexity int
 
 	// Decision points breakdown
 	IfStatements      int
@@ -51,12 +53,13 @@ func (cr *ComplexityResult) GetRiskLevel() string {
 
 func (cr *ComplexityResult) GetDetailedMetrics() map[string]int {
 	return map[string]int{
-		"nodes":              cr.Nodes,
-		"edges":              cr.Edges,
-		"if_statements":      cr.IfStatements,
-		"loop_statements":    cr.LoopStatements,
-		"exception_handlers": cr.ExceptionHandlers,
-		"switch_cases":       cr.SwitchCases,
+		"nodes":                cr.Nodes,
+		"edges":                cr.Edges,
+		"cognitive_complexity": cr.CognitiveComplexity,
+		"if_statements":        cr.IfStatements,
+		"loop_statements":      cr.LoopStatements,
+		"exception_handlers":   cr.ExceptionHandlers,
+		"switch_cases":         cr.SwitchCases,
 	}
 }
 
@@ -142,16 +145,14 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 
 	// Primary method: count decision points + 1
 	// This is more reliable for CFGs with entry/exit nodes
-	decisionPoints := countDecisionPoints(visitor)
+	astMetrics, hasASTMetrics := calculateASTComplexityMetrics(complexitySourceNode(cfg))
+	decisionPoints := countDecisionPoints(visitor, astMetrics, hasASTMetrics)
 	complexity := decisionPoints + 1
 
 	// Ensure minimum complexity of 1 for any function
 	if complexity < 1 {
 		complexity = 1
 	}
-
-	// Count actual conditional decisions (blocks with conditional outgoing edges)
-	conditionalDecisions := len(visitor.decisionPoints)
 
 	// Calculate nesting depth if the original AST node is available.
 	nestingDepth := 0
@@ -184,18 +185,24 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		StartCol:            startCol,
 		EndLine:             endLine,
 		NestingDepth:        nestingDepth,
-		IfStatements:        conditionalDecisions, // Accurate count of decision points
+		CognitiveComplexity: astMetrics.CognitiveComplexity,
+		IfStatements:        astMetrics.IfStatements,
 		LoopStatements:      visitor.loopStatements,
 		ExceptionHandlers:   visitor.exceptionHandlers,
 		SwitchCases:         visitor.switchCases,
 		RiskLevel:           complexityConfig.AssessRiskLevel(complexity),
+	}
+	if hasASTMetrics {
+		result.LoopStatements = astMetrics.LoopStatements
+		result.ExceptionHandlers = astMetrics.ExceptionHandlers
+		result.SwitchCases = astMetrics.SwitchCases
 	}
 
 	return result
 }
 
 // countDecisionPoints counts the number of decision points in the CFG
-func countDecisionPoints(visitor *complexityVisitor) int {
+func countDecisionPoints(visitor *complexityVisitor, astMetrics astComplexityMetrics, hasASTMetrics bool) int {
 	// Decision points are nodes that have multiple outgoing edges
 	// For McCabe complexity, each decision point adds 1 to complexity
 
@@ -205,7 +212,67 @@ func countDecisionPoints(visitor *complexityVisitor) int {
 	// Add other decision types
 	// Note: loops without conditions are just jumps, not decisions
 	// But loops with conditions are already counted in conditionals
-	return conditionalDecisions + visitor.exceptionHandlers + visitor.switchCases
+	exceptionHandlers := visitor.exceptionHandlers
+	switchCases := visitor.switchCases
+	if hasASTMetrics {
+		exceptionHandlers = astMetrics.ExceptionHandlers
+		switchCases = astMetrics.SwitchCases
+	}
+	return conditionalDecisions + exceptionHandlers + switchCases
+}
+
+type astComplexityMetrics struct {
+	CognitiveComplexity int
+	IfStatements        int
+	LoopStatements      int
+	ExceptionHandlers   int
+	SwitchCases         int
+}
+
+func complexitySourceNode(cfg *CFG) *parser.Node {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.FunctionNode != nil {
+		return cfg.FunctionNode
+	}
+	return cfg.ModuleNode
+}
+
+func calculateASTComplexityMetrics(root *parser.Node) (astComplexityMetrics, bool) {
+	if root == nil {
+		return astComplexityMetrics{}, false
+	}
+
+	metrics := astComplexityMetrics{}
+	metrics.CognitiveComplexity = CalculateCognitiveComplexity(root).Total
+	for _, stmt := range root.Body {
+		collectASTStatementMetrics(stmt, &metrics)
+	}
+	return metrics, true
+}
+
+func collectASTStatementMetrics(node *parser.Node, metrics *astComplexityMetrics) {
+	if node == nil {
+		return
+	}
+
+	switch node.Type {
+	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef, parser.NodeClassDef:
+		return
+	case parser.NodeIf, parser.NodeElifClause:
+		metrics.IfStatements++
+	case parser.NodeFor, parser.NodeAsyncFor, parser.NodeWhile:
+		metrics.LoopStatements++
+	case parser.NodeExceptHandler:
+		metrics.ExceptionHandlers++
+	case parser.NodeMatchCase:
+		metrics.SwitchCases++
+	}
+
+	for _, child := range node.GetChildren() {
+		collectASTStatementMetrics(child, metrics)
+	}
 }
 
 // CalculateFileComplexity calculates complexity for all functions in a collection of CFGs

--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -146,7 +146,8 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 	// Primary method: count decision points + 1
 	// This is more reliable for CFGs with entry/exit nodes
 	astMetrics, hasASTMetrics := calculateASTComplexityMetrics(complexitySourceNode(cfg))
-	decisionPoints := countDecisionPoints(visitor, astMetrics, hasASTMetrics)
+	reportedMetrics := resolveComplexityMetrics(visitor, astMetrics, hasASTMetrics)
+	decisionPoints := countDecisionPoints(visitor, reportedMetrics, hasASTMetrics)
 	complexity := decisionPoints + 1
 
 	// Ensure minimum complexity of 1 for any function
@@ -185,40 +186,32 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		StartCol:            startCol,
 		EndLine:             endLine,
 		NestingDepth:        nestingDepth,
-		CognitiveComplexity: astMetrics.CognitiveComplexity,
-		IfStatements:        astMetrics.IfStatements,
-		LoopStatements:      visitor.loopStatements,
-		ExceptionHandlers:   visitor.exceptionHandlers,
-		SwitchCases:         visitor.switchCases,
+		CognitiveComplexity: reportedMetrics.CognitiveComplexity,
+		IfStatements:        reportedMetrics.IfStatements,
+		LoopStatements:      reportedMetrics.LoopStatements,
+		ExceptionHandlers:   reportedMetrics.ExceptionHandlers,
+		SwitchCases:         reportedMetrics.SwitchCases,
 		RiskLevel:           complexityConfig.AssessRiskLevel(complexity),
-	}
-	if hasASTMetrics {
-		result.LoopStatements = astMetrics.LoopStatements
-		result.ExceptionHandlers = astMetrics.ExceptionHandlers
-		result.SwitchCases = astMetrics.SwitchCases
 	}
 
 	return result
 }
 
 // countDecisionPoints counts the number of decision points in the CFG
-func countDecisionPoints(visitor *complexityVisitor, astMetrics astComplexityMetrics, hasASTMetrics bool) int {
+func countDecisionPoints(visitor *complexityVisitor, metrics astComplexityMetrics, hasASTMetrics bool) int {
 	// Decision points are nodes that have multiple outgoing edges
 	// For McCabe complexity, each decision point adds 1 to complexity
 
 	// Count actual conditional decisions (unique blocks with conditional edges)
 	conditionalDecisions := len(visitor.decisionPoints)
-
-	// Add other decision types
-	// Note: loops without conditions are just jumps, not decisions
-	// But loops with conditions are already counted in conditionals
-	exceptionHandlers := visitor.exceptionHandlers
-	switchCases := visitor.switchCases
-	if hasASTMetrics {
-		exceptionHandlers = astMetrics.ExceptionHandlers
-		switchCases = astMetrics.SwitchCases
+	if hasASTMetrics && metrics.MatchStatements > 0 {
+		conditionalDecisions -= metrics.MatchStatements
+		if conditionalDecisions < 0 {
+			conditionalDecisions = 0
+		}
 	}
-	return conditionalDecisions + exceptionHandlers + switchCases
+
+	return conditionalDecisions + metrics.ExceptionHandlers + metrics.SwitchCases
 }
 
 type astComplexityMetrics struct {
@@ -226,6 +219,7 @@ type astComplexityMetrics struct {
 	IfStatements        int
 	LoopStatements      int
 	ExceptionHandlers   int
+	MatchStatements     int
 	SwitchCases         int
 }
 
@@ -237,6 +231,18 @@ func complexitySourceNode(cfg *CFG) *parser.Node {
 		return cfg.FunctionNode
 	}
 	return cfg.ModuleNode
+}
+
+func resolveComplexityMetrics(visitor *complexityVisitor, astMetrics astComplexityMetrics, hasASTMetrics bool) astComplexityMetrics {
+	if hasASTMetrics {
+		return astMetrics
+	}
+	return astComplexityMetrics{
+		IfStatements:      len(visitor.decisionPoints),
+		LoopStatements:    visitor.loopStatements,
+		ExceptionHandlers: visitor.exceptionHandlers,
+		SwitchCases:       visitor.switchCases,
+	}
 }
 
 func calculateASTComplexityMetrics(root *parser.Node) (astComplexityMetrics, bool) {
@@ -260,6 +266,10 @@ func collectASTStatementMetrics(node *parser.Node, metrics *astComplexityMetrics
 	switch node.Type {
 	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef, parser.NodeClassDef:
 		return
+	case parser.NodeMatch:
+		if len(node.Body) > 0 {
+			metrics.MatchStatements++
+		}
 	case parser.NodeIf, parser.NodeElifClause:
 		metrics.IfStatements++
 	case parser.NodeFor, parser.NodeAsyncFor, parser.NodeWhile:

--- a/internal/analyzer/complexity_test.go
+++ b/internal/analyzer/complexity_test.go
@@ -327,6 +327,106 @@ for path in os.listdir("."):
 	}
 }
 
+func TestCalculateComplexity_StatementMetricsUseASTCounts(t *testing.T) {
+	source := `def debug_no_ifs():
+    values = []
+    for var in [1, 2, 3]:
+        values.append(var)
+    for factor in [1, 2, 3]:
+        for var in [1, 2, 3]:
+            values.append(var * factor)
+    for factor in [1, 2, 3]:
+        for var in [1, 2, 3]:
+            values.append(factor - var)
+    return values
+`
+
+	res := calculateFunctionComplexityForSource(t, source, "debug_no_ifs")
+
+	if res.Complexity != 6 {
+		t.Fatalf("Complexity = %d, want 6", res.Complexity)
+	}
+	if res.IfStatements != 0 {
+		t.Fatalf("IfStatements = %d, want 0", res.IfStatements)
+	}
+	if res.LoopStatements != 5 {
+		t.Fatalf("LoopStatements = %d, want 5", res.LoopStatements)
+	}
+	if res.ExceptionHandlers != 0 {
+		t.Fatalf("ExceptionHandlers = %d, want 0", res.ExceptionHandlers)
+	}
+}
+
+func TestCalculateComplexity_ExceptionHandlersUseClauses(t *testing.T) {
+	source := `def handle(value):
+    try:
+        risky(value)
+    except ValueError:
+        if value == 1:
+            return 1
+        elif value == 2:
+            return 2
+        return 3
+    except TypeError:
+        for item in value:
+            print(item)
+    except Exception:
+        return 4
+    return 0
+`
+
+	res := calculateFunctionComplexityForSource(t, source, "handle")
+
+	if res.ExceptionHandlers != 3 {
+		t.Fatalf("ExceptionHandlers = %d, want 3", res.ExceptionHandlers)
+	}
+	if res.IfStatements != 2 {
+		t.Fatalf("IfStatements = %d, want 2", res.IfStatements)
+	}
+	if res.LoopStatements != 1 {
+		t.Fatalf("LoopStatements = %d, want 1", res.LoopStatements)
+	}
+	if res.Complexity != 7 {
+		t.Fatalf("Complexity = %d, want 7", res.Complexity)
+	}
+}
+
+func TestCalculateComplexity_ComputesCognitiveComplexityInAnalyzer(t *testing.T) {
+	source := `def branch(value):
+    if value:
+        return 1
+    return 0
+`
+
+	res := calculateFunctionComplexityForSource(t, source, "branch")
+
+	if res.CognitiveComplexity != 1 {
+		t.Fatalf("CognitiveComplexity = %d, want 1", res.CognitiveComplexity)
+	}
+}
+
+func calculateFunctionComplexityForSource(t *testing.T, source, functionName string) *ComplexityResult {
+	t.Helper()
+
+	p := parser.New()
+	result, err := p.Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+
+	cfgs, err := NewCFGBuilder().BuildAll(result.AST)
+	if err != nil {
+		t.Fatalf("Failed to build CFGs: %v", err)
+	}
+
+	cfg, ok := cfgs[functionName]
+	if !ok {
+		t.Fatalf("Expected CFG for %q", functionName)
+	}
+
+	return CalculateComplexity(cfg)
+}
+
 func TestAssessRiskLevel(t *testing.T) {
 	// Test using config.ComplexityConfig.AssessRiskLevel instead of deprecated function
 	defaultConfig := config.DefaultConfig()

--- a/internal/analyzer/complexity_test.go
+++ b/internal/analyzer/complexity_test.go
@@ -405,6 +405,52 @@ func TestCalculateComplexity_ComputesCognitiveComplexityInAnalyzer(t *testing.T)
 	}
 }
 
+func TestCalculateComplexity_CFGOnlyKeepsDecisionFallback(t *testing.T) {
+	cfg := NewCFG("manual")
+	cond := cfg.CreateBlock("condition")
+	thenBlock := cfg.CreateBlock("then")
+	elseBlock := cfg.CreateBlock("else")
+
+	cfg.ConnectBlocks(cfg.Entry, cond, EdgeNormal)
+	cfg.ConnectBlocks(cond, thenBlock, EdgeCondTrue)
+	cfg.ConnectBlocks(cond, elseBlock, EdgeCondFalse)
+	cfg.ConnectBlocks(thenBlock, cfg.Exit, EdgeNormal)
+	cfg.ConnectBlocks(elseBlock, cfg.Exit, EdgeNormal)
+
+	res := CalculateComplexity(cfg)
+
+	if res.Complexity != 2 {
+		t.Fatalf("Complexity = %d, want 2", res.Complexity)
+	}
+	if res.IfStatements != 1 {
+		t.Fatalf("IfStatements = %d, want 1 for CFG-only fallback", res.IfStatements)
+	}
+}
+
+func TestCalculateComplexity_MatchCasesReplaceSingleCFGDecision(t *testing.T) {
+	source := `def handle(value):
+    match value:
+        case 0:
+            return "zero"
+        case 1:
+            return "one"
+        case _:
+            return "other"
+`
+
+	res := calculateFunctionComplexityForSource(t, source, "handle")
+
+	if res.SwitchCases != 3 {
+		t.Fatalf("SwitchCases = %d, want 3", res.SwitchCases)
+	}
+	if res.IfStatements != 0 {
+		t.Fatalf("IfStatements = %d, want 0", res.IfStatements)
+	}
+	if res.Complexity != 4 {
+		t.Fatalf("Complexity = %d, want 4", res.Complexity)
+	}
+}
+
 func calculateFunctionComplexityForSource(t *testing.T, source, functionName string) *ComplexityResult {
 	t.Helper()
 

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -245,15 +245,6 @@ func (s *ComplexityServiceImpl) calculateFunctionComplexities(filePath string, c
 			continue
 		}
 
-		cognitiveComplexity := 0
-		if complexityNode := cfg.FunctionNode; complexityNode != nil {
-			cognitiveResult := analyzer.CalculateCognitiveComplexity(complexityNode)
-			cognitiveComplexity = cognitiveResult.Total
-		} else if cfg.ModuleNode != nil {
-			cognitiveResult := analyzer.CalculateCognitiveComplexity(cfg.ModuleNode)
-			cognitiveComplexity = cognitiveResult.Total
-		}
-
 		riskLevel := s.calculateRiskLevel(result.Complexity, req)
 
 		function := domain.FunctionComplexity{
@@ -264,7 +255,7 @@ func (s *ComplexityServiceImpl) calculateFunctionComplexities(filePath string, c
 			EndLine:     result.EndLine,
 			Metrics: domain.ComplexityMetrics{
 				Complexity:          result.Complexity,
-				CognitiveComplexity: cognitiveComplexity,
+				CognitiveComplexity: result.CognitiveComplexity,
 				Nodes:               result.Nodes,
 				Edges:               result.Edges,
 				NestingDepth:        result.NestingDepth,

--- a/service/complexity_service_test.go
+++ b/service/complexity_service_test.go
@@ -30,6 +30,15 @@ func newDefaultComplexityRequest(paths ...string) domain.ComplexityRequest {
 	}
 }
 
+func findFunctionComplexity(functions []domain.FunctionComplexity, name string) *domain.FunctionComplexity {
+	for i := range functions {
+		if functions[i].Name == name {
+			return &functions[i]
+		}
+	}
+	return nil
+}
+
 func TestNewComplexityService(t *testing.T) {
 	service := NewComplexityService()
 
@@ -117,6 +126,55 @@ func TestComplexityService_Analyze(t *testing.T) {
 		require.NotNil(t, response)
 		require.Len(t, response.Functions, 1)
 		assert.Equal(t, "branch", response.Functions[0].Name)
+	})
+
+	t.Run("public metrics use literal statement counts", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := tempDir + "/literal_counts.py"
+		content := []byte(`def debug_no_ifs():
+    values = []
+    for var in [1, 2, 3]:
+        values.append(var)
+    for factor in [1, 2, 3]:
+        for var in [1, 2, 3]:
+            values.append(var * factor)
+    for factor in [1, 2, 3]:
+        for var in [1, 2, 3]:
+            values.append(factor - var)
+    return values
+
+def handle(value):
+    try:
+        risky(value)
+    except ValueError:
+        if value == 1:
+            return 1
+        elif value == 2:
+            return 2
+    except TypeError:
+        return 3
+`)
+		err := os.WriteFile(filePath, content, 0644)
+		require.NoError(t, err)
+
+		req := newDefaultComplexityRequest(filePath)
+
+		response, err := service.Analyze(ctx, req)
+
+		require.NoError(t, err)
+		require.NotNil(t, response)
+		noIfs := findFunctionComplexity(response.Functions, "debug_no_ifs")
+		require.NotNil(t, noIfs)
+		assert.Equal(t, 0, noIfs.Metrics.IfStatements)
+		assert.Equal(t, 5, noIfs.Metrics.LoopStatements)
+		assert.Equal(t, 0, noIfs.Metrics.ExceptionHandlers)
+
+		handler := findFunctionComplexity(response.Functions, "handle")
+		require.NotNil(t, handler)
+		assert.Equal(t, 2, handler.Metrics.IfStatements)
+		assert.Equal(t, 0, handler.Metrics.LoopStatements)
+		assert.Equal(t, 2, handler.Metrics.ExceptionHandlers)
+		assert.Equal(t, 5, handler.Metrics.CognitiveComplexity)
 	})
 
 	t.Run("module-level complexity includes cognitive and nesting metrics", func(t *testing.T) {


### PR DESCRIPTION
This tightens the complexity metrics so public counters come from the right source.

When a CFG has its original AST node, the analyzer now uses parser-backed counts for if/elif statements, loops, exception handlers, and match cases. CFG-only callers still keep the existing fallback behavior.

This also fixes match complexity so a match block does not get counted once as a synthetic CFG decision and again through its cases.

Added focused regression coverage and updated the complexity docs to match the analyzer behavior.

Validation:
go test ./...