### PR TITLE
fix(lcom): detect external ctypes fields

### DIFF
--- a/internal/analyzer/lcom.go
+++ b/internal/analyzer/lcom.go
@@ -72,10 +72,11 @@ func (a *LCOMAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*LCO
 
 	// Collect all class definitions
 	classes := a.collectClasses(ast)
+	ctypesFields := a.collectCtypesFields(ast, classes)
 
 	var results []*LCOMResult
 	for _, classNode := range classes {
-		result, err := a.analyzeClass(classNode, filePath)
+		result, err := a.analyzeClass(classNode, filePath, ctypesFields[classNode.Name])
 		if err != nil {
 			continue
 		}
@@ -86,7 +87,7 @@ func (a *LCOMAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*LCO
 }
 
 // analyzeClass computes LCOM4 for a single class using connected components
-func (a *LCOMAnalyzer) analyzeClass(classNode *parser.Node, filePath string) (*LCOMResult, error) {
+func (a *LCOMAnalyzer) analyzeClass(classNode *parser.Node, filePath string, declaredFields map[string]bool) (*LCOMResult, error) {
 	if classNode.Type != parser.NodeClassDef {
 		return nil, fmt.Errorf("node is not a class definition")
 	}
@@ -100,9 +101,21 @@ func (a *LCOMAnalyzer) analyzeClass(classNode *parser.Node, filePath string) (*L
 	}
 
 	// Step 1: Collect methods, their instance variable accesses, and intra-class calls
-	methods, excluded, methodCalls := a.collectMethods(classNode)
+	methods, excluded, methodCalls := a.collectMethods(classNode, declaredFields)
 	result.TotalMethods = len(methods) + excluded
 	result.ExcludedMethods = excluded
+
+	// Step 2: Collect all distinct instance variables
+	allVars := make(map[string]bool)
+	for _, vars := range methods {
+		for v := range vars {
+			allVars[v] = true
+		}
+	}
+	for v := range declaredFields {
+		allVars[v] = true
+	}
+	result.InstanceVariables = len(allVars)
 
 	// Classes with 0 or 1 methods are trivially cohesive
 	if len(methods) <= 1 {
@@ -115,15 +128,6 @@ func (a *LCOMAnalyzer) analyzeClass(classNode *parser.Node, filePath string) (*L
 		result.RiskLevel = a.assessRiskLevel(1)
 		return result, nil
 	}
-
-	// Step 2: Collect all distinct instance variables
-	allVars := make(map[string]bool)
-	for _, vars := range methods {
-		for v := range vars {
-			allVars[v] = true
-		}
-	}
-	result.InstanceVariables = len(allVars)
 
 	// Step 3: Compute connected components using Union-Find
 	methodNames := make([]string, 0, len(methods))
@@ -215,7 +219,7 @@ func (a *LCOMAnalyzer) analyzeClass(classNode *parser.Node, filePath string) (*L
 //   - methods: methodName -> set of instance variable names
 //   - excluded: count of excluded methods (@classmethod/@staticmethod)
 //   - calls: methodName -> set of called method names (self.xxx() intra-class calls)
-func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node) (map[string]map[string]bool, int, map[string]map[string]bool) {
+func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node, declaredFields map[string]bool) (map[string]map[string]bool, int, map[string]map[string]bool) {
 	methods := make(map[string]map[string]bool)
 	calls := make(map[string]map[string]bool)
 	excluded := 0
@@ -238,6 +242,11 @@ func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node) (map[string]map[st
 		// Extract self.xxx accesses from method body
 		vars := make(map[string]bool)
 		a.extractInstanceVars(node, vars)
+		if len(declaredFields) > 0 && a.hasBareSelfAccess(node) {
+			for field := range declaredFields {
+				vars[field] = true
+			}
+		}
 		methods[node.Name] = vars
 
 		// Extract self.xxx() method calls
@@ -319,6 +328,64 @@ func (a *LCOMAnalyzer) extractInstanceVars(methodNode *parser.Node, vars map[str
 	})
 }
 
+// hasBareSelfAccess reports whether a method uses self as a value rather than
+// only as the base object in self.attr. ctypes.Structure methods commonly pass
+// self to C functions that read or mutate fields declared in _fields_.
+func (a *LCOMAnalyzer) hasBareSelfAccess(node *parser.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Type {
+	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
+		for _, bodyNode := range node.Body {
+			if a.hasBareSelfAccess(bodyNode) {
+				return true
+			}
+		}
+		return false
+	case parser.NodeName:
+		return node.Name == "self"
+	case parser.NodeAttribute:
+		if valueNode := nodeValue(node); valueNode != nil {
+			if valueNode.Type == parser.NodeName && valueNode.Name == "self" {
+				return false
+			}
+			if a.hasBareSelfAccess(valueNode) {
+				return true
+			}
+		}
+		for _, child := range parser.OrderedChildren(node, nil) {
+			if child != nodeValue(node) && a.hasBareSelfAccess(child) {
+				return true
+			}
+		}
+		return false
+	case parser.NodeCall:
+		if valueNode := nodeValue(node); valueNode != nil && a.hasBareSelfAccess(valueNode) {
+			return true
+		}
+		for _, arg := range node.Args {
+			if a.hasBareSelfAccess(arg) {
+				return true
+			}
+		}
+		for _, keyword := range node.Keywords {
+			if a.hasBareSelfAccess(keyword) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, child := range parser.OrderedChildren(node, nil) {
+		if a.hasBareSelfAccess(child) {
+			return true
+		}
+	}
+	return false
+}
+
 // isSelfAccess checks if an attribute node represents self.xxx access
 func (a *LCOMAnalyzer) isSelfAccess(attrNode *parser.Node) bool {
 	// The object (self) can be in Value or Left field
@@ -359,6 +426,128 @@ func (a *LCOMAnalyzer) collectClasses(ast *parser.Node) []*parser.Node {
 		return true
 	})
 	return classes
+}
+
+func (a *LCOMAnalyzer) collectCtypesFields(ast *parser.Node, classes []*parser.Node) map[string]map[string]bool {
+	fieldsByClass := make(map[string]map[string]bool)
+	ctypesClasses := make(map[string]*parser.Node, len(classes))
+	for _, classNode := range classes {
+		if a.isCtypesStructureClass(classNode) {
+			ctypesClasses[classNode.Name] = classNode
+		}
+	}
+	if len(ctypesClasses) == 0 {
+		return fieldsByClass
+	}
+
+	for className, classNode := range ctypesClasses {
+		for _, bodyNode := range classNode.Body {
+			if bodyNode == nil {
+				continue
+			}
+			if !isAssignmentNode(bodyNode) || !a.assignmentTargetsName(bodyNode, "_fields_") {
+				continue
+			}
+			a.addFields(fieldsByClass, className, a.extractCtypesFieldNames(bodyNode.Value))
+		}
+	}
+
+	ast.WalkDeep(func(node *parser.Node) bool {
+		if node == nil || !isAssignmentNode(node) {
+			return true
+		}
+		for _, target := range node.Targets {
+			className := a.ctypesFieldsAssignmentClass(target)
+			if className == "" {
+				continue
+			}
+			if _, ok := ctypesClasses[className]; !ok {
+				continue
+			}
+			a.addFields(fieldsByClass, className, a.extractCtypesFieldNames(node.Value))
+		}
+		return true
+	})
+
+	return fieldsByClass
+}
+
+func (a *LCOMAnalyzer) isCtypesStructureClass(classNode *parser.Node) bool {
+	if classNode == nil || classNode.Type != parser.NodeClassDef {
+		return false
+	}
+	for _, base := range classNode.Bases {
+		if base == nil {
+			continue
+		}
+		if base.Type == parser.NodeName && base.Name == "Structure" {
+			return true
+		}
+		if base.Type == parser.NodeAttribute && base.Name == "Structure" {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *LCOMAnalyzer) assignmentTargetsName(assignNode *parser.Node, name string) bool {
+	for _, target := range assignNode.Targets {
+		if target != nil && target.Type == parser.NodeName && target.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *LCOMAnalyzer) ctypesFieldsAssignmentClass(target *parser.Node) string {
+	if target == nil || target.Type != parser.NodeAttribute || target.Name != "_fields_" {
+		return ""
+	}
+	valueNode := nodeValue(target)
+	if valueNode == nil || valueNode.Type != parser.NodeName {
+		return ""
+	}
+	return valueNode.Name
+}
+
+func (a *LCOMAnalyzer) extractCtypesFieldNames(value interface{}) []string {
+	valueNode, ok := value.(*parser.Node)
+	if !ok || valueNode == nil {
+		return nil
+	}
+
+	var fields []string
+	for _, fieldNode := range valueNode.Children {
+		if fieldNode == nil || fieldNode.Type != parser.NodeTuple || len(fieldNode.Children) == 0 {
+			continue
+		}
+		nameNode := fieldNode.Children[0]
+		if nameNode == nil || nameNode.Type != parser.NodeConstant {
+			continue
+		}
+		fieldName, ok := nameNode.Value.(string)
+		if !ok || fieldName == "" {
+			continue
+		}
+		fields = append(fields, fieldName)
+	}
+	return fields
+}
+
+func (a *LCOMAnalyzer) addFields(fieldsByClass map[string]map[string]bool, className string, fields []string) {
+	if len(fields) == 0 {
+		return
+	}
+	if fieldsByClass[className] == nil {
+		fieldsByClass[className] = make(map[string]bool, len(fields))
+	}
+	for _, field := range fields {
+		fieldsByClass[className][field] = true
+	}
+}
+
+func isAssignmentNode(node *parser.Node) bool {
+	return node != nil && (node.Type == parser.NodeAssign || node.Type == parser.NodeAnnAssign)
 }
 
 // CalculateLCOM is a convenience function that creates an analyzer with defaults and runs it

--- a/internal/analyzer/lcom.go
+++ b/internal/analyzer/lcom.go
@@ -76,7 +76,7 @@ func (a *LCOMAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*LCO
 
 	var results []*LCOMResult
 	for _, classNode := range classes {
-		result, err := a.analyzeClass(classNode, filePath, ctypesFields[classNode.Name])
+		result, err := a.analyzeClass(classNode, filePath, ctypesFields[classNode])
 		if err != nil {
 			continue
 		}
@@ -428,19 +428,32 @@ func (a *LCOMAnalyzer) collectClasses(ast *parser.Node) []*parser.Node {
 	return classes
 }
 
-func (a *LCOMAnalyzer) collectCtypesFields(ast *parser.Node, classes []*parser.Node) map[string]map[string]bool {
-	fieldsByClass := make(map[string]map[string]bool)
-	ctypesClasses := make(map[string]*parser.Node, len(classes))
+func (a *LCOMAnalyzer) collectCtypesFields(ast *parser.Node, classes []*parser.Node) map[*parser.Node]map[string]bool {
+	fieldsByClass := make(map[*parser.Node]map[string]bool)
+	// Map class name -> node, with nil marking names that resolve ambiguously
+	// (e.g. two ctypes classes share a name across scopes). Ambiguous names are
+	// skipped for external `<Name>._fields_ = ...` assignments since we cannot
+	// safely attribute them to a specific class.
+	ctypesByName := make(map[string]*parser.Node, len(classes))
+	var ctypesClasses []*parser.Node
 	for _, classNode := range classes {
-		if a.isCtypesStructureClass(classNode) {
-			ctypesClasses[classNode.Name] = classNode
+		if !a.isCtypesStructureClass(classNode) {
+			continue
 		}
+		ctypesClasses = append(ctypesClasses, classNode)
+		if existing, ok := ctypesByName[classNode.Name]; ok {
+			if existing != nil {
+				ctypesByName[classNode.Name] = nil
+			}
+			continue
+		}
+		ctypesByName[classNode.Name] = classNode
 	}
 	if len(ctypesClasses) == 0 {
 		return fieldsByClass
 	}
 
-	for className, classNode := range ctypesClasses {
+	for _, classNode := range ctypesClasses {
 		for _, bodyNode := range classNode.Body {
 			if bodyNode == nil {
 				continue
@@ -448,7 +461,7 @@ func (a *LCOMAnalyzer) collectCtypesFields(ast *parser.Node, classes []*parser.N
 			if !isAssignmentNode(bodyNode) || !a.assignmentTargetsName(bodyNode, "_fields_") {
 				continue
 			}
-			a.addFields(fieldsByClass, className, a.extractCtypesFieldNames(bodyNode.Value))
+			a.addFields(fieldsByClass, classNode, a.extractCtypesFieldNames(bodyNode.Value))
 		}
 	}
 
@@ -461,15 +474,28 @@ func (a *LCOMAnalyzer) collectCtypesFields(ast *parser.Node, classes []*parser.N
 			if className == "" {
 				continue
 			}
-			if _, ok := ctypesClasses[className]; !ok {
+			classNode, ok := ctypesByName[className]
+			if !ok || classNode == nil {
 				continue
 			}
-			a.addFields(fieldsByClass, className, a.extractCtypesFieldNames(node.Value))
+			a.addFields(fieldsByClass, classNode, a.extractCtypesFieldNames(node.Value))
 		}
 		return true
 	})
 
 	return fieldsByClass
+}
+
+// ctypesStructureBases lists the ctypes base classes whose subclasses declare
+// fields via the _fields_ class attribute (often assigned outside the class
+// body to allow self-referential pointer types).
+var ctypesStructureBases = map[string]bool{
+	"Structure":             true,
+	"Union":                 true,
+	"BigEndianStructure":    true,
+	"LittleEndianStructure": true,
+	"BigEndianUnion":        true,
+	"LittleEndianUnion":     true,
 }
 
 func (a *LCOMAnalyzer) isCtypesStructureClass(classNode *parser.Node) bool {
@@ -480,11 +506,11 @@ func (a *LCOMAnalyzer) isCtypesStructureClass(classNode *parser.Node) bool {
 		if base == nil {
 			continue
 		}
-		if base.Type == parser.NodeName && base.Name == "Structure" {
-			return true
-		}
-		if base.Type == parser.NodeAttribute && base.Name == "Structure" {
-			return true
+		switch base.Type {
+		case parser.NodeName, parser.NodeAttribute:
+			if ctypesStructureBases[base.Name] {
+				return true
+			}
 		}
 	}
 	return false
@@ -534,15 +560,15 @@ func (a *LCOMAnalyzer) extractCtypesFieldNames(value interface{}) []string {
 	return fields
 }
 
-func (a *LCOMAnalyzer) addFields(fieldsByClass map[string]map[string]bool, className string, fields []string) {
-	if len(fields) == 0 {
+func (a *LCOMAnalyzer) addFields(fieldsByClass map[*parser.Node]map[string]bool, classNode *parser.Node, fields []string) {
+	if len(fields) == 0 || classNode == nil {
 		return
 	}
-	if fieldsByClass[className] == nil {
-		fieldsByClass[className] = make(map[string]bool, len(fields))
+	if fieldsByClass[classNode] == nil {
+		fieldsByClass[classNode] = make(map[string]bool, len(fields))
 	}
 	for _, field := range fields {
-		fieldsByClass[className][field] = true
+		fieldsByClass[classNode][field] = true
 	}
 }
 

--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -582,3 +582,83 @@ class MultipleItems:
 		})
 	}
 }
+
+func TestLCOMAnalyzer_CtypesFieldsAssignedOutsideClass(t *testing.T) {
+	p := parser.New()
+	code := `
+import ctypes
+
+class Image(ctypes.Structure):
+    def __init__(self, data=None, width=None, height=None, mipmaps=None, format_=None):
+        super(Image, self).__init__(
+            data,
+            width or 0,
+            height or 0,
+            mipmaps or 1,
+            format_ or 7,
+        )
+
+    @property
+    def is_ready(self):
+        return _IsImageReady(self)
+
+    def resize(self, width, height):
+        _ImageResize(self, width, height)
+
+    def export(self, file_name):
+        return _ExportImage(self, file_name)
+
+Image._fields_ = [
+    ("data", ctypes.c_void_p),
+    ("width", ctypes.c_int),
+    ("height", ctypes.c_int),
+    ("mipmaps", ctypes.c_int),
+    ("format", ctypes.c_int),
+]
+`
+	result, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	analyzer := NewLCOMAnalyzer(nil)
+	results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, "Image", r.ClassName)
+	assert.Equal(t, 1, r.LCOM4)
+	assert.Equal(t, 5, r.InstanceVariables)
+	assert.Equal(t, [][]string{{"__init__", "export", "is_ready", "resize"}}, r.MethodGroups)
+}
+
+func TestLCOMAnalyzer_CtypesFieldsDoNotTreatSelfParameterAsFieldAccess(t *testing.T) {
+	p := parser.New()
+	code := `
+import ctypes
+
+class Packet(ctypes.Structure):
+    def touches_state(self):
+        _TouchPacket(self)
+
+    def utility(self):
+        return 42
+
+Packet._fields_ = [
+    ("kind", ctypes.c_int),
+    ("size", ctypes.c_int),
+]
+`
+	result, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	analyzer := NewLCOMAnalyzer(nil)
+	results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	r := results[0]
+	assert.Equal(t, "Packet", r.ClassName)
+	assert.Equal(t, 2, r.LCOM4)
+	assert.Equal(t, 2, r.InstanceVariables)
+	assert.Equal(t, [][]string{{"touches_state"}, {"utility"}}, r.MethodGroups)
+}

--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -662,3 +662,86 @@ Packet._fields_ = [
 	assert.Equal(t, 2, r.InstanceVariables)
 	assert.Equal(t, [][]string{{"touches_state"}, {"utility"}}, r.MethodGroups)
 }
+
+func TestLCOMAnalyzer_CtypesUnionAndEndianBases(t *testing.T) {
+	p := parser.New()
+	code := `
+import ctypes
+from ctypes import Union, BigEndianStructure
+
+class Payload(Union):
+    def as_int(self):
+        return _AsInt(self)
+
+    def as_float(self):
+        return _AsFloat(self)
+
+Payload._fields_ = [
+    ("i", ctypes.c_int),
+    ("f", ctypes.c_float),
+]
+
+class NetHeader(BigEndianStructure):
+    def serialize(self):
+        return _Serialize(self)
+
+NetHeader._fields_ = [
+    ("magic", ctypes.c_uint32),
+    ("length", ctypes.c_uint16),
+]
+`
+	result, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	analyzer := NewLCOMAnalyzer(nil)
+	results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byName := map[string]*LCOMResult{}
+	for _, r := range results {
+		byName[r.ClassName] = r
+	}
+	require.Contains(t, byName, "Payload")
+	require.Contains(t, byName, "NetHeader")
+	assert.Equal(t, 1, byName["Payload"].LCOM4)
+	assert.Equal(t, 2, byName["Payload"].InstanceVariables)
+	assert.Equal(t, 2, byName["NetHeader"].InstanceVariables)
+}
+
+func TestLCOMAnalyzer_CtypesAmbiguousClassNameSkipsExternalFields(t *testing.T) {
+	p := parser.New()
+	// Two ctypes Structure classes share the name "Inner" at different scopes.
+	// External `Inner._fields_ = ...` cannot be safely attributed to either, so
+	// neither should receive the declared fields.
+	code := `
+import ctypes
+
+def factory_a():
+    class Inner(ctypes.Structure):
+        def use(self):
+            _Use(self)
+    return Inner
+
+def factory_b():
+    class Inner(ctypes.Structure):
+        def use(self):
+            _Use(self)
+    return Inner
+
+Inner._fields_ = [
+    ("x", ctypes.c_int),
+]
+`
+	result, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	analyzer := NewLCOMAnalyzer(nil)
+	results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+	require.NoError(t, err)
+	for _, r := range results {
+		if r.ClassName == "Inner" {
+			assert.Equal(t, 0, r.InstanceVariables, "ambiguous external _fields_ must not be attributed")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Detect ctypes `Structure._fields_` declarations assigned outside the class body for LCOM analysis.
- Treat bare `self` usage in ctypes structure methods as access to the declared fields, matching wrapper methods that pass `self` to C APIs.
- Add regression coverage for issue #475 and guard against counting the method `self` parameter as a field access.

Fixes #475.

## Verification

- `go test ./...`
- `go vet ./...`
- `go run ./cmd/pyscn analyze --json --select lcom /private/tmp/raylibpy_1f8a98d_init.py`

raylib-py repro check:

- `Image`: `LCOM4=1`, `InstanceVariables=5`
- `AudioStream`: `LCOM4=1`
- `Music`: `LCOM4=1`

Note: `make lint` still fails at `golangci-lint run` in this environment with `context loading failed: no go files to analyze`; `go vet ./...` succeeds.
