### PR TITLE
docs: add French (fr) translation

### DIFF
--- a/website/docs/configuration/examples.md
+++ b/website/docs/configuration/examples.md
@@ -15,7 +15,7 @@ max_complexity = 15
 min_severity = "critical"
 ```
 
-## Strict CI gate
+## Strict CI gate { #strict-ci-gate }
 
 Fail the build on any quality regression. Pair with `pyscn check`.
 

--- a/website/docs/fr/assets/icon.svg
+++ b/website/docs/fr/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M7 9C7 7.34315 8.34315 6 10 6H14C15.6569 6 17 7.34315 17 9V13C17 14.6569 15.6569 16 14 16H10C8.34315 16 7 17.3431 7 19V20" stroke="#2563eb" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="17" cy="19" r="2" fill="#8b5cf6"/>
+</svg>

--- a/website/docs/fr/cli/analyze.md
+++ b/website/docs/fr/cli/analyze.md
@@ -1,0 +1,117 @@
+# `pyscn analyze`
+
+Exécute toutes les analyses disponibles sur des fichiers Python et produit un rapport.
+
+```text
+pyscn analyze [flags] <paths...>
+```
+
+`<paths...>` correspond à un ou plusieurs fichiers ou répertoires. Les répertoires sont parcourus récursivement en utilisant les `include_patterns` et `exclude_patterns` de votre configuration.
+
+## Ce qu'elle fait
+
+Par défaut, `analyze` exécute simultanément chaque analyseur activé :
+
+- Complexité cyclomatique
+- Détection de code mort
+- Détection de clones (Type 1 à 4)
+- Couplage entre classes (CBO)
+- Cohésion des classes (LCOM4)
+- Dépendances entre modules
+- Validation des couches d'architecture
+
+Les résultats sont combinés dans un rapport unique avec un [Score de Santé](../output/health-score.md).
+
+## Options
+
+### Format de sortie
+
+Une seule de ces options peut être définie par invocation. Si aucune n'est définie, le HTML est généré.
+
+| Option        | Description |
+| ----------- | --- |
+| `--html`    | Génère un rapport HTML (par défaut). |
+| `--json`    | Génère un rapport JSON. |
+| `--yaml`    | Génère un rapport YAML. |
+| `--csv`     | Génère un résumé CSV (métriques uniquement, sans détail par constatation). |
+| `--no-open` | N'ouvre pas le rapport HTML dans un navigateur. |
+
+Les fichiers de sortie sont placés par défaut dans `.pyscn/reports/`, nommés `analyze_YYYYMMDD_HHMMSS.{ext}`. Configurez le répertoire avec `[output] directory = "..."`.
+
+### Sélection des analyses
+
+| Option | Description |
+| --- | --- |
+| `--select <list>` | N'exécute que les analyses listées. Séparées par des virgules : `complexity,deadcode,clones,cbo,lcom,deps`. |
+| `--skip-complexity` | Ignore l'analyse de complexité. |
+| `--skip-deadcode`   | Ignore la détection de code mort. |
+| `--skip-clones`     | Ignore la détection de clones (l'analyse la plus lente). |
+| `--skip-cbo`        | Ignore l'analyse de couplage entre classes. |
+| `--skip-lcom`       | Ignore l'analyse de cohésion des classes. |
+| `--skip-deps`       | Ignore l'analyse des dépendances entre modules. |
+
+`--select` et `--skip-*` peuvent être combinées ; la sélection s'applique en premier, puis les exclusions.
+
+### Surcharges rapides de seuils
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| `--min-complexity <N>`    | `5`        | N'affiche que les fonctions de complexité ≥ N. |
+| `--min-severity <level>`  | `warning`  | Sévérité minimale du code mort : `info`, `warning`, `critical`. |
+| `--clone-threshold <F>`   | `0.65`     | Similarité minimale (0.0–1.0) pour la détection de clones. |
+| `--min-cbo <N>`           | `0`        | N'affiche que les classes dont le CBO est ≥ N. |
+
+### Configuration
+
+| Option | Description |
+| --- | --- |
+| `-c, --config <path>` | Charge la configuration depuis un fichier spécifique au lieu de découvrir `.pyscn.toml` / `pyproject.toml`. |
+| `-v, --verbose`        | Affiche la progression détaillée et les journaux par fichier. |
+
+## Codes de sortie
+
+| Code | Signification |
+| --- | --- |
+| `0` | Analyse terminée. Les problèmes signalés dans le rapport n'affectent pas le code de sortie. |
+| `1` | Échec de l'analyse — arguments invalides, fichiers illisibles, erreurs d'analyse syntaxique. |
+
+`analyze` n'échoue jamais le processus en fonction des constatations ; utilisez [`pyscn check`](check.md) pour une sémantique succès/échec.
+
+## Exemples
+
+```bash
+# Analyse complète du répertoire courant avec rapport HTML
+pyscn analyze .
+
+# JSON pour les pipelines
+pyscn analyze --json src/
+
+# Ignorer l'analyseur le plus lent
+pyscn analyze --skip-clones src/
+
+# Uniquement complexité et code mort
+pyscn analyze --select complexity,deadcode src/
+
+# Seuils plus stricts
+pyscn analyze --min-complexity 10 --min-severity critical src/
+
+# Utiliser un fichier de configuration spécifique
+pyscn analyze --config ./configs/strict.toml src/
+
+# Ne pas ouvrir le navigateur (utile dans des sandbox ou des conteneurs)
+pyscn analyze --no-open .
+```
+
+## Quand utiliser `analyze` vs `check`
+
+| Cas d'usage | Commande |
+| --- | --- |
+| Développement local, « donnez-moi la vue d'ensemble » | `pyscn analyze` |
+| Garde-fou qualité en CI avec succès/échec | [`pyscn check`](check.md) |
+| Sortie lisible par machine pour outillage personnalisé | `pyscn analyze --json` |
+
+## Voir aussi
+
+- [Référence de configuration](../configuration/reference.md) — tous les réglages.
+- [Score de Santé](../output/health-score.md) — comment le nombre 0–100 est calculé.
+- [Schémas de sortie](../output/schemas.md) — définitions des champs JSON / YAML / CSV.

--- a/website/docs/fr/cli/check.md
+++ b/website/docs/fr/cli/check.md
@@ -1,0 +1,100 @@
+# `pyscn check`
+
+Garde-fou qualité pour les pipelines CI/CD. Écrit les constatations au format linter sur **stderr** et sort avec un code non nul si un problème dépasse un seuil.
+
+```text
+pyscn check [flags] [paths...]
+```
+
+Les chemins sont par défaut le répertoire courant.
+
+## Ce qu'elle fait
+
+`check` est le compagnon CI de [`analyze`](analyze.md) :
+
+- **Les constatations vont sur stderr** au format linter (`file:line:col: message`).
+- **Sortie 0** en cas de succès, **sortie 1** en cas d'échec (problèmes détectés *ou* erreur d'exécution).
+- **Valeurs par défaut strictes** — toute fonction de complexité supérieure à 10 échoue ; toute dépendance circulaire échoue (lorsque `--select deps` est défini).
+- **Rapide** — n'exécute que les analyses sélectionnées ; pas de génération de rapport.
+
+## Options
+
+### Sélection des analyses
+
+| Option | Description |
+| --- | --- |
+| `-s, --select <list>` | N'exécute que les analyses listées. Valeurs : `complexity`, `deadcode`, `clones`, `deps` (alias `circular`), `mockdata`, `di`. |
+| `--skip-clones`       | N'exécute pas la détection de clones. |
+
+Par défaut (sans `--select`) : exécute `complexity`, `deadcode`, **et `clones`**. `deps`, `mockdata` et `di` sont en opt-in via `--select`. Passez `--skip-clones` pour ignorer la détection de clones sans passer à `--select`.
+
+### Surcharges de seuils
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| `--max-complexity <N>`   | `10` | Échoue si une fonction dépasse cette complexité cyclomatique. |
+| `--max-cycles <N>`       | `0`  | Nombre maximal de cycles de dépendance circulaire avant échec. |
+| `--allow-dead-code`      | off  | Traite le code mort comme un simple avertissement ; ne fait pas échouer la vérification. |
+| `--allow-circular-deps`  | off  | Traite les cycles comme de simples avertissements ; ne fait pas échouer la vérification. |
+
+### Sortie
+
+| Option | Description |
+| --- | --- |
+| `-q, --quiet`          | Supprime la sortie sauf si des problèmes sont détectés. |
+| `-c, --config <path>`  | Charge la configuration depuis un fichier spécifique. |
+| `-v, --verbose`        | Affiche la progression détaillée. |
+
+## Codes de sortie
+
+| Code | Signification |
+| --- | --- |
+| `0` | Toutes les vérifications ont réussi. |
+| `1` | Une ou plusieurs vérifications ont échoué, ou une erreur d'exécution s'est produite. |
+
+`check` ne distingue pas « problèmes détectés » de « échec de l'outil » avec des codes de sortie différents. En CI, fiez-vous à la sortie stderr et au code non nul de pyscn pour la sémantique succès/échec uniquement.
+
+## Exemples
+
+```bash
+# Garde-fou CI standard (exécute complexity, deadcode, clones)
+pyscn check .
+
+# Garde-fou plus rapide : ignore la détection de clones
+pyscn check --skip-clones .
+
+# Complexité uniquement, avec un seuil plus élevé pour du code hérité
+pyscn check --select complexity --max-complexity 15 src/
+
+# Vérifier les imports circulaires
+pyscn check --select deps src/
+
+# Tolérer le code mort existant pendant le nettoyage
+pyscn check --allow-dead-code src/
+
+# Détecter les anti-patterns DI (opt-in)
+pyscn check --select di src/
+
+# Mode silencieux — idéal pour les journaux CI
+pyscn check --quiet .
+```
+
+## Relation avec `analyze`
+
+`check` utilise les mêmes analyseurs et le même fichier de configuration qu'`analyze`. Les différences :
+
+| Aspect | `analyze` | `check` |
+| --- | --- | --- |
+| Sortie | Fichier de rapport (HTML/JSON/YAML/CSV) | stderr au format linter |
+| Sortie en cas de problèmes | Toujours `0` (sauf erreur) | Sortie `1` si un problème dépasse un seuil |
+| Détection de clones | Activée par défaut | Activée par défaut (désactiver avec `--skip-clones`) |
+| Analyse des dépendances | Activée par défaut | Désactivée par défaut (opt-in via `--select deps`) |
+| Vitesse | Plus lent (tous les analyseurs, génération de rapport) | Rapide (uniquement les analyses sélectionnées, sans rapport) |
+| Cas d'usage | Revue interactive | Garde-fou qualité en CI |
+
+Utilisez les deux : `analyze` pour comprendre les problèmes, `check` pour prévenir les régressions.
+
+## Voir aussi
+
+- [Intégration CI/CD](../integrations/ci-cd.md) — exemples GitHub Actions / pre-commit / GitLab.
+- [`pyscn analyze`](analyze.md) — Analyse complète avec rapports.

--- a/website/docs/fr/cli/index.md
+++ b/website/docs/fr/cli/index.md
@@ -1,0 +1,12 @@
+# Référence CLI
+
+pyscn expose quatre commandes principales :
+
+| Commande | Rôle |
+| ------- | ------- |
+| [`analyze`](analyze.md) | Exécute toutes les analyses et produit un rapport (HTML par défaut). |
+| [`check`](check.md)     | Garde-fou qualité rapide et strict pour CI/CD. Code de sortie 0/1/2. |
+| [`init`](init.md)       | Génère un fichier de configuration `.pyscn.toml` commenté. |
+| [`version`](version.md) | Affiche les informations de version. |
+
+L'option globale `-v / --verbose` fonctionne avec chacune des commandes.

--- a/website/docs/fr/cli/init.md
+++ b/website/docs/fr/cli/init.md
@@ -1,0 +1,64 @@
+# `pyscn init`
+
+Génère un fichier de configuration `.pyscn.toml` avec toutes les options documentées en commentaires.
+
+```text
+pyscn init [flags]
+```
+
+## Ce qu'elle fait
+
+Écrit un fichier TOML commenté avec les sections les plus couramment ajustées :
+
+- `[output]`, `[complexity]`, `[dead_code]`, `[clones]`, `[cbo]`, `[analysis]`, `[architecture]` (plus des exemples `[[architecture.layers]]` et `[[architecture.rules]]`)
+- Valeurs par défaut renseignées
+- Commentaires expliquant chaque clé
+
+Le fichier généré n'inclut **pas** toutes les sections configurables. Les options pour la cohésion LCOM4 (`[lcom]`), l'analyse des dépendances entre modules (`[dependencies]`), la détection de données factices (`[mock_data]`) et les anti-patterns DI (`[di]`) sont valides mais doivent être ajoutées manuellement. Consultez la [Référence de configuration](../configuration/reference.md) pour toutes les clés.
+
+Une fois le fichier en place, chaque exécution ultérieure de `pyscn analyze` / `pyscn check` dans ce projet (ou tout sous-répertoire) le détecte automatiquement.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| `-c, --config <path>` | `.pyscn.toml` | Chemin du fichier de sortie. |
+| `-f, --force`         | off          | Écrase un fichier existant. |
+
+## Codes de sortie
+
+| Code | Signification |
+| --- | --- |
+| `0` | Fichier écrit avec succès. |
+| `1` | Le fichier existe déjà (utilisez `--force` pour écraser) ou l'écriture a échoué. |
+
+## Exemples
+
+```bash
+# Créer .pyscn.toml dans le répertoire courant
+pyscn init
+
+# Utiliser un nom de fichier personnalisé
+pyscn init --config tools/pyscn.toml
+
+# Écraser une configuration existante
+pyscn init --force
+```
+
+## Que modifier en premier
+
+Après avoir exécuté `init`, les réglages que la plupart des projets finissent par ajuster sont :
+
+| Réglage | Ajustement habituel |
+| --- | --- |
+| `[complexity].max_complexity` | À fixer à `10`, `15` ou `20` selon le niveau de rigueur souhaité en CI. |
+| `[dead_code].min_severity`     | Passer à `"critical"` si les avertissements sont trop bruyants. |
+| `[clones].similarity_threshold`| Abaisser à `0.80` pour trouver plus de clones, monter à `0.90` pour réduire le bruit. |
+| `[analysis].exclude_patterns`  | Ajouter les chemins de code généré, migrations, etc. |
+
+Consultez la [Référence de configuration](../configuration/reference.md) complète.
+
+## Voir aussi
+
+- [Référence de configuration](../configuration/reference.md) — toutes les options expliquées.
+- [Exemples de configuration](../configuration/examples.md) — CI stricte, gros codebase, surcharges minimales.

--- a/website/docs/fr/cli/version.md
+++ b/website/docs/fr/cli/version.md
@@ -1,0 +1,42 @@
+# `pyscn version`
+
+Affiche les informations de version et de build.
+
+```text
+pyscn version [flags]
+```
+
+## Options
+
+| Option | Description |
+| --- | --- |
+| `-s, --short` | Affiche uniquement le numéro de version, pour utilisation dans des scripts. |
+
+## Exemples
+
+```bash
+$ pyscn version
+pyscn v0.2.0
+  commit:   a3671f4
+  built:    2026-02-14T08:42:11Z
+  go:       go1.24.6
+  platform: darwin/arm64
+
+$ pyscn version --short
+0.2.0
+```
+
+## Utilisation dans des scripts
+
+```bash
+# Sauvegarder pour utilisation ultérieure
+VERSION=$(pyscn version --short)
+
+# Se prémunir contre des versions incompatibles
+if [ "$(pyscn version --short)" != "0.2.0" ]; then
+  echo "Expected pyscn 0.2.0" >&2
+  exit 1
+fi
+```
+
+`pyscn version` se termine toujours avec le code `0`.

--- a/website/docs/fr/configuration/examples.md
+++ b/website/docs/fr/configuration/examples.md
@@ -1,10 +1,10 @@
-# 配置示例
+# Exemples de configuration
 
-适用于常见场景的可复制粘贴的起始配置。
+Points de départ à copier-coller pour les scénarios courants.
 
-## 最小覆盖
+## Surcharge minimale
 
-仅设置几个严格的阈值；其余保持默认值。
+Juste quelques seuils stricts ; tout le reste reste par défaut.
 
 ```toml
 # .pyscn.toml
@@ -15,9 +15,9 @@ max_complexity = 15
 min_severity = "critical"
 ```
 
-## 严格 CI 门禁 { #strict-ci-gate }
+## Garde-fou CI strict { #strict-ci-gate }
 
-在任何质量退化时使构建失败。与 `pyscn check` 配合使用。
+Faites échouer le build en cas de régression de qualité. À associer à `pyscn check`.
 
 ```toml
 [complexity]
@@ -30,7 +30,7 @@ detect_after_raise = true
 detect_unreachable_branches = true
 
 [clones]
-# 仅标记几乎完全相同的代码
+# Ne signaler que du code quasi-identique
 similarity_threshold = 0.90
 min_lines = 15
 
@@ -42,40 +42,40 @@ enabled = true
 detect_cycles = true
 ```
 
-运行：
+Exécution :
 
 ```bash
 pyscn check --select complexity,deadcode,deps --max-cycles 0 src/
 ```
 
-## 遗留代码库过渡期
+## Période de grâce pour un codebase hérité
 
-你正在旧项目上引入 pyscn — 你希望获得分析信号而不会被大量失败所淹没。
+Vous adoptez pyscn sur un projet plus ancien — vous voulez du signal sans un déluge immédiat d'échecs.
 
 ```toml
 [complexity]
-max_complexity = 25    # 允许现有的复杂度
+max_complexity = 25    # autorise la complexité existante
 
 [dead_code]
-min_severity = "critical"   # 仅报告最严重的问题
+min_severity = "critical"   # uniquement le pire
 
 [clones]
-min_lines = 20              # 仅报告较长的重复代码
+min_lines = 20              # uniquement les duplications longues
 similarity_threshold = 0.90
 
 [analysis]
 exclude_patterns = [
-  "legacy/**",     # 隔离旧代码
+  "legacy/**",     # mettre en quarantaine l'ancien code
   "**/_archive/*",
   "generated/**",
 ]
 ```
 
-随着时间推移逐步收紧阈值。
+Resserrez les seuils progressivement au fil du temps.
 
-## 大型代码库（10k+ 文件）
+## Gros codebase (10 000+ fichiers)
 
-优化吞吐量。LSH 会自动启用，但需要提高并行度。
+Optimisez pour le débit. LSH s'active automatiquement, mais poussez le parallélisme.
 
 ```toml
 [clones]
@@ -84,7 +84,7 @@ max_goroutines = 16
 max_memory_mb = 2048
 batch_size = 500
 timeout_seconds = 600
-min_lines = 15           # 更少但更有意义的候选片段
+min_lines = 15           # candidats moins nombreux et plus significatifs
 
 [analysis]
 exclude_patterns = [
@@ -96,9 +96,9 @@ exclude_patterns = [
 ]
 ```
 
-## 整洁架构验证
+## Validation d'architecture en couches
 
-强制分层架构：表现层 → 应用层 → 领域层，基础设施层在边缘。
+Imposez une architecture en couches : presentation → application → domain, infrastructure à la périphérie.
 
 ```toml
 [architecture]
@@ -137,20 +137,20 @@ from = "domain"
 deny = ["presentation", "application", "infrastructure"]
 ```
 
-## 数据密集型 ML / 研究代码库
+## Codebase ML / recherche orienté données
 
-在 notebook 转化而来的模块中，高复杂度是正常的。重点关注代码重复和死代码。
+Une forte complexité est attendue dans les modules issus de notebooks. Concentrez-vous sur la duplication et le code mort.
 
 ```toml
 [complexity]
-max_complexity = 30    # 数据管道天然具有较多分支
+max_complexity = 30    # les pipelines de données sont naturellement très branchés
 
 [dead_code]
 min_severity = "critical"
 
 [clones]
-# 研究代码常常有几乎相同的实验变体；
-# 提高阈值以避免被大量结果淹没
+# Le code de recherche comporte souvent des variantes d'expérience quasi-identiques ;
+# relevez les seuils pour ne pas être submergé
 min_lines = 20
 similarity_threshold = 0.85
 
@@ -161,15 +161,15 @@ exclude_patterns = [
 ]
 ```
 
-## 与 `pyproject.toml` 共存
+## Cohabitation avec `pyproject.toml`
 
-如果你已经有 `pyproject.toml`，可以将 pyscn 配置放在其中，而无需创建新文件：
+Si vous avez déjà un `pyproject.toml`, vous pouvez y placer la configuration pyscn au lieu de créer un nouveau fichier :
 
 ```toml
 # pyproject.toml
 [project]
 name = "my-package"
-# ... 其他项目元数据
+# ... autres métadonnées du projet
 
 [tool.pyscn.complexity]
 max_complexity = 15
@@ -182,9 +182,9 @@ similarity_threshold = 0.85
 ```
 
 !!! note
-    如果两者都存在，`.pyscn.toml` 优先于 `pyproject.toml`。建议只使用其中一个以避免混淆。
+    `.pyscn.toml` est prioritaire sur `pyproject.toml` si les deux existent. Choisissez-en un pour éviter la confusion.
 
-## 另请参阅
+## Voir aussi
 
-- [配置文件格式](format.md)
-- [配置参考手册](reference.md)
+- [Format du fichier de configuration](format.md)
+- [Référence de configuration](reference.md)

--- a/website/docs/fr/configuration/format.md
+++ b/website/docs/fr/configuration/format.md
@@ -1,0 +1,87 @@
+# Format du fichier de configuration
+
+pyscn lit la configuration au format **TOML**. Vous pouvez conserver vos réglages dans un fichier `.pyscn.toml` dédié ou dans une section `[tool.pyscn]` de votre `pyproject.toml` existant.
+
+## Découverte des fichiers
+
+Lorsque vous exécutez `pyscn analyze` ou `pyscn check`, pyscn remonte depuis le chemin cible à la recherche de :
+
+1. `.pyscn.toml` (priorité la plus haute)
+2. `pyproject.toml` contenant une section `[tool.pyscn]`
+
+Le premier fichier trouvé est utilisé. Les répertoires parents sont parcourus jusqu'à trouver une correspondance ou atteindre la racine du système de fichiers. Si aucun fichier n'est trouvé, les valeurs par défaut intégrées sont utilisées.
+
+Vous pouvez également passer un chemin explicite :
+
+```bash
+pyscn analyze --config ./configs/strict.toml src/
+```
+
+Cela contourne la découverte.
+
+## Ordre de priorité
+
+Lorsqu'un réglage apparaît à plusieurs endroits, le dernier l'emporte :
+
+1. **Valeurs par défaut intégrées** (priorité la plus basse)
+2. **`pyproject.toml` → `[tool.pyscn]`**
+3. **`.pyscn.toml`**
+4. **Options en ligne de commande** (priorité la plus haute)
+
+Les options en ligne de commande ne sont prises en compte que si elles ont été **explicitement définies** — les valeurs par défaut inchangées ne surchargent pas les valeurs de configuration.
+
+## Deux styles de fichier
+
+=== ".pyscn.toml"
+
+    ```toml
+    [complexity]
+    max_complexity = 15
+
+    [dead_code]
+    min_severity = "critical"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.pyscn.complexity]
+    max_complexity = 15
+
+    [tool.pyscn.dead_code]
+    min_severity = "critical"
+    ```
+
+Si les deux fichiers existent dans le même répertoire, `.pyscn.toml` l'emporte.
+
+## Générer un fichier de démarrage
+
+```bash
+pyscn init
+```
+
+Cela écrit un fichier `.pyscn.toml` entièrement commenté avec chaque option, sa valeur par défaut et une courte description. Modifiez les valeurs qui vous intéressent et supprimez (ou laissez tel quel) le reste.
+
+```bash
+pyscn init --force   # écraser l'existant
+pyscn init --config tools/pyscn.toml   # chemin personnalisé
+```
+
+## Validation
+
+pyscn valide la configuration au chargement et se termine avec le code `2` en cas de problème. Règles de validation courantes :
+
+- Les seuils de complexité doivent satisfaire `low ≥ 1` et `medium > low`.
+- Le format de sortie doit être l'un de `text`, `json`, `yaml`, `csv`, `html`.
+- La sévérité du code mort doit être `info`, `warning` ou `critical`.
+- Les seuils de similarité des clones doivent être dans `[0.0, 1.0]`.
+- Au moins un motif d'inclusion doit être spécifié.
+
+## Variables d'environnement
+
+pyscn ne lit **pas** la configuration depuis des variables d'environnement. Le serveur MCP fait une exception : `PYSCN_CONFIG` peut pointer vers un fichier de configuration.
+
+## Étapes suivantes
+
+- [Référence](reference.md) — chaque clé, documentée.
+- [Exemples](examples.md) — CI stricte, gros codebase, surcharges minimales.

--- a/website/docs/fr/configuration/index.md
+++ b/website/docs/fr/configuration/index.md
@@ -1,0 +1,13 @@
+# Configuration
+
+pyscn lit la configuration depuis `.pyscn.toml` ou la section `[tool.pyscn]` de `pyproject.toml`. Les options en ligne de commande priment sur la configuration ; la configuration prime sur les valeurs par défaut intégrées.
+
+- **[Format du fichier de configuration](format.md)** — Règles de découverte, emplacements des fichiers, ordre de priorité.
+- **[Référence](reference.md)** — Chaque clé de configuration, son type, sa valeur par défaut et son effet.
+- **[Exemples](examples.md)** — CI stricte, gros codebase, surcharges minimales.
+
+Générez un fichier de démarrage commenté avec :
+
+```bash
+pyscn init
+```

--- a/website/docs/fr/configuration/reference.md
+++ b/website/docs/fr/configuration/reference.md
@@ -1,0 +1,315 @@
+# Référence de configuration
+
+Chaque clé configurable dans `.pyscn.toml` (ou `[tool.pyscn.*]` dans `pyproject.toml`). Exécutez `pyscn init` pour générer un fichier de démarrage commenté.
+
+---
+
+## `[output]`
+
+Contrôle la façon dont les résultats sont rapportés.
+
+| Clé              | Type    | Défaut       | Description |
+| ---------------- | ------- | ------------- | --- |
+| `format`         | string  | `"text"`      | `text`, `json`, `yaml`, `csv` ou `html`. Les options en ligne de commande comme `--json` la surchargent. |
+| `directory`      | string  | `""`          | Répertoire de sortie. Vide = `.pyscn/reports/` sous le CWD. |
+| `show_details`   | bool    | `false`       | Inclut le détail par constatation dans le résumé. |
+| `sort_by`        | string  | `"complexity"`| `name`, `complexity` ou `risk`. |
+| `min_complexity` | int     | `1`           | Filtre les fonctions en dessous de cette complexité. Surcharge `[complexity].min_complexity` lorsqu'elle est définie. |
+
+---
+
+## `[complexity]`
+
+Analyse de complexité cyclomatique.
+
+| Clé                | Type | Défaut | Description |
+| ------------------ | ---- | ------- | --- |
+| `enabled`          | bool | `true`  | Exécute l'analyseur. |
+| `low_threshold`    | int  | `9`     | Borne supérieure du « risque faible » (incluse). |
+| `medium_threshold` | int  | `19`    | Borne supérieure du « risque moyen ». |
+| `max_complexity`   | int  | `0`     | Seuil d'échec en CI. `0` = aucune limite. |
+| `min_complexity`   | int  | `1`     | N'affiche pas les fonctions en dessous. |
+| `report_unchanged` | bool | `true`  | Inclut les fonctions de complexité = 1. |
+
+Voir [high-cyclomatic-complexity](../rules/high-cyclomatic-complexity.md) pour des recommandations de seuils.
+
+---
+
+## `[dead_code]`
+
+Détection de code mort.
+
+| Clé                              | Type   | Défaut      | Description |
+| -------------------------------- | ------ | ------------ | --- |
+| `enabled`                        | bool   | `true`       | Exécute l'analyseur. |
+| `min_severity`                   | string | `"warning"`  | `info`, `warning` ou `critical`. |
+| `show_context`                   | bool   | `false`      | Inclut les lignes source environnantes. |
+| `context_lines`                  | int    | `3`          | Lignes de contexte (0–20). |
+| `sort_by`                        | string | `"severity"` | `severity`, `line`, `file` ou `function`. |
+| `detect_after_return`            | bool   | `true`       | Signale les instructions après `return`. |
+| `detect_after_break`             | bool   | `true`       | Signale les instructions après `break`. |
+| `detect_after_continue`          | bool   | `true`       | Signale les instructions après `continue`. |
+| `detect_after_raise`             | bool   | `true`       | Signale les instructions après `raise`. |
+| `detect_unreachable_branches`    | bool   | `true`       | Signale les branches qui ne peuvent jamais être empruntées. |
+| `ignore_patterns`                | string[] | `[]`       | Motifs regex pour les lignes à ignorer. |
+
+---
+
+## `[clones]`
+
+Détection de clones (l'analyseur le plus configurable).
+
+### Sélection des fragments
+
+| Clé              | Type | Défaut | Description |
+| ---------------- | ---- | ------- | --- |
+| `min_lines`      | int  | `10`    | Nombre minimal de lignes pour considérer un fragment. |
+| `min_nodes`      | int  | `20`    | Nombre minimal de nœuds AST. |
+| `skip_docstrings`| bool | `true`  | Ignore les docstrings lors du hachage. |
+
+### Seuils par type (0.0–1.0)
+
+| Clé                    | Défaut | Type de clone |
+| ---------------------- | ------- | --- |
+| `type1_threshold`      | `0.85`  | Identique (espaces/commentaires uniquement). |
+| `type2_threshold`      | `0.75`  | Identifiants/littéraux renommés. |
+| `type3_threshold`      | `0.70`  | Structurellement similaire avec modifications. |
+| `type4_threshold`      | `0.65`  | Équivalence sémantique. |
+| `similarity_threshold` | `0.65`  | Minimum global pour tout clone. |
+
+### Algorithme
+
+| Clé                 | Type   | Défaut    | Description |
+| ------------------- | ------ | ---------- | --- |
+| `cost_model_type`   | string | `"python"` | `default`, `python` ou `weighted`. |
+| `ignore_literals`   | bool   | `false`    | Traite les littéraux différents comme équivalents. |
+| `ignore_identifiers`| bool   | `false`    | Traite les noms de variables différents comme équivalents. |
+| `max_edit_distance` | float  | `50.0`     | Plafond sur la distance d'édition d'arbre. |
+| `enable_dfa`        | bool   | `true`     | Analyse de flot de données pour Type-4. |
+| `enabled_clone_types` | string[] | tous     | Sous-ensemble de `type1`, `type2`, `type3`, `type4`. |
+
+### Accélération LSH
+
+| Clé                        | Type           | Défaut  | Description |
+| -------------------------- | -------------- | -------- | --- |
+| `lsh_enabled`              | `true\|false\|"auto"` | `"auto"` | Active LSH (`auto` = en fonction du nombre de fragments ou du nombre estimé de paires). |
+| `lsh_auto_threshold`       | int            | `500`    | Seuil de fragments pour l'activation automatique ; auto s'active aussi au-delà de 10 000 paires estimées. |
+| `lsh_similarity_threshold` | float          | `0.50`   | Pré-filtre des candidats LSH. |
+| `lsh_bands`                | int            | `32`     | Bandes LSH. |
+| `lsh_rows`                 | int            | `4`      | Lignes par bande. |
+| `lsh_hashes`               | int            | `128`    | Nombre de fonctions de hachage. |
+
+### Regroupement
+
+| Clé                  | Type   | Défaut       | Description |
+| -------------------- | ------ | ------------- | --- |
+| `grouping_mode`      | string | `"connected"` | `connected`, `star`, `complete_linkage`, `k_core`. |
+| `grouping_threshold` | float  | `0.65`        | Similarité minimale pour le regroupement. |
+| `k_core_k`           | int    | `2`           | Paramètre k pour le mode `k_core`. |
+
+### Performance
+
+| Clé               | Type | Défaut | Description |
+| ----------------- | ---- | ------- | --- |
+| `max_memory_mb`   | int  | `100`   | Plafond mémoire (Mo). `0` = pas de limite. |
+| `batch_size`      | int  | `100`   | Fichiers par lot. |
+| `enable_batching` | bool | `true`  | Traitement par lots. |
+| `max_goroutines`  | int  | `4`     | Workers concurrents. |
+| `timeout_seconds` | int  | `300`   | Délai par analyse. |
+
+### Filtrage de la sortie
+
+| Clé             | Type  | Défaut          | Description |
+| --------------- | ----- | --------------- | --- |
+| `min_similarity`| float | `0.0`           | Filtre les paires en dessous. |
+| `max_similarity`| float | `1.0`           | Filtre les paires au-dessus. |
+| `max_results`   | int   | `10000`         | Nombre maximal de paires à rapporter. `0` = pas de limite. |
+| `show_details`  | bool  | `false`         | Sortie verbeuse. |
+| `show_content`  | bool  | `false`         | Inclut le code source dans le rapport. |
+| `sort_by`       | string| `"similarity"`  | `similarity`, `size`, `location`, `type`. |
+| `group_clones`  | bool  | `true`          | Regroupe les clones associés. |
+
+---
+
+## `[cbo]`
+
+Coupling Between Objects (couplage entre classes).
+
+| Clé                | Type | Défaut | Description |
+| ------------------ | ---- | ------- | --- |
+| `enabled`          | bool | `true`  | Exécute l'analyseur. |
+| `low_threshold`    | int  | `3`     | Borne supérieure du « risque faible ». |
+| `medium_threshold` | int  | `7`     | Borne supérieure du « risque moyen ». |
+| `min_cbo`          | int  | `0`     | Filtre les classes dont le CBO est en dessous. |
+| `max_cbo`          | int  | `0`     | Filtre les classes au-dessus. `0` = pas de limite. |
+| `show_zeros`       | bool | `false` | Inclut les classes avec CBO = 0. |
+| `include_builtins` | bool | `false` | Compte `list`/`dict`/`str` comme des dépendances. |
+| `include_imports`  | bool | `true`  | Compte les références aux modules importés. |
+
+---
+
+## `[lcom]`
+
+Lack of Cohesion of Methods (LCOM4).
+
+| Clé                | Type | Défaut | Description |
+| ------------------ | ---- | ------- | --- |
+| `low_threshold`    | int  | `2`     | Borne supérieure du « risque faible » (bonne cohésion). |
+| `medium_threshold` | int  | `5`     | Borne supérieure du « risque moyen ». |
+
+---
+
+## `[analysis]`
+
+Règles de découverte des fichiers.
+
+| Clé                | Type     | Défaut       | Description |
+| ------------------ | -------- | ------------- | --- |
+| `recursive`        | bool     | `true`        | Descend dans les sous-répertoires. |
+| `follow_symlinks`  | bool     | `false`       | Suit les liens symboliques. |
+| `include_patterns` | string[] | `["**/*.py"]` | Motifs glob à inclure. |
+| `exclude_patterns` | string[] | voir ci-dessous | Motifs glob à exclure. |
+
+`exclude_patterns` par défaut :
+
+```toml
+[
+  "test_*.py", "*_test.py",
+  "**/__pycache__/*", "**/*.pyc",
+  "**/.pytest_cache/", ".tox/",
+  "venv/", "env/", ".venv/", ".env/",
+]
+```
+
+---
+
+## `[architecture]`
+
+Validation des couches. Toutes les clés sont facultatives — si vous ne définissez pas de couches, l'analyse architecturale s'exécute en mode permissif.
+
+| Clé                        | Type  | Défaut | Description |
+| -------------------------- | ----- | ------- | --- |
+| `enabled`                  | bool  | `true`  | Exécute la validation des couches. |
+| `validate_layers`          | bool  | `true`  | Vérifie les règles inter-couches. |
+| `validate_cohesion`        | bool  | `true`  | Vérifie la cohésion des paquets. |
+| `validate_responsibility`  | bool  | `true`  | Vérifie le nombre de responsabilités des modules. |
+| `strict_mode`              | bool  | `true`  | Validation stricte. |
+| `fail_on_violations`       | bool  | `false` | Code de sortie non nul en cas de violation. |
+| `min_cohesion`             | float | `0.5`   | Cohésion minimale des paquets. |
+| `max_coupling`             | int   | `10`    | Couplage inter-couches maximal. |
+| `max_responsibilities`     | int   | `3`     | Préoccupations maximales par module. |
+| `neutral_prefixes`         | string[] | `[]` | Segments de module de premier niveau à retirer avant la correspondance des paquets de couche. Utile lorsque chaque module commence par le même préfixe projet (ex. `app`, `src`). |
+
+### Définitions de couches
+
+```toml
+[[architecture.layers]]
+name = "presentation"
+packages = ["router", "routers", "handler", "handlers", "controller", "api"]
+
+[[architecture.layers]]
+name = "application"
+packages = ["service", "services", "usecase", "usecases"]
+
+[[architecture.layers]]
+name = "domain"
+packages = ["model", "models", "entity", "entities"]
+
+[[architecture.layers]]
+name = "infrastructure"
+packages = ["repository", "repositories", "db", "database"]
+```
+
+### Règles de couches
+
+```toml
+[[architecture.rules]]
+from = "presentation"
+allow = ["application", "domain"]
+deny = ["infrastructure"]
+
+[[architecture.rules]]
+from = "application"
+allow = ["domain"]
+```
+
+### Préfixes neutres
+
+Si chaque module du projet commence par le même segment racine (`app.`, `src.`, ...), la correspondance des couches peut échouer car le préfixe projet masque le nom de la couche. Listez ces segments sous `neutral_prefixes` et pyscn les retirera avant de résoudre un module vers une couche :
+
+```toml
+[architecture]
+neutral_prefixes = ["app", "src"]
+```
+
+Avec ce réglage, `app.routers.user_router` est mis en correspondance comme `routers.user_router` et résolu vers la couche `presentation`.
+
+---
+
+## `[dependencies]`
+
+Analyse des dépendances entre modules. **Opt-in** pour `pyscn check` ; toujours active pour `pyscn analyze` sauf si ignorée.
+
+| Clé                  | Type   | Défaut | Description |
+| -------------------- | ------ | ------- | --- |
+| `enabled`            | bool   | `false` | Exécute l'analyseur (analyze l'exécute toujours quoi qu'il en soit). |
+| `include_stdlib`     | bool   | `false` | Inclut les imports de la bibliothèque standard. |
+| `include_third_party`| bool   | `true`  | Inclut les imports tiers. |
+| `follow_relative`    | bool   | `true`  | Suit les imports relatifs. |
+| `detect_cycles`      | bool   | `true`  | Détecte les imports circulaires. |
+| `calculate_metrics`  | bool   | `true`  | Calcule Ca/Ce/I/A/D. |
+| `find_long_chains`   | bool   | `true`  | Signale les plus longues chaînes de dépendance. |
+| `cycle_reporting`    | string | `"summary"` | `all`, `critical`, `summary`. |
+| `max_cycles_to_show` | int    | `10`    | Plafond sur les cycles rapportés. |
+| `sort_by`            | string | `"name"` | `name`, `coupling`, `instability`, `distance`, `risk`. |
+| `show_matrix`        | bool   | `false` | Inclut la matrice de dépendances. |
+| `generate_dot_graph` | bool   | `false` | Émet une sortie Graphviz DOT. |
+
+---
+
+## `[mock_data]`
+
+Détection de données factices / placeholder. **Opt-in**.
+
+| Clé              | Type     | Défaut      | Description |
+| ---------------- | -------- | ----------- | --- |
+| `enabled`        | bool     | `false`     | Exécute l'analyseur. |
+| `min_severity`   | string   | `"warning"` | `info`, `warning`, `error`. |
+| `ignore_tests`   | bool     | `true`      | Ignore les fichiers de test. |
+| `keywords`       | string[] | intégré     | Mots signalés comme indicateurs de mock. |
+| `domains`        | string[] | intégré     | Domaines signalés (`example.com`, `test.com`, etc.). |
+| `ignore_patterns`| string[] | `[]`        | Fichiers/motifs regex à ignorer. |
+
+---
+
+## `[di]`
+
+Détection d'anti-patterns d'injection de dépendances. **Opt-in**.
+
+| Clé                            | Type   | Défaut      | Description |
+| ------------------------------ | ------ | ----------- | --- |
+| `enabled`                      | bool   | `false`     | Exécute l'analyseur. |
+| `min_severity`                 | string | `"warning"` | `info`, `warning`, `error`. |
+| `constructor_param_threshold`  | int    | `5`         | Signale les `__init__` avec plus de paramètres. |
+
+---
+
+## Correspondance option CLI → clé de configuration
+
+Les options qui ne se mappent pas directement sur une clé de configuration (`--select`, `--skip-*`, `--no-open`) fonctionnent par-dessus la configuration chargée.
+
+| Option CLI                | Clé de configuration              |
+| ----------------------- | --------------------------------- |
+| `--config <path>`       | — (contourne la découverte)       |
+| `--json/--yaml/--csv/--html` | `[output] format`            |
+| `--min-complexity`      | `[complexity] min_complexity`     |
+| `--max-complexity`      | `[complexity] max_complexity`     |
+| `--min-severity`        | `[dead_code] min_severity`        |
+| `--clone-threshold`     | `[clones] similarity_threshold`   |
+| `--min-cbo`             | `[cbo] min_cbo`                   |
+| `--max-cycles`          | — (commande check uniquement)     |
+
+## Voir aussi
+
+- [Format du fichier de configuration](format.md) — découverte et priorité.
+- [Exemples](examples.md) — configurations prêtes à l'emploi.

--- a/website/docs/fr/faq.md
+++ b/website/docs/fr/faq.md
@@ -1,0 +1,157 @@
+# FAQ
+
+## Généralités
+
+### En quoi pyscn diffère-t-il de ruff, pylint ou mypy ?
+
+Ruff et pylint sont des linters ; mypy est un vérificateur de types. pyscn est un analyseur structurel : il construit des graphes de flux de contrôle, des représentations arborescentes et des graphes de dépendances pour mesurer la complexité, l'accessibilité, la duplication et le couplage. Ils sont complémentaires.
+
+### Que ne détecte pas pyscn ?
+
+- Les bugs à l'exécution
+- Les vulnérabilités de sécurité
+- Les problèmes de performance
+- Les violations de style (utilisez ruff)
+- Les erreurs de typage (utilisez mypy / pyright)
+
+### pyscn a-t-il besoin d'un accès réseau ?
+
+Non. pyscn s'exécute entièrement en local. Aucune télémétrie, aucun appel distant.
+
+### Fonctionne-t-il avec du code asynchrone ?
+
+Oui. `async def` et `await` sont analysés de la même manière que le code synchrone.
+
+### Puis-je analyser des notebooks Jupyter ?
+
+Non. Convertissez d'abord avec `jupyter nbconvert --to script`.
+
+## Configuration
+
+### Où placer mon fichier de configuration ?
+
+Placez `.pyscn.toml` à la racine du dépôt. pyscn le découvre en remontant depuis les fichiers analysés.
+
+### J'ai déjà `pyproject.toml`. Devrais-je utiliser `[tool.pyscn]` à la place ?
+
+Les deux fonctionnent. `.pyscn.toml` l'emporte si les deux existent.
+
+### Comment exclure le code généré / les migrations / les dépendances vendues ?
+
+```toml
+[analysis]
+exclude_patterns = [
+  "**/migrations/**",
+  "**/__generated__/**",
+  "vendor/**",
+]
+```
+
+### Puis-je avoir des seuils différents selon les parties du projet ?
+
+Pas dans un seul fichier de configuration. Utilisez des configurations par répertoire :
+
+```bash
+pyscn check --config backend/.pyscn.toml backend/
+pyscn check --config scripts/.pyscn.toml scripts/
+```
+
+## Exécution de pyscn
+
+### Le rapport HTML n'a pas ouvert mon navigateur.
+
+L'ouverture automatique est supprimée lorsque stdin n'est pas un TTY, en SSH, ou lorsque `CI` est défini. Le chemin du rapport est imprimé sur stderr. Forcez avec `--no-open`.
+
+### `pyscn analyze` est lent sur mon dépôt.
+
+- `--skip-clones` (les clones sont l'analyseur le plus lent)
+- Restreignez le périmètre : `pyscn analyze src/`
+- Augmentez `min_lines` / `min_nodes` sous `[clones]`
+- Augmentez `max_goroutines` sous `[clones]`
+
+### J'obtiens des erreurs d'analyse syntaxique sur du code Python valide.
+
+pyscn utilise tree-sitter, qui prend en charge Python jusqu'à la 3.13. Ouvrez une issue avec une reproduction minimale.
+
+### pyscn peut-il corriger automatiquement les problèmes ?
+
+Non. pyscn rapporte ; il ne modifie jamais le code source.
+
+## Scores et seuils
+
+### Mon score de santé a chuté du jour au lendemain.
+
+Vérifiez les scores par catégorie. Causes fréquentes :
+
+- Une nouvelle fonction volumineuse a augmenté la complexité moyenne.
+- Un refactoring a laissé du code mort.
+- Un copier-coller a créé des clones.
+- Un nouvel import a introduit un cycle.
+
+Comparez la sortie JSON entre deux exécutions pour identifier le changement.
+
+### Pourquoi mon score de couplage est-il si bas sur une petite base de code ?
+
+La pénalité est calculée en pourcentage : un ratio problématique de 3/10 produit la même pénalité que 300/1000. Pour les projets de moins de 20 classes, examinez les valeurs CBO brutes plutôt que le score de la catégorie.
+
+### Qu'est-ce qu'un « bon » score de santé ?
+
+| Plage | Signification |
+| --- | --- |
+| 90+ | Excellent |
+| 70–90 | Normal pour une base de code saine |
+| 50–70 | Travail réel nécessaire ; récupérable |
+| < 50 | Refactoring ciblé requis |
+
+La tendance compte plus que la valeur absolue.
+
+## MCP
+
+### L'assistant voit les outils pyscn, mais les appels échouent.
+
+Vérifiez que le binaire est dans le PATH, ou utilisez `uvx pyscn-mcp`. Testez directement :
+
+```bash
+uvx pyscn-mcp
+```
+
+Voir le [guide MCP](integrations/mcp.md).
+
+### Le serveur MCP peut-il refactorer mon code ?
+
+Non. Le MCP de pyscn est en lecture seule.
+
+## Dépannage
+
+### `pyscn: command not found` après installation via pip.
+
+L'emplacement d'installation n'est pas dans le PATH. Inspectez avec :
+
+```bash
+python -m pip show -f pyscn | grep bin/pyscn
+```
+
+Sous Linux/macOS, ajoutez `~/.local/bin` au PATH, ou installez avec `uvx pyscn@latest <command>` (sans étape d'installation), `uv tool install pyscn`, ou `pipx install pyscn`.
+
+### Le rapport affiche 0 fichier analysé.
+
+Les motifs include/exclude ont tout exclu. Valeurs par défaut : `include_patterns = ["**/*.py"]` ; les exclusions comprennent `test_*.py` et `*_test.py`. Surchargez pour analyser les tests :
+
+```toml
+[analysis]
+exclude_patterns = [
+  "**/__pycache__/*",
+  "**/*.pyc",
+  ".venv/**",
+]
+```
+
+### `Warning: parse error in <file>`.
+
+Le fichier contient une erreur de syntaxe dont tree-sitter n'a pas pu récupérer. Le fichier est ignoré ; les autres fichiers sont analysés normalement.
+
+## Obtenir de l'aide
+
+- [GitHub Issues](https://github.com/ludo-technologies/pyscn/issues) — bugs et demandes de fonctionnalités.
+- [GitHub Discussions](https://github.com/ludo-technologies/pyscn/discussions) — questions et idées.
+- [Code source](https://github.com/ludo-technologies/pyscn).

--- a/website/docs/fr/getting-started/installation.md
+++ b/website/docs/fr/getting-started/installation.md
@@ -1,0 +1,45 @@
+# Installation
+
+## Prérequis
+
+- Python 3.8–3.13 (lanceur uniquement ; pyscn n'a aucune dépendance d'exécution Python)
+- Linux / macOS / Windows, x86_64 ou arm64
+
+## Installation
+
+| Méthode | Commande | Remarques |
+| --- | --- | --- |
+| **uvx** (recommandé) | `uvx pyscn@latest <command>` | S'exécute sans installation ; mise en cache après le premier appel. |
+| uv tool | `uv tool install pyscn` | Installation persistante, isolée des dépendances du projet. |
+| pipx | `pipx install pyscn` | Installation persistante, isolée des dépendances du projet. |
+| pip | `pip install pyscn` | Installe dans l'environnement courant. |
+| Go | `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest` | N'installe pas `pyscn-mcp`. |
+
+`uvx` est la voie la plus rapide pour un usage ponctuel et fonctionne bien en CI. Utilisez `uv tool install` ou `pipx` pour un usage local répété sans polluer les dépendances du projet.
+
+Des binaires précompilés sont joints à chaque [release GitHub](https://github.com/ludo-technologies/pyscn/releases).
+
+## Vérification
+
+```bash
+pyscn version
+pyscn version --short    # uniquement le numéro de version
+```
+
+## Mise à jour
+
+```bash
+uv tool upgrade pyscn        # si installé avec uv tool
+pipx upgrade pyscn           # si installé avec pipx
+pip install --upgrade pyscn  # si installé avec pip
+```
+
+`uvx pyscn@latest` résout toujours vers la dernière version, donc aucune étape de mise à jour n'est nécessaire.
+
+## Désinstallation
+
+```bash
+uv tool uninstall pyscn
+pipx uninstall pyscn
+pip uninstall pyscn
+```

--- a/website/docs/fr/getting-started/quick-start.md
+++ b/website/docs/fr/getting-started/quick-start.md
@@ -1,0 +1,52 @@
+# Démarrage rapide
+
+## Lancer une analyse
+
+```bash
+uvx pyscn@latest analyze .
+```
+
+Si `pyscn` est déjà installé (via `uv tool install pyscn`, `pipx install pyscn`, ou `pip install pyscn`), supprimez le préfixe `uvx pyscn@latest` :
+
+```bash
+pyscn analyze .
+```
+
+Écrit un rapport HTML dans `.pyscn/reports/analyze_YYYYMMDD_HHMMSS.html` et l'ouvre dans le navigateur par défaut.
+
+## Choisir le format de sortie
+
+```bash
+pyscn analyze --json .
+pyscn analyze --yaml .
+pyscn analyze --csv .
+pyscn analyze --no-open .       # supprime l'ouverture du navigateur
+```
+
+## Exécuter des analyseurs spécifiques
+
+```bash
+pyscn analyze --select complexity .
+pyscn analyze --select complexity,deadcode .
+pyscn analyze --skip-clones .
+```
+
+Voir [`analyze`](../cli/analyze.md) pour toutes les options.
+
+## Garde-fou de qualité en CI
+
+```bash
+pyscn check .                              # sortie 0 = succès, 1 = échec
+pyscn check --max-complexity 15 src/
+pyscn check --select complexity,deadcode,deps src/
+```
+
+Voir [`check`](../cli/check.md) et [Intégration CI/CD](../integrations/ci-cd.md).
+
+## Générer un fichier de configuration
+
+```bash
+pyscn init
+```
+
+Crée `.pyscn.toml` avec toutes les options commentées. Voir la [Référence de configuration](../configuration/reference.md).

--- a/website/docs/fr/index.md
+++ b/website/docs/fr/index.md
@@ -1,0 +1,47 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
+# pyscn
+
+Analyseur statique structurel pour Python. Détecte le code mort, la duplication, la complexité et les problèmes de couplage via l'analyse du flux de contrôle et d'arbres.
+
+```bash
+uvx pyscn@latest analyze .
+```
+
+## Fonctionnalités
+
+- **33 règles** couvrant le code inatteignable, le code dupliqué, la complexité, la conception de classes, l'injection de dépendances, la structure des modules et les données factices.
+- **Accessibilité basée sur le CFG** qui détecte le code mort après `return` / `raise` / `break` / `continue` ainsi que les branches inatteignables.
+- **Détection de clones APTED + LSH** sur les quatre types de clones (identique, renommé, modifié, sémantique).
+- **Métriques de couplage et de cohésion de classes** CBO / LCOM4.
+- **Détection des imports circulaires** via l'algorithme SCC de Tarjan.
+- **Score de santé** (0–100) avec décomposition par catégorie.
+- **Prêt pour la CI** grâce à `pyscn check`, une sortie de type linter et des codes de sortie déterministes.
+- **Serveur MCP** (`pyscn-mcp`) pour Claude Code, Cursor et autres clients MCP.
+
+Écrit en Go. Plus de 100 000 lignes/s sur du matériel courant. Aucune dépendance d'exécution Python.
+
+## Installation
+
+```bash
+uvx pyscn@latest <command>   # exécution sans installation (recommandé)
+uv tool install pyscn        # installation via uv
+pipx install pyscn           # installation via pipx
+pip install pyscn            # installation via pip
+```
+
+Voir [Installation](getting-started/installation.md) pour toutes les options.
+
+## Démarrage rapide
+
+```bash
+pyscn analyze .                         # analyse complète, rapport HTML
+pyscn check --select complexity,deadcode src/   # garde-fou CI
+pyscn init                              # génère .pyscn.toml
+```
+
+Voir [Démarrage rapide](getting-started/quick-start.md) et le [Catalogue de règles](rules/index.md).

--- a/website/docs/fr/integrations/ci-cd.md
+++ b/website/docs/fr/integrations/ci-cd.md
@@ -1,0 +1,210 @@
+# Intégration CI/CD
+
+`pyscn check` renvoie un code de sortie non nul en cas de problème et produit une sortie de style linter. Voir la [référence `check`](../cli/check.md).
+
+```bash
+pyscn check .                        # exit 0 = pass, 1 = fail (issues or error)
+pyscn check --max-complexity 15 .
+pyscn check --select complexity,deadcode,deps .
+```
+
+Les constats sont écrits sur **stderr** au format linter. Capturez-les avec `2>` dans le shell ; la plupart des systèmes CI consignent stderr par défaut.
+
+## GitHub Actions
+
+Minimal (recommandé — uvx, sans étape d'installation) :
+
+```yaml
+# .github/workflows/quality.yml
+name: Quality
+on: [pull_request, push]
+
+jobs:
+  pyscn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uvx pyscn@latest check .
+```
+
+Avec le rapport complet en tant qu'artefact :
+
+```yaml
+jobs:
+  pyscn:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+
+      - name: Quality gate
+        run: uvx pyscn@latest check --max-complexity 15 src/
+
+      - name: Full report
+        if: always()
+        run: uvx pyscn@latest analyze --no-open --html src/
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pyscn-report
+          path: .pyscn/reports/*.html
+```
+
+N'exécuter que sur les modifications Python :
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - '**/*.py'
+      - '.pyscn.toml'
+      - 'pyproject.toml'
+```
+
+Avec `pip` plutôt qu'uvx :
+
+```yaml
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pyscn
+      - run: pyscn check .
+```
+
+## pre-commit
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: pyscn
+        name: pyscn check
+        entry: pyscn check
+        language: python
+        additional_dependencies: [pyscn]
+        pass_filenames: false
+        files: '\.py$'
+```
+
+Limiter aux fichiers indexés :
+
+```yaml
+      - id: pyscn
+        name: pyscn check (staged)
+        entry: bash -c 'pyscn check --quiet "$@"' --
+        language: python
+        additional_dependencies: [pyscn]
+        files: '\.py$'
+```
+
+## GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+stages: [quality]
+
+pyscn:
+  stage: quality
+  image: python:3.12-slim
+  script:
+    - pip install pyscn
+    - pyscn check src/
+  artifacts:
+    when: always
+    paths:
+      - .pyscn/reports/
+    expire_in: 1 week
+  rules:
+    - changes:
+        - '**/*.py'
+        - '.pyscn.toml'
+```
+
+## CircleCI
+
+```yaml
+version: 2.1
+jobs:
+  pyscn:
+    docker:
+      - image: cimg/python:3.12
+    steps:
+      - checkout
+      - run: pip install pyscn
+      - run: pyscn check .
+      - store_artifacts:
+          path: .pyscn/reports
+          destination: pyscn-reports
+```
+
+## Bitbucket Pipelines
+
+```yaml
+# bitbucket-pipelines.yml
+image: python:3.12
+pipelines:
+  default:
+    - step:
+        name: Code quality
+        script:
+          - pip install pyscn
+          - pyscn check .
+        artifacts:
+          - .pyscn/reports/**
+```
+
+## Codes de sortie
+
+| Code | Signification                        | Action |
+| ---- | ------------------------------------ | ------ |
+| `0`  | Aucun problème                       | Réussi |
+| `1`  | Problèmes trouvés ou erreur d'exécution | Échec |
+
+`check` renvoie le code `1` à la fois pour « problèmes ayant dépassé les seuils » et « l'analyse n'a pas pu se terminer » — les deux cas ne sont pas distinguables par le code de sortie. Inspectez stderr pour les différencier.
+
+## Stratégies
+
+Projet neuf :
+
+```bash
+pyscn check --max-complexity 10 --max-cycles 0 .
+```
+
+Adoption sur du code existant : commencez de manière permissive et resserrez à chaque sprint :
+
+```bash
+pyscn check --max-complexity 25 .
+```
+
+Monorepo avec des standards mixtes :
+
+```bash
+pyscn check --config packages/backend/.pyscn.toml packages/backend
+pyscn check --config packages/tooling/.pyscn.toml packages/tooling
+```
+
+## Commentaire de PR à partir de JSON
+
+`pyscn analyze --json` écrit dans un fichier horodaté sous `.pyscn/reports/`, pas sur stdout. Récupérez le fichier généré :
+
+```bash
+pyscn analyze --json --no-open .
+report=$(ls -t .pyscn/reports/analyze_*.json | head -1)
+jq -r '
+  "## pyscn report\n" +
+  "- **Health Score:** " + (.summary.health_score | tostring) + " / 100 (" + .summary.grade + ")\n" +
+  "- Complexity: " + (.summary.complexity_score | tostring) + "\n" +
+  "- Dead code: " + (.summary.dead_code_score | tostring) + "\n"
+' "$report" > comment.md
+
+gh pr comment $PR_NUMBER --body-file comment.md
+```
+
+## Voir aussi
+
+- [`pyscn check`](../cli/check.md)
+- [Exemples de configuration — Garde-fou strict pour la CI](../configuration/examples.md#strict-ci-gate)
+- [Score de santé](../output/health-score.md)

--- a/website/docs/fr/integrations/index.md
+++ b/website/docs/fr/integrations/index.md
@@ -1,0 +1,5 @@
+# Intégrations
+
+- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI.
+- **[MCP](mcp.md)** — Claude Code, Cursor et autres clients MCP.
+- **[Empaquetage Python](python-packaging.md)** — détails sur pip, pipx, uv et la distribution de wheels.

--- a/website/docs/fr/integrations/mcp.md
+++ b/website/docs/fr/integrations/mcp.md
@@ -1,0 +1,157 @@
+# Intégration MCP
+
+`pyscn-mcp` est un serveur Model Context Protocol qui expose les analyseurs de pyscn comme outils utilisables par les clients MCP (Claude Code, Cursor, ChatGPT desktop, etc.).
+
+## Outils
+
+| Outil | Équivalent CLI |
+| --- | --- |
+| `analyze_code` | `pyscn analyze` |
+| `check_complexity` | Analyseur de complexité |
+| `detect_clones` | Détecteur de clones |
+| `check_coupling` | Analyseur CBO |
+| `find_dead_code` | Analyseur de code mort |
+| `get_health_score` | Score récapitulatif |
+
+Tous les outils acceptent des arguments de chemin et des surcharges de seuils optionnelles. Les résultats sont du JSON structuré.
+
+## Installation
+
+| Méthode | Commande |
+| --- | --- |
+| uvx (à la demande) | — |
+| uv tool | `uv tool install pyscn` |
+| pipx | `pipx install pyscn` |
+| pip | `pip install pyscn` |
+
+## Configuration des clients
+
+### Claude Code / Claude Desktop
+
+Éditez `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) ou `%APPDATA%/Claude/claude_desktop_config.json` (Windows) :
+
+```json
+{
+  "mcpServers": {
+    "pyscn": {
+      "command": "uvx",
+      "args": ["pyscn-mcp"]
+    }
+  }
+}
+```
+
+Redémarrez l'application.
+
+### Cursor
+
+Settings → Features → Model Context Protocol → Add server :
+
+```json
+{
+  "pyscn": {
+    "command": "uvx",
+    "args": ["pyscn-mcp"]
+  }
+}
+```
+
+### Version figée
+
+```json
+{
+  "mcpServers": {
+    "pyscn": {
+      "command": "uvx",
+      "args": ["pyscn-mcp==0.2.0"]
+    }
+  }
+}
+```
+
+### Fichier de configuration personnalisé
+
+```json
+{
+  "mcpServers": {
+    "pyscn": {
+      "command": "uvx",
+      "args": ["pyscn-mcp"],
+      "env": {
+        "PYSCN_CONFIG": "/abs/path/to/.pyscn.toml"
+      }
+    }
+  }
+}
+```
+
+Sans `PYSCN_CONFIG`, le serveur découvre la configuration en remontant depuis le chemin analysé.
+
+### Binaire installé
+
+=== "macOS"
+
+    ```json
+    {
+      "mcpServers": {
+        "pyscn": {
+          "command": "/Users/you/Library/Application Support/uv/tools/pyscn/bin/pyscn-mcp"
+        }
+      }
+    }
+    ```
+
+=== "Linux"
+
+    ```json
+    {
+      "mcpServers": {
+        "pyscn": {
+          "command": "/home/you/.local/share/uv/tools/pyscn/bin/pyscn-mcp"
+        }
+      }
+    }
+    ```
+
+=== "Windows"
+
+    ```json
+    {
+      "mcpServers": {
+        "pyscn": {
+          "command": "C:/Users/you/AppData/Local/uv/tools/pyscn/bin/pyscn-mcp.exe"
+        }
+      }
+    }
+    ```
+
+## Exemple d'invite
+
+> Exécute pyscn sur ce projet et dis-moi quoi corriger en premier.
+
+## Tester
+
+```bash
+uvx pyscn-mcp
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | uvx pyscn-mcp
+npx @modelcontextprotocol/inspector uvx pyscn-mcp
+```
+
+## Modèle de sécurité
+
+- Lecture seule : analyse statique, aucune exécution de code.
+- Chemins validés contre la traversée de répertoires.
+- Délais d'attente et limites de mémoire par invocation.
+
+Le serveur peut lire tout fichier que le processus appelant peut lire.
+
+## Limitations
+
+- Pas de mode incrémental ; chaque appel relance l'analyse depuis zéro.
+- `detect_clones` sur des dépôts de 10 000 fichiers peut prendre plus de 30 secondes.
+- Aucun outil d'écriture ; le refactoring s'appuie sur les propres outils d'édition de fichiers de l'assistant.
+
+## Voir aussi
+
+- [Référence CLI](../cli/index.md)
+- [Configuration](../configuration/index.md)

--- a/website/docs/fr/integrations/python-packaging.md
+++ b/website/docs/fr/integrations/python-packaging.md
@@ -1,0 +1,88 @@
+# Empaquetage Python
+
+pyscn est distribué sur PyPI sous forme de wheel contenant un binaire Go natif. La couche Python est un lanceur basé sur la bibliothèque standard ; il n'y a aucune dépendance Python d'exécution.
+
+## Quel installateur choisir ?
+
+| Outil | Adapté à | Notes |
+| --- | --- | --- |
+| `uvx` (recommandé) | Exécutions ponctuelles, CI | S'exécute sans installation ; mise en cache après le premier appel. |
+| `uv tool install` | Gestion d'outils persistante | Rapide et isolé. |
+| `pipx` | Installation persistante d'un CLI | Isolé des dépendances du projet. |
+| `pip` | Installation dans un venv | Pas d'isolation. |
+
+CI : `uvx pyscn@latest check .`. Développement local : `uv tool install pyscn` ou `pipx install pyscn`.
+
+## Plateformes prises en charge
+
+| OS | Architectures |
+| --- | --- |
+| Linux | x86_64, arm64 |
+| macOS | x86_64, arm64 |
+| Windows | x86_64, arm64 |
+
+Python 3.8–3.13.
+
+## Paquets
+
+| Paquet | Contient | À installer quand |
+| --- | --- | --- |
+| `pyscn` | CLI + serveur MCP | Vous voulez le CLI. |
+| `pyscn-mcp` | Serveur MCP uniquement | Vous ne voulez que le serveur MCP. |
+
+## Versionnage
+
+[PEP 440](https://peps.python.org/pep-0440/), correspondant à l'étiquette Git :
+
+- `0.1.0` — stable
+- `0.2.0.dev1` — développement
+- `0.2.0b1` — bêta
+
+Figez la version pour la reproductibilité :
+
+```bash
+pip install pyscn==0.2.0
+```
+
+## Conteneurs
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir pyscn
+ENTRYPOINT ["pyscn"]
+```
+
+## Contenu du wheel
+
+```
+pyscn-0.2.0-py3-none-manylinux_2_17_x86_64.whl
+├── pyscn/
+│   ├── __init__.py
+│   ├── __main__.py        # CLI launcher
+│   ├── mcp_main.py        # MCP launcher
+│   └── bin/
+│       └── pyscn          # Go binary
+```
+
+Le lanceur détecte l'OS et l'architecture puis appelle `exec` sur le binaire correspondant.
+
+## Versions
+
+Les versions sont publiées sur les étiquettes Git commençant par `v` :
+
+```bash
+git tag -a v0.2.0 -m "Release v0.2.0"
+git push origin v0.2.0
+```
+
+GitHub Actions compile en croisé, fabrique des wheels spécifiques à chaque plateforme, exécute `twine check`, lance des tests de fumée à travers la matrice OS × Python, publie sur PyPI et crée une release GitHub. Voir la [page des Releases](https://github.com/ludo-technologies/pyscn/releases).
+
+## Alternatives à PyPI
+
+- `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest` (Go 1.22+ ; n'installe pas `pyscn-mcp`).
+- Téléchargements binaires depuis GitHub Releases.
+
+## Voir aussi
+
+- [Installation](../getting-started/installation.md)
+- [Intégration CI/CD](ci-cd.md)

--- a/website/docs/fr/output/health-score.md
+++ b/website/docs/fr/output/health-score.md
@@ -1,0 +1,409 @@
+# Score de santé
+
+## Vue d'ensemble
+
+Le score de santé est un entier sur 0–100 qui synthétise en une seule valeur toutes les analyses activées (complexité, code mort, duplication, couplage, cohésion, dépendances, architecture). Le calcul est pur et déterministe — avec les mêmes entrées `AnalyzeSummary`, `CalculateHealthScore()` produit toujours le même score. Il est conçu pour être stocké par commit dans la CI afin de suivre les évolutions au fil du temps.
+
+## Note
+
+Le score est converti en une note littérale à l'aide de seuils stricts `≥` :
+
+| Note | Plage de score | Constante de seuil   |
+| ---- | -------------- | -------------------- |
+| A    | 90–100         | `GradeAThreshold = 90` |
+| B    | 75–89          | `GradeBThreshold = 75` |
+| C    | 60–74          | `GradeCThreshold = 60` |
+| D    | 45–59          | `GradeDThreshold = 45` |
+| F    | 0–44           | (sous D)               |
+
+Définies dans `domain/analyze.go:90-93`. Un projet est considéré « en bonne santé » à `HealthScore ≥ 70` (`HealthyThreshold`, `domain/analyze.go:103`).
+
+## Formule
+
+```
+score = 100
+      - complexityPenalty       (0–20)
+      - deadCodePenalty         (0–20)
+      - duplicationPenalty      (0–20)
+      - couplingPenalty         (0–20)
+      - cohesionPenalty         (0–20)
+      - dependencyPenalty       (0–16)
+      - architecturePenalty     (0–12)
+
+HealthScore = max(0, score)
+```
+
+Chaque pénalité est plafonnée à son propre maximum :
+
+| Catégorie    | Pénalité max | Constante                       |
+| ------------ | ------------ | ------------------------------- |
+| Complexité   | 20           | littéral `20.0` dans la formule |
+| Code mort    | 20           | `MaxDeadCodePenalty = 20`       |
+| Duplication  | 20           | littéral `20.0` dans la formule |
+| Couplage     | 20           | littéral `20.0` dans la formule |
+| Cohésion     | 20           | littéral `20.0` dans la formule |
+| Dépendances  | 16           | `MaxDependencyPenalty = 10+3+3` |
+| Architecture | 12           | `MaxArchitecturePenalty = 12`   |
+
+Le plancher du score est `MinimumScore = 0` (`domain/analyze.go:102`), appliqué après la sommation des pénalités.
+
+## Spécifications des pénalités
+
+### Complexité
+
+**Entrées.** `AverageComplexity` (float64).
+
+**Formule.**
+
+```
+if AverageComplexity <= 2.0:
+    penalty = 0
+else:
+    penalty = min(20, round((AverageComplexity - 2.0) / 13.0 * 20.0))
+```
+
+**Constantes.**
+
+| Nom       | Valeur | Signification                                   |
+| --------- | ------ | ----------------------------------------------- |
+| baseline  | 2.0    | Complexité moyenne en dessous de laquelle pénalité = 0 |
+| range     | 13.0   | Dénominateur — pénalité max atteinte à moyenne = 15 |
+| max       | 20.0   | Plafond de pénalité                             |
+
+**Saturation.** Atteint 20 à `AverageComplexity >= 15.0`.
+
+**Cas limites.** `AverageComplexity = 0` ou toute valeur `≤ 2.0` donne une pénalité de 0. `Validate()` rejette les valeurs négatives.
+
+Source : `domain/analyze.go:266-279`.
+
+### Code mort
+
+**Entrées.** `CriticalDeadCode`, `WarningDeadCode`, `InfoDeadCode` (int). `TotalFiles` (int) sert à dériver le facteur de normalisation dans `CalculateHealthScore()`.
+
+**Formule.**
+
+```
+weighted = CriticalDeadCode * 1.0
+         + WarningDeadCode  * 0.5
+         + InfoDeadCode     * 0.2
+
+if TotalFiles <= 10:
+    normalization = 1.0
+else:
+    normalization = 1.0 + log10(TotalFiles / 10.0)
+
+if weighted <= 0:
+    penalty = 0
+else:
+    penalty = int(min(20.0, weighted / normalization))
+```
+
+**Constantes.**
+
+| Nom                       | Valeur | Signification                          |
+| ------------------------- | ------ | -------------------------------------- |
+| poids critical            | 1.0    | Poids complet pour les constats Critical |
+| poids warning             | 0.5    | Demi-poids pour les constats Warning   |
+| poids info                | 0.2    | Poids minimal pour les constats Info   |
+| seuil de normalisation    | 10     | Fichiers en dessous desquels le facteur de normalisation = 1 |
+| `MaxDeadCodePenalty`      | 20     | Plafond de pénalité                    |
+
+**Saturation.** Atteint 20 lorsque `weighted / normalization >= 20.0`.
+
+**Cas limites.** Zéro constat donne une pénalité de 0. La troncature utilise `int()` (vers zéro), pas `math.Round` — ainsi une valeur calculée de `1.99` devient `1`.
+
+Source : `domain/analyze.go:283-296`. Facteur de normalisation dérivé dans `CalculateHealthScore()` à `domain/analyze.go:474-477`.
+
+### Duplication
+
+**Entrées.** `CodeDuplication` (float64). Ce champ est un pourcentage de duplication pré-calculé, plafonné à 10 par le calcul en amont.
+
+**Formule.**
+
+```
+if CodeDuplication <= 0:
+    penalty = 0
+else:
+    penalty = min(20, round(CodeDuplication / 10.0 * 20.0))
+```
+
+**Constantes.**
+
+| Nom                          | Valeur | Signification                  |
+| ---------------------------- | ------ | ------------------------------ |
+| `DuplicationThresholdLow`    | 0.0    | 0 % de duplication = pénalité 0 |
+| `DuplicationThresholdHigh`   | 10.0   | 10 % de duplication = pénalité max |
+| max                          | 20.0   | Plafond de pénalité            |
+
+**Calcul en amont.** `CodeDuplication` est calculé dans `app/analyze_usecase.go:570-583` :
+
+```
+lines_in_thousands = max(GroupDensityMinLines, total_lines / GroupDensityLinesUnit)
+group_density      = clone_groups / lines_in_thousands
+CodeDuplication    = min(DuplicationThresholdHigh, group_density * GroupDensityCoefficient)
+```
+
+Où `GroupDensityLinesUnit = 1000.0`, `GroupDensityMinLines = 1.0`, `GroupDensityCoefficient = 20.0`, `DuplicationThresholdHigh = 10.0` (`domain/analyze.go:52, 62-64`).
+
+**Saturation.** Atteint 20 lorsque `CodeDuplication >= 10.0`. Comme la valeur en amont est plafonnée à 10, la saturation est atteinte à exactement 0,5 groupe de clones pour 1000 lignes analysées.
+
+**Cas limites.** Aucun groupe de clones ou aucune ligne analysée → `CodeDuplication = 0` → pénalité 0. `Validate()` rejette les valeurs hors de `[0, 100]`.
+
+Source : `domain/analyze.go:300-314`.
+
+### Couplage (CBO)
+
+**Entrées.** `CBOClasses`, `HighCouplingClasses` (CBO > 7), `MediumCouplingClasses` (3 < CBO ≤ 7).
+
+**Formule.**
+
+```
+if CBOClasses == 0:
+    penalty = 0
+else:
+    weighted = HighCouplingClasses + 0.5 * MediumCouplingClasses
+    ratio    = weighted / CBOClasses
+    penalty  = min(20, round(ratio / 0.25 * 20.0))
+```
+
+**Constantes.**
+
+| Nom              | Valeur | Signification                                       |
+| ---------------- | ------ | --------------------------------------------------- |
+| poids haut       | 1.0    | Poids complet pour les classes à haut couplage      |
+| poids moyen      | 0.5    | Demi-poids pour les classes à couplage moyen        |
+| ratio saturation | 0.25   | 25 % de classes problématiques pondérées → pénalité max |
+| max              | 20.0   | Plafond de pénalité                                 |
+
+**Saturation.** Atteint 20 lorsque le ratio pondéré est `≥ 0.25`.
+
+**Cas limites.** `CBOClasses = 0` → pénalité 0. `Validate()` garantit que haut + moyen ≤ total.
+
+Source : `domain/analyze.go:318-336`.
+
+### Cohésion (LCOM)
+
+**Entrées.** `LCOMClasses`, `HighLCOMClasses` (LCOM4 > 5), `MediumLCOMClasses` (2 < LCOM4 ≤ 5).
+
+**Formule.**
+
+```
+if LCOMClasses == 0:
+    penalty = 0
+else:
+    weighted = HighLCOMClasses + 0.5 * MediumLCOMClasses
+    ratio    = weighted / LCOMClasses
+    penalty  = min(20, round(ratio / 0.30 * 20.0))
+```
+
+**Constantes.**
+
+| Nom              | Valeur | Signification                                      |
+| ---------------- | ------ | -------------------------------------------------- |
+| poids haut       | 1.0    | Poids complet pour les classes à LCOM élevé        |
+| poids moyen      | 0.5    | Demi-poids pour les classes à LCOM moyen           |
+| ratio saturation | 0.30   | 30 % de classes problématiques pondérées → pénalité max |
+| max              | 20.0   | Plafond de pénalité                                |
+
+**Saturation.** Atteint 20 lorsque le ratio pondéré est `≥ 0.30`.
+
+**Cas limites.** `LCOMClasses = 0` → pénalité 0. `Validate()` garantit que haut + moyen ≤ total.
+
+Source : `domain/analyze.go:340-358`.
+
+### Dépendances
+
+**Entrées.** `DepsEnabled` (bool), `DepsTotalModules`, `DepsModulesInCycles`, `DepsMaxDepth` (int), `DepsMainSequenceDeviation` (float64, 0–1).
+
+**Formule.** Somme de trois sous-pénalités :
+
+```
+if not DepsEnabled:
+    return 0
+
+# Cycles sub-penalty (max 10)
+if DepsTotalModules > 0:
+    ratio  = clamp(0, 1, DepsModulesInCycles / DepsTotalModules)
+    cycles = round(10 * ratio)
+else:
+    cycles = 0
+
+# Depth sub-penalty (max 3)
+if DepsTotalModules > 0:
+    expected = max(3, ceil(log2(DepsTotalModules + 1)) + 1)
+    depth    = clamp(0, 3, DepsMaxDepth - expected)
+else:
+    depth = 0
+
+# Main Sequence Deviation sub-penalty (max 3)
+if DepsMainSequenceDeviation > 0:
+    msd = round(3 * clamp(0, 1, DepsMainSequenceDeviation))
+else:
+    msd = 0
+
+penalty = cycles + depth + msd     # max 16
+```
+
+**Constantes.**
+
+| Nom                    | Valeur | Signification                       |
+| ---------------------- | ------ | ----------------------------------- |
+| `MaxCyclesPenalty`     | 10     | Plafond pour la sous-pénalité cycles |
+| `MaxDepthPenalty`      | 3      | Plafond pour la sous-pénalité profondeur |
+| `MaxMSDPenalty`        | 3      | Plafond pour la sous-pénalité MSD   |
+| `MaxDependencyPenalty` | 16     | Somme des trois plafonds            |
+
+**Saturation.** Atteint 16 lorsque chaque module est dans un cycle, que la profondeur dépasse l'attendu de ≥ 3, et que MSD ≥ 1.
+
+**Cas limites.** `DepsEnabled = false` → pénalité 0. `DepsTotalModules = 0` → cycles et profondeur contribuent 0 ; seul MSD peut s'activer. `Validate()` impose `MSD ∈ [0, 1]` et `DepsModulesInCycles ≤ DepsTotalModules`.
+
+Source : `domain/analyze.go:361-406`.
+
+### Architecture
+
+**Entrées.** `ArchEnabled` (bool), `ArchCompliance` (float64, 0–1).
+
+**Formule.**
+
+```
+if not ArchEnabled:
+    penalty = 0
+else:
+    penalty = round(12 * (1 - clamp(0, 1, ArchCompliance)))
+```
+
+**Constantes.**
+
+| Nom                      | Valeur | Signification          |
+| ------------------------ | ------ | ---------------------- |
+| `MaxArchPenalty`         | 12     | Plafond de pénalité    |
+| `MaxArchitecturePenalty` | 12     | Alias du plafond       |
+
+**Saturation.** Atteint 12 à `ArchCompliance = 0.0`.
+
+**Cas limites.** `ArchEnabled = false` → pénalité 0. `Validate()` impose `ArchCompliance ∈ [0, 1]` lorsqu'activé.
+
+Source : `domain/analyze.go:409-422`.
+
+## Scores par catégorie
+
+Chaque catégorie expose un score sur 0–100 dans le rapport. La conversion dépend de l'échelle de pénalité de la catégorie.
+
+**La plupart des catégories (Complexité, Code mort, Duplication, Couplage, Cohésion).** Toutes ont une pénalité plafonnée à 20 (`MaxScoreBase = 20`). Le score est calculé par `penaltyToScore(penalty, 20)` :
+
+```
+score = 100 - round(penalty * 100 / 20) = 100 - penalty * 5
+```
+
+Effectivement, chaque unité de pénalité coûte 5 points de score. Une pénalité de 0 donne 100 ; une pénalité de 20 donne 0.
+
+**Dépendances.** Le plafond de pénalité est 16, donc le score est d'abord normalisé sur l'échelle 20 points via `normalizeToScoreBase` :
+
+```
+normalized = round(dependencyPenalty / 16 * 20)
+DependencyScore = 100 - round(normalized * 100 / 20) = 100 - normalized * 5
+```
+
+**Architecture.** Cas particulier — le score est pris directement à partir de la conformité :
+
+```
+ArchitectureScore = round(ArchCompliance * 100)
+```
+
+Ainsi `ArchCompliance = 0.98` donne `ArchitectureScore = 98`, indépendamment des arrondis de pénalité qui alimentent le score global.
+
+Source : `domain/analyze.go:426-453`, `domain/analyze.go:483-510`.
+
+## Exemple détaillé
+
+Entrées :
+
+| Champ                         | Valeur |
+| ----------------------------- | ------ |
+| `TotalFiles`                  | 50     |
+| `AverageComplexity`           | 8.0    |
+| `CriticalDeadCode`            | 2      |
+| `WarningDeadCode`             | 1      |
+| `InfoDeadCode`                | 0      |
+| `CodeDuplication`             | 7.5    |
+| `CBOClasses`                  | 20     |
+| `HighCouplingClasses`         | 3      |
+| `MediumCouplingClasses`       | 2      |
+| `LCOMClasses`                 | 20     |
+| `HighLCOMClasses`             | 1      |
+| `MediumLCOMClasses`           | 3      |
+| `DepsEnabled`                 | true   |
+| `DepsTotalModules`            | 8      |
+| `DepsModulesInCycles`         | 1      |
+| `DepsMaxDepth`                | 5      |
+| `DepsMainSequenceDeviation`   | 0.2    |
+| `ArchEnabled`                 | true   |
+| `ArchCompliance`              | 0.85   |
+
+**Pénalité de complexité.** `(8.0 − 2.0) / 13.0 × 20.0 = 9.2308 → arrondi → 9`.
+
+**Pénalité de code mort.** `weighted = 2×1.0 + 1×0.5 + 0×0.2 = 2.5`. `normalization = 1.0 + log10(50/10) = 1.0 + log10(5) ≈ 1.6990`. `2.5 / 1.6990 ≈ 1.4715`. `int(min(20.0, 1.4715)) = 1`.
+
+**Pénalité de duplication.** `7.5 / 10.0 × 20.0 = 15.0 → arrondi → 15`.
+
+**Pénalité de couplage.** `weighted = 3 + 0.5×2 = 4`. `ratio = 4/20 = 0.20`. `0.20 / 0.25 × 20.0 = 16.0 → arrondi → 16`.
+
+**Pénalité de cohésion.** `weighted = 1 + 0.5×3 = 2.5`. `ratio = 2.5/20 = 0.125`. `0.125 / 0.30 × 20.0 ≈ 8.333 → arrondi → 8`.
+
+**Pénalité de dépendances.**
+- Cycles : `ratio = 1/8 = 0.125`. `round(10 × 0.125) = round(1.25) = 1`.
+- Profondeur : `expected = max(3, ceil(log2(9)) + 1) = max(3, 4 + 1) = 5`. Excédent = `5 − 5 = 0`.
+- MSD : `round(3 × 0.2) = round(0.6) = 1`.
+- Total : `1 + 0 + 1 = 2`.
+
+**Pénalité d'architecture.** `round(12 × (1 − 0.85)) = round(1.8) = 2`.
+
+**Somme.** `9 + 1 + 15 + 16 + 8 + 2 + 2 = 53`.
+
+**HealthScore.** `max(0, 100 − 53) = 47`. Note : `47 ≥ 45` → **D**.
+
+**Scores par catégorie (tels que rapportés).**
+
+| Catégorie    | Pénalité | Score                                            |
+| ------------ | -------- | ------------------------------------------------ |
+| Complexité   | 9        | `100 − 9×5 = 55`                                 |
+| Code mort    | 1        | `100 − 1×5 = 95`                                 |
+| Duplication  | 15       | `100 − 15×5 = 25`                                |
+| Couplage     | 16       | `100 − 16×5 = 20`                                |
+| Cohésion     | 8        | `100 − 8×5 = 60`                                 |
+| Dépendances  | 2        | `normalized = round(2/16 × 20) = 3` ; `100 − 3×5 = 85` |
+| Architecture | —        | `round(0.85 × 100) = 85`                         |
+
+## Score de repli
+
+`CalculateHealthScore()` appelle d'abord `Validate()` sur le résumé. Si la validation échoue — par exemple `AverageComplexity < 0`, `CodeDuplication` hors de `[0, 100]`, `ArchCompliance` hors de `[0, 1]` quand activé, `DepsMainSequenceDeviation` hors de `[0, 1]` quand activé, ou la somme des classes haut + moyen dépassant le total pour LCOM ou CBO — les scores du résumé sont remis à zéro, la note est fixée à `"N/A"`, et une erreur est renvoyée. L'appelant peut alors invoquer `CalculateFallbackScore()` comme chemin dégradé : en partant de 100, il soustrait `FallbackComplexityThreshold = 10` si `AverageComplexity > 10`, et `FallbackPenalty = 5` pour chacun de `DeadCodeCount > 0`, `HighComplexityCount > 0` et `HighLCOMClasses > 0`, avec un plancher à `MinimumScore = 0`.
+
+Source : `domain/analyze.go:200-262` (`Validate`), `domain/analyze.go:456-470` (branche de validation dans `CalculateHealthScore`), `domain/analyze.go:538-566` (`CalculateFallbackScore`).
+
+## Arrondi
+
+Tous les intermédiaires non entiers sont ramenés à des entiers via `math.Round` de Go, qui applique l'arrondi du banquier pour les valeurs exactement à `.5` (round-half-away-from-zero pour les valeurs positives dans l'implémentation Go). Le score de santé final est borné à `[0, 100]` via `MinimumScore`. Les scores par catégorie sont bornés à `[0, 100]` à l'intérieur de `penaltyToScore` (`domain/analyze.go:441-453`). La seule exception à `math.Round` est la pénalité de code mort, qui utilise la troncature `int()` après `math.Min` (`domain/analyze.go:294`).
+
+## Suivi au fil du temps
+
+La formule est déterministe — des entrées identiques produisent toujours des scores identiques entre exécutions et plateformes. Pour suivre la santé au fil du temps, persistez `summary.health_score` issu de la sortie JSON par commit et comparez-le dans la CI. Les scores par catégorie (`complexity_score`, `dead_code_score`, etc.) sont également stables et peuvent être suivis individuellement.
+
+## Références
+
+Tous les numéros de ligne se rapportent à `domain/analyze.go` :
+
+- `CalculateHealthScore()` — lignes 456–534
+- `calculateComplexityPenalty()` — lignes 266–279
+- `calculateDeadCodePenalty(normalizationFactor)` — lignes 283–296
+- `calculateDuplicationPenalty()` — lignes 300–314
+- `calculateCouplingPenalty()` — lignes 318–336
+- `calculateCohesionPenalty()` — lignes 340–358
+- `calculateDependencyPenalty()` — lignes 361–406
+- `calculateArchitecturePenalty()` — lignes 409–422
+- `CalculateFallbackScore()` — lignes 538–566
+- `Validate()` — lignes 200–262
+- `penaltyToScore()` — lignes 441–453
+- `normalizeToScoreBase()` — lignes 426–438
+- `GetGradeFromScore()` — lignes 569–582
+
+Calcul amont de `CodeDuplication` : `app/analyze_usecase.go:570-583`.

--- a/website/docs/fr/output/html-report.md
+++ b/website/docs/fr/output/html-report.md
@@ -1,0 +1,98 @@
+# Rapport HTML
+
+Spécification de la sortie HTML générée par `pyscn analyze` (et par défaut lorsque aucun drapeau `--json`/`--yaml`/`--csv` n'est fourni).
+
+## Caractéristiques du fichier
+
+| Propriété | Valeur |
+| --- | --- |
+| Chemin | `.pyscn/reports/analyze_YYYYMMDD_HHMMSS.html` |
+| Encodage | UTF-8 |
+| Ressources externes | Aucune (CSS et JS intégrés) |
+| Dépendances | Aucune (pas de CDN, pas de polices chargées à distance) |
+| Taille | Généralement entre 50 et 500 Ko |
+
+Le fichier est autonome : on peut l'archiver, l'envoyer par e-mail ou le servir depuis n'importe quel hébergeur statique en toute sécurité.
+
+## Structure du document
+
+| Élément | Contenu |
+| --- | --- |
+| En-tête | Nom du projet, horodatage de génération, version de pyscn, durée. |
+| Carte du score global | Score de santé (0–100), badge de note (A–F). |
+| Cartes de score par catégorie | Une par analyseur activé avec son score sur 0–100. |
+| Onglets | Résumé, Complexité, Code mort, Clones, Couplage, Cohésion, Dépendances, Architecture. |
+| Pied de page | Lien vers le dépôt pyscn et chaîne de version. |
+
+Les cartes de score par catégorie et les onglets n'apparaissent que pour les analyseurs qui ont été exécutés. L'onglet Architecture n'apparaît que si des couches `[architecture]` sont configurées.
+
+## Onglets
+
+| Onglet | Contenu |
+| --- | --- |
+| Résumé | Chiffres globaux et note. |
+| Complexité | Tableau triable des fonctions avec complexité McCabe / cognitive, profondeur d'imbrication, risque. |
+| Code mort | Constats regroupés par sévérité avec fichier:ligne et motif. |
+| Clones | Groupes de clones avec similarité et type de clone. |
+| Couplage | Classes par CBO avec ventilation par type de dépendance. |
+| Cohésion | Classes par LCOM4 avec regroupement des méthodes. |
+| Dépendances | Graphe de modules, métriques Ca/Ce/I/A/D, cycles. |
+| Architecture | Violations des règles entre couches. |
+
+## JavaScript
+
+Une seule fonction intégrée, `showTab(id)`, permet de basculer entre les onglets. Aucun autre script ne s'exécute. Aucune requête réseau.
+
+## CSS
+
+Les styles utilisent des propriétés personnalisées CSS portant ces noms :
+
+| Variable | Rôle sémantique |
+| --- | --- |
+| `--color-success` | Constats à faible risque, note A. |
+| `--color-warning` | Constats à risque moyen, notes B/C. |
+| `--color-danger` | Constats à risque élevé, notes D/F. |
+| `--color-text` | Texte courant. |
+| `--color-muted` | Texte secondaire. |
+
+Le mode sombre suit la requête média `prefers-color-scheme` ; aucun interrupteur n'est fourni.
+
+## Ouverture automatique
+
+Le rapport s'ouvre dans le navigateur par défaut lorsque **toutes** les conditions suivantes sont remplies :
+
+- Le format est HTML.
+- Stdin est un TTY.
+- Les variables d'environnement `SSH_TTY` et `SSH_CONNECTION` ne sont pas définies.
+- La variable d'environnement `CI` n'est pas définie.
+- `--no-open` n'est pas passé.
+
+Mécanisme d'ouverture : `open` sur macOS, `xdg-open` (ou `gnome-open` / `kde-open`) sous Linux, `cmd /c start` sous Windows.
+
+Forme de l'URL de fichier : `file:///{chemin-absolu-vers-le-rapport}`.
+
+Le chemin du rapport est toujours affiché sur stderr, indépendamment de l'ouverture automatique.
+
+## Désactiver l'ouverture automatique
+
+```bash
+pyscn analyze --no-open .
+```
+
+Ou exportez `CI=true` dans l'environnement.
+
+## Correspondance des badges de note
+
+| Note | Score | Couleur de fond du badge |
+| ---- | ----- | --- |
+| A | 90–100 | Vert (`--color-success`) |
+| B | 75–89  | Teinté vert |
+| C | 60–74  | Orange (`--color-warning`) |
+| D | 45–59  | Teinté rouge (`--color-danger`) |
+| F | 0–44   | Rouge (`--color-danger`) |
+
+## Références croisées
+
+- [Score de santé](health-score.md) — formule du score global.
+- [Schémas](schemas.md) — alternatives lisibles par une machine.
+- [Formats de sortie](index.md) — tous les formats de sortie et le contrat de stabilité.

--- a/website/docs/fr/output/index.md
+++ b/website/docs/fr/output/index.md
@@ -1,0 +1,44 @@
+# Formats de sortie
+
+pyscn écrit les résultats d'analyse dans des fichiers situés dans un répertoire de sortie. Tous les formats partagent une sémantique de champ stable d'une version corrective à l'autre.
+
+## Répertoire de sortie
+
+Par défaut : `.pyscn/reports/` sous le répertoire de travail courant.
+
+Configurable via `.pyscn.toml` :
+
+```toml
+[output]
+directory = "build/reports"
+```
+
+## Convention de nommage
+
+```
+{command}_YYYYMMDD_HHMMSS.{ext}
+```
+
+`{command}` vaut `analyze` (la seule commande pyscn qui écrit des rapports). L'horodatage est en heure locale. Les fichiers existants ne sont jamais écrasés.
+
+## Formats pris en charge
+
+| Format | Extension | Drapeau           | Spécification                    |
+| ------ | --------- | ----------------- | -------------------------------- |
+| text   | —         | (terminal)        | lisible par un humain, non stable |
+| json   | `.json`   | `--json`          | [schemas.md](schemas.md)         |
+| yaml   | `.yaml`   | `--yaml`          | [schemas.md](schemas.md)         |
+| csv    | `.csv`    | `--csv`           | [schemas.md](schemas.md)         |
+| html   | `.html`   | `--html` (défaut) | [html-report.md](html-report.md) |
+
+Le format `text` est destiné à l'affichage dans le terminal et ne fait l'objet d'aucun contrat de stabilité ; sa présentation peut changer entre n'importe quelles versions.
+
+## Contrat de stabilité
+
+Entre versions correctives et mineures d'une même version majeure :
+
+- **Stable** : noms de champs, types et signification sémantique dans `json`, `yaml` et `csv`.
+- **Peut changer** : ordre des éléments dans les tableaux, ajout de nouveaux champs, ajout de nouvelles sections de premier niveau, modifications cosmétiques de `text` et `html`.
+- **Changements incompatibles** : limités aux changements de version majeure (suppression ou renommage de champs, modification du type d'un champ).
+
+Les intégrations tierces doivent ignorer les champs inconnus et ne pas dépendre de l'ordre des champs au sein d'un objet.

--- a/website/docs/fr/output/schemas.md
+++ b/website/docs/fr/output/schemas.md
@@ -1,0 +1,741 @@
+# Schémas de sortie
+
+Cette spécification définit la forme exacte des sorties JSON, YAML et CSV produites par pyscn. Tous les noms de champs, types et sémantiques documentés ici sont stables d'une version corrective à l'autre au sein d'une même version majeure.
+
+## Contrat de stabilité
+
+| Garantie          | Portée                                                                            |
+| ----------------- | --------------------------------------------------------------------------------- |
+| Stable            | noms de champs, types de champs, sémantique des champs, valeurs d'énumération     |
+| Peut changer      | ordre des champs au sein d'un objet, ordre des éléments d'un tableau, ajout de nouveaux champs |
+| Incompatible      | suppression ou renommage de champs, modification du type d'un champ, suppression de valeurs d'énumération |
+
+Les changements incompatibles sont limités aux changements de version majeure. Les consommateurs DOIVENT ignorer les champs inconnus.
+
+<!-- Field naming note: in `pyscn analyze` JSON/YAML, nested analyzer objects (`complexity`, `cbo`, `lcom`, `system`) use Go-style PascalCase field names because their response structs do not carry JSON tags. Top-level keys, `dead_code`, `clone`, `suggestions`, and `summary` use snake_case. -->
+
+## Structure de premier niveau (`pyscn analyze`)
+
+Les sorties JSON et YAML sérialisent la structure Go `AnalyzeResponse` définie dans `domain/analyze.go`. Les clés de premier niveau sont :
+
+```json
+{
+  "complexity":    { /* ComplexityResponse, present when enabled */ },
+  "dead_code":     { /* DeadCodeResponse, present when enabled */ },
+  "clone":         { /* CloneResponse, present when enabled */ },
+  "cbo":           { /* CBOResponse, present when enabled */ },
+  "lcom":          { /* LCOMResponse, present when enabled */ },
+  "system":        { /* SystemAnalysisResponse, present when deps/arch enabled */ },
+  "mock_data":     { /* MockDataResponse, present when enabled */ },
+  "suggestions":   [ /* Suggestion array, omitted when empty */ ],
+  "summary":       { /* AnalyzeSummary, always present */ },
+  "generated_at":  "2026-04-14T10:18:23Z",
+  "duration_ms":   2347,
+  "version":       "0.14.0"
+}
+```
+
+| Champ         | Type              | Description                                                       | Stabilité |
+| ------------- | ----------------- | ----------------------------------------------------------------- | --------- |
+| `complexity`  | object \| absent  | Présent lorsque l'analyse de complexité a été exécutée.           | stable    |
+| `dead_code`   | object \| absent  | Présent lorsque l'analyse de code mort a été exécutée.            | stable    |
+| `clone`       | object \| absent  | Présent lorsque la détection de clones a été exécutée.            | stable    |
+| `cbo`         | object \| absent  | Présent lorsque l'analyse CBO a été exécutée.                     | stable    |
+| `lcom`        | object \| absent  | Présent lorsque l'analyse LCOM a été exécutée.                    | stable    |
+| `system`      | object \| absent  | Présent lorsque l'analyse des dépendances ou de l'architecture a été exécutée. | stable |
+| `mock_data`   | object \| absent  | Présent lorsque la détection de données fictives a été exécutée.  | stable    |
+| `suggestions` | array \| absent   | Suggestions dérivées. Omis lorsque vide.                          | stable    |
+| `summary`     | object            | Toujours présent. Voir [`summary`](#summary-object).               | stable    |
+| `generated_at`| string (RFC 3339) | Heure de fin d'analyse.                                           | stable    |
+| `duration_ms` | integer           | Durée totale d'analyse en millisecondes.                          | stable    |
+| `version`     | string            | Version sémantique de pyscn.                                      | stable    |
+
+## Objet `summary` { #summary-object }
+
+Reflet de `domain.AnalyzeSummary`. Tous les compteurs numériques valent `0` par défaut lorsque l'analyseur correspondant est désactivé. Tous les champs sont toujours présents.
+
+### Statistiques de fichiers
+
+| Champ            | Type    | Description                                       |
+| ---------------- | ------- | ------------------------------------------------- |
+| `total_files`    | integer | Nombre de fichiers Python découverts.             |
+| `analyzed_files` | integer | Nombre de fichiers analysés avec succès.          |
+| `skipped_files`  | integer | Fichiers ignorés à cause d'erreurs de parsing ou de filtres. |
+
+### Indicateurs d'état des analyseurs
+
+| Champ                | Type    | Description                                                 |
+| -------------------- | ------- | ----------------------------------------------------------- |
+| `complexity_enabled` | boolean | `true` si l'analyse de complexité a produit des résultats. |
+| `dead_code_enabled`  | boolean | `true` si l'analyse de code mort a produit des résultats.  |
+| `clone_enabled`      | boolean | `true` si la détection de clones a produit des résultats.  |
+| `cbo_enabled`        | boolean | `true` si l'analyse CBO a produit des résultats.           |
+| `lcom_enabled`       | boolean | `true` si l'analyse LCOM a produit des résultats.          |
+| `deps_enabled`       | boolean | `true` si l'analyse des dépendances a produit des résultats. |
+| `arch_enabled`       | boolean | `true` si la validation d'architecture a produit des résultats. |
+| `mock_data_enabled`  | boolean | `true` si la détection de données fictives a produit des résultats. |
+
+### Métriques de complexité
+
+| Champ                   | Type    | Description                                       |
+| ----------------------- | ------- | ------------------------------------------------- |
+| `total_functions`       | integer | Total des fonctions analysées.                    |
+| `average_complexity`    | number  | Complexité cyclomatique moyenne. `0` quand il n'y a aucune fonction. |
+| `high_complexity_count` | integer | Fonctions avec complexité > 10 (seuil moyen).     |
+
+### Métriques de code mort
+
+| Champ                | Type    | Description                                  |
+| -------------------- | ------- | -------------------------------------------- |
+| `dead_code_count`    | integer | Total des constats.                          |
+| `critical_dead_code` | integer | Constats de sévérité `critical`.             |
+| `warning_dead_code`  | integer | Constats de sévérité `warning`.              |
+| `info_dead_code`     | integer | Constats de sévérité `info`.                 |
+
+### Métriques de clones
+
+| Champ                         | Type    | Description                                              |
+| ----------------------------- | ------- | -------------------------------------------------------- |
+| `total_clones`                | integer | Fragments de code distincts identifiés comme clones.     |
+| `clone_pairs`                 | integer | Nombre de paires de clones.                              |
+| `clone_groups`                | integer | Nombre de groupes de clones.                             |
+| `code_duplication_percentage` | number  | Taux de duplication estimé, `0`–`100`.                   |
+
+### Métriques CBO
+
+| Champ                     | Type    | Description                                              |
+| ------------------------- | ------- | -------------------------------------------------------- |
+| `cbo_classes`             | integer | Total des classes analysées.                             |
+| `high_coupling_classes`   | integer | Classes avec CBO > 7.                                    |
+| `medium_coupling_classes` | integer | Classes avec 3 < CBO ≤ 7.                                |
+| `average_coupling`        | number  | Valeur CBO moyenne.                                      |
+
+### Métriques LCOM
+
+| Champ                 | Type    | Description                                  |
+| --------------------- | ------- | -------------------------------------------- |
+| `lcom_classes`        | integer | Total des classes analysées.                 |
+| `high_lcom_classes`   | integer | Classes avec LCOM4 > 5.                      |
+| `medium_lcom_classes` | integer | Classes avec 2 < LCOM4 ≤ 5.                  |
+| `average_lcom`        | number  | Valeur LCOM4 moyenne.                        |
+
+### Métriques de dépendances
+
+| Champ                          | Type    | Description                                                    |
+| ------------------------------ | ------- | -------------------------------------------------------------- |
+| `deps_total_modules`           | integer | Total des modules analysés.                                    |
+| `deps_modules_in_cycles`       | integer | Modules participant à au moins une dépendance circulaire.      |
+| `deps_max_depth`               | integer | Longueur de la plus longue chaîne de dépendances.              |
+| `deps_main_sequence_deviation` | number  | Distance moyenne à la séquence principale de Martin, `0`–`1`.  |
+
+### Métriques d'architecture
+
+| Champ             | Type   | Description                                                            |
+| ----------------- | ------ | ---------------------------------------------------------------------- |
+| `arch_compliance` | number | Taux de conformité architecturale, `0`–`1`. `1.0` = entièrement conforme. |
+
+### Métriques de données fictives
+
+| Champ                     | Type    | Description                                         |
+| ------------------------- | ------- | --------------------------------------------------- |
+| `mock_data_count`         | integer | Total des constats de données fictives.             |
+| `mock_data_error_count`   | integer | Constats de sévérité error.                         |
+| `mock_data_warning_count` | integer | Constats de sévérité warning.                       |
+| `mock_data_info_count`    | integer | Constats de sévérité info.                          |
+
+### Notation de santé
+
+| Champ                | Type    | Description                                                          |
+| -------------------- | ------- | -------------------------------------------------------------------- |
+| `health_score`       | integer | Score composite, `0`–`100`. Voir [Score de santé](health-score.md).  |
+| `grade`              | string  | Note littérale. L'une de : `A`, `B`, `C`, `D`, `F`, `N/A`.           |
+| `complexity_score`   | integer | Score par catégorie, `0`–`100`.                                      |
+| `dead_code_score`    | integer | Score par catégorie, `0`–`100`.                                      |
+| `duplication_score`  | integer | Score par catégorie, `0`–`100`.                                      |
+| `coupling_score`     | integer | Score par catégorie, `0`–`100`.                                      |
+| `cohesion_score`     | integer | Score par catégorie, `0`–`100`.                                      |
+| `dependency_score`   | integer | Score par catégorie, `0`–`100`.                                      |
+| `architecture_score` | integer | Score par catégorie, `0`–`100`.                                      |
+
+## Objet `complexity`
+
+Reflet de `domain.ComplexityResponse`. Les noms de champs imbriqués sont en PascalCase Go.
+
+```json
+{
+  "Functions": [ /* FunctionComplexity array */ ],
+  "Summary": { /* ComplexitySummary */ },
+  "raw_metrics": [ /* RawMetrics array, present when computed */ ],
+  "raw_metrics_summary": { /* RawMetricsSummary, present when computed */ },
+  "Warnings": [ "..." ],
+  "Errors": [ "..." ],
+  "GeneratedAt": "2026-04-14T10:18:23Z",
+  "Version": "0.14.0",
+  "Config": null
+}
+```
+
+### Élément de `Functions[]` (`FunctionComplexity`)
+
+| Champ         | Type    | Description                                                  |
+| ------------- | ------- | ------------------------------------------------------------ |
+| `Name`        | string  | Nom de la fonction. `__main__` pour le code au niveau du module. |
+| `FilePath`    | string  | Chemin du fichier source.                                    |
+| `StartLine`   | integer | Ligne de début, base 1.                                      |
+| `StartColumn` | integer | Colonne de début, base 0.                                    |
+| `EndLine`     | integer | Ligne de fin, base 1.                                        |
+| `Metrics`     | object  | Voir [`ComplexityMetrics`](#complexitymetrics-object).        |
+| `RiskLevel`   | string  | L'une de : `low`, `medium`, `high`.                          |
+
+### Objet `ComplexityMetrics` { #complexitymetrics-object }
+
+| Champ                 | Type    | Description                                        |
+| --------------------- | ------- | -------------------------------------------------- |
+| `Complexity`          | integer | Complexité cyclomatique de McCabe.                 |
+| `CognitiveComplexity` | integer | Complexité cognitive (style SonarQube).            |
+| `Nodes`               | integer | Nombre de nœuds du CFG.                            |
+| `Edges`               | integer | Nombre d'arêtes du CFG.                            |
+| `NestingDepth`        | integer | Profondeur d'imbrication maximale.                 |
+| `IfStatements`        | integer | Nombre d'instructions `if`.                        |
+| `LoopStatements`      | integer | Nombre de boucles `for`/`while`.                   |
+| `ExceptionHandlers`   | integer | Nombre de clauses `except`.                        |
+| `SwitchCases`         | integer | Nombre de cas `match` (Python 3.10+).              |
+
+### Objet `Summary` (`ComplexitySummary`)
+
+| Champ                    | Type    | Description                                                                  |
+| ------------------------ | ------- | ---------------------------------------------------------------------------- |
+| `TotalFunctions`         | integer | Total des fonctions analysées.                                               |
+| `AverageComplexity`      | number  | Moyenne arithmétique de `Complexity` sur toutes les fonctions.               |
+| `MaxComplexity`          | integer | Complexité maximale observée.                                                |
+| `MinComplexity`          | integer | Complexité minimale observée.                                                |
+| `FilesAnalyzed`          | integer | Fichiers contribuant au moins une fonction.                                  |
+| `LowRiskFunctions`       | integer | Fonctions avec `RiskLevel = low`.                                            |
+| `MediumRiskFunctions`    | integer | Fonctions avec `RiskLevel = medium`.                                         |
+| `HighRiskFunctions`      | integer | Fonctions avec `RiskLevel = high`.                                           |
+| `ComplexityDistribution` | object  | Histogramme indexé par tranche de complexité (string) vers compteur (integer), ou `null`. |
+
+### Élément de `raw_metrics[]` (`RawMetrics`)
+
+| Champ             | Type    | Description                                         |
+| ----------------- | ------- | --------------------------------------------------- |
+| `file_path`       | string  | Chemin du fichier source.                           |
+| `sloc`            | integer | Lignes de code source (non vides, non commentaires). |
+| `lloc`            | integer | Lignes de code logiques.                            |
+| `comment_lines`   | integer | Lignes contenant des commentaires.                  |
+| `docstring_lines` | integer | Lignes à l'intérieur de docstrings.                 |
+| `blank_lines`     | integer | Lignes vides ou ne contenant que des espaces.       |
+| `total_lines`     | integer | Total des lignes physiques.                         |
+| `comment_ratio`   | number  | `(comment_lines + docstring_lines) / total_lines`, `0`–`1`. |
+
+
+## Objet `dead_code`
+
+Reflet de `domain.DeadCodeResponse`. Utilise des noms de champs en snake_case partout.
+
+```json
+{
+  "files": [ /* FileDeadCode array */ ],
+  "summary": { /* DeadCodeSummary */ },
+  "warnings": null,
+  "errors": null,
+  "generated_at": "",
+  "version": "",
+  "config": null
+}
+```
+
+### Élément de `files[]` (`FileDeadCode`)
+
+| Champ               | Type    | Description                                          |
+| ------------------- | ------- | ---------------------------------------------------- |
+| `file_path`         | string  | Chemin du fichier source.                            |
+| `functions`         | array   | Résultats par fonction (voir ci-dessous).            |
+| `total_findings`    | integer | Somme des constats sur les fonctions de ce fichier.  |
+| `total_functions`   | integer | Fonctions analysées dans ce fichier.                 |
+| `affected_functions`| integer | Fonctions avec au moins un constat.                  |
+| `dead_code_ratio`   | number  | Blocs morts / blocs totaux, `0`–`1`.                 |
+
+### Élément de `files[].functions[]` (`FunctionDeadCode`)
+
+| Champ             | Type    | Description                                  |
+| ----------------- | ------- | -------------------------------------------- |
+| `name`            | string  | Nom de la fonction.                          |
+| `file_path`       | string  | Chemin du fichier source.                    |
+| `findings`        | array   | Constats dans cette fonction (voir ci-dessous). |
+| `total_blocks`    | integer | Total des blocs CFG dans la fonction.        |
+| `dead_blocks`     | integer | Blocs CFG inatteignables.                    |
+| `reachable_ratio` | number  | `(total_blocks - dead_blocks) / total_blocks`, `0`–`1`. |
+| `critical_count`  | integer | Constats de sévérité `critical`.             |
+| `warning_count`   | integer | Constats de sévérité `warning`.              |
+| `info_count`      | integer | Constats de sévérité `info`.                 |
+
+### Élément de `files[].functions[].findings[]` (`DeadCodeFinding`)
+
+| Champ           | Type    | Description                                                   |
+| --------------- | ------- | ------------------------------------------------------------- |
+| `location`      | object  | Voir [`DeadCodeLocation`](#deadcodelocation-object).           |
+| `function_name` | string  | Nom de la fonction englobante.                                |
+| `code`          | string  | Extrait du code source mort.                                  |
+| `reason`        | string  | Classification — voir l'énumération ci-dessous.               |
+| `severity`      | string  | L'une de : `critical`, `warning`, `info`.                     |
+| `description`   | string  | Description lisible par un humain.                            |
+| `context`       | array of string \| absent | Lignes de code environnantes. Présent avec `--show-context`. |
+| `block_id`      | string \| absent | Identifiant du bloc CFG.                               |
+
+Énumération `reason` :
+
+| Valeur                | Signification                                |
+| --------------------- | -------------------------------------------- |
+| `after_return`        | Code suivant une instruction `return`.       |
+| `after_break`         | Code suivant une instruction `break`.        |
+| `after_continue`      | Code suivant une instruction `continue`.     |
+| `after_raise`         | Code suivant une instruction `raise`.        |
+| `unreachable_branch`  | Branche conditionnelle jamais empruntée.     |
+
+### Objet `DeadCodeLocation` { #deadcodelocation-object }
+
+| Champ          | Type    | Description                |
+| -------------- | ------- | -------------------------- |
+| `file_path`    | string  | Chemin du fichier source.  |
+| `start_line`   | integer | Ligne de début, base 1.    |
+| `end_line`     | integer | Ligne de fin, base 1.      |
+| `start_column` | integer | Colonne de début, base 0.  |
+| `end_column`   | integer | Colonne de fin, base 0.    |
+
+### Objet `summary` (`DeadCodeSummary`)
+
+| Champ                      | Type    | Description                                      |
+| -------------------------- | ------- | ------------------------------------------------ |
+| `total_files`              | integer | Fichiers analysés.                               |
+| `total_functions`          | integer | Fonctions analysées.                             |
+| `total_findings`           | integer | Total des constats sur tous les fichiers.        |
+| `files_with_dead_code`     | integer | Fichiers avec au moins un constat.               |
+| `functions_with_dead_code` | integer | Fonctions avec au moins un constat.              |
+| `critical_findings`        | integer | Constats de sévérité `critical`.                 |
+| `warning_findings`         | integer | Constats de sévérité `warning`.                  |
+| `info_findings`            | integer | Constats de sévérité `info`.                     |
+| `findings_by_reason`       | object \| null | Histogramme indexé par valeur de `reason`. |
+| `total_blocks`             | integer | Blocs CFG sur toutes les fonctions.              |
+| `dead_blocks`              | integer | Blocs CFG inatteignables sur toutes les fonctions. |
+| `overall_dead_ratio`       | number  | `dead_blocks / total_blocks`, `0`–`1`.           |
+
+## Objet `clone`
+
+Reflet de `domain.CloneResponse`. Utilise des noms de champs en snake_case partout.
+
+```json
+{
+  "clones": [ /* Clone array, or null */ ],
+  "clone_pairs": [ /* ClonePair array, or null */ ],
+  "clone_groups": [ /* CloneGroup array, or null */ ],
+  "statistics": { /* CloneStatistics */ },
+  "duration_ms": 123,
+  "success": true,
+  "error": ""
+}
+```
+
+### Élément de `clones[]` (`Clone`)
+
+| Champ        | Type    | Description                                                  |
+| ------------ | ------- | ------------------------------------------------------------ |
+| `id`         | integer | Identifiant du clone, unique dans la réponse.                |
+| `type`       | integer | Type de clone en entier : `1`, `2`, `3` ou `4`.              |
+| `location`   | object  | Voir [`CloneLocation`](#clonelocation-object).                |
+| `content`    | string  | Texte source brut. Présent uniquement si `--show-content` est défini. |
+| `hash`       | string  | Hachage d'empreinte (algorithme dépendant du type de clone). |
+| `size`       | integer | Nombre de nœuds AST.                                         |
+| `line_count` | integer | Nombre de lignes du fragment.                                |
+| `complexity` | integer | Complexité cyclomatique du fragment.                         |
+
+Énumération `type` (valeurs entières) :
+
+| Valeur | Signification                                                        |
+| ------ | -------------------------------------------------------------------- |
+| `1`    | Type-1 : identiques aux espaces/commentaires près.                   |
+| `2`    | Type-2 : syntaxiquement identiques, identifiants/littéraux différents. |
+| `3`    | Type-3 : structurellement similaires avec modifications.             |
+| `4`    | Type-4 : sémantiquement équivalents, syntaxiquement différents.      |
+
+### Objet `CloneLocation` { #clonelocation-object }
+
+| Champ        | Type    | Description              |
+| ------------ | ------- | ------------------------ |
+| `file_path`  | string  | Chemin du fichier source. |
+| `start_line` | integer | Ligne de début, base 1.   |
+| `end_line`   | integer | Ligne de fin, base 1.     |
+| `start_col`  | integer | Colonne de début, base 0. |
+| `end_col`    | integer | Colonne de fin, base 0.   |
+
+### Élément de `clone_pairs[]` (`ClonePair`)
+
+| Champ        | Type    | Description                                            |
+| ------------ | ------- | ------------------------------------------------------ |
+| `id`         | integer | Identifiant de paire.                                  |
+| `clone1`     | object  | Premier clone (objet `Clone`).                         |
+| `clone2`     | object  | Second clone (objet `Clone`).                          |
+| `similarity` | number  | Score de similarité, `0`–`1`.                          |
+| `distance`   | number  | Distance d'édition d'arbre (Type-3) ou `0` sinon.      |
+| `type`       | integer | Type de clone (même énumération que `clones[].type`).  |
+| `confidence` | number  | Confiance du détecteur, `0`–`1`.                       |
+
+### Élément de `clone_groups[]` (`CloneGroup`)
+
+| Champ        | Type    | Description                                            |
+| ------------ | ------- | ------------------------------------------------------ |
+| `id`         | integer | Identifiant du groupe.                                 |
+| `clones`     | array   | Objets `Clone` membres.                                |
+| `type`       | integer | Type de clone dominant.                                |
+| `similarity` | number  | Similarité représentative, `0`–`1`.                    |
+| `size`       | integer | Nombre de membres (`len(clones)`).                     |
+
+### Objet `statistics` (`CloneStatistics`)
+
+| Champ                | Type    | Description                                                |
+| -------------------- | ------- | ---------------------------------------------------------- |
+| `total_fragments`    | integer | Tous les fragments extraits (fonctions, classes, etc.).    |
+| `total_clones`       | integer | Fragments classés comme clones.                            |
+| `total_clone_pairs`  | integer | Nombre de paires détectées.                                |
+| `total_clone_groups` | integer | Nombre de groupes.                                         |
+| `clones_by_type`     | object \| null | Map de l'étiquette de type (`Type-1`…`Type-4`) vers le compteur. |
+| `average_similarity` | number  | Similarité moyenne sur les paires, `0`–`1`.                |
+| `lines_analyzed`     | integer | Total des lignes source considérées.                       |
+| `nodes_analyzed`     | integer | Total des nœuds AST considérés.                            |
+| `files_analyzed`     | integer | Fichiers distincts contribuant à des fragments.            |
+
+Autres champs de `CloneResponse` :
+
+| Champ         | Type    | Description                                        |
+| ------------- | ------- | -------------------------------------------------- |
+| `duration_ms` | integer | Durée de détection de clones en millisecondes.     |
+| `success`     | boolean | `true` en cas d'achèvement normal.                 |
+| `error`       | string \| absent | Message d'erreur si `success=false`.        |
+
+## Objet `cbo`
+
+Reflet de `domain.CBOResponse`. Les noms de champs imbriqués sont en PascalCase Go.
+
+```json
+{
+  "Classes": [ /* ClassCoupling array */ ],
+  "Summary": { /* CBOSummary */ },
+  "Warnings": null,
+  "Errors": null,
+  "GeneratedAt": "",
+  "Version": "",
+  "Config": null
+}
+```
+
+### Élément de `Classes[]` (`ClassCoupling`)
+
+| Champ         | Type    | Description                                 |
+| ------------- | ------- | ------------------------------------------- |
+| `Name`        | string  | Nom de la classe.                           |
+| `FilePath`    | string  | Chemin du fichier source.                   |
+| `StartLine`   | integer | Ligne de début, base 1.                     |
+| `EndLine`     | integer | Ligne de fin, base 1.                       |
+| `Metrics`     | object  | Voir [`CBOMetrics`](#cbometrics-object).     |
+| `RiskLevel`   | string  | L'une de : `low`, `medium`, `high`.         |
+| `IsAbstract`  | boolean | `true` si la classe est abstraite.          |
+| `BaseClasses` | array of string \| null | Classes de base directes.   |
+
+### Objet `CBOMetrics` { #cbometrics-object }
+
+| Champ                         | Type    | Description                                                |
+| ----------------------------- | ------- | ---------------------------------------------------------- |
+| `CouplingCount`               | integer | Valeur CBO : classes distinctes dont dépend cette classe.  |
+| `InheritanceDependencies`     | integer | Dépendances par classes de base.                           |
+| `TypeHintDependencies`        | integer | Dépendances par annotations de type.                       |
+| `InstantiationDependencies`   | integer | Dépendances par instanciation d'objets.                    |
+| `AttributeAccessDependencies` | integer | Dépendances par appels de méthodes et accès aux attributs. |
+| `ImportDependencies`          | integer | Dépendances par imports explicites.                        |
+| `DependentClasses`            | array of string \| null | Noms des classes couplées.                 |
+
+### Objet `Summary` (`CBOSummary`)
+
+| Champ                      | Type    | Description                                       |
+| -------------------------- | ------- | ------------------------------------------------- |
+| `TotalClasses`             | integer | Total des classes analysées.                      |
+| `AverageCBO`               | number  | CBO moyen.                                        |
+| `MaxCBO`                   | integer | CBO maximal observé.                              |
+| `MinCBO`                   | integer | CBO minimal observé.                              |
+| `ClassesAnalyzed`          | integer | Classes avec des métriques valides.               |
+| `FilesAnalyzed`            | integer | Fichiers contribuant au moins une classe.         |
+| `LowRiskClasses`           | integer | Classes avec CBO ≤ seuil bas (par défaut `3`).    |
+| `MediumRiskClasses`        | integer | Classes avec seuil bas < CBO ≤ seuil moyen.       |
+| `HighRiskClasses`          | integer | Classes avec CBO > seuil moyen (par défaut `7`).  |
+| `CBODistribution`          | object \| null | Histogramme indexé par étiquette de tranche vers compteur. |
+| `MostCoupledClasses`       | array \| null | Top 10 des classes par CBO (`ClassCoupling`). |
+| `MostDependedUponClasses`  | array of string \| null | Classes avec le plus fort degré entrant. |
+
+## Objet `lcom`
+
+Reflet de `domain.LCOMResponse`. Les noms de champs imbriqués sont en PascalCase Go.
+
+```json
+{
+  "Classes": [ /* ClassCohesion array */ ],
+  "Summary": { /* LCOMSummary */ },
+  "Warnings": null,
+  "Errors": null,
+  "GeneratedAt": "",
+  "Version": "",
+  "Config": null
+}
+```
+
+### Élément de `Classes[]` (`ClassCohesion`)
+
+| Champ       | Type    | Description                                      |
+| ----------- | ------- | ------------------------------------------------ |
+| `Name`      | string  | Nom de la classe.                                |
+| `FilePath`  | string  | Chemin du fichier source.                        |
+| `StartLine` | integer | Ligne de début, base 1.                          |
+| `EndLine`   | integer | Ligne de fin, base 1.                            |
+| `Metrics`   | object  | Voir [`LCOMMetrics`](#lcommetrics-object).        |
+| `RiskLevel` | string  | L'une de : `low`, `medium`, `high`.              |
+
+### Objet `LCOMMetrics` { #lcommetrics-object }
+
+| Champ               | Type    | Description                                                  |
+| ------------------- | ------- | ------------------------------------------------------------ |
+| `LCOM4`             | integer | Composantes connexes dans le graphe méthodes-variables.      |
+| `TotalMethods`      | integer | Toutes les méthodes de la classe.                            |
+| `ExcludedMethods`   | integer | Méthodes exclues de LCOM4 (`@classmethod`, `@staticmethod`). |
+| `InstanceVariables` | integer | Variables `self.x` distinctes accédées.                      |
+| `MethodGroups`      | array of array of string \| null | Noms de méthodes groupés par composante connexe. |
+
+### Objet `Summary` (`LCOMSummary`)
+
+| Champ                  | Type    | Description                                          |
+| ---------------------- | ------- | ---------------------------------------------------- |
+| `TotalClasses`         | integer | Classes analysées.                                   |
+| `AverageLCOM`          | number  | LCOM4 moyen.                                         |
+| `MaxLCOM`              | integer | LCOM4 maximal observé.                               |
+| `MinLCOM`              | integer | LCOM4 minimal observé.                               |
+| `ClassesAnalyzed`      | integer | Classes avec des métriques valides.                  |
+| `FilesAnalyzed`        | integer | Fichiers contribuant au moins une classe.            |
+| `LowRiskClasses`       | integer | Classes avec LCOM4 ≤ seuil bas (par défaut `2`).     |
+| `MediumRiskClasses`    | integer | Classes avec seuil bas < LCOM4 ≤ seuil moyen.        |
+| `HighRiskClasses`      | integer | Classes avec LCOM4 > seuil moyen (par défaut `5`).   |
+| `LCOMDistribution`     | object \| null | Histogramme indexé par étiquette de tranche vers compteur. |
+| `LeastCohesiveClasses` | array \| null | Top 10 des classes par LCOM4 (`ClassCohesion`).|
+
+## Objet `system`
+
+Reflet de `domain.SystemAnalysisResponse`. Les noms de champs imbriqués sont en PascalCase Go.
+
+```json
+{
+  "DependencyAnalysis":   { /* DependencyAnalysisResult, or null */ },
+  "ArchitectureAnalysis": { /* ArchitectureAnalysisResult, or null */ },
+  "Summary":              { /* SystemAnalysisSummary */ },
+  "Issues":               [ /* SystemIssue array */ ],
+  "Recommendations":      [ /* SystemRecommendation array */ ],
+  "Warnings":             [ ],
+  "Errors":               [ ],
+  "GeneratedAt":          "0001-01-01T00:00:00Z",
+  "Duration":             0,
+  "Version":              "",
+  "Config":               null
+}
+```
+
+### Objet `Summary` (`SystemAnalysisSummary`)
+
+| Champ                      | Type    | Description                                       |
+| -------------------------- | ------- | ------------------------------------------------- |
+| `TotalModules`             | integer | Total des modules analysés.                       |
+| `TotalPackages`            | integer | Total des paquets.                                |
+| `TotalDependencies`        | integer | Total des arêtes de dépendances.                  |
+| `ProjectRoot`              | string  | Répertoire racine du projet.                      |
+| `OverallQualityScore`      | number  | Score de qualité composite, `0`–`100`.            |
+| `MaintainabilityScore`     | number  | Indice de maintenabilité moyen.                   |
+| `ArchitectureScore`        | number  | Score de conformité architecturale.               |
+| `ModularityScore`          | number  | Score de modularité du système.                   |
+| `TechnicalDebtHours`       | number  | Dette technique totale estimée en heures.         |
+| `AverageCoupling`          | number  | Couplage moyen entre modules.                     |
+| `AverageInstability`       | number  | Instabilité moyenne (I).                          |
+| `CyclicDependencies`       | integer | Modules participant à des cycles.                 |
+| `ArchitectureViolations`   | integer | Nombre de violations des règles architecturales.  |
+| `HighRiskModules`          | integer | Modules signalés à risque élevé.                  |
+| `CriticalIssues`           | integer | Nombre de problèmes critiques.                    |
+| `RefactoringCandidates`    | integer | Modules nécessitant un refactoring.               |
+| `ArchitectureImprovements` | integer | Améliorations architecturales suggérées.          |
+
+### Objet `DependencyAnalysis`
+
+| Champ                  | Type    | Description                                                          |
+| ---------------------- | ------- | -------------------------------------------------------------------- |
+| `TotalModules`         | integer | Total des modules dans le graphe de dépendances.                     |
+| `TotalDependencies`    | integer | Total des arêtes.                                                    |
+| `RootModules`          | array of string | Modules sans dépendance sortante.                            |
+| `LeafModules`          | array of string | Modules sans dépendance entrante.                            |
+| `ModuleMetrics`        | object  | Map du nom de module vers `ModuleDependencyMetrics`.                 |
+| `DependencyMatrix`     | object  | Map de module vers map de module vers booléen.                       |
+| `CircularDependencies` | object  | Résultats de détection de cycles ; contient `Cycles` (array) et `TotalCycles` (integer). |
+| `CouplingAnalysis`     | object  | Métriques de couplage par module : `Ca`, `Ce`, `Instability`, `Abstractness`, `Distance`. |
+| `LongestChains`        | array   | Tableau d'objets `DependencyPath`.                                   |
+| `MaxDepth`             | integer | Profondeur de dépendance maximale.                                   |
+
+### Objet `ModuleDependencyMetrics`
+
+| Champ                    | Type    | Description                                              |
+| ------------------------ | ------- | -------------------------------------------------------- |
+| `ModuleName`             | string  | Nom complet du module.                                   |
+| `Package`                | string  | Paquet parent.                                           |
+| `FilePath`               | string  | Chemin du fichier source.                                |
+| `IsPackage`              | boolean | `true` s'il s'agit d'un paquet (possède `__init__.py`).  |
+| `LinesOfCode`            | integer | Total des lignes de code.                                |
+| `FunctionCount`          | integer | Nombre de fonctions.                                     |
+| `ClassCount`             | integer | Nombre de classes.                                       |
+| `AbstractClassCount`     | integer | Nombre de classes abstraites.                            |
+| `PublicInterface`        | array of string | Noms dans `__all__` ou noms publics de haut niveau. |
+| `AfferentCoupling`       | integer | Ca — modules dépendant de celui-ci.                      |
+| `EfferentCoupling`       | integer | Ce — modules dont celui-ci dépend.                       |
+| `Instability`            | number  | `I = Ce / (Ca + Ce)`, `0`–`1`.                           |
+| `Abstractness`           | number  | A — classes abstraites / classes totales, `0`–`1`.       |
+| `Distance`               | number  | `D = |A + I - 1|`, `0`–`1`. Distance à la séquence principale. |
+| `Maintainability`        | number  | Indice de maintenabilité, `0`–`100`.                     |
+| `TechnicalDebt`          | number  | Dette technique estimée en heures.                       |
+| `RiskLevel`              | string  | L'une de : `low`, `medium`, `high`.                      |
+| `DirectDependencies`     | array of string | Dépendances directes.                            |
+| `TransitiveDependencies` | array of string | Toutes les dépendances transitives.              |
+| `Dependents`             | array of string | Modules dépendant de celui-ci.                   |
+
+### Objet `CircularDependencyAnalysis`
+
+| Champ                      | Type    | Description                                           |
+| -------------------------- | ------- | ----------------------------------------------------- |
+| `HasCircularDependencies`  | boolean | `true` s'il existe au moins un cycle.                 |
+| `TotalCycles`              | integer | Nombre de cycles.                                     |
+| `TotalModulesInCycles`     | integer | Modules impliqués dans des cycles.                    |
+| `CircularDependencies`     | array   | Tableau d'objets `CircularDependency`.                |
+| `CycleBreakingSuggestions` | array of string | Suggestions pour briser les cycles.           |
+| `CoreInfrastructure`       | array of string | Modules apparaissant dans plusieurs cycles.   |
+
+Énumération `CircularDependency.Severity` : `low`, `medium`, `high`, `critical`.
+
+### Objet `CouplingAnalysis`
+
+| Champ                   | Type    | Description                                            |
+| ----------------------- | ------- | ------------------------------------------------------ |
+| `AverageCoupling`       | number  | Couplage moyen entre les modules.                      |
+| `CouplingDistribution`  | object  | Map de la valeur de couplage (clé entière) vers compteur. |
+| `HighlyCoupledModules`  | array of string | Modules à fort couplage.                       |
+| `LooselyCoupledModules` | array of string | Modules à faible couplage.                     |
+| `AverageInstability`    | number  | Instabilité moyenne.                                   |
+| `StableModules`         | array of string | Modules à faible instabilité.                  |
+| `InstableModules`       | array of string | Modules à forte instabilité.                   |
+| `MainSequenceDeviation` | number  | Distance moyenne à la séquence principale, `0`–`1`.    |
+| `ZoneOfPain`            | array of string | Modules stables + concrets.                    |
+| `ZoneOfUselessness`     | array of string | Modules instables + abstraits.                 |
+| `MainSequence`          | array of string | Modules bien positionnés.                      |
+
+### Objet `ArchitectureAnalysis`
+
+| Champ                 | Type    | Description                                                 |
+| --------------------- | ------- | ----------------------------------------------------------- |
+| `ComplianceScore`     | number  | Score de conformité, `0`–`1`. `1.0` = entièrement conforme. |
+| `TotalViolations`     | integer | Total des violations trouvées.                              |
+| `TotalRules`          | integer | Total des règles évaluées.                                  |
+| `LayerAnalysis`       | object \| null | Résultats d'analyse par couches.                     |
+| `CohesionAnalysis`    | object \| null | Analyse de cohésion des paquets.                     |
+| `ResponsibilityAnalysis` | object \| null | Analyse des violations du principe SRP.           |
+| `Violations`          | array   | Tableau d'objets `ArchitectureViolation`.                   |
+| `SeverityBreakdown`   | object  | Map de la sévérité vers le compteur.                        |
+| `Recommendations`     | array   | Tableau d'objets `ArchitectureRecommendation`.              |
+| `RefactoringTargets`  | array of string | Modules nécessitant un refactoring.                 |
+
+Énumération `ArchitectureViolation.Type` : `layer`, `cycle`, `coupling`, `responsibility`, `cohesion`.
+
+Énumération `ArchitectureViolation.Severity` : `info`, `warning`, `error`, `critical`.
+
+## Tableau `suggestions`
+
+Tableau d'objets `Suggestion`. Utilise des noms de champs en snake_case.
+
+| Champ         | Type    | Requis | Description                                       |
+| ------------- | ------- | ------ | ------------------------------------------------- |
+| `category`    | string  | oui    | Voir l'énumération ci-dessous.                    |
+| `severity`    | string  | oui    | L'une de : `critical`, `warning`, `info`.         |
+| `effort`      | string  | oui    | L'une de : `easy`, `moderate`, `hard`.            |
+| `title`       | string  | oui    | Titre court lisible par un humain.                |
+| `description` | string  | oui    | Description complète.                             |
+| `steps`       | array of string | non | Étapes concrètes. Omis lorsque vide.         |
+| `file_path`   | string  | non    | Référence vers le fichier source.                 |
+| `function`    | string  | non    | Référence vers un nom de fonction.                |
+| `class_name`  | string  | non    | Référence vers un nom de classe.                  |
+| `start_line`  | integer | non    | Référence de ligne, base 1. Omis lorsque `0`.     |
+| `metric_value`| string  | non    | Valeur observée de la métrique sous forme de chaîne. |
+| `threshold`   | string  | non    | Valeur du seuil sous forme de chaîne.             |
+
+Énumération `category` : `complexity`, `dead_code`, `clone`, `coupling`, `cohesion`, `dependency`, `architecture`.
+
+Les suggestions sont triées par priorité (sévérité × effort). Voir `domain/suggestion.go` pour la fonction de tri exacte.
+
+## Schémas CSV
+
+Les sorties CSV sont écrites avec les règles de mise en guillemets RFC 4180 via le paquet Go `encoding/csv`.
+
+### `pyscn analyze --csv`
+
+Résumé uniquement. Deux colonnes. Chaînes UTF-8 littérales, sans annotation de type.
+
+| Colonne  | Type   | Description                            |
+| -------- | ------ | -------------------------------------- |
+| `Metric` | string | Nom de la métrique.                    |
+| `Value`  | string | Valeur de la métrique sous forme de chaîne. |
+
+Lignes (dans cet ordre fixe) :
+
+```csv
+Metric,Value
+Health Score,<integer>
+Grade,<A|B|C|D|F|N/A>
+Total Files,<integer>
+Analyzed Files,<integer>
+Average Complexity,<float with 2 decimals>
+High Complexity Count,<integer>
+Dead Code Count,<integer>
+Critical Dead Code,<integer>
+Unique Fragments,<integer>
+Clone Groups,<integer>
+Code Duplication,<float with 2 decimals>
+Total Classes Analyzed,<integer>
+High Coupling (CBO) Classes,<integer>
+Average CBO,<float with 2 decimals>
+```
+
+pyscn n'expose actuellement pas de schémas CSV par analyseur via le CLI — `--csv` ne produit que le résumé ci-dessus. Pour les détails par constat, utilisez `--json` ou `--yaml`.
+
+## Horodatages et versionnage
+
+| Champ          | Format                    | Notes                                                   |
+| -------------- | ------------------------- | ------------------------------------------------------- |
+| `generated_at` | RFC 3339 (ISO 8601)       | Sérialisation `time.Time` ; peut inclure une précision sous-seconde et un décalage de fuseau horaire. |
+| `duration_ms`  | integer (millisecondes)   | Durée d'analyse en horloge murale.                      |
+| `version`      | string (version sémantique) | Version de pyscn, par exemple `"0.14.0"`.            |
+
+## Invoquer chaque format
+
+`pyscn analyze` accepte l'un de `--json`, `--yaml`, `--csv`, `--html` (défaut). Il n'existe pas de drapeau `--format`, et il n'y a pas de sous-commandes autonomes `complexity` / `deadcode` / `clone` / `deps`. Exécutez un seul analyseur via `--select`.
+
+```bash
+pyscn analyze --json src/
+pyscn analyze --yaml src/
+pyscn analyze --csv  src/
+pyscn analyze --html src/    # default
+pyscn analyze --json --select complexity src/
+pyscn analyze --csv  --select deadcode   src/
+pyscn analyze --yaml --select clones     src/
+```
+
+Les fichiers de sortie sont placés dans `.pyscn/reports/` ; voir [Formats de sortie](index.md) pour les détails de chemin et de nom de fichier.
+
+## Voir aussi
+
+- [Rapport HTML](html-report.md) — spécification de la sortie HTML.
+- [Score de santé](health-score.md) — dérivation de `summary.health_score` et des scores par catégorie.

--- a/website/docs/fr/rules/circular-import.md
+++ b/website/docs/fr/rules/circular-import.md
@@ -1,0 +1,98 @@
+# circular-import
+
+**Catégorie** : Structure des modules  
+**Sévérité** : Configurable selon la taille du cycle (Low / Medium / High / Critical)  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select circular`
+
+## Ce qu'elle fait
+
+Signale les groupes de modules qui forment un cycle d'imports — le module A importe B (directement ou transitivement) et B importe A. Les cycles sont détectés en exécutant l'algorithme des composantes fortement connexes de Tarjan sur le graphe de dépendances des modules.
+
+La sévérité est attribuée en fonction de la taille du cycle et du fan-in de ses membres :
+
+| Membres du cycle | Sévérité |
+| --- | --- |
+| 2 | Low |
+| 3 – 5 | Medium |
+| 6 – 9 | High |
+| 10+, ou tout membre avec un fan-in > 10 | Critical |
+
+## Pourquoi est-ce un problème ?
+
+Un import circulaire signifie que deux modules ou plus ne peuvent pas être compris, testés ou livrés indépendamment. Concrètement :
+
+- **Erreurs à l'import.** Python initialise partiellement les modules pendant les imports circulaires ; l'accès à un attribut sur le module à moitié chargé lève `ImportError` ou `AttributeError` selon l'ordre des instructions.
+- **Couplage fort.** Les membres du cycle partagent un unique « module logique » réparti sur plusieurs fichiers. Une modification dans l'un tend à imposer une modification dans tous les autres.
+- **Refactorisation bloquée.** Vous ne pouvez pas déplacer, renommer ou supprimer un membre du cycle sans toucher aux autres.
+- **Aggravation avec la croissance du cycle.** Un cycle à 2 modules est une nuisance ; un cycle à 10 modules est un échec architectural — d'où l'échelle de sévérité.
+
+## Exemple
+
+```python
+# myapp/orders.py
+from myapp.billing import Invoice
+
+class Order:
+    def invoice(self) -> Invoice:
+        return Invoice(self)
+```
+
+```python
+# myapp/billing.py
+from myapp.orders import Order
+
+class Invoice:
+    def __init__(self, order: "Order"):
+        self.order = order
+```
+
+`orders` importe `billing` pour le type de retour ; `billing` importe `orders` pour le paramètre du constructeur. Exécuter l'un ou l'autre fichier au niveau supérieur déclenche le cycle.
+
+## À utiliser à la place
+
+Extrayez les types partagés dans un troisième module afin que les deux en dépendent au lieu de dépendre l'un de l'autre :
+
+```python
+# myapp/domain.py
+class Order: ...
+class Invoice: ...
+```
+
+```python
+# myapp/orders.py
+from myapp.domain import Order, Invoice
+```
+
+```python
+# myapp/billing.py
+from myapp.domain import Order, Invoice
+```
+
+Si l'arête inverse n'est nécessaire que pour les annotations de type, protégez-la avec `TYPE_CHECKING` afin qu'elle ne soit pas évaluée à l'exécution :
+
+```python
+# myapp/billing.py
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from myapp.orders import Order
+
+class Invoice:
+    def __init__(self, order: "Order"): ...
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`dependencies.detect_cycles`](../configuration/reference.md#dependencies) | `true` | Mettre à `false` pour désactiver cette règle. |
+| [`dependencies.cycle_reporting`](../configuration/reference.md#dependencies) | `"summary"` | `all`, `critical` ou `summary` — contrôle le nombre de cycles affichés dans le rapport. |
+| [`dependencies.max_cycles_to_show`](../configuration/reference.md#dependencies) | `10` | Plafond des cycles rapportés. |
+| `--max-cycles N` (check) | `0` | Fait échouer la commande `check` lorsque le nombre de cycles dépasse `N`. |
+| `--allow-circular-deps` (check) | off | Rétrograde les cycles en avertissements plutôt qu'en échecs. |
+
+## Références
+
+- Implémentation Tarjan SCC (`internal/analyzer/circular_detector.go`), construction du graphe de modules (`internal/analyzer/module_analyzer.go`).
+- [Catalogue des règles](index.md) · [deep-import-chain](deep-import-chain.md)

--- a/website/docs/fr/rules/concrete-instantiation-dependency.md
+++ b/website/docs/fr/rules/concrete-instantiation-dependency.md
@@ -1,0 +1,57 @@
+# concrete-instantiation-dependency
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Avertissement  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale une classe qui construit un collaborateur concret à l'intérieur de `__init__` (par exemple `self.repo = SqlUserRepository()`) au lieu de le recevoir comme paramètre.
+
+## Pourquoi est-ce un problème ?
+
+Lorsqu'une classe construit ses propres collaborateurs, elle s'approprie également leur configuration, leur durée de vie et leurs dépendances transitives. `OrderService()` exige soudainement une chaîne de connexion à la base de données, un client HTTP et des identifiants — tous obtenus implicitement — parce que `SqlUserRepository()` et `StripeGateway()` en ont besoin.
+
+Les tests le ressentent en premier. Il n'existe aucune jointure pour intercaler un faux : chaque test doit soit lancer le vrai collaborateur, soit monkey-patcher la classe en cours de construction. Les tests d'intégration et les tests unitaires se confondent, et la suite de tests ralentit.
+
+Passer le collaborateur rend la dépendance explicite, garde la classe centrée sur sa propre logique et permet à différents sites d'appel de câbler différentes implémentations — un vrai dépôt en production, un dépôt en mémoire dans les tests.
+
+## Exemple
+
+```python
+class OrderService:
+    def __init__(self):
+        self.repo = SqlOrderRepository(DATABASE_URL)
+        self.payments = StripeGateway(api_key=STRIPE_KEY)
+
+    def place(self, order):
+        self.repo.save(order)
+        self.payments.charge(order)
+```
+
+## À utiliser à la place
+
+Recevez les collaborateurs via `__init__` et construisez-les une seule fois à la racine de composition.
+
+```python
+class OrderService:
+    def __init__(self, repo, payments):
+        self.repo = repo
+        self.payments = payments
+
+    def place(self, order):
+        self.repo.save(order)
+        self.payments.charge(order)
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Augmentez à `"error"` pour supprimer cette règle. |
+
+## Références
+
+- Détection des dépendances concrètes (`internal/analyzer/concrete_dependency_detector.go`).
+- [Catalogue des règles](index.md) · [Dépendance à une annotation de type concrète](concrete-type-hint-dependency.md) · [Patron de localisateur de services](service-locator-pattern.md)

--- a/website/docs/fr/rules/concrete-type-hint-dependency.md
+++ b/website/docs/fr/rules/concrete-type-hint-dependency.md
@@ -1,0 +1,55 @@
+# concrete-type-hint-dependency
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Info  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale un paramètre `__init__` dont l'annotation de type est une classe concrète plutôt qu'un `Protocol`, une classe de base abstraite ou une interface.
+
+## Pourquoi est-ce un problème ?
+
+Une annotation de type concrète indique au lecteur — et au vérificateur de types — que cette classe n'acceptera qu'une implémentation spécifique. Même si l'exécution accepte volontiers des substituts en duck typing, le contrat déclaré dit l'inverse, et les outils qui respectent l'annotation (mypy, l'autocomplétion de l'IDE, les mocks de tests construits à partir du type) refuseront les alternatives.
+
+En pratique, cela rend les tests plus difficiles à écrire : un test qui souhaite substituer un faux en mémoire doit soit hériter de la classe concrète (en récupérant tout son comportement), soit supprimer l'erreur de type. Cela lie aussi le consommateur à tous les imports dont la classe concrète a besoin, donc un petit utilitaire finit par entraîner toute la pile base de données.
+
+Dépendre d'un `Protocol` ou d'une interface abstraite documente ce que la classe utilise réellement — une méthode ou deux — et laisse de la place pour les faux, les adaptateurs et les futures implémentations.
+
+## Exemple
+
+```python
+class SqlUserRepository:
+    def find(self, user_id): ...
+
+class UserService:
+    def __init__(self, repo: SqlUserRepository):
+        self.repo = repo
+```
+
+## À utiliser à la place
+
+Déclarez un `Protocol` décrivant les méthodes sur lesquelles vous vous appuyez et dépendez-en.
+
+```python
+from typing import Protocol
+
+class UserRepository(Protocol):
+    def find(self, user_id: str) -> User: ...
+
+class UserService:
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Cette règle se signale au niveau `info` ; abaissez `min_severity` à `"info"` pour la voir. |
+
+## Références
+
+- Détection des dépendances concrètes (`internal/analyzer/concrete_dependency_detector.go`).
+- [Catalogue des règles](index.md) · [Dépendance par instanciation concrète](concrete-instantiation-dependency.md) · [Trop de paramètres de constructeur](too-many-constructor-parameters.md)

--- a/website/docs/fr/rules/deep-import-chain.md
+++ b/website/docs/fr/rules/deep-import-chain.md
@@ -1,0 +1,63 @@
+# deep-import-chain
+
+**Catégorie** : Structure des modules  
+**Sévérité** : Info  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select deps`
+
+## Ce qu'elle fait
+
+Rapporte la plus longue chaîne d'imports acyclique du projet lorsque sa profondeur dépasse la profondeur attendue pour un projet de cette taille. pyscn utilise `log₂(module_count) + 1` comme référence — un projet de 64 modules ne devrait pas avoir de chaînes plus longues que 7.
+
+Une chaîne est un chemin dans le graphe de dépendances des modules : `a → b → c → …`, où chaque flèche représente un `import`.
+
+## Pourquoi est-ce un problème ?
+
+Des chaînes profondes indiquent un mauvais découpage en couches. Chaque maillon supplémentaire est un module qui doit être chargé, analysé et initialisé avant que le bas de la chaîne ne devienne utilisable, et chaque maillon est un endroit où un changement sans rapport peut se propager vers le bas.
+
+Symptômes d'une chaîne trop profonde :
+
+- **Démarrage lent.** L'import du module feuille déclenche une cascade d'effets de bord au niveau supérieur.
+- **Tests fragiles.** Un test unitaire pour la feuille embarque la chaîne entière et casse dès qu'un élément en amont change.
+- **Couplage caché.** Les modules au milieu de la chaîne n'existent souvent que comme des relais, masquant la véritable dépendance.
+- **Difficile à appréhender.** Il n'y a pas un seul « niveau » auquel le code vit.
+
+## Exemple
+
+```
+myapp.cli
+  → myapp.commands
+    → myapp.services
+      → myapp.orchestrator
+        → myapp.workers
+          → myapp.adapters
+            → myapp.drivers
+```
+
+Sept niveaux pour atteindre le driver. En pratique, la couche CLI n'a pas besoin de savoir que les workers existent, et les workers n'ont pas besoin de connaître la CLI — mais une modification de `drivers` peut forcer à retester toutes les couches au-dessus.
+
+## À utiliser à la place
+
+Introduisez une façade à la frontière pour que les couches supérieures parlent à un seul module, pas à une chaîne :
+
+```
+myapp.cli
+  → myapp.commands
+    → myapp.services        # point d'entrée unique
+        (câble en interne orchestrator / workers / adapters / drivers)
+```
+
+Ou aplatissez : si `services`, `orchestrator` et `workers` font tous de la coordination, fusionnez-les en une seule couche et laissez-la dépendre directement de `adapters`.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`dependencies.find_long_chains`](../configuration/reference.md#dependencies) | `true` | Mettre à `false` pour désactiver cette règle. |
+| [`dependencies.enabled`](../configuration/reference.md#dependencies) | `false` | Opt-in pour `pyscn check` ; toujours actif pour `pyscn analyze`. |
+
+Il n'existe pas de seuil de profondeur explicite — pyscn compare la chaîne la plus longue à `log₂(module_count) + 1` et signale lorsqu'il est dépassé.
+
+## Références
+
+- Recherche du plus long chemin dans le DAG des modules (`internal/analyzer/module_analyzer.go`, `internal/analyzer/coupling_metrics.go`).
+- [Catalogue des règles](index.md) · [circular-import](circular-import.md)

--- a/website/docs/fr/rules/duplicate-code-identical.md
+++ b/website/docs/fr/rules/duplicate-code-identical.md
@@ -1,0 +1,68 @@
+# duplicate-code-identical
+
+**Catégorie** : Code dupliqué  
+**Sévérité** : Avertissement  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select clones`
+
+## Ce que fait cette règle
+
+Signale deux blocs de code ou plus textuellement identiques, à l'exception de l'espacement, de la mise en page ou des commentaires (clones de Type 1, similarité ≥ 0,85).
+
+## Pourquoi est-ce un problème ?
+
+Le code copié-collé est la forme la moins coûteuse de duplication, mais la plus coûteuse à maintenir. Lorsqu'il faut modifier la logique, chaque copie doit être retrouvée et mise à jour. Un endroit est corrigé, les autres divergent, et l'incohérence devient un bug.
+
+Les blocs identiques gonflent aussi la base de code sans ajouter de comportement. Les lecteurs perdent du temps à confirmer que deux zones sont vraiment identiques au lieu de lire quelque chose de nouveau.
+
+Comme les clones sont littéraux, la correction est presque toujours mécanique : extrayez le bloc dans une fonction et appelez-la depuis les deux endroits.
+
+## Exemple
+
+```python
+def send_welcome_email(user):
+    subject = "Welcome"
+    body = render_template("welcome.html", user=user)
+    msg = Message(subject=subject, body=body, to=user.email)
+    smtp.send(msg)
+    log.info("sent welcome to %s", user.email)
+
+def send_reset_email(user):
+    subject = "Reset"
+    body = render_template("reset.html", user=user)
+    msg = Message(subject=subject, body=body, to=user.email)
+    smtp.send(msg)
+    log.info("sent reset to %s", user.email)
+```
+
+## À utiliser à la place
+
+Extrayez le bloc partagé dans une fonction utilitaire et passez les éléments qui varient.
+
+```python
+def send_email(user, subject, template, tag):
+    body = render_template(template, user=user)
+    msg = Message(subject=subject, body=body, to=user.email)
+    smtp.send(msg)
+    log.info("sent %s to %s", tag, user.email)
+
+def send_welcome_email(user):
+    send_email(user, "Welcome", "welcome.html", "welcome")
+
+def send_reset_email(user):
+    send_email(user, "Reset", "reset.html", "reset")
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`clones.type1_threshold`](../configuration/reference.md#clones) | `0.85` | Similarité minimale pour qu'une paire soit signalée comme identique. |
+| [`clones.similarity_threshold`](../configuration/reference.md#clones) | `0.65` | Plancher global appliqué avant les seuils par type. |
+| [`clones.min_lines`](../configuration/reference.md#clones) | `5` | Taille minimale du fragment en lignes. |
+| [`clones.min_nodes`](../configuration/reference.md#clones) | `10` | Taille minimale du fragment en nœuds AST. |
+| [`clones.enabled_clone_types`](../configuration/reference.md#clones) | `["type1","type2","type4"]` | Incluez `"type1"` pour garder cette règle active. |
+
+## Références
+
+- Implémentation de la détection de clones (`internal/analyzer/clone_detector.go`, `internal/analyzer/apted.go`).
+- [Catalogue des règles](index.md) · [Clones renommés](duplicate-code-renamed.md) · [Clones modifiés](duplicate-code-modified.md) · [Clones sémantiques](duplicate-code-semantic.md)

--- a/website/docs/fr/rules/duplicate-code-modified.md
+++ b/website/docs/fr/rules/duplicate-code-modified.md
@@ -1,0 +1,74 @@
+# duplicate-code-modified
+
+**Catégorie** : Code dupliqué  
+**Sévérité** : Info  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select clones`
+
+## Ce que fait cette règle
+
+Signale les blocs de code qui partagent la majeure partie de leur structure mais comportent des instructions ajoutées, supprimées ou modifiées (clones de Type 3, similarité ≥ 0,70). Désactivée par défaut ; activez-la en ajoutant `"type3"` à `clones.enabled_clone_types`.
+
+## Pourquoi est-ce un problème ?
+
+Les quasi-doublons sont le type de clones le plus courant dans les bases de code réelles, et souvent le plus difficile à nettoyer. Deux fonctions font presque la même chose, mais l'une a une étape de validation supplémentaire ou un chemin d'erreur légèrement différent. La partie commune devrait vivre à un seul endroit ; les différences devraient être la seule chose qui varie entre les sites d'appel.
+
+Laissés en l'état, les clones modifiés divergent : un bug est corrigé dans une copie mais pas dans l'autre, une nouvelle fonctionnalité est ajoutée à l'une mais oubliée dans la suivante. Les relecteurs cessent de faire confiance au fait qu'un code d'apparence similaire se comporte de la même manière.
+
+Cette règle est en Info parce que le refactoring approprié est moins mécanique que pour les clones de Type 1 ou de Type 2 — parfois les différences sont précisément l'objectif, et fusionner nuirait à la clarté. Considérez les constats comme des candidats à examiner, pas comme des défauts automatiques.
+
+## Exemple
+
+```python
+def export_users_csv(users, path):
+    with open(path, "w") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "name", "email"])
+        for u in users:
+            writer.writerow([u.id, u.name, u.email])
+
+def export_orders_csv(orders, path):
+    with open(path, "w") as f:
+        writer = csv.writer(f)
+        writer.writerow(["id", "total", "status"])
+        for o in orders:
+            if o.status != "draft":
+                writer.writerow([o.id, o.total, o.status])
+```
+
+## À utiliser à la place
+
+Extrayez la structure commune et paramétrez l'en-tête, la forme des lignes et tout filtre éventuel.
+
+```python
+def export_csv(rows, path, header, to_row, keep=lambda _: True):
+    with open(path, "w") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        for row in rows:
+            if keep(row):
+                writer.writerow(to_row(row))
+
+def export_users_csv(users, path):
+    export_csv(users, path, ["id", "name", "email"],
+               lambda u: [u.id, u.name, u.email])
+
+def export_orders_csv(orders, path):
+    export_csv(orders, path, ["id", "total", "status"],
+               lambda o: [o.id, o.total, o.status],
+               keep=lambda o: o.status != "draft")
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`clones.type3_threshold`](../configuration/reference.md#clones) | `0.70` | Similarité minimale pour qu'une paire soit signalée comme modifiée. |
+| [`clones.enabled_clone_types`](../configuration/reference.md#clones) | `["type1","type2","type4"]` | Ajoutez `"type3"` pour activer cette règle. |
+| [`clones.similarity_threshold`](../configuration/reference.md#clones) | `0.65` | Plancher global appliqué avant les seuils par type. |
+| [`clones.min_lines`](../configuration/reference.md#clones) | `5` | Taille minimale du fragment en lignes. |
+| [`clones.min_nodes`](../configuration/reference.md#clones) | `10` | Taille minimale du fragment en nœuds AST. |
+
+## Références
+
+- Implémentation de la détection de clones (`internal/analyzer/clone_detector.go`, `internal/analyzer/apted.go`).
+- [Catalogue des règles](index.md) · [Clones identiques](duplicate-code-identical.md) · [Clones renommés](duplicate-code-renamed.md) · [Clones sémantiques](duplicate-code-semantic.md)

--- a/website/docs/fr/rules/duplicate-code-renamed.md
+++ b/website/docs/fr/rules/duplicate-code-renamed.md
@@ -1,0 +1,64 @@
+# duplicate-code-renamed
+
+**Catégorie** : Code dupliqué  
+**Sévérité** : Avertissement  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select clones`
+
+## Ce que fait cette règle
+
+Signale les blocs de code ayant la même structure mais des identifiants ou littéraux différents (clones de Type 2, similarité ≥ 0,75).
+
+## Pourquoi est-ce un problème ?
+
+Les clones renommés apparaissent quand quelqu'un copie une fonction, lance un rechercher-remplacer sur les noms de variables et passe à autre chose. La structure est identique, seuls les noms ont changé. Le coût de maintenance est le même que pour des clones textuellement identiques — chaque modification doit être appliquée à plusieurs endroits — mais la duplication est plus difficile à repérer à l'œil nu parce que les mots diffèrent.
+
+C'est aussi le signe que le code original n'était pas paramétré alors qu'il aurait dû l'être. Ce qui varie (un type, un nom de champ, une constante) est un argument de fonction naturel.
+
+## Exemple
+
+```python
+def total_for_orders(orders):
+    total = 0
+    for order in orders:
+        if order.status == "paid":
+            total += order.amount
+    return total
+
+def total_for_invoices(invoices):
+    total = 0
+    for invoice in invoices:
+        if invoice.status == "settled":
+            total += invoice.amount
+    return total
+```
+
+## À utiliser à la place
+
+Extrayez une fonction utilitaire générique qui prend le prédicat variable et les accesseurs de champs en paramètres.
+
+```python
+def total_where(items, is_active):
+    return sum(item.amount for item in items if is_active(item))
+
+def total_for_orders(orders):
+    return total_where(orders, lambda o: o.status == "paid")
+
+def total_for_invoices(invoices):
+    return total_where(invoices, lambda i: i.status == "settled")
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`clones.type2_threshold`](../configuration/reference.md#clones) | `0.75` | Similarité minimale pour qu'une paire soit signalée comme renommée. |
+| [`clones.similarity_threshold`](../configuration/reference.md#clones) | `0.65` | Plancher global appliqué avant les seuils par type. |
+| [`clones.ignore_identifiers`](../configuration/reference.md#clones) | `true` | Considère les noms de variables différents comme équivalents lors du calcul de la similarité. |
+| [`clones.ignore_literals`](../configuration/reference.md#clones) | `true` | Considère les littéraux numériques et chaînes différents comme équivalents. |
+| [`clones.min_lines`](../configuration/reference.md#clones) | `5` | Taille minimale du fragment en lignes. |
+| [`clones.enabled_clone_types`](../configuration/reference.md#clones) | `["type1","type2","type4"]` | Incluez `"type2"` pour garder cette règle active. |
+
+## Références
+
+- Implémentation de la détection de clones (`internal/analyzer/clone_detector.go`, `internal/analyzer/apted.go`).
+- [Catalogue des règles](index.md) · [Clones identiques](duplicate-code-identical.md) · [Clones modifiés](duplicate-code-modified.md) · [Clones sémantiques](duplicate-code-semantic.md)

--- a/website/docs/fr/rules/duplicate-code-semantic.md
+++ b/website/docs/fr/rules/duplicate-code-semantic.md
@@ -1,0 +1,58 @@
+# duplicate-code-semantic
+
+**Catégorie** : Code dupliqué  
+**Sévérité** : Avertissement  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select clones`
+
+## Ce que fait cette règle
+
+Signale les blocs de code syntaxiquement différents qui calculent le même résultat (clones de Type 4, similarité ≥ 0,65). Utilise l'analyse de flot de données pour comparer le comportement plutôt que la structure.
+
+## Pourquoi est-ce un problème ?
+
+Les clones sémantiques sont les duplications que vous ne remarquez pas pendant la revue. Une fonction utilise une boucle, l'autre une compréhension ; l'une construit un dictionnaire via `update`, l'autre via la syntaxe de fusion. Le code a l'air différent et passe donc l'inspection visuelle, mais les deux implémentations font le même travail.
+
+Les risques sont les mêmes que pour toute duplication — les modifications doivent être faites à plusieurs endroits — mais il y a un coût supplémentaire. Les lecteurs ne peuvent pas dire d'un coup d'œil si les deux implémentations s'accordent sur les cas limites. La version en boucle saute-t-elle aussi les `None` ? La compréhension lève-t-elle une exception sur une entrée vide ? L'audit mental doit être refait à chaque fois.
+
+Réduire à une implémentation unique supprime l'audit et la divergence.
+
+## Exemple
+
+```python
+def unique_emails(users):
+    seen = set()
+    result = []
+    for u in users:
+        if u.email not in seen:
+            seen.add(u.email)
+            result.append(u.email)
+    return result
+
+def distinct_emails(users):
+    return list({u.email: None for u in users}.keys())
+```
+
+## À utiliser à la place
+
+Choisissez une implémentation et utilisez-la partout. Préférez la version la plus claire ; si les deux ont du mérite, conservez l'une et documentez pourquoi.
+
+```python
+def unique_emails(users):
+    """Return user emails in first-seen order, without duplicates."""
+    return list(dict.fromkeys(u.email for u in users))
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`clones.type4_threshold`](../configuration/reference.md#clones) | `0.65` | Similarité minimale pour qu'une paire soit signalée comme sémantique. |
+| [`clones.enable_dfa`](../configuration/reference.md#clones) | `true` | Active l'analyse de flot de données qui alimente la détection de Type 4. |
+| [`clones.similarity_threshold`](../configuration/reference.md#clones) | `0.65` | Plancher global appliqué avant les seuils par type. |
+| [`clones.enabled_clone_types`](../configuration/reference.md#clones) | `["type1","type2","type4"]` | Incluez `"type4"` pour garder cette règle active. |
+| [`clones.min_lines`](../configuration/reference.md#clones) | `5` | Taille minimale du fragment en lignes. |
+
+## Références
+
+- Implémentation de la détection de clones (`internal/analyzer/clone_detector.go`, `internal/analyzer/apted.go`).
+- [Catalogue des règles](index.md) · [Clones identiques](duplicate-code-identical.md) · [Clones renommés](duplicate-code-renamed.md) · [Clones modifiés](duplicate-code-modified.md)

--- a/website/docs/fr/rules/global-state-dependency.md
+++ b/website/docs/fr/rules/global-state-dependency.md
@@ -1,0 +1,54 @@
+# global-state-dependency
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Erreur  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale une méthode de classe qui utilise une instruction `global` pour lire ou modifier un état au niveau du module.
+
+## Pourquoi est-ce un problème ?
+
+Un `global` à l'intérieur d'une méthode lie la classe à une variable de module spécifique qui n'est pas visible depuis l'interface de la classe. Rien dans `OrderService(...)` n'indique à un lecteur que la construire ne suffit pas — une valeur au niveau du module doit aussi être amorcée, sinon la méthode se comportera de manière inattendue.
+
+Les tests en souffrent le plus. Pour exercer une méthode qui touche un état global, chaque test doit accéder au module, sauvegarder l'ancienne valeur, en installer une nouvelle et la restaurer au teardown — et tout test qui oublie de nettoyer laisse fuiter l'état vers le suivant. Exécuter les tests en parallèle devient dangereux.
+
+La dépendance est réelle ; elle est simplement cachée. En faire un paramètre explicite du constructeur supprime la surprise.
+
+## Exemple
+
+```python
+_current_user = None
+
+class AuditLog:
+    def record(self, action):
+        global _current_user
+        entry = {"user": _current_user, "action": action}
+        db.insert("audit", entry)
+```
+
+## À utiliser à la place
+
+Passez la valeur via `__init__` pour que la dépendance soit visible et substituable.
+
+```python
+class AuditLog:
+    def __init__(self, user):
+        self.user = user
+
+    def record(self, action):
+        db.insert("audit", {"user": self.user, "action": action})
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Cette règle se signale au niveau `error` ; elle est affichée sauf si `min_severity` est élevée au-dessus de `error`. |
+
+## Références
+
+- Détection des dépendances cachées (`internal/analyzer/hidden_dependency_detector.go`).
+- [Catalogue des règles](index.md) · [Dépendance à une variable de module](module-variable-dependency.md) · [Dépendance au patron singleton](singleton-pattern-dependency.md)

--- a/website/docs/fr/rules/high-class-coupling.md
+++ b/website/docs/fr/rules/high-class-coupling.md
@@ -1,0 +1,96 @@
+# high-class-coupling
+
+**Catégorie** : Conception de classes  
+**Sévérité** : Configurable par seuil  
+**Déclenché par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les classes qui dépendent de trop d'autres classes (la métrique Coupling Between Objects, ou CBO, de Chidamber & Kemerer). pyscn compte le nombre de classes distinctes qu'une classe référence via l'héritage, les annotations de type, l'instanciation directe, l'accès aux attributs sur des modules importés et les imports.
+
+En clair : *trop de choses doivent être en place pour que cette classe fonctionne.*
+
+## Pourquoi est-ce un problème ?
+
+Une classe fortement couplée est difficile à vivre :
+
+- **Difficile à tester** — la construire dans un test unitaire entraîne tout un réseau de collaborateurs, donc les tests deviennent des tests d'intégration ou reposent sur un mocking massif.
+- **Difficile à modifier** — un changement de signature dans l'une des dépendances se répercute sur cette classe.
+- **Difficile à réutiliser** — vous ne pouvez pas l'extraire vers un autre projet sans extraire tout son voisinage.
+- **Signe d'une abstraction manquante** — la classe orchestre probablement des choses qui devraient se trouver derrière une interface plus petite.
+
+## Exemple
+
+```python
+from billing.stripe_gateway import StripeGateway
+from billing.paypal_gateway import PayPalGateway
+from notifications.sendgrid import SendGridClient
+from notifications.twilio import TwilioClient
+from storage.s3 import S3Bucket
+from storage.postgres import PostgresConnection
+from audit.datadog import DatadogLogger
+from auth.okta import OktaClient
+
+class OrderService:
+    def __init__(self):
+        self.stripe = StripeGateway()
+        self.paypal = PayPalGateway()
+        self.email = SendGridClient()
+        self.sms = TwilioClient()
+        self.blobs = S3Bucket("orders")
+        self.db = PostgresConnection()
+        self.audit = DatadogLogger()
+        self.auth = OktaClient()
+
+    def place(self, user, cart): ...
+```
+
+`OrderService` est couplé à 8 classes concrètes de fournisseurs. Remplacer Stripe par Adyen, ou exécuter un test sans Postgres opérationnel, implique de modifier `OrderService`.
+
+## À utiliser à la place
+
+Dépendez de petits protocoles et injectez les collaborateurs via `__init__`. Le service ne sait plus quel fournisseur se trouve à l'autre extrémité.
+
+```python
+from typing import Protocol
+
+class PaymentGateway(Protocol):
+    def charge(self, amount: int, token: str) -> str: ...
+
+class Notifier(Protocol):
+    def notify(self, user_id: str, message: str) -> None: ...
+
+class OrderRepository(Protocol):
+    def save(self, order) -> None: ...
+
+class OrderService:
+    def __init__(
+        self,
+        payments: PaymentGateway,
+        notifier: Notifier,
+        repo: OrderRepository,
+    ):
+        self._payments = payments
+        self._notifier = notifier
+        self._repo = repo
+
+    def place(self, user, cart): ...
+```
+
+Si une classe a réellement besoin de nombreux collaborateurs, scindez-la par responsabilité (par exemple `Checkout`, `Fulfillment`, `Receipt`) et laissez un orchestrateur les appeler.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`cbo.low_threshold`](../configuration/reference.md#cbo) | `3` | À ce seuil ou en dessous, la classe est signalée comme à faible risque. |
+| [`cbo.medium_threshold`](../configuration/reference.md#cbo) | `7` | Au-dessus de ce seuil, la classe est à risque élevé. |
+| [`cbo.min_cbo`](../configuration/reference.md#cbo) | `0` | Les classes dont le couplage est inférieur à cette valeur sont omises du rapport. |
+| [`cbo.include_builtins`](../configuration/reference.md#cbo) | `false` | Compter les types intégrés (`list`, `dict`, `Exception`, …) comme dépendances. |
+| [`cbo.include_imports`](../configuration/reference.md#cbo) | `true` | Compter les classes atteintes uniquement via des instructions `import`. |
+
+## Références
+
+- Chidamber, S. R. & Kemerer, C. F. *A Metrics Suite for Object Oriented Design.* IEEE TSE, 1994.
+- Implémentation : `internal/analyzer/cbo.go`.
+- [Catalogue des règles](index.md) · [low-class-cohesion](low-class-cohesion.md)

--- a/website/docs/fr/rules/high-cyclomatic-complexity.md
+++ b/website/docs/fr/rules/high-cyclomatic-complexity.md
@@ -1,0 +1,111 @@
+# high-cyclomatic-complexity
+
+**Catégorie** : Complexité  
+**Sévérité** : Configurable selon un seuil  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les fonctions dont la complexité cyclomatique de McCabe dépasse le seuil configuré. Chaque `if`, `elif`, `for`, `while`, `except`, `match case` et clause booléenne à l'intérieur d'une compréhension ajoute un au compteur. Une fonction linéaire commence à 1.
+
+pyscn ne compte pas les opérateurs de court-circuit `and` / `or` comme des branches séparées.
+
+## Pourquoi est-ce un problème ?
+
+Un nombre élevé de branches signifie :
+
+- **Plus de chemins à lire** — chaque relecteur doit simuler mentalement chaque branche pour comprendre ce que fait la fonction.
+- **Plus de chemins à tester** — une couverture de branches complète exige un test par chemin ; en pratique, la plupart des fonctions très ramifiées sont sous-testées.
+- **Une densité de défauts plus élevée** — des études empiriques depuis McCabe (1976) corrèlent la complexité avec le taux de bugs.
+- **Plus difficile à modifier en toute sécurité** — une petite édition dans une branche peut silencieusement casser une autre.
+
+Les fonctions au-dessus d'environ 10 assument généralement plusieurs tâches qui pourraient être nommées et séparées.
+
+## Exemple
+
+```python
+def price_for(user, cart, coupon, region):
+    total = 0
+    for item in cart:
+        if item.category == "book":
+            if region == "EU":
+                total += item.price * 0.95
+            elif region == "US":
+                total += item.price
+            else:
+                total += item.price * 1.10
+        elif item.category == "food":
+            if user.is_student:
+                total += item.price * 0.90
+            else:
+                total += item.price
+        else:
+            total += item.price
+    if coupon:
+        if coupon.kind == "percent":
+            total *= 1 - coupon.value
+        elif coupon.kind == "fixed":
+            total -= coupon.value
+    if total < 0:
+        total = 0
+    return total
+```
+
+Complexité cyclomatique : 13.
+
+## À utiliser à la place
+
+Extrayez la tarification par article et la gestion des coupons, et remplacez la condition imbriquée par une table de dispatch.
+
+```python
+REGION_BOOK_MULTIPLIER = {"EU": 0.95, "US": 1.00}
+
+def _book_price(item, region):
+    return item.price * REGION_BOOK_MULTIPLIER.get(region, 1.10)
+
+def _food_price(item, user):
+    return item.price * (0.90 if user.is_student else 1.00)
+
+PRICERS = {"book": _book_price, "food": _food_price}
+
+def _item_price(item, user, region):
+    pricer = PRICERS.get(item.category)
+    return pricer(item, region) if item.category == "book" else \
+           pricer(item, user)   if item.category == "food" else \
+           item.price
+
+def _apply_coupon(total, coupon):
+    if coupon is None:
+        return total
+    if coupon.kind == "percent":
+        return total * (1 - coupon.value)
+    return total - coupon.value
+
+def price_for(user, cart, coupon, region):
+    subtotal = sum(_item_price(i, user, region) for i in cart)
+    return max(0, _apply_coupon(subtotal, coupon))
+```
+
+Chaque fonction utilitaire a désormais une complexité de 1 à 3 et une responsabilité unique. Les gardes (`if coupon is None: return`) aplatissent les branches restantes.
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`complexity.max_complexity`](../configuration/reference.md#complexity) | `0` | Limite stricte appliquée par `pyscn check`. `0` signifie qu'aucune application n'est faite dans `analyze` ; `pyscn check --max-complexity` utilise `10` si non défini. |
+| [`complexity.low_threshold`](../configuration/reference.md#complexity) | `9` | Les fonctions à cette valeur ou en dessous sont signalées comme à faible risque. |
+| [`complexity.medium_threshold`](../configuration/reference.md#complexity) | `19` | Au-dessus de cette valeur, une fonction est à risque élevé. |
+| [`complexity.min_complexity`](../configuration/reference.md#complexity) | `1` | Les fonctions en dessous de cette valeur sont omises du rapport. |
+
+## Métriques associées
+
+pyscn calcule deux autres mesures liées à la complexité à côté du compteur de McCabe. Elles apparaissent dans le rapport HTML et la sortie JSON, mais ne sont *pas* appliquées par `complexity.max_complexity` :
+
+- **Complexité cognitive** (style SonarQube). Pénalise plus lourdement l'imbrication et les ruptures du flot linéaire que McCabe — utile pour repérer les fonctions qui *paraissent* difficiles à suivre même lorsque leur complexité cyclomatique est modérée. Apparaît sous le nom `CognitiveComplexity` par fonction dans la sortie JSON.
+- **Métriques de code brutes** par fichier (SLOC, LLOC, lignes de commentaires, lignes vides, densité de commentaires). Voir [`raw_metrics`](../output/schemas.md) dans la référence des schémas.
+
+## Références
+
+- McCabe, T. J. *A Complexity Measure.* IEEE Transactions on Software Engineering, 1976.
+- Construction du graphe de flot de contrôle et comptage cyclomatique : `internal/analyzer/complexity.go`, `internal/analyzer/complexity_analyzer.go`, `internal/analyzer/cfg_builder.go`.
+- [Catalogue des règles](index.md) · [too-many-constructor-parameters](too-many-constructor-parameters.md)

--- a/website/docs/fr/rules/index.md
+++ b/website/docs/fr/rules/index.md
@@ -1,0 +1,113 @@
+# Catalogue des règles
+
+pyscn propose 33 règles réparties sur 7 catégories. Chaque règle dispose d'une page décrivant ce qu'elle détecte, pourquoi il s'agit d'un problème, un mauvais exemple et comment corriger.
+
+Cliquez sur le nom d'une règle pour ouvrir sa page.
+
+## Code inatteignable
+
+Code mort qui ne peut jamais s'exécuter. Détecté grâce à l'analyse d'accessibilité sur le graphe de flot de contrôle.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`unreachable-after-return`](unreachable-after-return.md) | Critique |
+| [`unreachable-after-raise`](unreachable-after-raise.md) | Critique |
+| [`unreachable-after-break`](unreachable-after-break.md) | Critique |
+| [`unreachable-after-continue`](unreachable-after-continue.md) | Critique |
+| [`unreachable-after-infinite-loop`](unreachable-after-infinite-loop.md) | Avertissement |
+| [`unreachable-branch`](unreachable-branch.md) | Avertissement |
+
+## Code dupliqué
+
+Fragments de code copiés-collés ou quasi identiques au sein du projet.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`duplicate-code-identical`](duplicate-code-identical.md) | Avertissement |
+| [`duplicate-code-renamed`](duplicate-code-renamed.md) | Avertissement |
+| [`duplicate-code-modified`](duplicate-code-modified.md) | Info (activation manuelle) |
+| [`duplicate-code-semantic`](duplicate-code-semantic.md) | Avertissement |
+
+## Complexité
+
+Fonctions trop ramifiées pour être testées ou raisonnées de manière fiable.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`high-cyclomatic-complexity`](high-cyclomatic-complexity.md) | Selon seuil |
+
+## Conception des classes
+
+Classes qui dépendent de trop d'éléments ou qui assument trop de responsabilités sans rapport.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`high-class-coupling`](high-class-coupling.md) | Selon seuil |
+| [`low-class-cohesion`](low-class-cohesion.md) | Selon seuil |
+
+## Injection de dépendances
+
+Schémas de constructeurs et de collaborateurs qui nuisent à la testabilité.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`too-many-constructor-parameters`](too-many-constructor-parameters.md) | Avertissement |
+| [`global-state-dependency`](global-state-dependency.md) | Erreur |
+| [`module-variable-dependency`](module-variable-dependency.md) | Avertissement |
+| [`singleton-pattern-dependency`](singleton-pattern-dependency.md) | Avertissement |
+| [`concrete-type-hint-dependency`](concrete-type-hint-dependency.md) | Info |
+| [`concrete-instantiation-dependency`](concrete-instantiation-dependency.md) | Avertissement |
+| [`service-locator-pattern`](service-locator-pattern.md) | Avertissement |
+
+## Structure des modules
+
+Problèmes du graphe d'imports : cycles, chaînes longues, violations de couches.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`circular-import`](circular-import.md) | Selon la taille du cycle |
+| [`deep-import-chain`](deep-import-chain.md) | Info |
+| [`layer-violation`](layer-violation.md) | Selon la règle d'architecture |
+| [`low-package-cohesion`](low-package-cohesion.md) | Avertissement |
+| [`single-responsibility`](single-responsibility.md) | Avertissement / Erreur |
+
+## Données factices
+
+Données fictives livrées par accident en production.
+
+| Règle | Sévérité |
+| ---- | -------- |
+| [`mock-keyword-in-code`](mock-keyword-in-code.md) | Info / Avertissement |
+| [`mock-domain-in-string`](mock-domain-in-string.md) | Avertissement |
+| [`mock-email-address`](mock-email-address.md) | Avertissement |
+| [`placeholder-phone-number`](placeholder-phone-number.md) | Avertissement |
+| [`placeholder-uuid`](placeholder-uuid.md) | Avertissement |
+| [`placeholder-comment`](placeholder-comment.md) | Info |
+| [`repetitive-string-literal`](repetitive-string-literal.md) | Info |
+| [`test-credential-in-code`](test-credential-in-code.md) | Avertissement |
+
+## Sélectionner les règles en ligne de commande
+
+La plupart des utilisateurs exécutent toutes les règles avec `pyscn analyze`. Pour la CI, filtrez par catégorie d'analyseur :
+
+```bash
+pyscn check --select deadcode          # uniquement les règles de code inatteignable
+pyscn check --select clones            # uniquement les règles de code dupliqué
+pyscn check --select complexity        # uniquement high-cyclomatic-complexity
+pyscn check --select deps              # circular-import + deep-import-chain + layer-violation
+pyscn check --select di                # toutes les règles d'injection de dépendances (activation manuelle)
+pyscn check --select mockdata          # toutes les règles de données factices (activation manuelle)
+pyscn check --select complexity,deadcode,deps   # combinaison
+```
+
+Consultez [`pyscn check`](../cli/check.md) pour la liste complète des options.
+
+## Signification des sévérités
+
+| Sévérité | Intention |
+| -------- | --- |
+| **Critique** | Presque toujours un bug. À corriger avant la fusion. |
+| **Erreur** | Schéma à haut risque. Doit en général faire échouer la CI. |
+| **Avertissement** | À examiner. Seuil d'échec par défaut pour `pyscn check`. |
+| **Info** | Informatif. N'apparaît que lorsque `min_severity = "info"` ou équivalent. |
+| **Selon seuil** | La sévérité dépend d'un seuil numérique (voir les options de la règle). |

--- a/website/docs/fr/rules/layer-violation.md
+++ b/website/docs/fr/rules/layer-violation.md
@@ -1,0 +1,93 @@
+# layer-violation
+
+**Catégorie** : Structure des modules  
+**Sévérité** : Configurable via `architecture.rules[].severity`  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select deps`
+
+## Ce qu'elle fait
+
+Signale une instruction `import` lorsque la couche du module source n'est pas autorisée à dépendre de la couche du module cible, selon les `[[architecture.rules]]` que vous avez configurées. Les couches sont assignées aux modules en faisant correspondre les fragments de noms de paquets définis dans `[[architecture.layers]]`.
+
+## Pourquoi est-ce un problème ?
+
+Une architecture en couches n'apporte de bénéfice que tant que les couches tiennent. Un seul raccourci de `presentation` vers `infrastructure` suffit à :
+
+- **Anéantir la testabilité.** La couche de présentation ne peut désormais être exercée qu'avec une vraie base de données / un vrai client HTTP derrière.
+- **Créer un couplage caché.** Remplacer l'implémentation de l'infrastructure casse silencieusement du code d'UI qui n'était pas censé en connaître l'existence.
+- **Normaliser la violation.** Dès qu'un raccourci existe, le suivant est plus facile à justifier.
+
+La règle est l'application automatisée du schéma d'architecture que vous avez déjà dessiné dans un document de conception.
+
+## Exemple
+
+Configuration :
+
+```toml
+[[architecture.layers]]
+name = "presentation"
+packages = ["api", "handlers"]
+
+[[architecture.layers]]
+name = "application"
+packages = ["services", "usecases"]
+
+[[architecture.layers]]
+name = "infrastructure"
+packages = ["repositories", "db"]
+
+[[architecture.rules]]
+from = "presentation"
+allow = ["application"]
+deny = ["infrastructure"]
+```
+
+Code en infraction :
+
+```python
+# myapp/api/orders.py  (presentation)
+from myapp.repositories.orders import OrderRepository   # ← interdit
+
+def list_orders():
+    return OrderRepository().all()
+```
+
+`presentation` saute par-dessus `application` pour aller directement dans `infrastructure`.
+
+## À utiliser à la place
+
+Faites passer l'appel par la couche application :
+
+```python
+# myapp/services/orders.py  (application)
+from myapp.repositories.orders import OrderRepository
+
+def list_orders():
+    return OrderRepository().all()
+```
+
+```python
+# myapp/api/orders.py  (presentation)
+from myapp.services.orders import list_orders
+
+def get():
+    return list_orders()
+```
+
+`api` ne dépend désormais que de `services`, et l'infrastructure est remplaçable sans toucher à la couche de présentation.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`[[architecture.layers]]`](../configuration/reference.md#architecture) | — | Définit les couches et les fragments de paquets qui appartiennent à chacune. |
+| [`[[architecture.rules]]`](../configuration/reference.md#architecture) | — | `from` / `allow` / `deny` / `severity` optionnel par règle. |
+| [`architecture.validate_layers`](../configuration/reference.md#architecture) | `true` | Mettre à `false` pour désactiver cette règle. |
+| [`architecture.strict_mode`](../configuration/reference.md#architecture) | `true` | En mode strict, tout ce qui n'est pas explicitement autorisé est refusé. |
+| [`architecture.fail_on_violations`](../configuration/reference.md#architecture) | `false` | Code de sortie non nul lorsqu'une violation est détectée. |
+
+Sans couches configurées, l'analyseur fonctionne en mode permissif et cette règle ne produit aucun résultat.
+
+## Références
+
+- Résolution des couches et évaluation des règles (`internal/analyzer/module_analyzer.go`).
+- [Catalogue des règles](index.md) · [low-package-cohesion](low-package-cohesion.md)

--- a/website/docs/fr/rules/low-class-cohesion.md
+++ b/website/docs/fr/rules/low-class-cohesion.md
@@ -1,0 +1,111 @@
+# low-class-cohesion
+
+**Catégorie** : Conception de classes  
+**Sévérité** : Configurable par seuil  
+**Déclenché par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les classes dont les méthodes ne partagent pas d'état d'instance (la métrique LCOM4 — Lack of Cohesion of Methods, version 4). pyscn construit un graphe dans lequel deux méthodes sont connectées si elles touchent un attribut `self.` commun, puis compte les composantes connexes. `LCOM4 = 1` signifie que chaque méthode est liée à toutes les autres ; `LCOM4 = N` signifie que la classe est en réalité `N` sous-classes indépendantes collées ensemble.
+
+Les méthodes décorées avec `@staticmethod` ou `@classmethod` ne référencent pas `self` et sont exclues du graphe.
+
+En clair : *cette classe accomplit des tâches sans rapport — scindez-la, ou faites-en un module de fonctions.*
+
+## Pourquoi est-ce un problème ?
+
+Une classe est censée regrouper un état avec les opérations qui agissent dessus. Lorsque les méthodes ne touchent pas le même état :
+
+- **Le nom de la classe ment** — elle prétend être une chose mais se comporte comme deux ou trois.
+- **Les changements se dispersent** — un bogue dans une responsabilité ne peut être trouvé qu'en lisant du code qui n'a rien à voir avec lui.
+- **La réutilisation est bloquée** — vous ne pouvez pas extraire la partie dont vous avez besoin sans entraîner tout le reste.
+- **Cela précède souvent une vraie abstraction** — la classe « Utilities » ou « Manager » est un symptôme classique.
+
+## Exemple
+
+```python
+class UserUtility:
+    def __init__(self, db, smtp, clock):
+        self.db = db
+        self.smtp = smtp
+        self.clock = clock
+        self.cache = {}
+
+    # --- persistence ---
+    def load(self, user_id):
+        if user_id in self.cache:
+            return self.cache[user_id]
+        row = self.db.fetch("users", user_id)
+        self.cache[user_id] = row
+        return row
+
+    def save(self, user):
+        self.db.upsert("users", user)
+        self.cache[user.id] = user
+
+    # --- email ---
+    def send_welcome(self, address):
+        self.smtp.send(address, "Welcome")
+
+    def send_reset(self, address, token):
+        self.smtp.send(address, f"Reset: {token}")
+
+    # --- formatting ---
+    def format_joined_at(self, user):
+        return self.clock.format(user.joined_at)
+```
+
+`LCOM4 = 3` : `{load, save}` partagent `db` et `cache`, `{send_welcome, send_reset}` partagent `smtp`, `{format_joined_at}` est isolé. Trois composantes, une seule classe.
+
+## À utiliser à la place
+
+Scindez en classes cohésives et déplacez la partie sans état vers des fonctions libres.
+
+```python
+class UserRepository:
+    def __init__(self, db):
+        self._db = db
+        self._cache = {}
+
+    def load(self, user_id):
+        if user_id in self._cache:
+            return self._cache[user_id]
+        row = self._db.fetch("users", user_id)
+        self._cache[user_id] = row
+        return row
+
+    def save(self, user):
+        self._db.upsert("users", user)
+        self._cache[user.id] = user
+
+
+class UserMailer:
+    def __init__(self, smtp):
+        self._smtp = smtp
+
+    def send_welcome(self, address):
+        self._smtp.send(address, "Welcome")
+
+    def send_reset(self, address, token):
+        self._smtp.send(address, f"Reset: {token}")
+
+
+# user_formatting.py — no class, no state
+def format_joined_at(user, clock):
+    return clock.format(user.joined_at)
+```
+
+Chaque classe a maintenant `LCOM4 = 1`, et le formateur est une fonction d'une ligne, là où il doit être.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`lcom.low_threshold`](../configuration/reference.md#lcom) | `2` | À ce seuil ou en dessous, la classe est signalée comme à faible risque. |
+| [`lcom.medium_threshold`](../configuration/reference.md#lcom) | `5` | Au-dessus de ce seuil, la classe est à risque élevé. |
+
+## Références
+
+- Hitz, M. & Montazeri, B. *Chidamber and Kemerer's Metrics Suite: A Measurement Theory Perspective.* IEEE TSE, 1996 (définition de LCOM4).
+- Implémentation : `internal/analyzer/lcom.go`.
+- [Catalogue des règles](index.md) · [high-class-coupling](high-class-coupling.md)

--- a/website/docs/fr/rules/low-package-cohesion.md
+++ b/website/docs/fr/rules/low-package-cohesion.md
@@ -1,0 +1,56 @@
+# low-package-cohesion
+
+**Catégorie** : Structure des modules  
+**Sévérité** : Warning  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select deps`
+
+## Ce qu'elle fait
+
+Signale un paquet dont le score de cohésion interne tombe en dessous de `architecture.min_cohesion` (par défaut `0.5`). La cohésion est mesurée comme le rapport entre les imports intra-paquet réels et le nombre possible entre ses sous-modules — un paquet dont les modules ne s'importent jamais entre eux obtient `0`.
+
+## Pourquoi est-ce un problème ?
+
+Un paquet est censé être un concept unique qui se trouve réparti entre plusieurs fichiers. Quand les fichiers ne se référencent pas entre eux, le paquet n'est qu'un dossier de code sans rapport partageant un espace de noms :
+
+- **Chemins d'import trompeurs.** `from myapp.utils import X` suggère une relation entre `X` et tout le reste de `utils` ; une faible cohésion signifie que cette promesse est vide.
+- **Aucun propriétaire naturel.** Personne n'est responsable d'« `utils` » dans son ensemble, parce qu'il n'y a pas d'ensemble.
+- **Croissance sans limite.** Les paquets fourre-tout accumulent des utilitaires sans rapport jusqu'à devenir une décharge.
+- **Cache une abstraction manquante.** Souvent, la bonne action n'est pas « continuer à ajouter », mais trouver le vrai concept que deux des sous-modules partagent et l'extraire.
+
+## Exemple
+
+```
+myapp/utils/
+    __init__.py
+    string_utils.py     # slugify, truncate
+    math_utils.py       # clamp, lerp
+    io_utils.py         # atomic_write, read_json
+```
+
+Aucun de ces trois modules n'importe les autres. Le paquet `utils` a une cohésion nulle.
+
+## À utiliser à la place
+
+Découpez le paquet en paquets ciblés nommés d'après ce qu'ils font réellement :
+
+```
+myapp/text/          # slugify, truncate, et les utilitaires qu'ils partagent
+myapp/geometry/      # clamp, lerp
+myapp/fs/            # atomic_write, read_json
+```
+
+Ou — si le contenu est réellement constitué d'utilitaires ponctuels sans rapport — reconnaissez-le et arrêtez de prétendre le contraire. Nommez le paquet `misc` ou déplacez chaque utilitaire vers le module qui l'utilise réellement, et excluez le fourre-tout des contrôles de cohésion.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`architecture.validate_cohesion`](../configuration/reference.md#architecture) | `true` | Mettre à `false` pour désactiver cette règle. |
+| [`architecture.min_cohesion`](../configuration/reference.md#architecture) | `0.5` | Les paquets en dessous de ce score sont signalés. |
+| [`architecture.enabled`](../configuration/reference.md#architecture) | `true` | Interrupteur principal de l'analyse d'architecture. |
+| [`architecture.fail_on_violations`](../configuration/reference.md#architecture) | `false` | Code de sortie non nul en cas de violation. |
+
+## Références
+
+- Calcul de la cohésion de paquet (`internal/analyzer/coupling_metrics.go`, `internal/analyzer/module_analyzer.go`).
+- [Catalogue des règles](index.md) · [layer-violation](layer-violation.md)

--- a/website/docs/fr/rules/mock-domain-in-string.md
+++ b/website/docs/fr/rules/mock-domain-in-string.md
@@ -1,0 +1,49 @@
+# mock-domain-in-string
+
+**Catégorie** : Données fictives  
+**Sévérité** : Warning  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les littéraux de chaînes contenant des domaines réservés à la documentation et aux tests : `example.com`, `example.org`, `example.net`, `test.com`, `localhost`, `invalid`, `foo.com`, `bar.com`, et noms similaires définis par les RFC 2606 / RFC 6761.
+
+## Pourquoi est-ce un problème ?
+
+Ces domaines existent précisément pour que les exemples et les tests n'entrent pas en collision avec du vrai trafic. C'est utile pendant la rédaction de la documentation — et problématique une fois qu'un littéral est livré. Une URL `example.com` codée en dur en production est en général soit :
+
+- Un placeholder qui devait être remplacé avant la sortie, soit
+- Une valeur de configuration qui n'aurait jamais dû être codée en dur en premier lieu.
+
+Dans les deux cas, le mode de défaillance est silencieux : les requêtes réussissent (le domaine résout vers une page de documentation ou rien du tout), aucune exception n'est levée, et le bug n'est remarqué que lorsque quelqu'un demande pourquoi les inscriptions n'arrivent pas.
+
+## Exemple
+
+```python
+SIGNUP_URL = "https://example.com/signup"
+```
+
+## À utiliser à la place
+
+Déplacez la valeur dans la configuration, ou mettez la vraie URL en clair.
+
+```python
+SIGNUP_URL = settings.signup_url
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.domains`](../configuration/reference.md#mock_data) | *(liste RFC 2606)* | Remplace ou étend la liste de domaines réservés. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour ne conserver que les résultats de ce niveau. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- RFC 2606 : *Reserved Top Level DNS Names.*
+- RFC 6761 : *Special-Use Domain Names.*
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [mock-email-address](mock-email-address.md) · [mock-keyword-in-code](mock-keyword-in-code.md)

--- a/website/docs/fr/rules/mock-email-address.md
+++ b/website/docs/fr/rules/mock-email-address.md
@@ -1,0 +1,45 @@
+# mock-email-address
+
+**Catégorie** : Données fictives  
+**Sévérité** : Warning  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les adresses e-mail dont la partie domaine est réservée aux tests : `test@example.com`, `admin@test.com`, `foo@localhost`, et similaires.
+
+## Pourquoi est-ce un problème ?
+
+Un e-mail avec un domaine de test dans du code applicatif est presque toujours un reliquat d'une fixture, d'un tutoriel, ou d'un stub « à remplir plus tard ». Contrairement à une adresse mal formée, il passe la validation et la sérialisation sans encombre, et finit donc silencieusement dans des lignes de base de données, des files de notifications et des en-têtes « from ». Le chemin habituel de découverte est un ticket de support demandant pourquoi personne n'a reçu de lien de réinitialisation.
+
+Cette règle complète [mock-domain-in-string](mock-domain-in-string.md) mais traite spécifiquement la forme e-mail afin de garder la liste de domaines restreinte et la correspondance précise.
+
+## Exemple
+
+```python
+admin_email = "admin@example.com"
+```
+
+## À utiliser à la place
+
+Lisez l'adresse depuis la configuration, ou acceptez-la comme paramètre.
+
+```python
+admin_email = settings.admin_email
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.domains`](../configuration/reference.md#mock_data) | *(liste RFC 2606)* | Domaines considérés comme placeholder ; partagés avec `mock-domain-in-string`. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour ne conserver que les résultats de ce niveau. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- RFC 2606 : *Reserved Top Level DNS Names.*
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [mock-domain-in-string](mock-domain-in-string.md) · [test-credential-in-code](test-credential-in-code.md)

--- a/website/docs/fr/rules/mock-keyword-in-code.md
+++ b/website/docs/fr/rules/mock-keyword-in-code.md
@@ -1,0 +1,49 @@
+# mock-keyword-in-code
+
+**Catégorie** : Données fictives  
+**Sévérité** : Info (dans les chaînes) / Warning (dans les identifiants)  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les identifiants et les littéraux de chaînes contenant des mots-clés de placeholder courants : `mock`, `fake`, `dummy`, `test`, `sample`, `example`, `placeholder`, `stub`, `fixture`, `temp`, `foo`, `bar`, `baz`, `lorem`, `ipsum`.
+
+## Pourquoi est-ce un problème ?
+
+Ce sont les mots que vous tapez quand vous êtes encore en train de réfléchir à quelque chose. Ils sont parfaits dans un notebook, un fichier de test ou une expérimentation rapide — mais quand l'un d'eux survit jusqu'en production, cela signifie en général qu'un stub n'a jamais été remplacé. Le nom `foo` dans un module commité n'est presque jamais ce que l'auteur voulait livrer.
+
+Les correspondances dans les **identifiants** sont traitées comme des warnings parce qu'un nom lié (`foo = get_user()`) change le comportement. Les correspondances dans les **littéraux de chaînes** sont au niveau info car un `"fake_user"` oublié est plus souvent cosmétique que cassé — mais il vaut quand même la peine d'être revu avant une mise en production.
+
+## Exemple
+
+```python
+def create_user():
+    name = "fake_user"    # correspondance sur littéral de chaîne
+    foo = get_user()      # correspondance sur l'identifiant `foo`
+    return foo
+```
+
+## À utiliser à la place
+
+Supprimez le placeholder. Utilisez de vraies données, lisez depuis la configuration, ou déplacez le stub dans une fixture de test où il a sa place.
+
+```python
+def create_user(name: str):
+    user = get_user(name)
+    return user
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in ; toute la catégorie est désactivée par défaut. |
+| [`mock_data.keywords`](../configuration/reference.md#mock_data) | *(liste intégrée)* | Remplace la liste de mots-clés pour cette règle. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | `"warning"` ne conserve que les correspondances dans les identifiants. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers qui ressemblent à des tests. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers ; les correspondances sont supprimées. |
+
+## Références
+
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [mock-domain-in-string](mock-domain-in-string.md) · [test-credential-in-code](test-credential-in-code.md) · [placeholder-comment](placeholder-comment.md)

--- a/website/docs/fr/rules/module-variable-dependency.md
+++ b/website/docs/fr/rules/module-variable-dependency.md
@@ -1,0 +1,54 @@
+# module-variable-dependency
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Avertissement  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale une classe qui lit ou écrit directement une variable mutable au niveau du module sans instruction `global` — un couplage implicite à l'état du module.
+
+## Pourquoi est-ce un problème ?
+
+Contrairement à une affectation `global`, la lecture d'un nom au niveau du module est silencieuse : la classe semble autonome, mais son comportement dépend en réalité de ce qui se trouve dans cette variable de module au moment de l'appel. Un test qui instancie la classe de manière isolée peut quand même réussir ou échouer en fonction d'un import sans rapport.
+
+Cela casse également la substituabilité. Vous ne pouvez pas donner à la classe un collaborateur différent sans monkey-patcher le module, ce qui est fragile et dépend de l'ordre. Deux instances de la classe sont forcées de partager le même objet sous-jacent, que vous le vouliez ou non.
+
+Faire du collaborateur un paramètre du constructeur documente la dépendance, permet une configuration par instance et autorise les tests à injecter un faux sans toucher aux variables globales du module.
+
+## Exemple
+
+```python
+config = load_config()
+
+class UserRepository:
+    def find(self, user_id):
+        conn = connect(config.database_url)
+        return conn.query("SELECT * FROM users WHERE id = ?", user_id)
+```
+
+## À utiliser à la place
+
+Acceptez le collaborateur comme paramètre du constructeur.
+
+```python
+class UserRepository:
+    def __init__(self, database_url):
+        self.database_url = database_url
+
+    def find(self, user_id):
+        conn = connect(self.database_url)
+        return conn.query("SELECT * FROM users WHERE id = ?", user_id)
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Augmentez à `"error"` pour supprimer cette règle. |
+
+## Références
+
+- Détection des dépendances cachées (`internal/analyzer/hidden_dependency_detector.go`).
+- [Catalogue des règles](index.md) · [Dépendance à l'état global](global-state-dependency.md) · [Dépendance au patron singleton](singleton-pattern-dependency.md)

--- a/website/docs/fr/rules/placeholder-comment.md
+++ b/website/docs/fr/rules/placeholder-comment.md
@@ -1,0 +1,47 @@
+# placeholder-comment
+
+**Catégorie** : Données fictives  
+**Sévérité** : Info  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les commentaires contenant des marqueurs de travail inachevé : `TODO`, `FIXME`, `XXX`, `HACK`, `BUG`, `NOTE`.
+
+## Pourquoi est-ce un problème ?
+
+Un `# TODO` dans le code source est une promesse que l'auteur s'est faite à son futur lui-même, sans échéance ni relecteur. La plupart des codebases en accumulent plus vite qu'elles ne les résolvent. Chacun est un petit morceau de périmètre caché — le lecteur doit décider s'il est encore pertinent, s'il bloque une modification, et si quelqu'un en assure réellement le suivi.
+
+Cette règle ne prétend pas que chaque marqueur est un bug. Elle expose la liste pour que vous puissiez décider, projet par projet, de les résoudre, de les convertir en tickets suivis, ou de les accepter avec une politique explicite.
+
+## Exemple
+
+```python
+def process_order(order):
+    # TODO: handle refunds
+    ...
+```
+
+## À utiliser à la place
+
+Soit vous implémentez le travail, soit vous convertissez le marqueur en lien vers un ticket suivi pour que l'intention vive quelque part avec un état de clôture.
+
+```python
+def process_order(order):
+    # Les remboursements sont gérés par le service de facturation : voir ticket #1423.
+    ...
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour exclure cette règle. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [mock-keyword-in-code](mock-keyword-in-code.md)

--- a/website/docs/fr/rules/placeholder-phone-number.md
+++ b/website/docs/fr/rules/placeholder-phone-number.md
@@ -1,0 +1,41 @@
+# placeholder-phone-number
+
+**Catégorie** : Données fictives  
+**Sévérité** : Warning  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les numéros de téléphone dans les littéraux de chaînes qui suivent des motifs manifestement factices : que des zéros (`000-0000-0000`), des chiffres séquentiels (`123-456-7890`, `012-345-6789`), ou de longues séries de chiffres répétés.
+
+## Pourquoi est-ce un problème ?
+
+Un numéro de téléphone placeholder est le genre de valeur qui survit depuis la première version d'un formulaire et n'est jamais revisitée. Il valide, il se formate et il transite correctement par la base de données — donc rien ne casse jusqu'à ce qu'un véritable utilisateur le voie sur un écran de confirmation ou qu'un agent de support tente de l'appeler.
+
+## Exemple
+
+```python
+default_phone = "000-0000-0000"
+```
+
+## À utiliser à la place
+
+Laissez le champ vide, exigez-le de l'appelant, ou tirez-le de la configuration. Un numéro de téléphone inconnu doit être absent, pas falsifié.
+
+```python
+default_phone: str | None = None
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour ne conserver que les résultats de ce niveau. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [placeholder-uuid](placeholder-uuid.md) · [repetitive-string-literal](repetitive-string-literal.md)

--- a/website/docs/fr/rules/placeholder-uuid.md
+++ b/website/docs/fr/rules/placeholder-uuid.md
@@ -1,0 +1,44 @@
+# placeholder-uuid
+
+**Catégorie** : Données fictives  
+**Sévérité** : Warning  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les littéraux de chaînes en forme de UUID avec une très faible entropie : le UUID nul (`00000000-0000-0000-0000-000000000000`), tout à un, tout en `f`, ou de longues séries de caractères répétés qui parsent néanmoins comme un UUID.
+
+## Pourquoi est-ce un problème ?
+
+Le UUID nul est une valeur légitime dans quelques contextes, mais dans la plupart du code applicatif c'est un reliquat d'un stub `DEFAULT_USER_ID = "00..."` qui devait être remplacé. Comme il parse et se sérialise comme n'importe quel autre UUID, les lookups de clés étrangères, les lignes de logs et les pistes d'audit l'acceptent tous — et des lignes commencent à fusionner sur le même « utilisateur » sans qu'aucune erreur ne soit levée.
+
+## Exemple
+
+```python
+DEFAULT_USER_ID = "00000000-0000-0000-0000-000000000000"
+```
+
+## À utiliser à la place
+
+Générez un vrai UUID au point d'utilisation, ou exigez de l'appelant qu'il en fournisse un. Ne transportez pas une valeur sentinelle qui ressemble à de la donnée.
+
+```python
+import uuid
+
+def new_user_id() -> uuid.UUID:
+    return uuid.uuid4()
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour ne conserver que les résultats de ce niveau. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [placeholder-phone-number](placeholder-phone-number.md) · [repetitive-string-literal](repetitive-string-literal.md)

--- a/website/docs/fr/rules/repetitive-string-literal.md
+++ b/website/docs/fr/rules/repetitive-string-literal.md
@@ -1,0 +1,45 @@
+# repetitive-string-literal
+
+**Catégorie** : Données fictives  
+**Sévérité** : Info  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les littéraux de chaînes de longueur 4 à 20 avec des motifs de caractères très répétitifs : `aaaa`, `1111`, `xxxxxxxx`, et autres séries similaires à un ou deux caractères.
+
+## Pourquoi est-ce un problème ?
+
+Une chaîne comme `"aaaaaaaaaaaaaaaa"` n'est presque jamais une vraie valeur — c'est la forme que prend quelque chose tapé pour passer un validateur pendant que le développeur câblait autre chose. Laissé en production, elle devient une clé d'API, une entrée de hash, ou un token qui ressemble à de la donnée et passe les vérifications de longueur sans avoir aucun sens.
+
+La règle est bornée en longueur (4–20 caractères) afin d'éviter de signaler des remplissages intentionnels comme des constantes de padding ou des vecteurs de test qui nécessitent légitimement des caractères répétés.
+
+## Exemple
+
+```python
+api_key = "aaaaaaaaaaaaaaaa"
+```
+
+## À utiliser à la place
+
+Lisez les secrets et les tokens depuis la configuration ou un coffre-fort de secrets. Ne mettez pas de valeurs placeholder en dur dans le code source.
+
+```python
+import os
+
+api_key = os.environ["SERVICE_API_KEY"]
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour exclure cette règle. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [test-credential-in-code](test-credential-in-code.md) · [placeholder-uuid](placeholder-uuid.md)

--- a/website/docs/fr/rules/service-locator-pattern.md
+++ b/website/docs/fr/rules/service-locator-pattern.md
@@ -1,0 +1,59 @@
+# service-locator-pattern
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Avertissement  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale une classe qui reçoit un localisateur, un registre ou un conteneur, et qui en extrait des dépendances nommées au moment de l'appel de méthode, par exemple `self.locator.get("payment_service")`.
+
+## Pourquoi est-ce un problème ?
+
+Un localisateur de services échange une dépendance claire contre de nombreuses dépendances cachées. La signature du constructeur suggère que la classe a besoin d'un seul objet, mais le vrai contrat est « tout ce que cette classe se trouve à rechercher à l'exécution ». Un lecteur doit parcourir toutes les méthodes à coups de grep pour découvrir qu'`OrderService` a en réalité besoin d'une passerelle de paiement, d'un notificateur et d'une horloge.
+
+Les tests doivent fournir un faux localisateur qui connaît chaque clé que la classe peut demander, et une clé manquante apparaît généralement sous forme d'`AttributeError` ou de `KeyError` au fond d'une méthode plutôt que comme un échec de construction clair. Renommer un service exige de retrouver chaque recherche par chaîne ; l'analyse statique et les outils de refactoring d'IDE ne peuvent pas aider.
+
+Passer directement les services réels via `__init__` donne à la classe un contrat vérifiable et élimine l'indirection par chaînes de caractères.
+
+## Exemple
+
+```python
+class OrderService:
+    def __init__(self, locator):
+        self.locator = locator
+
+    def place(self, order):
+        self.locator.get("order_repo").save(order)
+        self.locator.get("payment_service").charge(order)
+        self.locator.get("notifier").send(order.user, "placed")
+```
+
+## À utiliser à la place
+
+Recevez chaque service directement, afin que les dépendances soient visibles et vérifiables par typage.
+
+```python
+class OrderService:
+    def __init__(self, repo, payments, notifier):
+        self.repo = repo
+        self.payments = payments
+        self.notifier = notifier
+
+    def place(self, order):
+        self.repo.save(order)
+        self.payments.charge(order)
+        self.notifier.send(order.user, "placed")
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Augmentez à `"error"` pour supprimer cette règle. |
+
+## Références
+
+- Détection de localisateur de services (`internal/analyzer/service_locator_detector.go`).
+- [Catalogue des règles](index.md) · [Dépendance par instanciation concrète](concrete-instantiation-dependency.md) · [Trop de paramètres de constructeur](too-many-constructor-parameters.md)

--- a/website/docs/fr/rules/single-responsibility.md
+++ b/website/docs/fr/rules/single-responsibility.md
@@ -1,0 +1,71 @@
+# single-responsibility
+
+**Catégorie** : Structure des modules  
+**Sévérité** : Warning (Error lorsque le module est aussi un hub avec un fan-in/out très élevé)  
+**Déclenchée par** : `pyscn analyze`, `pyscn check --select deps`
+
+## Ce qu'elle fait
+
+Signale un module qui mélange plus de `architecture.max_responsibilities` (par défaut `3`) préoccupations de dépendance distinctes, ou qui agit comme un hub fan-in/fan-out pour plus de préoccupations que la moyenne du reste du projet.
+
+Une « préoccupation » est déduite des noms des voisins du module : pour chaque module que celui-ci importe ou qui l'importe, l'analyseur prend le premier segment du chemin du voisin qui ne fait pas partie du chemin du module courant et qui n'est pas un terme générique fourre-tout (`base`, `common`, `helpers`, `node`, `shared`, `util`, `utils`). Ces segments sont dédupliqués ; le compte donne le nombre de responsabilités que pyscn attribue au module.
+
+Un module est signalé lorsqu'au moins une des conditions suivantes est remplie :
+
+- Il possède plus de `max_responsibilities` préoccupations distinctes.
+- Son fan-in (nombre d'importateurs) et son fan-out (nombre d'imports) sont tous deux au-dessus de la `moyenne + écart-type` du projet, et il possède plus d'une préoccupation.
+
+## Pourquoi est-ce un problème ?
+
+Le principe de responsabilité unique (SRP) concerne les *axes de changement*. Un module qui participe à plusieurs clusters de dépendances sans rapport a plusieurs raisons de changer :
+
+- **Les modifications se propagent.** Toucher une préoccupation force à relire et retester les autres, parce qu'elles partagent toutes la même frontière de module.
+- **Les imports mentent.** `from myapp.core import X` ne dit rien au lecteur — `core` fait plusieurs choses.
+- **Les hubs deviennent des goulots d'étranglement.** Un module que tout le monde importe *et* qui importe tout est un point unique de contention pour les modifications, les revues et les fusions.
+- **Cache une couture manquante.** Quand deux préoccupations finissent constamment dans le même fichier, la bonne correction est en général un nouveau module qui nomme la relation entre elles.
+
+## Exemple
+
+```
+myapp/core.py
+```
+
+```python
+# myapp/core.py
+from myapp.routers import user_router, order_router
+from myapp.services import billing_service, notification_service
+from myapp.repositories import user_repo, order_repo
+from myapp.telemetry import metrics, tracing
+
+# ...code de glue qui rassemble tout...
+```
+
+`core` mélange quatre préoccupations (`routers`, `services`, `repositories`, `telemetry`), et il est importé à la fois par des routers et des services ailleurs — fan-in et fan-out sont tous deux élevés. pyscn le signale comme surchargé.
+
+## À utiliser à la place
+
+Découpez le module selon les préoccupations qui existent déjà. Chaque nouveau module doit nommer *un seul* axe de changement.
+
+```
+myapp/wiring/web.py          # câblage au niveau des routers
+myapp/wiring/services.py     # câblage au niveau des services
+myapp/wiring/persistence.py  # câblage des repositories
+myapp/wiring/observability.py
+```
+
+Ou, si le module est légitimement une racine de composition, restreignez sa portée : il ne devrait que *câbler* les parties entre elles, sans en plus implémenter des règles métier, définir des types ou posséder la télémétrie.
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`architecture.validate_responsibility`](../configuration/reference.md#architecture) | `true` | Mettre à `false` pour désactiver cette règle. |
+| [`architecture.max_responsibilities`](../configuration/reference.md#architecture) | `3` | Les modules possédant plus de préoccupations que cela sont signalés. |
+| [`architecture.enabled`](../configuration/reference.md#architecture) | `true` | Interrupteur principal de l'analyse d'architecture. |
+| [`architecture.fail_on_violations`](../configuration/reference.md#architecture) | `false` | Code de sortie non nul en cas de violation. |
+
+## Références
+
+- Inférence des responsabilités et règles de sévérité : `service/responsibility_analysis.go`.
+- Martin, R. C. *Agile Software Development: Principles, Patterns, and Practices*, 2002 (Chapitre 8 — SRP).
+- [Catalogue des règles](index.md) · [low-package-cohesion](low-package-cohesion.md) · [layer-violation](layer-violation.md)

--- a/website/docs/fr/rules/singleton-pattern-dependency.md
+++ b/website/docs/fr/rules/singleton-pattern-dependency.md
@@ -1,0 +1,59 @@
+# singleton-pattern-dependency
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Avertissement  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale une classe qui implémente le patron singleton en se mettant elle-même en cache sur un attribut `_instance` au niveau de la classe.
+
+## Pourquoi est-ce un problème ?
+
+Un singleton est un état global déguisé en classe. Chaque appelant qui écrit `PaymentGateway.instance()` dépend de l'unique objet que la classe choisit de retourner, et cet objet survit entre les tests à moins que chaque test ne pense à le réinitialiser. Un test distrait suffit pour que le suivant hérite d'un état périmé.
+
+Comme le singleton décide lui-même de sa durée de vie, les appelants ne peuvent pas lui fournir différents collaborateurs dans différents contextes — une seconde configuration, un faux pour les tests, une instance par locataire. La substitution exige d'accéder à la classe et de réinitialiser `_instance`, ce qui est exactement le couplage que le singleton était censé cacher.
+
+Le patron occulte également les vraies dépendances : lire le code d'une méthode qui appelle `X.instance()` ne vous dit rien sur ce dont `X` a besoin ou sur l'endroit où il a été configuré.
+
+## Exemple
+
+```python
+class PaymentGateway:
+    _instance = None
+
+    @classmethod
+    def instance(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def charge(self, order):
+        ...
+```
+
+## À utiliser à la place
+
+Construisez l'objet une seule fois en bordure de l'application et passez-le à ce qui en a besoin.
+
+```python
+class PaymentGateway:
+    def charge(self, order):
+        ...
+
+# wiring, done once at startup
+gateway = PaymentGateway()
+order_service = OrderService(gateway)
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Augmentez à `"error"` pour supprimer cette règle. |
+
+## Références
+
+- Détection des dépendances cachées (`internal/analyzer/hidden_dependency_detector.go`).
+- [Catalogue des règles](index.md) · [Dépendance à l'état global](global-state-dependency.md) · [Dépendance à une variable de module](module-variable-dependency.md)

--- a/website/docs/fr/rules/test-credential-in-code.md
+++ b/website/docs/fr/rules/test-credential-in-code.md
@@ -1,0 +1,48 @@
+# test-credential-in-code
+
+**Catégorie** : Données fictives  
+**Sévérité** : Warning  
+**Déclenchée par** : `pyscn check --select mockdata`
+
+## Ce qu'elle fait
+
+Signale les littéraux de chaînes qui ressemblent à des credentials de test évidents : `password123`, `secret123`, `testpassword`, `token0`, `api_key_test`, et autres motifs construits à partir de mots évoquant des identifiants plus des suffixes triviaux.
+
+## Pourquoi est-ce un problème ?
+
+Ce ne sont pas de vrais secrets — c'est précisément le problème. Ce sont les valeurs tapées en mettant en place un client, en écrivant un premier test, ou en remplissant un champ obligatoire. Une fois commités, ils présentent deux modes de défaillance :
+
+- **Embarras / correction** : le littéral est utilisé comme valeur par défaut et est livré aux utilisateurs, si bien que le « mot de passe administrateur par défaut » est vraiment `password123`.
+- **Rotation oubliée** : un vrai secret était censé remplacer le placeholder avant la sortie ; personne n'a remarqué que ce n'était pas fait.
+
+pyscn n'est pas un scanner de sécurité et ne tente pas de détecter les secrets à forte entropie. Cette règle attrape le cas inverse : des credentials à faible entropie, manifestement factices, qui n'auraient jamais dû figurer dans le code source.
+
+## Exemple
+
+```python
+DEFAULT_PASSWORD = "password123"
+```
+
+## À utiliser à la place
+
+Lisez les credentials depuis l'environnement ou un gestionnaire de secrets. Si une valeur par défaut est réellement nécessaire pour le développement local, conservez-la dans un fichier de configuration séparé qui n'est pas chargé en production.
+
+```python
+import os
+
+DEFAULT_PASSWORD = os.environ["APP_DEFAULT_PASSWORD"]
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`mock_data.enabled`](../configuration/reference.md#mock_data) | `false` | Opt-in. |
+| [`mock_data.min_severity`](../configuration/reference.md#mock_data) | `"info"` | Passer à `"warning"` pour ne conserver que les résultats de ce niveau. |
+| [`mock_data.ignore_tests`](../configuration/reference.md#mock_data) | `true` | Ignore les fichiers de test — les credentials de test ont leur place dans les tests. |
+| [`mock_data.ignore_patterns`](../configuration/reference.md#mock_data) | `[]` | Motifs regex confrontés aux chemins de fichiers. |
+
+## Références
+
+- Implémentation : `internal/analyzer/mock_data_detector.go`.
+- [Catalogue des règles](index.md) · [repetitive-string-literal](repetitive-string-literal.md) · [mock-keyword-in-code](mock-keyword-in-code.md)

--- a/website/docs/fr/rules/too-many-constructor-parameters.md
+++ b/website/docs/fr/rules/too-many-constructor-parameters.md
@@ -1,0 +1,68 @@
+# too-many-constructor-parameters
+
+**Catégorie** : Injection de dépendances  
+**Sévérité** : Avertissement  
+**Déclenché par** : `pyscn analyze`, `pyscn check --select di`
+
+## Ce que fait cette règle
+
+Signale une méthode `__init__` dont le nombre de paramètres (en excluant `self`) dépasse `di.constructor_param_threshold` (par défaut `5`).
+
+## Pourquoi est-ce un problème ?
+
+Une signature de constructeur longue est le symptôme d'une classe qui a pris trop de responsabilités. Chaque paramètre est un collaborateur que la classe connaît, et chaque site d'appel doit tous les fournir — y compris les tests, qui finissent par construire des fixtures élaborées juste pour instancier l'objet.
+
+Avec le temps, ajouter une dépendance de plus paraît anodin, donc la liste s'allonge. Les lecteurs perdent de vue ce dont la classe a réellement besoin par rapport à ce qui est accessoire, et réordonner ou ajouter des valeurs par défaut aux paramètres devient risqué.
+
+Lorsque vous voyez plus de cinq dépendances, la classe accomplit généralement deux ou trois tâches qui pourraient être séparées, ou plusieurs paramètres devraient être regroupés en un seul objet.
+
+## Exemple
+
+```python
+class OrderService:
+    def __init__(
+        self,
+        user_repo,
+        order_repo,
+        payment_gateway,
+        inventory,
+        notifier,
+        audit_log,
+        clock,
+    ):
+        self.user_repo = user_repo
+        self.order_repo = order_repo
+        ...
+```
+
+## À utiliser à la place
+
+Regroupez les collaborateurs liés en un objet de paramètres, ou scindez la classe selon ses responsabilités.
+
+```python
+@dataclass
+class OrderDependencies:
+    users: UserRepository
+    orders: OrderRepository
+    payments: PaymentGateway
+    inventory: Inventory
+    notifier: Notifier
+
+class OrderService:
+    def __init__(self, deps: OrderDependencies, clock: Clock):
+        self.deps = deps
+        self.clock = clock
+```
+
+## Options
+
+| Option | Défaut | Description |
+| --- | --- | --- |
+| [`di.enabled`](../configuration/reference.md#di) | `false` | Doit être `true` pour qu'`analyze` exécute les règles DI. `check --select di` l'active implicitement. |
+| [`di.min_severity`](../configuration/reference.md#di) | `"warning"` | Augmentez à `"error"` pour masquer cette règle, ou abaissez à `"info"` pour en faire ressortir davantage. |
+| [`di.constructor_param_threshold`](../configuration/reference.md#di) | `5` | Nombre de paramètres au-dessus duquel `__init__` est signalé. |
+
+## Références
+
+- Détection de sur-injection par constructeur (`internal/analyzer/constructor_analyzer.go`).
+- [Catalogue des règles](index.md) · [Dépendance par instanciation concrète](concrete-instantiation-dependency.md) · [Patron de localisateur de services](service-locator-pattern.md)

--- a/website/docs/fr/rules/unreachable-after-break.md
+++ b/website/docs/fr/rules/unreachable-after-break.md
@@ -1,0 +1,54 @@
+# unreachable-after-break
+
+**Catégorie** : Code inatteignable  
+**Sévérité** : Critique  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les instructions qui apparaissent après une instruction `break` à l'intérieur d'une boucle.
+
+## Pourquoi est-ce un problème ?
+
+`break` quitte immédiatement la boucle englobante. Tout ce qui se trouve après lui dans le même bloc s'exécute zéro fois.
+
+Causes fréquentes :
+
+- **Un incrément ou une mise à jour d'accumulateur mal placés** — l'auteur souhaitait qu'ils s'exécutent à la dernière itération.
+- **Du log ou du nettoyage résiduel** — déplacé sous le `break` lors d'un refactoring.
+- **Une confusion sur le flot de contrôle** — l'auteur pensait que `break` ne sautait qu'une partie de l'itération.
+
+Le code est inatteignable, donc les tests ne peuvent pas le couvrir et les bugs qu'il contient ne se manifesteront jamais.
+
+## Exemple
+
+```python
+for user in users:
+    if user.id == target_id:
+        break
+        user.last_seen = now()   # ← ne s'exécute jamais
+```
+
+## À utiliser à la place
+
+Effectuez le travail avant le `break`, ou supprimez l'instruction morte.
+
+```python
+for user in users:
+    if user.id == target_id:
+        user.last_seen = now()
+        break
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`dead_code.detect_after_break`](../configuration/reference.md#dead_code) | `true` | Mettez à `false` pour désactiver cette règle. |
+| [`dead_code.min_severity`](../configuration/reference.md#dead_code) | `"warning"` | `"critical"` ne conserve que ce type de constat ; `"info"` en remonte davantage. |
+| [`dead_code.ignore_patterns`](../configuration/reference.md#dead_code) | `[]` | Expressions régulières comparées à la ligne source ; les correspondances sont supprimées. |
+
+## Références
+
+- Analyse d'accessibilité sur le graphe de flot de contrôle (`internal/analyzer/dead_code.go`).
+- [Catalogue des règles](index.md) · [Code inatteignable après continue](unreachable-after-continue.md) · [Code inatteignable après return](unreachable-after-return.md)

--- a/website/docs/fr/rules/unreachable-after-continue.md
+++ b/website/docs/fr/rules/unreachable-after-continue.md
@@ -1,0 +1,56 @@
+# unreachable-after-continue
+
+**Catégorie** : Code inatteignable  
+**Sévérité** : Critique  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les instructions qui apparaissent après une instruction `continue` à l'intérieur d'une boucle.
+
+## Pourquoi est-ce un problème ?
+
+`continue` saute directement à l'itération suivante. Toute instruction qui le suit dans le même bloc est ignorée à chaque itération, donc elle s'exécute zéro fois.
+
+Causes typiques :
+
+- **Logique réordonnée** — une garde a été convertie en `continue` et le travail qui suivait a été laissé en place.
+- **Un effet de bord mal placé** — des mises à jour de compteur ou des logs qui auraient dû s'exécuter avant le saut.
+- **Sémantique mal comprise** — l'auteur s'attendait à ce que `continue` se comporte comme `pass`.
+
+Comme l'instruction est inatteignable, les tests ne peuvent pas la couvrir et le comportement voulu ne se produit jamais en silence.
+
+## Exemple
+
+```python
+for order in orders:
+    if order.status == "cancelled":
+        continue
+        metrics.record_skip(order.id)   # ← ne s'exécute jamais
+    process(order)
+```
+
+## À utiliser à la place
+
+Exécutez l'instruction avant `continue`, ou supprimez-la.
+
+```python
+for order in orders:
+    if order.status == "cancelled":
+        metrics.record_skip(order.id)
+        continue
+    process(order)
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`dead_code.detect_after_continue`](../configuration/reference.md#dead_code) | `true` | Mettez à `false` pour désactiver cette règle. |
+| [`dead_code.min_severity`](../configuration/reference.md#dead_code) | `"warning"` | `"critical"` ne conserve que ce type de constat ; `"info"` en remonte davantage. |
+| [`dead_code.ignore_patterns`](../configuration/reference.md#dead_code) | `[]` | Expressions régulières comparées à la ligne source ; les correspondances sont supprimées. |
+
+## Références
+
+- Analyse d'accessibilité sur le graphe de flot de contrôle (`internal/analyzer/dead_code.go`).
+- [Catalogue des règles](index.md) · [Code inatteignable après break](unreachable-after-break.md) · [Code inatteignable après return](unreachable-after-return.md)

--- a/website/docs/fr/rules/unreachable-after-infinite-loop.md
+++ b/website/docs/fr/rules/unreachable-after-infinite-loop.md
@@ -1,0 +1,56 @@
+# unreachable-after-infinite-loop
+
+**Catégorie** : Code inatteignable  
+**Sévérité** : Avertissement  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les instructions qui suivent une boucle sans sortie atteignable, comme un `while True:` sans `break` ni `return`.
+
+## Pourquoi est-ce un problème ?
+
+Si une boucle n'a aucun chemin de sortie, l'exécution ne dépasse jamais ce point. Tout ce qui est écrit après la boucle est mort.
+
+Il s'agit généralement de l'un des cas suivants :
+
+- **Une condition de sortie oubliée** — la boucle était censée se terminer mais le `break` a été perdu lors d'un refactoring.
+- **Un nettoyage mal placé** — du code d'arrêt ou de libération situé après une boucle de worker qui ne retourne jamais.
+- **Une erreur de copier-coller** — de la logique post-boucle laissée par une version antérieure de la fonction.
+
+Le lecteur s'attend à ce que le code qui suit finisse par s'exécuter. Ce n'est pas le cas.
+
+## Exemple
+
+```python
+def run_worker(queue):
+    while True:
+        job = queue.get()
+        job.run()
+    queue.close()   # ← ne s'exécute jamais
+```
+
+## À utiliser à la place
+
+Donnez à la boucle une sortie atteignable, ou supprimez la suite inatteignable.
+
+```python
+def run_worker(queue):
+    while not queue.closed:
+        job = queue.get()
+        job.run()
+    queue.close()
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`dead_code.enabled`](../configuration/reference.md#dead_code) | `true` | Cette règle n'a pas d'interrupteur dédié ; elle est contrôlée par `dead_code.enabled` et l'analyse CFG. |
+| [`dead_code.min_severity`](../configuration/reference.md#dead_code) | `"warning"` | Passez à `"critical"` pour masquer ces constats ; abaissez à `"info"` pour en remonter davantage. |
+| [`dead_code.ignore_patterns`](../configuration/reference.md#dead_code) | `[]` | Expressions régulières comparées à la ligne source ; les correspondances sont supprimées. |
+
+## Références
+
+- Analyse d'accessibilité sur le graphe de flot de contrôle (`internal/analyzer/dead_code.go`).
+- [Catalogue des règles](index.md) · [Code inatteignable après return](unreachable-after-return.md) · [Branche inatteignable](unreachable-branch.md)

--- a/website/docs/fr/rules/unreachable-after-raise.md
+++ b/website/docs/fr/rules/unreachable-after-raise.md
@@ -1,0 +1,55 @@
+# unreachable-after-raise
+
+**Catégorie** : Code inatteignable  
+**Sévérité** : Critique  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les instructions qui apparaissent après une instruction `raise` dans le même bloc de code.
+
+## Pourquoi est-ce un problème ?
+
+Un `raise` déroule la pile de manière inconditionnelle. Toute instruction qui le suit dans le même bloc n'est jamais exécutée.
+
+Cela indique généralement :
+
+- **Un nettoyage obsolète** — du code qui était censé s'exécuter avant que l'exception soit levée.
+- **Un artefact de refactoring** — le `raise` a remplacé une branche antérieure et les lignes voisines ont été laissées en place.
+- **Un bug de logique** — l'auteur supposait que l'exécution se poursuivrait au-delà du `raise`.
+
+Le code mort après `raise` ne sera jamais exercé par les tests et ne se manifestera jamais en production, donc tout bug qu'il dissimule reste silencieux.
+
+## Exemple
+
+```python
+def withdraw(account, amount):
+    if amount > account.balance:
+        raise InsufficientFunds(account.id)
+        account.balance -= amount   # ← ne s'exécute jamais
+    account.balance -= amount
+```
+
+## À utiliser à la place
+
+Déplacez l'instruction au-dessus du `raise`, ou supprimez-la.
+
+```python
+def withdraw(account, amount):
+    if amount > account.balance:
+        raise InsufficientFunds(account.id)
+    account.balance -= amount
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`dead_code.detect_after_raise`](../configuration/reference.md#dead_code) | `true` | Mettez à `false` pour désactiver cette règle. |
+| [`dead_code.min_severity`](../configuration/reference.md#dead_code) | `"warning"` | `"critical"` ne conserve que ce type de constat ; `"info"` en remonte davantage. |
+| [`dead_code.ignore_patterns`](../configuration/reference.md#dead_code) | `[]` | Expressions régulières comparées à la ligne source ; les correspondances sont supprimées. |
+
+## Références
+
+- Analyse d'accessibilité sur le graphe de flot de contrôle (`internal/analyzer/dead_code.go`).
+- [Catalogue des règles](index.md) · [Code inatteignable après return](unreachable-after-return.md) · [Branche inatteignable](unreachable-branch.md)

--- a/website/docs/fr/rules/unreachable-after-return.md
+++ b/website/docs/fr/rules/unreachable-after-return.md
@@ -1,0 +1,54 @@
+# unreachable-after-return
+
+**Catégorie** : Code inatteignable  
+**Sévérité** : Critique  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale les instructions qui apparaissent après une instruction `return` dans le même bloc de code.
+
+## Pourquoi est-ce un problème ?
+
+Le code placé après `return` ne s'exécute jamais. Il s'agit généralement de l'un des cas suivants :
+
+- **Un reliquat de refactoring** — le `return` a été remonté et le code en dessous a été oublié.
+- **Un bug** — le développeur s'attendait à ce que le code s'exécute, mais une modification du flot de contrôle l'a rendu inatteignable.
+- **Un nettoyage mal placé** — quelque chose qui aurait dû s'exécuter avant le retour.
+
+Dans tous les cas, le code est mort : il consomme du temps de lecture, il n'est pas couvert par les tests (parce qu'il ne peut pas l'être), et s'il dissimule un bug, ce bug ne sera jamais signalé par le comportement des utilisateurs.
+
+## Exemple
+
+```python
+def charge(order):
+    if order.total <= 0:
+        return None
+        log.debug("zero-value charge")   # ← ne s'exécute jamais
+    ...
+```
+
+## À utiliser à la place
+
+Déplacez l'instruction au-dessus du `return`, ou supprimez-la si elle n'est plus nécessaire.
+
+```python
+def charge(order):
+    if order.total <= 0:
+        log.debug("zero-value charge")
+        return None
+    ...
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`dead_code.detect_after_return`](../configuration/reference.md#dead_code) | `true` | Mettez à `false` pour désactiver cette règle. |
+| [`dead_code.min_severity`](../configuration/reference.md#dead_code) | `"warning"` | `"critical"` ne conserve que ce type de constat ; `"info"` en remonte davantage. |
+| [`dead_code.ignore_patterns`](../configuration/reference.md#dead_code) | `[]` | Expressions régulières comparées à la ligne source ; les correspondances sont supprimées. |
+
+## Références
+
+- Analyse d'accessibilité sur le graphe de flot de contrôle (`internal/analyzer/dead_code.go`).
+- [Catalogue des règles](index.md) · [Branche inatteignable](unreachable-branch.md) · [Code inatteignable après raise](unreachable-after-raise.md)

--- a/website/docs/fr/rules/unreachable-branch.md
+++ b/website/docs/fr/rules/unreachable-branch.md
@@ -1,0 +1,60 @@
+# unreachable-branch
+
+**Catégorie** : Code inatteignable  
+**Sévérité** : Avertissement  
+**Déclenchée par** : `pyscn analyze`, `pyscn check`
+
+## Ce que fait cette règle
+
+Signale une branche `if`, `elif` ou `else` qui ne peut pas être empruntée parce que toutes les branches précédentes se terminent par `return`, `raise`, `break` ou `continue`.
+
+## Pourquoi est-ce un problème ?
+
+Lorsque chaque branche antérieure quitte déjà la fonction ou la boucle, la branche restante est logiquement morte. La garde semble pourtant pertinente pour le lecteur, ce qui masque le véritable flot de contrôle.
+
+Cela indique généralement :
+
+- **Des conditions redondantes** — le `else` n'existe que parce que le `if` avait l'habitude de retomber.
+- **Un bug subtil** — l'auteur s'attendait à ce que la branche ultérieure s'exécute dans certains cas, mais les sorties précédentes la rendent impossible.
+- **Du code défensif obsolète** — un repli qui ne peut plus être atteint.
+
+Les tests ne peuvent pas couvrir la branche, et les relecteurs perdent du temps à raisonner sur un chemin qui ne s'exécute jamais.
+
+## Exemple
+
+```python
+def classify(payment):
+    if payment.amount < 0:
+        raise ValueError("negative amount")
+    elif payment.amount == 0:
+        return "empty"
+    else:
+        return "normal"
+    return "unknown"   # ← branche inatteignable
+```
+
+## À utiliser à la place
+
+Supprimez la branche morte, ou restructurez les branches précédentes pour que le repli soit réellement atteignable.
+
+```python
+def classify(payment):
+    if payment.amount < 0:
+        raise ValueError("negative amount")
+    if payment.amount == 0:
+        return "empty"
+    return "normal"
+```
+
+## Options
+
+| Option | Valeur par défaut | Description |
+| --- | --- | --- |
+| [`dead_code.detect_unreachable_branches`](../configuration/reference.md#dead_code) | `true` | Mettez à `false` pour désactiver cette règle. |
+| [`dead_code.min_severity`](../configuration/reference.md#dead_code) | `"warning"` | Passez à `"critical"` pour masquer ces constats ; abaissez à `"info"` pour en remonter davantage. |
+| [`dead_code.ignore_patterns`](../configuration/reference.md#dead_code) | `[]` | Expressions régulières comparées à la ligne source ; les correspondances sont supprimées. |
+
+## Références
+
+- Analyse d'accessibilité sur le graphe de flot de contrôle (`internal/analyzer/dead_code.go`).
+- [Catalogue des règles](index.md) · [Code inatteignable après return](unreachable-after-return.md) · [Code inatteignable après raise](unreachable-after-raise.md)

--- a/website/docs/ja/configuration/examples.md
+++ b/website/docs/ja/configuration/examples.md
@@ -15,7 +15,7 @@ max_complexity = 15
 min_severity = "critical"
 ```
 
-## 厳格な CI ゲート
+## 厳格な CI ゲート { #strict-ci-gate }
 
 品質低下があればビルドを失敗させます。`pyscn check` と組み合わせて使用します。
 

--- a/website/docs/ja/output/schemas.md
+++ b/website/docs/ja/output/schemas.md
@@ -45,12 +45,12 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `system`      | object \| absent  | 依存関係またはアーキテクチャ分析が実行された場合に存在します。 | stable    |
 | `mock_data`   | object \| absent  | モックデータ検出が実行された場合に存在します。         | stable    |
 | `suggestions` | array \| absent   | 導出された提案。空の場合は省略されます。               | stable    |
-| `summary`     | object            | 常に存在します。[`summary`](#summary-オブジェクト) を参照してください。 | stable    |
+| `summary`     | object            | 常に存在します。[`summary`](#summary-object) を参照してください。 | stable    |
 | `generated_at`| string (RFC 3339) | 分析完了時刻。                                         | stable    |
 | `duration_ms` | integer           | 分析の合計所要時間（ミリ秒）。                         | stable    |
 | `version`     | string            | pyscn のセマンティックバージョン。                     | stable    |
 
-## `summary` オブジェクト
+## `summary` オブジェクト { #summary-object }
 
 `domain.AnalyzeSummary` に対応します。対応するアナライザが無効の場合、すべての数値カウンタはデフォルト値 `0` になります。すべてのフィールドは常に存在します。
 
@@ -184,10 +184,10 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `StartLine`   | integer | 1始まりの開始行。                                            |
 | `StartColumn` | integer | 0始まりの開始列。                                            |
 | `EndLine`     | integer | 1始まりの終了行。                                            |
-| `Metrics`     | object  | [`ComplexityMetrics`](#complexitymetrics-オブジェクト) を参照。 |
+| `Metrics`     | object  | [`ComplexityMetrics`](#complexitymetrics-object) を参照。 |
 | `RiskLevel`   | string  | `low`、`medium`、`high` のいずれか。                         |
 
-### `ComplexityMetrics` オブジェクト
+### `ComplexityMetrics` オブジェクト { #complexitymetrics-object }
 
 | フィールド             | 型      | 説明                                               |
 | --------------------- | ------- | -------------------------------------------------- |
@@ -274,7 +274,7 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 
 | フィールド       | 型      | 説明                                                          |
 | --------------- | ------- | ------------------------------------------------------------- |
-| `location`      | object  | [`DeadCodeLocation`](#deadcodelocation-オブジェクト) を参照。 |
+| `location`      | object  | [`DeadCodeLocation`](#deadcodelocation-object) を参照。 |
 | `function_name` | string  | 包含する関数名。                                              |
 | `code`          | string  | デッドコードのソースコード断片。                              |
 | `reason`        | string  | 分類 — 下記の列挙を参照。                                    |
@@ -293,7 +293,7 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `after_raise`         | `raise` 文の後のコード。                     |
 | `unreachable_branch`  | 到達されない条件分岐。                       |
 
-### `DeadCodeLocation` オブジェクト
+### `DeadCodeLocation` オブジェクト { #deadcodelocation-object }
 
 | フィールド      | 型      | 説明                       |
 | -------------- | ------- | -------------------------- |
@@ -342,7 +342,7 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | ------------ | ------- | ------------------------------------------------------------ |
 | `id`         | integer | レスポンス内で一意のクローン識別子。                         |
 | `type`       | integer | 整数値のクローンタイプ: `1`、`2`、`3`、または `4`。          |
-| `location`   | object  | [`CloneLocation`](#clonelocation-オブジェクト) を参照。      |
+| `location`   | object  | [`CloneLocation`](#clonelocation-object) を参照。      |
 | `content`    | string  | 生のソーステキスト。`--show-content` 設定時のみ存在。        |
 | `hash`       | string  | フィンガープリントハッシュ（アルゴリズムはクローンタイプに依存）。 |
 | `size`       | integer | AST ノード数。                                               |
@@ -358,7 +358,7 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `3`   | Type-3: 変更を伴う構造的類似。                                       |
 | `4`   | Type-4: 意味的に等価、構文的に異なる。                               |
 
-### `CloneLocation` オブジェクト
+### `CloneLocation` オブジェクト { #clonelocation-object }
 
 | フィールド    | 型      | 説明                     |
 | ------------ | ------- | ------------------------ |
@@ -436,12 +436,12 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `FilePath`    | string  | ソースファイルのパス。                      |
 | `StartLine`   | integer | 1始まりの開始行。                           |
 | `EndLine`     | integer | 1始まりの終了行。                           |
-| `Metrics`     | object  | [`CBOMetrics`](#cbometrics-オブジェクト) を参照。 |
+| `Metrics`     | object  | [`CBOMetrics`](#cbometrics-object) を参照。 |
 | `RiskLevel`   | string  | `low`、`medium`、`high` のいずれか。        |
 | `IsAbstract`  | boolean | クラスが抽象クラスの場合に `true`。         |
 | `BaseClasses` | array of string \| null | 直接の基底クラス。          |
 
-### `CBOMetrics` オブジェクト
+### `CBOMetrics` オブジェクト { #cbometrics-object }
 
 | フィールド                     | 型      | 説明                                                      |
 | ----------------------------- | ------- | --------------------------------------------------------- |
@@ -494,10 +494,10 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | `FilePath`  | string  | ソースファイルのパス。                           |
 | `StartLine` | integer | 1始まりの開始行。                                |
 | `EndLine`   | integer | 1始まりの終了行。                                |
-| `Metrics`   | object  | [`LCOMMetrics`](#lcommetrics-オブジェクト) を参照。 |
+| `Metrics`   | object  | [`LCOMMetrics`](#lcommetrics-object) を参照。 |
 | `RiskLevel` | string  | `low`、`medium`、`high` のいずれか。             |
 
-### `LCOMMetrics` オブジェクト
+### `LCOMMetrics` オブジェクト { #lcommetrics-object }
 
 | フィールド           | 型      | 説明                                                        |
 | ------------------- | ------- | ----------------------------------------------------------- |

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -50,7 +50,7 @@ JSON and YAML outputs serialize the `AnalyzeResponse` Go struct defined in `doma
 | `duration_ms` | integer           | Total analysis duration in milliseconds.               | stable    |
 | `version`     | string            | pyscn semantic version.                                | stable    |
 
-## `summary` object
+## `summary` object { #summary-object }
 
 Mirrors `domain.AnalyzeSummary`. All numeric counters default to `0` when the corresponding analyzer is disabled. All fields are always present.
 
@@ -187,7 +187,7 @@ Mirrors `domain.ComplexityResponse`. Nested field names are Go PascalCase.
 | `Metrics`     | object  | See [`ComplexityMetrics`](#complexitymetrics-object).        |
 | `RiskLevel`   | string  | One of: `low`, `medium`, `high`.                             |
 
-### `ComplexityMetrics` object
+### `ComplexityMetrics` object { #complexitymetrics-object }
 
 | Field                 | Type    | Description                                        |
 | --------------------- | ------- | -------------------------------------------------- |
@@ -293,7 +293,7 @@ Mirrors `domain.DeadCodeResponse`. Uses snake_case field names throughout.
 | `after_raise`         | Code following a `raise` statement.          |
 | `unreachable_branch`  | Conditional branch that is never taken.      |
 
-### `DeadCodeLocation` object
+### `DeadCodeLocation` object { #deadcodelocation-object }
 
 | Field          | Type    | Description                |
 | -------------- | ------- | -------------------------- |
@@ -358,7 +358,7 @@ Mirrors `domain.CloneResponse`. Uses snake_case field names throughout.
 | `3`   | Type-3: structurally similar with modifications.                     |
 | `4`   | Type-4: semantically equivalent, syntactically different.            |
 
-### `CloneLocation` object
+### `CloneLocation` object { #clonelocation-object }
 
 | Field        | Type    | Description              |
 | ------------ | ------- | ------------------------ |
@@ -441,7 +441,7 @@ Mirrors `domain.CBOResponse`. Nested field names are Go PascalCase.
 | `IsAbstract`  | boolean | `true` if the class is abstract.            |
 | `BaseClasses` | array of string \| null | Direct base classes.        |
 
-### `CBOMetrics` object
+### `CBOMetrics` object { #cbometrics-object }
 
 | Field                         | Type    | Description                                               |
 | ----------------------------- | ------- | --------------------------------------------------------- |
@@ -497,7 +497,7 @@ Mirrors `domain.LCOMResponse`. Nested field names are Go PascalCase.
 | `Metrics`   | object  | See [`LCOMMetrics`](#lcommetrics-object).        |
 | `RiskLevel` | string  | One of: `low`, `medium`, `high`.                 |
 
-### `LCOMMetrics` object
+### `LCOMMetrics` object { #lcommetrics-object }
 
 | Field               | Type    | Description                                                 |
 | ------------------- | ------- | ----------------------------------------------------------- |

--- a/website/docs/zh/output/schemas.md
+++ b/website/docs/zh/output/schemas.md
@@ -50,7 +50,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `duration_ms` | integer           | 总分析耗时（毫秒）。                                   | 稳定      |
 | `version`     | string            | pyscn 语义版本号。                                     | 稳定      |
 
-## `summary` 对象
+## `summary` 对象 { #summary-object }
 
 对应 `domain.AnalyzeSummary`。当对应分析器未启用时，所有数值计数器默认为 `0`。所有字段始终存在。
 
@@ -187,7 +187,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `Metrics`     | object  | 见 [`ComplexityMetrics`](#complexitymetrics-object)。|
 | `RiskLevel`   | string  | 取值：`low`、`medium`、`high`。                      |
 
-### `ComplexityMetrics` 对象
+### `ComplexityMetrics` 对象 { #complexitymetrics-object }
 
 | 字段                  | 类型    | 说明                                       |
 | --------------------- | ------- | ------------------------------------------ |
@@ -293,7 +293,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `after_raise`         | `raise` 语句之后的代码。                     |
 | `unreachable_branch`  | 永远不会执行的条件分支。                     |
 
-### `DeadCodeLocation` 对象
+### `DeadCodeLocation` 对象 { #deadcodelocation-object }
 
 | 字段           | 类型    | 说明               |
 | -------------- | ------- | ------------------ |
@@ -358,7 +358,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `3`   | Type-3：结构相似但有修改。                                   |
 | `4`   | Type-4：语义等价，语法不同。                                 |
 
-### `CloneLocation` 对象
+### `CloneLocation` 对象 { #clonelocation-object }
 
 | 字段         | 类型    | 说明               |
 | ------------ | ------- | ------------------ |
@@ -441,7 +441,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `IsAbstract`  | boolean | 抽象类时为 `true`。                 |
 | `BaseClasses` | array of string \| null | 直接基类。          |
 
-### `CBOMetrics` 对象
+### `CBOMetrics` 对象 { #cbometrics-object }
 
 | 字段                          | 类型    | 说明                                              |
 | ----------------------------- | ------- | ------------------------------------------------- |
@@ -497,7 +497,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | `Metrics`   | object  | 见 [`LCOMMetrics`](#lcommetrics-object)。|
 | `RiskLevel` | string  | 取值：`low`、`medium`、`high`。          |
 
-### `LCOMMetrics` 对象
+### `LCOMMetrics` 对象 { #lcommetrics-object }
 
 | 字段                | 类型    | 说明                                                |
 | ------------------- | ------- | --------------------------------------------------- |

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -130,6 +130,38 @@ plugins:
             Integrations: 集成
             Python Packaging: Python 打包
             FAQ: 常见问题
+        - locale: fr
+          name: Français
+          build: true
+          site_name: pyscn
+          nav_translations:
+            Home: Accueil
+            Getting Started: Démarrage
+            Installation: Installation
+            Quick Start: Démarrage rapide
+            Rules: Règles
+            Overview: Vue d'ensemble
+            Unreachable Code: Code inatteignable
+            Duplicate Code: Code dupliqué
+            Complexity: Complexité
+            Class Design: Conception de classe
+            Dependency Injection: Injection de dépendances
+            Module Structure: Structure des modules
+            Mock Data: Données fictives
+            CLI Reference: Référence CLI
+            Configuration: Configuration
+            Config File Format: Format du fichier de configuration
+            Reference: Référence
+            Examples: Exemples
+            Output Formats: Formats de sortie
+            HTML Report: Rapport HTML
+            Schemas: Schémas
+            Health Score: Score de santé
+            Integrations: Intégrations
+            CI/CD: CI/CD
+            MCP: MCP
+            Python Packaging: Packaging Python
+            FAQ: FAQ
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
## Summary
- Add French (fr) locale to the docs site, mirroring en/ja/zh — 55 pages translated under `website/docs/fr/`
- Register `fr` in `mkdocs.yml` (`mkdocs-static-i18n`) with nav translations
- Stabilize a few in-page anchors that broke once headings were translated: added explicit `{#strict-ci-gate}` and `{#*-object}` ids and pointed ja/fr links at the ASCII anchors

## Test plan
- [x] `mkdocs build --strict` passes with no anchor warnings across en/ja/zh/fr
- [ ] Spot-check `/fr/` pages in the rendered site (nav labels, in-page anchor links)
- [ ] Native French review pass for terminology consistency (follow-up welcome)