### PR TITLE
[codex] fix clone skip-docstrings config

### DIFF
--- a/service/clone_config_loader.go
+++ b/service/clone_config_loader.go
@@ -242,6 +242,7 @@ func (c *CloneConfigurationLoader) cloneConfigToCloneRequest(cloneCfg *config.Py
 		MaxEditDistance:     cloneCfg.Analysis.MaxEditDistance,
 		IgnoreLiterals:      domain.BoolValue(cloneCfg.Analysis.IgnoreLiterals, false),
 		IgnoreIdentifiers:   domain.BoolValue(cloneCfg.Analysis.IgnoreIdentifiers, false),
+		SkipDocstrings:      domain.BoolValue(cloneCfg.Analysis.SkipDocstrings, true),
 		Type1Threshold:      cloneCfg.Thresholds.Type1Threshold,
 		Type2Threshold:      cloneCfg.Thresholds.Type2Threshold,
 		Type3Threshold:      cloneCfg.Thresholds.Type3Threshold,
@@ -313,6 +314,7 @@ func (c *CloneConfigurationLoader) updateConfigFromCloneRequest(cfg *config.Conf
 	cfg.Clones.Analysis.CostModelType = "python" // Default cost model
 	cfg.Clones.Analysis.IgnoreLiterals = domain.BoolPtr(req.IgnoreLiterals)
 	cfg.Clones.Analysis.IgnoreIdentifiers = domain.BoolPtr(req.IgnoreIdentifiers)
+	cfg.Clones.Analysis.SkipDocstrings = domain.BoolPtr(req.SkipDocstrings)
 
 	cfg.Clones.Thresholds.Type1Threshold = req.Type1Threshold
 	cfg.Clones.Thresholds.Type2Threshold = req.Type2Threshold

--- a/service/clone_config_loader_test.go
+++ b/service/clone_config_loader_test.go
@@ -79,6 +79,22 @@ show_content = true
 	assert.Equal(t, "connected", req.GroupMode)
 	assert.Equal(t, domain.DefaultCloneGroupingThreshold, req.GroupThreshold)
 	assert.Equal(t, 2, req.KCoreK)
+	assert.True(t, req.SkipDocstrings)
+}
+
+func TestCloneConfigurationLoader_LoadCloneConfig_HonorsSkipDocstrings(t *testing.T) {
+	loader := NewCloneConfigurationLoader()
+	configPath := filepath.Join(t.TempDir(), ".pyscn.toml")
+	configContent := `[clones]
+skip_docstrings = false
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+	req, err := loader.LoadCloneConfig(configPath)
+	require.NoError(t, err)
+	require.NotNil(t, req)
+
+	assert.False(t, req.SkipDocstrings)
 }
 
 func TestCloneConfigurationLoaderWithFlags_MergeConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve clone `skip_docstrings` when loading config into `CloneRequest`.
- Persist `skip_docstrings` when saving clone config from a request.
- Add loader coverage for the default `true` value and explicit `false` override.

## Rationale
`cloneConfigToCloneRequest` omitted `SkipDocstrings`, so config-backed requests received Go's `false` zero value even though the default clone behavior skips docstrings. This made `.pyscn.toml` / `pyproject.toml` driven runs diverge from the default request behavior.

## Validation
- `go test ./service`
- `go test ./internal/config`
- `go test ./app`
- `go test ./...`