### PR TITLE
Fix CBO dependency identity

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -73,6 +74,36 @@ type CBOAnalyzer struct {
 	regexCache       map[string]*regexp.Regexp // pattern -> compiled regex cache
 }
 
+type cboDependencyKind int
+
+const (
+	dependencyKindInheritance cboDependencyKind = iota
+	dependencyKindTypeHint
+	dependencyKindInstantiation
+	dependencyKindAttributeAccess
+	dependencyKindImport
+)
+
+type cboDependencies struct {
+	all               map[string]bool
+	inheritance       map[string]bool
+	typeHints         map[string]bool
+	instantiations    map[string]bool
+	attributeAccesses map[string]bool
+	imports           map[string]bool
+}
+
+func newCBODependencies() *cboDependencies {
+	return &cboDependencies{
+		all:               make(map[string]bool),
+		inheritance:       make(map[string]bool),
+		typeHints:         make(map[string]bool),
+		instantiations:    make(map[string]bool),
+		attributeAccesses: make(map[string]bool),
+		imports:           make(map[string]bool),
+	}
+}
+
 // NewCBOAnalyzer creates a new CBO analyzer
 func NewCBOAnalyzer(options *CBOOptions) *CBOAnalyzer {
 	if options == nil {
@@ -104,10 +135,9 @@ func (a *CBOAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*CBOR
 	classes := a.collectClasses(ast)
 	imports := a.collectImports(ast)
 
-	// Update imported names mapping
-	for alias, module := range imports {
-		a.importedNames[alias] = module
-	}
+	// Import aliases are file-local. Reset the map on each AST so one analyzed file
+	// cannot change dependency identity in the next file.
+	a.importedNames = imports
 
 	var results []*CBOResult
 
@@ -145,8 +175,7 @@ func (a *CBOAnalyzer) analyzeClass(classNode *parser.Node, filePath string, allC
 		Attributes:       []string{},
 	}
 
-	// Track unique dependencies
-	dependencies := make(map[string]bool)
+	dependencies := newCBODependencies()
 
 	// 1. Analyze inheritance dependencies
 	a.analyzeInheritance(classNode, dependencies, result)
@@ -158,8 +187,13 @@ func (a *CBOAnalyzer) analyzeClass(classNode *parser.Node, filePath string, allC
 	a.analyzeInstantiationAndAccess(classNode, dependencies, result, allClasses)
 
 	// 4. Calculate final metrics
-	result.CouplingCount = len(dependencies)
-	result.DependentClasses = a.mapToSlice(dependencies)
+	result.CouplingCount = len(dependencies.all)
+	result.DependentClasses = a.mapToSlice(dependencies.all)
+	result.InheritanceDependencies = len(dependencies.inheritance)
+	result.TypeHintDependencies = len(dependencies.typeHints)
+	result.InstantiationDependencies = len(dependencies.instantiations)
+	result.AttributeAccessDependencies = len(dependencies.attributeAccesses)
+	result.ImportDependencies = len(dependencies.imports)
 	result.RiskLevel = a.assessRiskLevel(result.CouplingCount)
 
 	// 5. Check if class is abstract
@@ -169,27 +203,23 @@ func (a *CBOAnalyzer) analyzeClass(classNode *parser.Node, filePath string, allC
 }
 
 // analyzeInheritance analyzes inheritance-based coupling
-func (a *CBOAnalyzer) analyzeInheritance(classNode *parser.Node, dependencies map[string]bool, result *CBOResult) {
+func (a *CBOAnalyzer) analyzeInheritance(classNode *parser.Node, dependencies *cboDependencies, result *CBOResult) {
 	// Analyze base classes from Bases field
 	for _, baseNode := range classNode.Bases {
 		if baseNode != nil {
 			baseName := a.extractClassName(baseNode)
-			if baseName != "" && a.shouldIncludeDependency(baseName) {
-				dependencies[baseName] = true
+			if baseName != "" {
 				result.BaseClasses = append(result.BaseClasses, baseName)
-				// Check if this is an imported dependency
-				if a.isImportedDependency(baseName) {
-					result.ImportDependencies++
-				} else {
-					result.InheritanceDependencies++
-				}
+			}
+			if baseName != "" && a.shouldIncludeDependencyForClass(baseName, result.ClassName) {
+				a.addDependency(dependencies, baseName, dependencyKindInheritance)
 			}
 		}
 	}
 }
 
 // analyzeTypeHints analyzes type annotation dependencies
-func (a *CBOAnalyzer) analyzeTypeHints(classNode *parser.Node, dependencies map[string]bool, result *CBOResult) {
+func (a *CBOAnalyzer) analyzeTypeHints(classNode *parser.Node, dependencies *cboDependencies, result *CBOResult) {
 	// Walk through class body looking for type annotations
 	a.walkNode(classNode, func(node *parser.Node) bool {
 		switch node.Type {
@@ -221,18 +251,12 @@ func (a *CBOAnalyzer) isTypeAnnotation(node *parser.Node) bool {
 }
 
 // extractTypeAnnotationDependencies extracts class dependencies from type annotations
-func (a *CBOAnalyzer) extractTypeAnnotationDependencies(node *parser.Node, dependencies map[string]bool, result *CBOResult) {
+func (a *CBOAnalyzer) extractTypeAnnotationDependencies(node *parser.Node, dependencies *cboDependencies, result *CBOResult) {
 	switch node.Type {
 	case parser.NodeName:
 		// Simple type: User
-		if node.Name != "" && a.shouldIncludeDependency(node.Name) {
-			dependencies[node.Name] = true
-			// Check if this is an imported dependency
-			if a.isImportedDependency(node.Name) {
-				result.ImportDependencies++
-			} else {
-				result.TypeHintDependencies++
-			}
+		if node.Name != "" && a.shouldIncludeDependencyForClass(node.Name, result.ClassName) {
+			a.addDependency(dependencies, node.Name, dependencyKindTypeHint)
 		}
 	case parser.NodeSubscript:
 		// Generic type: List[User], Dict[str, User]
@@ -245,14 +269,8 @@ func (a *CBOAnalyzer) extractTypeAnnotationDependencies(node *parser.Node, depen
 	case parser.NodeAttribute:
 		// Module.Type: typing.List, mymodule.MyClass
 		typeName := a.extractClassName(node)
-		if typeName != "" && a.shouldIncludeDependency(typeName) {
-			dependencies[typeName] = true
-			// Check if this is an imported dependency
-			if a.isImportedDependency(typeName) {
-				result.ImportDependencies++
-			} else {
-				result.TypeHintDependencies++
-			}
+		if typeName != "" && a.shouldIncludeDependencyForClass(typeName, result.ClassName) {
+			a.addDependency(dependencies, typeName, dependencyKindTypeHint)
 		}
 	case parser.NodeTypeNode:
 		// Tree-sitter 'type' node - recurse into children
@@ -291,7 +309,7 @@ func (a *CBOAnalyzer) extractTypeAnnotationDependencies(node *parser.Node, depen
 }
 
 // analyzeMethodTypeHints analyzes type hints in method signatures
-func (a *CBOAnalyzer) analyzeMethodTypeHints(methodNode *parser.Node, dependencies map[string]bool, result *CBOResult) {
+func (a *CBOAnalyzer) analyzeMethodTypeHints(methodNode *parser.Node, dependencies *cboDependencies, result *CBOResult) {
 	if methodNode.Name != "" {
 		result.Methods = append(result.Methods, methodNode.Name)
 	}
@@ -316,7 +334,7 @@ func (a *CBOAnalyzer) analyzeMethodTypeHints(methodNode *parser.Node, dependenci
 }
 
 // analyzeInstantiationAndAccess analyzes object instantiation and attribute access
-func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, dependencies map[string]bool, result *CBOResult, allClasses map[string]*parser.Node) {
+func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, dependencies *cboDependencies, result *CBOResult, allClasses map[string]*parser.Node) {
 	a.walkNode(classNode, func(node *parser.Node) bool {
 		switch node.Type {
 		case parser.NodeAssign:
@@ -326,19 +344,15 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 				if valueNode, ok := node.Value.(*parser.Node); ok {
 					if valueNode.Type == parser.NodeCall {
 						className := a.extractClassNameFromCallNode(valueNode)
-						if className != "" && a.shouldIncludeDependency(className) {
-							// Check if this is an imported dependency
+						if className != "" && a.shouldIncludeDependencyForClass(className, result.ClassName) {
 							if a.isImportedDependency(className) {
-								dependencies[className] = true
-								result.ImportDependencies++
+								a.addDependency(dependencies, className, dependencyKindImport)
 							} else if _, isClass := allClasses[className]; isClass {
 								// Known local class (instantiation)
-								dependencies[className] = true
-								result.InstantiationDependencies++
+								a.addDependency(dependencies, className, dependencyKindInstantiation)
 							} else if a.options.IncludeBuiltins && a.builtinTypes[className] {
 								// Builtin type (only if explicitly enabled)
-								dependencies[className] = true
-								result.InstantiationDependencies++
+								a.addDependency(dependencies, className, dependencyKindInstantiation)
 							}
 							// Note: function calls are NOT added to dependencies
 						}
@@ -349,19 +363,15 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 			// Function/class call - could be instantiation
 			// Use structural AST analysis instead of string parsing
 			className := a.extractClassNameFromCallNode(node)
-			if className != "" && a.shouldIncludeDependency(className) {
-				// Check if this is an imported dependency
+			if className != "" && a.shouldIncludeDependencyForClass(className, result.ClassName) {
 				if a.isImportedDependency(className) {
-					dependencies[className] = true
-					result.ImportDependencies++
+					a.addDependency(dependencies, className, dependencyKindImport)
 				} else if _, isClass := allClasses[className]; isClass {
 					// Known local class (instantiation)
-					dependencies[className] = true
-					result.InstantiationDependencies++
+					a.addDependency(dependencies, className, dependencyKindInstantiation)
 				} else if a.options.IncludeBuiltins && a.builtinTypes[className] {
 					// Builtin type (only if explicitly enabled)
-					dependencies[className] = true
-					result.InstantiationDependencies++
+					a.addDependency(dependencies, className, dependencyKindInstantiation)
 				}
 				// Note: function calls are NOT added to dependencies
 			}
@@ -369,13 +379,11 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 			// Attribute access: obj.method() or obj.attr
 			if objNode := node.Left; objNode != nil {
 				objType := a.inferObjectType(objNode)
-				if objType != "" && a.shouldIncludeDependency(objType) {
-					dependencies[objType] = true
-					// Check if this is an imported dependency
+				if objType != "" && a.shouldIncludeDependencyForClass(objType, result.ClassName) {
 					if a.isImportedDependency(objType) {
-						result.ImportDependencies++
+						a.addDependency(dependencies, objType, dependencyKindImport)
 					} else {
-						result.AttributeAccessDependencies++
+						a.addDependency(dependencies, objType, dependencyKindAttributeAccess)
 					}
 				}
 			}
@@ -513,6 +521,101 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 	}
 
 	return true
+}
+
+func (a *CBOAnalyzer) shouldIncludeDependencyForClass(className, ownerClass string) bool {
+	if !a.shouldIncludeDependency(className) {
+		return false
+	}
+	if ownerClass != "" && a.sameDependencyIdentity(className, ownerClass) {
+		return false
+	}
+	return !a.isStandardLibraryDependency(className)
+}
+
+func (a *CBOAnalyzer) addDependency(dependencies *cboDependencies, className string, kind cboDependencyKind) {
+	if dependencies == nil || className == "" {
+		return
+	}
+
+	dependencies.all[className] = true
+
+	if a.isImportedDependency(className) {
+		dependencies.imports[className] = true
+		return
+	}
+
+	switch kind {
+	case dependencyKindInheritance:
+		dependencies.inheritance[className] = true
+	case dependencyKindTypeHint:
+		dependencies.typeHints[className] = true
+	case dependencyKindInstantiation:
+		dependencies.instantiations[className] = true
+	case dependencyKindAttributeAccess:
+		dependencies.attributeAccesses[className] = true
+	case dependencyKindImport:
+		dependencies.imports[className] = true
+	}
+}
+
+func (a *CBOAnalyzer) sameDependencyIdentity(className, ownerClass string) bool {
+	if className == ownerClass {
+		return true
+	}
+	if strings.HasSuffix(className, "."+ownerClass) {
+		return true
+	}
+	if imported, exists := a.importedNames[className]; exists {
+		return imported == ownerClass || strings.HasSuffix(imported, "."+ownerClass)
+	}
+	return false
+}
+
+func (a *CBOAnalyzer) isStandardLibraryDependency(className string) bool {
+	if className == "" {
+		return false
+	}
+
+	if a.isTypeSystemName(className) {
+		return true
+	}
+	if a.standardLibraryRoot(className) {
+		return true
+	}
+	if imported, exists := a.importedNames[className]; exists {
+		return a.isTypeSystemName(imported) || a.standardLibraryRoot(imported)
+	}
+
+	return false
+}
+
+func (a *CBOAnalyzer) standardLibraryRoot(className string) bool {
+	root := className
+	if strings.Contains(root, ".") {
+		root = strings.SplitN(root, ".", 2)[0]
+	}
+	return a.standardLibs[root]
+}
+
+func (a *CBOAnalyzer) isTypeSystemName(className string) bool {
+	if strings.Contains(className, ".") {
+		parts := strings.Split(className, ".")
+		className = parts[len(parts)-1]
+	}
+
+	switch className {
+	case "ABC", "ABCMeta", "Any", "BinaryIO", "Callable", "ClassVar",
+		"Concatenate", "Dict", "Final", "Generic", "IO", "Iterable",
+		"Iterator", "List", "Literal", "Mapping", "NamedTuple", "Never",
+		"NewType", "NoReturn", "NotRequired", "Optional", "ParamSpec",
+		"Protocol", "Required", "Self", "Sequence", "Set", "Tuple",
+		"Type", "TypeAlias", "TypedDict", "TypeGuard", "TypeVar",
+		"TypeVarTuple", "Union":
+		return true
+	default:
+		return false
+	}
 }
 
 // isBuiltinFunction checks if a name is a built-in function
@@ -723,6 +826,7 @@ func (a *CBOAnalyzer) mapToSlice(m map[string]bool) []string {
 	for key := range m {
 		result = append(result, key)
 	}
+	sort.Strings(result)
 	return result
 }
 
@@ -763,6 +867,7 @@ func (a *CBOAnalyzer) initializeStandardLibs() {
 		"os", "sys", "re", "json", "datetime", "collections", "itertools",
 		"functools", "operator", "math", "random", "string", "io", "pathlib",
 		"unittest", "logging", "argparse", "configparser", "urllib", "http",
+		"abc", "typing", "typing_extensions",
 	}
 
 	for _, stdlib := range stdlibs {

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -599,14 +599,14 @@ func (a *CBOAnalyzer) isTypeSystemDependency(className string) bool {
 		return false
 	}
 
-	dependencyName := className
 	if imported, exists := a.importedNames[className]; exists {
-		dependencyName = imported
-	} else if !strings.Contains(className, ".") {
-		return false
+		return a.typeSystemRoot(imported)
+	}
+	if strings.Contains(className, ".") {
+		return a.typeSystemRoot(className)
 	}
 
-	return a.typeSystemRoot(dependencyName) && a.isTypeSystemName(dependencyName)
+	return false
 }
 
 func (a *CBOAnalyzer) isStandardLibraryDependency(className string) bool {
@@ -640,26 +640,6 @@ func (a *CBOAnalyzer) typeSystemRoot(className string) bool {
 
 	switch root {
 	case "abc", "typing", "typing_extensions":
-		return true
-	default:
-		return false
-	}
-}
-
-func (a *CBOAnalyzer) isTypeSystemName(className string) bool {
-	if strings.Contains(className, ".") {
-		parts := strings.Split(className, ".")
-		className = parts[len(parts)-1]
-	}
-
-	switch className {
-	case "ABC", "ABCMeta", "Any", "BinaryIO", "Callable", "ClassVar",
-		"Concatenate", "Dict", "Final", "Generic", "IO", "Iterable",
-		"Iterator", "List", "Literal", "Mapping", "NamedTuple", "Never",
-		"NewType", "NoReturn", "NotRequired", "Optional", "ParamSpec",
-		"Protocol", "Required", "Self", "Sequence", "Set", "Tuple",
-		"Type", "TypeAlias", "TypedDict", "TypeGuard", "TypeVar",
-		"TypeVarTuple", "Union":
 		return true
 	default:
 		return false

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -416,21 +416,29 @@ func (a *CBOAnalyzer) collectImports(ast *parser.Node) map[string]string {
 		switch node.Type {
 		case parser.NodeImport:
 			// import module as alias
+			aliasedNames := make(map[string]bool)
 			for _, child := range node.Children {
 				if child.Type == parser.NodeAlias {
 					module := child.Name
-					alias := child.Name // Default to module name
+					alias := importBindingName(module)
 					if child.Value != nil {
 						if aliasStr, ok := child.Value.(string); ok {
 							alias = aliasStr
+							aliasedNames[module] = true
 						}
 					}
 					imports[alias] = module
 				}
 			}
+			for _, name := range node.Names {
+				if !aliasedNames[name] {
+					imports[importBindingName(name)] = name
+				}
+			}
 		case parser.NodeImportFrom:
 			// from module import name as alias
 			module := node.Module
+			aliasedNames := make(map[string]bool)
 			for _, child := range node.Children {
 				if child.Type == parser.NodeAlias {
 					name := child.Name
@@ -438,9 +446,15 @@ func (a *CBOAnalyzer) collectImports(ast *parser.Node) map[string]string {
 					if child.Value != nil {
 						if aliasStr, ok := child.Value.(string); ok {
 							alias = aliasStr
+							aliasedNames[name] = true
 						}
 					}
 					imports[alias] = module + "." + name
+				}
+			}
+			for _, name := range node.Names {
+				if !aliasedNames[name] {
+					imports[name] = module + "." + name
 				}
 			}
 		}
@@ -448,6 +462,13 @@ func (a *CBOAnalyzer) collectImports(ast *parser.Node) map[string]string {
 	})
 
 	return imports
+}
+
+func importBindingName(module string) string {
+	if strings.Contains(module, ".") {
+		return strings.SplitN(module, ".", 2)[0]
+	}
+	return module
 }
 
 // extractClassName extracts class name from a node
@@ -577,14 +598,11 @@ func (a *CBOAnalyzer) isStandardLibraryDependency(className string) bool {
 		return false
 	}
 
-	if a.isTypeSystemName(className) {
-		return true
-	}
-	if a.standardLibraryRoot(className) {
-		return true
-	}
 	if imported, exists := a.importedNames[className]; exists {
 		return a.isTypeSystemName(imported) || a.standardLibraryRoot(imported)
+	}
+	if strings.Contains(className, ".") {
+		return a.isTypeSystemName(className) || a.standardLibraryRoot(className)
 	}
 
 	return false

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -345,13 +345,7 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 					if valueNode.Type == parser.NodeCall {
 						className := a.extractClassNameFromCallNode(valueNode)
 						if className != "" && a.shouldIncludeDependencyForClass(className, result.ClassName) {
-							if a.isImportedDependency(className) {
-								a.addDependency(dependencies, className, dependencyKindImport)
-							} else if _, isClass := allClasses[className]; isClass {
-								// Known local class (instantiation)
-								a.addDependency(dependencies, className, dependencyKindInstantiation)
-							} else if a.options.IncludeBuiltins && a.builtinTypes[className] {
-								// Builtin type (only if explicitly enabled)
+							if a.isCallDependency(className, allClasses) {
 								a.addDependency(dependencies, className, dependencyKindInstantiation)
 							}
 							// Note: function calls are NOT added to dependencies
@@ -364,13 +358,7 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 			// Use structural AST analysis instead of string parsing
 			className := a.extractClassNameFromCallNode(node)
 			if className != "" && a.shouldIncludeDependencyForClass(className, result.ClassName) {
-				if a.isImportedDependency(className) {
-					a.addDependency(dependencies, className, dependencyKindImport)
-				} else if _, isClass := allClasses[className]; isClass {
-					// Known local class (instantiation)
-					a.addDependency(dependencies, className, dependencyKindInstantiation)
-				} else if a.options.IncludeBuiltins && a.builtinTypes[className] {
-					// Builtin type (only if explicitly enabled)
+				if a.isCallDependency(className, allClasses) {
 					a.addDependency(dependencies, className, dependencyKindInstantiation)
 				}
 				// Note: function calls are NOT added to dependencies
@@ -380,11 +368,7 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 			if objNode := node.Left; objNode != nil {
 				objType := a.inferObjectType(objNode)
 				if objType != "" && a.shouldIncludeDependencyForClass(objType, result.ClassName) {
-					if a.isImportedDependency(objType) {
-						a.addDependency(dependencies, objType, dependencyKindImport)
-					} else {
-						a.addDependency(dependencies, objType, dependencyKindAttributeAccess)
-					}
+					a.addDependency(dependencies, objType, dependencyKindAttributeAccess)
 				}
 			}
 		}
@@ -538,6 +522,16 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 	}
 
 	return true
+}
+
+func (a *CBOAnalyzer) isCallDependency(className string, allClasses map[string]*parser.Node) bool {
+	if a.isImportedDependency(className) {
+		return true
+	}
+	if _, isClass := allClasses[className]; isClass {
+		return true
+	}
+	return a.options.IncludeBuiltins && a.builtinTypes[className]
 }
 
 func (a *CBOAnalyzer) shouldIncludeDependencyForClass(className, ownerClass string) bool {

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -581,9 +581,17 @@ func (a *CBOAnalyzer) sameDependencyIdentity(className, ownerClass string) bool 
 		return true
 	}
 	if imported, exists := a.importedNames[className]; exists {
-		return imported == ownerClass
+		return dependencyLeafName(imported) == ownerClass
 	}
 	return false
+}
+
+func dependencyLeafName(className string) string {
+	if strings.Contains(className, ".") {
+		parts := strings.Split(className, ".")
+		return parts[len(parts)-1]
+	}
+	return className
 }
 
 func (a *CBOAnalyzer) isTypeSystemDependency(className string) bool {

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -482,12 +482,23 @@ func (a *CBOAnalyzer) extractClassName(node *parser.Node) string {
 		return node.Name
 	case parser.NodeAttribute:
 		// Handle module.ClassName
-		if node.Left != nil && node.Right != nil {
-			left := a.extractClassName(node.Left)
-			right := a.extractClassName(node.Right)
-			if left != "" && right != "" {
-				return left + "." + right
+		left := a.extractClassName(node.Left)
+		if left == "" {
+			if valueNode, ok := node.Value.(*parser.Node); ok {
+				left = a.extractClassName(valueNode)
 			}
+		}
+
+		right := a.extractClassName(node.Right)
+		if right == "" {
+			right = node.Name
+		}
+
+		if left != "" && right != "" {
+			return left + "." + right
+		}
+		if right != "" {
+			return right
 		}
 	case parser.NodeSubscript:
 		// Handle generic types like List[User], Dict[str, User]
@@ -526,21 +537,6 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 		return false
 	}
 
-	// Skip standard library if not included
-	if !a.options.IncludeImports {
-		// Check both direct match and root module for qualified names like json.JSONDecoder
-		if a.standardLibs[className] {
-			return false
-		}
-		// Check root module for fully qualified names
-		if strings.Contains(className, ".") {
-			rootModule := strings.SplitN(className, ".", 2)[0]
-			if a.standardLibs[rootModule] {
-				return false
-			}
-		}
-	}
-
 	return true
 }
 
@@ -551,7 +547,13 @@ func (a *CBOAnalyzer) shouldIncludeDependencyForClass(className, ownerClass stri
 	if ownerClass != "" && a.sameDependencyIdentity(className, ownerClass) {
 		return false
 	}
-	return !a.isStandardLibraryDependency(className)
+	if a.isTypeSystemDependency(className) {
+		return false
+	}
+	if !a.options.IncludeImports && a.isStandardLibraryDependency(className) {
+		return false
+	}
+	return true
 }
 
 func (a *CBOAnalyzer) addDependency(dependencies *cboDependencies, className string, kind cboDependencyKind) {
@@ -584,13 +586,25 @@ func (a *CBOAnalyzer) sameDependencyIdentity(className, ownerClass string) bool 
 	if className == ownerClass {
 		return true
 	}
-	if strings.HasSuffix(className, "."+ownerClass) {
-		return true
-	}
 	if imported, exists := a.importedNames[className]; exists {
-		return imported == ownerClass || strings.HasSuffix(imported, "."+ownerClass)
+		return imported == ownerClass
 	}
 	return false
+}
+
+func (a *CBOAnalyzer) isTypeSystemDependency(className string) bool {
+	if className == "" {
+		return false
+	}
+
+	dependencyName := className
+	if imported, exists := a.importedNames[className]; exists {
+		dependencyName = imported
+	} else if !strings.Contains(className, ".") {
+		return false
+	}
+
+	return a.typeSystemRoot(dependencyName) && a.isTypeSystemName(dependencyName)
 }
 
 func (a *CBOAnalyzer) isStandardLibraryDependency(className string) bool {
@@ -599,10 +613,10 @@ func (a *CBOAnalyzer) isStandardLibraryDependency(className string) bool {
 	}
 
 	if imported, exists := a.importedNames[className]; exists {
-		return a.isTypeSystemName(imported) || a.standardLibraryRoot(imported)
+		return a.standardLibraryRoot(imported)
 	}
 	if strings.Contains(className, ".") {
-		return a.isTypeSystemName(className) || a.standardLibraryRoot(className)
+		return a.standardLibraryRoot(className)
 	}
 
 	return false
@@ -614,6 +628,20 @@ func (a *CBOAnalyzer) standardLibraryRoot(className string) bool {
 		root = strings.SplitN(root, ".", 2)[0]
 	}
 	return a.standardLibs[root]
+}
+
+func (a *CBOAnalyzer) typeSystemRoot(className string) bool {
+	root := className
+	if strings.Contains(root, ".") {
+		root = strings.SplitN(root, ".", 2)[0]
+	}
+
+	switch root {
+	case "abc", "typing", "typing_extensions":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *CBOAnalyzer) isTypeSystemName(className string) bool {
@@ -670,8 +698,11 @@ func (a *CBOAnalyzer) extractClassNameFromCallNode(callNode *parser.Node) string
 	// Method 3: Check Value field if it's a Node with Name type
 	if callNode.Value != nil {
 		if valueNode, ok := callNode.Value.(*parser.Node); ok {
-			if valueNode.Type == parser.NodeName && valueNode.Name != "" {
+			switch valueNode.Type {
+			case parser.NodeName:
 				return valueNode.Name
+			case parser.NodeAttribute:
+				return a.extractClassNameFromAttribute(valueNode)
 			}
 		}
 	}
@@ -685,25 +716,25 @@ func (a *CBOAnalyzer) extractClassNameFromAttribute(attrNode *parser.Node) strin
 		return ""
 	}
 
-	// For module.Class pattern, we want the rightmost name (Class)
-	// but for full qualification, we might want module.Class
-
-	// Get the rightmost part (the actual class name)
+	rightName := attrNode.Name
 	if attrNode.Right != nil && attrNode.Right.Type == parser.NodeName {
-		rightName := attrNode.Right.Name
-
-		// Get the left part (module name) if needed
-		if attrNode.Left != nil && attrNode.Left.Type == parser.NodeName {
-			leftName := attrNode.Left.Name
-			// Return full qualification for better accuracy
-			return leftName + "." + rightName
-		}
-
-		// Return just the class name if no module prefix
-		return rightName
+		rightName = attrNode.Right.Name
+	}
+	if rightName == "" {
+		return ""
 	}
 
-	return ""
+	leftName := a.extractClassName(attrNode.Left)
+	if leftName == "" {
+		if valueNode, ok := attrNode.Value.(*parser.Node); ok {
+			leftName = a.extractClassName(valueNode)
+		}
+	}
+	if leftName != "" {
+		return leftName + "." + rightName
+	}
+
+	return rightName
 }
 
 // isImportedDependency checks if a dependency comes from imports

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -520,6 +520,31 @@ class Widget:
 	assert.Equal(t, []string{"models.Widget"}, widget.DependentClasses)
 }
 
+func TestCBOAnalyzer_ImportedSameNameDependencyIsSelfReference(t *testing.T) {
+	pythonCode := `
+from pkg import Widget
+
+class Widget:
+    parent: Widget
+
+    def clone(self) -> Widget:
+        return Widget()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "widget.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	widget := results[0]
+	assert.Equal(t, "Widget", widget.ClassName)
+	assert.Equal(t, 0, widget.CouplingCount)
+	assert.Equal(t, 0, widget.ImportDependencies)
+	assert.Empty(t, widget.DependentClasses)
+}
+
 func TestCBOAnalyzer_QualifiedProjectTypeSystemNameStillCounts(t *testing.T) {
 	pythonCode := `
 import models

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -443,6 +443,105 @@ class UsesLocal:
 	assert.Equal(t, []string{"TypedDict"}, usesLocal.DependentClasses)
 }
 
+func TestCBOAnalyzer_IncludeImportsControlsStandardLibraryDependencies(t *testing.T) {
+	pythonCode := `
+from pathlib import Path as FilePath
+
+class Reader:
+    path: FilePath
+
+    def make_path(self) -> FilePath:
+        return FilePath("data.txt")
+`
+
+	tests := []struct {
+		name                     string
+		includeImports           bool
+		expectedCBO              int
+		expectedImportDeps       int
+		expectedDependentClasses []string
+	}{
+		{
+			name:                     "include stdlib imports",
+			includeImports:           true,
+			expectedCBO:              1,
+			expectedImportDeps:       1,
+			expectedDependentClasses: []string{"FilePath"},
+		},
+		{
+			name:                     "exclude stdlib imports",
+			includeImports:           false,
+			expectedCBO:              0,
+			expectedImportDeps:       0,
+			expectedDependentClasses: []string{},
+		},
+	}
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := DefaultCBOOptions()
+			options.IncludeImports = tt.includeImports
+
+			results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "reader.py")
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			reader := results[0]
+			assert.Equal(t, "Reader", reader.ClassName)
+			assert.Equal(t, tt.expectedCBO, reader.CouplingCount)
+			assert.Equal(t, tt.expectedImportDeps, reader.ImportDependencies)
+			assert.Equal(t, tt.expectedDependentClasses, reader.DependentClasses)
+		})
+	}
+}
+
+func TestCBOAnalyzer_QualifiedSameNameDependencyIsNotSelfReference(t *testing.T) {
+	pythonCode := `
+import models
+
+class Widget:
+    parent: models.Widget
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "widget.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	widget := results[0]
+	assert.Equal(t, "Widget", widget.ClassName)
+	assert.Equal(t, 1, widget.CouplingCount)
+	assert.Equal(t, 1, widget.ImportDependencies)
+	assert.Equal(t, []string{"models.Widget"}, widget.DependentClasses)
+}
+
+func TestCBOAnalyzer_QualifiedProjectTypeSystemNameStillCounts(t *testing.T) {
+	pythonCode := `
+import models
+
+class Service:
+    contract: models.Protocol
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "service.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	service := results[0]
+	assert.Equal(t, "Service", service.ClassName)
+	assert.Equal(t, 1, service.CouplingCount)
+	assert.Equal(t, 1, service.ImportDependencies)
+	assert.Equal(t, []string{"models.Protocol"}, service.DependentClasses)
+}
+
 func TestCBOAnalyzer_ExcludePatterns(t *testing.T) {
 	pythonCode := `
 class TestClass:

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -545,6 +545,37 @@ class Widget:
 	assert.Empty(t, widget.DependentClasses)
 }
 
+func TestCBOAnalyzer_TypeSystemImportRootExcludesTypingNames(t *testing.T) {
+	pythonCode := `
+import typing
+from abc import ABCMeta
+from typing_extensions import NotRequired
+
+class Contract(ABCMeta):
+    mapping: typing.MutableMapping
+    task: typing.Awaitable
+    coro: typing.Coroutine
+    gen: typing.Generator
+    annotated: typing.Annotated
+    missing: NotRequired
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "contract.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	contract := results[0]
+	assert.Equal(t, "Contract", contract.ClassName)
+	assert.Equal(t, 0, contract.CouplingCount)
+	assert.Equal(t, 0, contract.InheritanceDependencies)
+	assert.Equal(t, 0, contract.TypeHintDependencies)
+	assert.Equal(t, []string{"ABCMeta"}, contract.BaseClasses)
+	assert.Empty(t, contract.DependentClasses)
+}
+
 func TestCBOAnalyzer_QualifiedProjectTypeSystemNameStillCounts(t *testing.T) {
 	pythonCode := `
 import models

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -397,6 +397,52 @@ class Service:
 	assert.Equal(t, []string{"Dependency"}, service.DependentClasses)
 }
 
+func TestCBOAnalyzer_ImportedTypingNamesDoNotHideLocalClasses(t *testing.T) {
+	firstFile := `
+from typing import TypedDict
+
+class Payload(TypedDict):
+    name: str
+`
+
+	secondFile := `
+class TypedDict:
+    pass
+
+class UsesLocal:
+    payload: TypedDict
+`
+
+	analyzer := NewCBOAnalyzer(DefaultCBOOptions())
+
+	firstAST, err := parseCode(firstFile)
+	require.NoError(t, err)
+
+	firstResults, err := analyzer.AnalyzeClasses(firstAST, "first.py")
+	require.NoError(t, err)
+	require.Len(t, firstResults, 1)
+	assert.Equal(t, "Payload", firstResults[0].ClassName)
+	assert.Equal(t, 0, firstResults[0].CouplingCount)
+	assert.Empty(t, firstResults[0].DependentClasses)
+
+	secondAST, err := parseCode(secondFile)
+	require.NoError(t, err)
+
+	secondResults, err := analyzer.AnalyzeClasses(secondAST, "second.py")
+	require.NoError(t, err)
+
+	resultMap := make(map[string]*CBOResult)
+	for _, result := range secondResults {
+		resultMap[result.ClassName] = result
+	}
+
+	usesLocal := resultMap["UsesLocal"]
+	require.NotNil(t, usesLocal)
+	assert.Equal(t, 1, usesLocal.CouplingCount)
+	assert.Equal(t, 1, usesLocal.TypeHintDependencies)
+	assert.Equal(t, []string{"TypedDict"}, usesLocal.DependentClasses)
+}
+
 func TestCBOAnalyzer_ExcludePatterns(t *testing.T) {
 	pythonCode := `
 class TestClass:

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -315,6 +315,88 @@ class MyClass:
 	}
 }
 
+func TestCBOAnalyzer_DependencyIdentityContract(t *testing.T) {
+	pythonCode := `
+from __future__ import annotations
+from abc import ABC
+from typing import Protocol, TypedDict
+
+class Dependency:
+    pass
+
+class Payload(TypedDict):
+    name: str
+
+class Contract(Protocol):
+    def handle(self, item: Dependency) -> Dependency:
+        ...
+
+class AbstractBase(ABC):
+    pass
+
+class Widget:
+    other: Widget
+
+    def adopt(self, owner: Widget) -> Widget:
+        return Widget()
+
+class Service:
+    field: Dependency
+
+    def set_one(self, item: Dependency) -> Dependency:
+        return item
+
+    def set_two(self, item: Dependency) -> Dependency:
+        return item
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	analyzer := NewCBOAnalyzer(DefaultCBOOptions())
+	results, err := analyzer.AnalyzeClasses(ast, "test.py")
+	require.NoError(t, err)
+
+	resultMap := make(map[string]*CBOResult)
+	for _, result := range results {
+		resultMap[result.ClassName] = result
+	}
+
+	payload := resultMap["Payload"]
+	require.NotNil(t, payload)
+	assert.Equal(t, 0, payload.CouplingCount)
+	assert.Equal(t, 0, payload.InheritanceDependencies)
+	assert.Equal(t, []string{"TypedDict"}, payload.BaseClasses)
+	assert.Empty(t, payload.DependentClasses)
+
+	contract := resultMap["Contract"]
+	require.NotNil(t, contract)
+	assert.Equal(t, 1, contract.CouplingCount)
+	assert.Equal(t, 1, contract.TypeHintDependencies)
+	assert.Equal(t, []string{"Dependency"}, contract.DependentClasses)
+	assert.Equal(t, []string{"Protocol"}, contract.BaseClasses)
+
+	abstractBase := resultMap["AbstractBase"]
+	require.NotNil(t, abstractBase)
+	assert.Equal(t, 0, abstractBase.CouplingCount)
+	assert.Equal(t, 0, abstractBase.InheritanceDependencies)
+	assert.Equal(t, []string{"ABC"}, abstractBase.BaseClasses)
+	assert.Empty(t, abstractBase.DependentClasses)
+
+	widget := resultMap["Widget"]
+	require.NotNil(t, widget)
+	assert.Equal(t, 0, widget.CouplingCount)
+	assert.Equal(t, 0, widget.TypeHintDependencies)
+	assert.Equal(t, 0, widget.InstantiationDependencies)
+	assert.Empty(t, widget.DependentClasses)
+
+	service := resultMap["Service"]
+	require.NotNil(t, service)
+	assert.Equal(t, 1, service.CouplingCount)
+	assert.Equal(t, 1, service.TypeHintDependencies)
+	assert.Equal(t, []string{"Dependency"}, service.DependentClasses)
+}
+
 func TestCBOAnalyzer_ExcludePatterns(t *testing.T) {
 	pythonCode := `
 class TestClass:

--- a/service/cbo_service_test.go
+++ b/service/cbo_service_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -169,6 +171,86 @@ func TestCBOService_Analyze(t *testing.T) {
 		assert.NotNil(t, response)
 		// When including builtins, CBO counts may be higher
 	})
+}
+
+func TestCBOService_AnalyzeDependencyIdentityContract(t *testing.T) {
+	source := `
+from abc import ABC
+from typing import Protocol, TypedDict
+
+class Dependency:
+    pass
+
+class Payload(TypedDict):
+    name: str
+
+class Contract(Protocol):
+    def handle(self, item: Dependency) -> Dependency:
+        ...
+
+class AbstractBase(ABC):
+    pass
+
+class Widget:
+    other: Widget
+
+    def adopt(self, owner: Widget) -> Widget:
+        return Widget()
+
+class Service:
+    field: Dependency
+
+    def set_one(self, item: Dependency) -> Dependency:
+        return item
+
+    def set_two(self, item: Dependency) -> Dependency:
+        return item
+`
+
+	filePath := filepath.Join(t.TempDir(), "contract.py")
+	require.NoError(t, os.WriteFile(filePath, []byte(source), 0o600))
+
+	response, err := NewCBOService().Analyze(context.Background(), newDefaultCBORequest(filePath))
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Empty(t, response.Errors)
+
+	classes := make(map[string]domain.ClassCoupling, len(response.Classes))
+	for _, class := range response.Classes {
+		classes[class.Name] = class
+	}
+
+	payload, ok := classes["Payload"]
+	require.True(t, ok)
+	assert.Equal(t, 0, payload.Metrics.CouplingCount)
+	assert.Equal(t, 0, payload.Metrics.InheritanceDependencies)
+	assert.Equal(t, []string{"TypedDict"}, payload.BaseClasses)
+	assert.Empty(t, payload.Metrics.DependentClasses)
+
+	contract, ok := classes["Contract"]
+	require.True(t, ok)
+	assert.Equal(t, 1, contract.Metrics.CouplingCount)
+	assert.Equal(t, 1, contract.Metrics.TypeHintDependencies)
+	assert.Equal(t, []string{"Dependency"}, contract.Metrics.DependentClasses)
+	assert.Equal(t, []string{"Protocol"}, contract.BaseClasses)
+
+	abstractBase, ok := classes["AbstractBase"]
+	require.True(t, ok)
+	assert.Equal(t, 0, abstractBase.Metrics.CouplingCount)
+	assert.Equal(t, 0, abstractBase.Metrics.InheritanceDependencies)
+	assert.Equal(t, []string{"ABC"}, abstractBase.BaseClasses)
+	assert.Empty(t, abstractBase.Metrics.DependentClasses)
+
+	widget, ok := classes["Widget"]
+	require.True(t, ok)
+	assert.Equal(t, 0, widget.Metrics.CouplingCount)
+	assert.Empty(t, widget.Metrics.DependentClasses)
+
+	service, ok := classes["Service"]
+	require.True(t, ok)
+	assert.Equal(t, 1, service.Metrics.CouplingCount)
+	assert.Equal(t, 1, service.Metrics.TypeHintDependencies)
+	assert.Equal(t, []string{"Dependency"}, service.Metrics.DependentClasses)
 }
 
 func TestCBOService_AnalyzeFile(t *testing.T) {


### PR DESCRIPTION
This fixes CBO false positives caused by counting repeated dependency sightings, type-system bases, self references, and leaked import aliases as real coupling.

CBO now tracks unique dependency identities by dependency kind. Type-system imports from typing, typing_extensions, and abc are preserved in base class metadata but no longer inflate CBO. IncludeImports still controls normal stdlib imports, and qualified project dependencies such as models.Widget or models.Protocol continue to count.

Added analyzer and service-level regression coverage for the public output contract.

Validation:
go test ./internal/analyzer ./service -count=1
go test ./... -count=1
