### PR TITLE
chore(ci): drop Codecov upload step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,9 @@ jobs:
     # - name: Run staticcheck
     #   run: staticcheck ./...
     
-    - name: Run tests with coverage
-      run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+    - name: Run tests
+      run: go test -v ./...
       timeout-minutes: 5
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.txt
-        flags: unittests
-        name: codecov-umbrella
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Codecov PR comments showed up inconsistently because of tokenless upload rate-limit flakiness and the GitHub App not being installed. Rather than stabilizing it, we're dropping Codecov entirely.
- Removed the Codecov upload step and the `-coverprofile`/`-covermode` flags from `.github/workflows/ci.yml`.
- Coverage is still available locally via `make coverage`.

## Test plan
- [ ] CI (`test` / `build` / `lint`) is green