### PR TITLE
fix(architecture): expose WeightedViolations to make ComplianceScore reproducible (#444)

### DIFF
--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -216,9 +216,10 @@ type CouplingAnalysis struct {
 // ArchitectureAnalysisResult contains architecture validation results
 type ArchitectureAnalysisResult struct {
 	// Overall architecture compliance
-	ComplianceScore float64 // Overall compliance score (0-1, where 1.0 = 100% compliant)
-	TotalViolations int     // Total number of violations
-	TotalRules      int     // Total number of rules checked
+	ComplianceScore    float64 // Overall compliance score (0-1, where 1.0 = 100% compliant). Computed as 1 - WeightedViolations/TotalRules (clamped to [0,1]).
+	TotalViolations    int     // Raw number of violations (one per ArchitectureViolation entry).
+	WeightedViolations int     // Severity-weighted violation count used as the ComplianceScore numerator: error * 5 + warning * 1.
+	TotalRules         int     // Total number of rule invocations checked (ComplianceScore denominator).
 
 	// Layer analysis
 	LayerAnalysis          *LayerAnalysis          // Layer violation analysis

--- a/service/responsibility_analysis_test.go
+++ b/service/responsibility_analysis_test.go
@@ -218,4 +218,20 @@ func TestAnalyzeArchitectureRunsResponsibilityWithoutLayerRules(t *testing.T) {
 		"TotalRules should count every module checked against the SRP rule, not just the violations")
 	assert.Greater(t, result.ComplianceScore, 0.0,
 		"ComplianceScore should not be zero when most modules pass the responsibility rule")
+
+	// Regression for #444: ComplianceScore must be reproducible from the
+	// WeightedViolations / TotalRules fields exposed in the result, so JSON
+	// consumers can rebuild the score without knowing the severity weights.
+	severities := result.SeverityBreakdown
+	expectedWeighted := severities[domain.ViolationSeverityError]*5 + severities[domain.ViolationSeverityWarning]*1
+	assert.Equal(t, expectedWeighted, result.WeightedViolations,
+		"WeightedViolations should equal error*5 + warning*1")
+	if result.TotalRules > 0 {
+		expectedScore := 1.0 - float64(result.WeightedViolations)/float64(result.TotalRules)
+		if expectedScore < 0 {
+			expectedScore = 0
+		}
+		assert.InDelta(t, expectedScore, result.ComplianceScore, 1e-9,
+			"ComplianceScore must match 1 - WeightedViolations/TotalRules (clamped)")
+	}
 }

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -456,7 +456,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 		checked := responsibilityChecks
 		errorCount := severityCounts[domain.ViolationSeverityError]
 		warningCount := severityCounts[domain.ViolationSeverityWarning]
-		compliance := s.calculateComplianceWeighted(errorCount, warningCount, checked)
+		compliance, weighted := s.calculateComplianceWeighted(errorCount, warningCount, checked)
 		recommendations := s.generateArchitectureRecommendations(responsibilityViolations, map[string]float64{}, nil, compliance)
 		refactoringTargets := s.identifyArchitectureRefactoringTargets(responsibilityViolations, map[string]string{})
 		return s.buildArchitectureResultWithRecommendations(
@@ -467,6 +467,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 			nil,
 			0,
 			compliance,
+			weighted,
 			checked,
 			map[string]string{},
 			recommendations,
@@ -502,7 +503,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 	checked += responsibilityChecks
 	errorCount := severityCounts[domain.ViolationSeverityError]
 	warningCount := severityCounts[domain.ViolationSeverityWarning]
-	compliance := s.calculateComplianceWeighted(errorCount, warningCount, checked)
+	compliance, weighted := s.calculateComplianceWeighted(errorCount, warningCount, checked)
 
 	// Generate architecture recommendations
 	recommendations := s.generateArchitectureRecommendations(violations, layerCohesion, problematic, compliance)
@@ -512,7 +513,7 @@ func (s *SystemAnalysisServiceImpl) analyzeArchitectureGraph(ctx context.Context
 
 	// Build result
 	return s.buildArchitectureResultWithRecommendations(violations, severityCounts, layerCoupling, layerCohesion,
-		problematic, layersAnalyzed, compliance, checked, moduleToLayer, recommendations, refactoringTargets,
+		problematic, layersAnalyzed, compliance, weighted, checked, moduleToLayer, recommendations, refactoringTargets,
 		cohesionAnalysis, responsibilityAnalysis), nil
 }
 
@@ -642,17 +643,19 @@ func (s *SystemAnalysisServiceImpl) calculateLayerMetrics(layerCoupling map[stri
 }
 
 // calculateComplianceWeighted calculates compliance with severity weights.
-// Error = 5 points, Warning = 1 point.
-func (s *SystemAnalysisServiceImpl) calculateComplianceWeighted(errorCount, warningCount, checked int) float64 {
+// Error = 5 points, Warning = 1 point. Returns the compliance score and the
+// weighted violation count used as its numerator, so callers can expose both
+// in the result struct and keep ComplianceScore reproducible from JSON.
+func (s *SystemAnalysisServiceImpl) calculateComplianceWeighted(errorCount, warningCount, checked int) (float64, int) {
+	weighted := errorCount*5 + warningCount*1
 	if checked == 0 {
-		return 1.0
+		return 1.0, weighted
 	}
-	weightedViolations := float64(errorCount*5 + warningCount*1)
-	compliance := 1.0 - (weightedViolations / float64(checked))
+	compliance := 1.0 - (float64(weighted) / float64(checked))
 	if compliance < 0 {
 		compliance = 0
 	}
-	return compliance
+	return compliance, weighted
 }
 
 // buildArchitectureResultWithRecommendations constructs the final result with recommendations
@@ -664,6 +667,7 @@ func (s *SystemAnalysisServiceImpl) buildArchitectureResultWithRecommendations(
 	problematic []string,
 	layersAnalyzed int,
 	compliance float64,
+	weightedViolations int,
 	checked int,
 	moduleToLayer map[string]string,
 	recommendations []domain.ArchitectureRecommendation,
@@ -682,6 +686,7 @@ func (s *SystemAnalysisServiceImpl) buildArchitectureResultWithRecommendations(
 	return &domain.ArchitectureAnalysisResult{
 		ComplianceScore:        compliance,
 		TotalViolations:        len(violations),
+		WeightedViolations:     weightedViolations,
 		TotalRules:             checked,
 		LayerAnalysis:          layerAnalysis,
 		CohesionAnalysis:       cohesionAnalysis,

--- a/website/docs/fr/output/schemas.md
+++ b/website/docs/fr/output/schemas.md
@@ -132,7 +132,7 @@ Reflet de `domain.AnalyzeSummary`. Tous les compteurs numériques valent `0` par
 
 | Champ             | Type   | Description                                                            |
 | ----------------- | ------ | ---------------------------------------------------------------------- |
-| `arch_compliance` | number | Taux de conformité architecturale, `0`–`1`. `1.0` = entièrement conforme. |
+| `arch_compliance` | number | Taux de conformité architecturale, `0`–`1`. Pondéré par sévérité (`error × 5 + warning × 1`) ; voir `system.ArchitectureAnalysis.WeightedViolations` pour le numérateur. |
 
 ### Métriques de données fictives
 
@@ -638,9 +638,10 @@ Reflet de `domain.SystemAnalysisResponse`. Les noms de champs imbriqués sont en
 
 | Champ                 | Type    | Description                                                 |
 | --------------------- | ------- | ----------------------------------------------------------- |
-| `ComplianceScore`     | number  | Score de conformité, `0`–`1`. `1.0` = entièrement conforme. |
-| `TotalViolations`     | integer | Total des violations trouvées.                              |
-| `TotalRules`          | integer | Total des règles évaluées.                                  |
+| `ComplianceScore`     | number  | Score de conformité, `0`–`1`. Calculé comme `max(0, 1 - WeightedViolations / TotalRules)` ; `1.0` si aucune règle évaluée. |
+| `TotalViolations`     | integer | Nombre brut de violations (une par entrée de `Violations`). |
+| `WeightedViolations`  | integer | Nombre de violations pondéré par sévérité, utilisé comme numérateur de `ComplianceScore` : `error × 5 + warning × 1`. |
+| `TotalRules`          | integer | Total des invocations de règles évaluées (dénominateur de `ComplianceScore`). |
 | `LayerAnalysis`       | object \| null | Résultats d'analyse par couches.                     |
 | `CohesionAnalysis`    | object \| null | Analyse de cohésion des paquets.                     |
 | `ResponsibilityAnalysis` | object \| null | Analyse des violations du principe SRP.           |

--- a/website/docs/ja/output/schemas.md
+++ b/website/docs/ja/output/schemas.md
@@ -132,7 +132,7 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 
 | フィールド         | 型     | 説明                                                              |
 | ----------------- | ------ | ----------------------------------------------------------------- |
-| `arch_compliance` | number | アーキテクチャ準拠率、`0`–`1`。`1.0` = 完全準拠。                 |
+| `arch_compliance` | number | アーキテクチャ準拠率、`0`–`1`。重大度重み付き（`error × 5 + warning × 1`）。分子は `system.ArchitectureAnalysis.WeightedViolations` を参照。 |
 
 ### モックデータメトリクス
 
@@ -638,9 +638,10 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 
 | フィールド                 | 型      | 説明                                                        |
 | ------------------------- | ------- | ----------------------------------------------------------- |
-| `ComplianceScore`         | number  | 準拠スコア、`0`–`1`。`1.0` = 完全準拠。                     |
-| `TotalViolations`         | integer | 検出された違反の合計数。                                    |
-| `TotalRules`              | integer | 評価されたルールの合計数。                                  |
+| `ComplianceScore`         | number  | 準拠スコア、`0`–`1`。`max(0, 1 - WeightedViolations / TotalRules)` で計算。ルール未評価時は `1.0`。 |
+| `TotalViolations`         | integer | 違反の生カウント（`Violations` 配列の要素数と一致）。       |
+| `WeightedViolations`      | integer | `ComplianceScore` の分子に用いる重み付き違反数：`error × 5 + warning × 1`。 |
+| `TotalRules`              | integer | 評価されたルール呼び出しの合計数（`ComplianceScore` の分母）。 |
 | `LayerAnalysis`           | object \| null | レイヤー分析結果。                                   |
 | `CohesionAnalysis`        | object \| null | パッケージ凝集度分析。                               |
 | `ResponsibilityAnalysis`  | object \| null | SRP 違反分析。                                       |

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -132,7 +132,7 @@ Mirrors `domain.AnalyzeSummary`. All numeric counters default to `0` when the co
 
 | Field             | Type   | Description                                                       |
 | ----------------- | ------ | ----------------------------------------------------------------- |
-| `arch_compliance` | number | Architecture compliance ratio, `0`–`1`. `1.0` = fully compliant.  |
+| `arch_compliance` | number | Architecture compliance ratio, `0`–`1`. Severity-weighted (`error × 5 + warning × 1`); see `system.ArchitectureAnalysis.WeightedViolations` for the numerator. |
 
 ### Mock data metrics
 
@@ -638,9 +638,10 @@ Mirrors `domain.SystemAnalysisResponse`. Nested field names are Go PascalCase.
 
 | Field                 | Type    | Description                                                 |
 | --------------------- | ------- | ----------------------------------------------------------- |
-| `ComplianceScore`     | number  | Compliance score, `0`–`1`. `1.0` = fully compliant.         |
-| `TotalViolations`     | integer | Total violations found.                                     |
-| `TotalRules`          | integer | Total rules evaluated.                                      |
+| `ComplianceScore`     | number  | Compliance score, `0`–`1`. Computed as `max(0, 1 - WeightedViolations / TotalRules)`; `1.0` when no rules were evaluated. |
+| `TotalViolations`     | integer | Raw count of violations (one per entry in `Violations`).    |
+| `WeightedViolations`  | integer | Severity-weighted violation count used as the `ComplianceScore` numerator: `error × 5 + warning × 1`. |
+| `TotalRules`          | integer | Total rule invocations evaluated (the `ComplianceScore` denominator). |
 | `LayerAnalysis`       | object \| null | Layer analysis results.                              |
 | `CohesionAnalysis`    | object \| null | Package cohesion analysis.                           |
 | `ResponsibilityAnalysis` | object \| null | SRP violation analysis.                           |

--- a/website/docs/zh/output/schemas.md
+++ b/website/docs/zh/output/schemas.md
@@ -132,7 +132,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 
 | 字段              | 类型   | 说明                                                      |
 | ----------------- | ------ | --------------------------------------------------------- |
-| `arch_compliance` | number | 架构合规率，`0`–`1`。`1.0` = 完全合规。                   |
+| `arch_compliance` | number | 架构合规率，`0`–`1`。按严重度加权（`error × 5 + warning × 1`）；分子参见 `system.ArchitectureAnalysis.WeightedViolations`。 |
 
 ### 模拟数据指标
 
@@ -638,9 +638,10 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 
 | 字段                  | 类型    | 说明                                                |
 | --------------------- | ------- | --------------------------------------------------- |
-| `ComplianceScore`     | number  | 合规评分，`0`–`1`。`1.0` = 完全合规。               |
-| `TotalViolations`     | integer | 发现的违规总数。                                    |
-| `TotalRules`          | integer | 评估的规则总数。                                    |
+| `ComplianceScore`     | number  | 合规评分，`0`–`1`。按 `max(0, 1 - WeightedViolations / TotalRules)` 计算；无规则评估时为 `1.0`。 |
+| `TotalViolations`     | integer | 原始违规计数（与 `Violations` 数组长度一致）。      |
+| `WeightedViolations`  | integer | 用作 `ComplianceScore` 分子的加权违规数：`error × 5 + warning × 1`。 |
+| `TotalRules`          | integer | 评估的规则调用总数（`ComplianceScore` 的分母）。    |
 | `LayerAnalysis`       | object \| null | 分层分析结果。                               |
 | `CohesionAnalysis`    | object \| null | 包内聚性分析。                               |
 | `ResponsibilityAnalysis` | object \| null | 单一职责原则违规分析。                    |


### PR DESCRIPTION
## Summary

Fixes #444.

`system.ArchitectureAnalysis.ComplianceScore` is computed from severity-**weighted** violations (`error × 5 + warning × 1`), but the sibling `TotalViolations` field exposed only the **raw** count. A JSON consumer who tried to reproduce `(TotalRules - TotalViolations) / TotalRules` got a different number than the reported score, with no field on the result that explained the gap.

This PR adds a new sibling field `WeightedViolations` so the formula `ComplianceScore = max(0, 1 - WeightedViolations / TotalRules)` holds against the data in the report, and documents the weighting in the schema docs (en / ja / zh / fr).

## Changes

- **`domain/system_analysis.go`** — add `WeightedViolations int` on `ArchitectureAnalysisResult`; rewrite the field doc comments to make the formula and units explicit (raw count vs. weighted numerator vs. rule-invocation denominator).
- **`service/system_analysis_service.go`** — `calculateComplianceWeighted` now returns `(score, weighted)`; both callers (with-layer-rules and SRP-only) pass the weighted count through `buildArchitectureResultWithRecommendations` into the result struct.
- **`service/responsibility_analysis_test.go`** — regression test for #444: asserts `WeightedViolations == error×5 + warning×1` and `ComplianceScore ≈ 1 - WeightedViolations/TotalRules` (clamped to [0,1]) on the SRP-only path.
- **`website/docs/output/schemas.md`** (+ ja / zh / fr) — `arch_compliance` and `ArchitectureAnalysis.ComplianceScore` descriptions updated; new `WeightedViolations` row added.

## Behavior change

- JSON / HTML / CSV / text consumers see **one new field** (`WeightedViolations`) on `ArchitectureAnalysis`. All existing fields — `ComplianceScore`, `TotalViolations`, `TotalRules`, `SeverityBreakdown`, `Violations[]`, `LayerAnalysis`, etc. — are unchanged numerically. UI surfaces (HTML cards, text summary) still display the raw `TotalViolations`.
- No CI gate on `arch_compliance` should move.

## Why not Option 3 (drop the weighting)

Reverting to a raw count would also fix the inconsistency, but it would discard the design intent from `9f7420e` ("more meaningful scores that consider both violation severity and codebase size") and silently shift `arch_compliance` upward for everyone gating CI on it. Exposing the weighted count is strictly additive and preserves both the score and reproducibility.

## Test plan

- [x] `go test ./...` passes
- [x] New regression assertions in `TestAnalyzeArchitectureRunsResponsibilityWithoutLayerRules` (algebraic invariant between `ComplianceScore`, `WeightedViolations`, `TotalRules`)
- [x] Existing tests covering `ComplianceScore`, `TotalViolations`, `TotalRules` consistency (`system_analysis_service_test.go`) unchanged and still passing