### PR TITLE
[codex] fix clone group type classification

### DIFF
--- a/internal/analyzer/connected_grouping.go
+++ b/internal/analyzer/connected_grouping.go
@@ -145,6 +145,9 @@ func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) Cl
 		for j := i + 1; j < len(members); j++ {
 			key := pairKey(members[i], members[j])
 			if t, ok := typeMap[key]; ok {
+				if t == 0 {
+					continue
+				}
 				counts[t]++
 			}
 		}
@@ -158,7 +161,7 @@ func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) Cl
 		}
 	}
 	if maxC < 0 {
-		return Type3Clone // fallback reasonable default
+		return Type4Clone // conservative fallback: never report unknown as Type-1
 	}
 	return best
 }

--- a/internal/analyzer/star_medoid_grouping.go
+++ b/internal/analyzer/star_medoid_grouping.go
@@ -41,7 +41,7 @@ func (s *StarMedoidGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
 	if len(fragments) == 0 {
 		return []*CloneGroup{}
 	}
-	simMap := s.buildSimilarityMap(pairs)
+	simMap, typeMap := clonePairMetadata(pairs)
 	graph := s.buildSimilarityGraph(pairs)
 
 	// 2. Initialize clusters: each fragment alone, with union-find to merge via medoids
@@ -166,6 +166,7 @@ func (s *StarMedoidGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
 		}
 		// Compute average similarity from cache among group members
 		group.Similarity = averageGroupSimilarity(simMap, filtered)
+		group.CloneType = majorityCloneType(typeMap, filtered)
 		result = append(result, group)
 	}
 

--- a/internal/analyzer/star_medoid_grouping.go
+++ b/internal/analyzer/star_medoid_grouping.go
@@ -270,21 +270,6 @@ func (s *StarMedoidGrouping) collectFragments(pairs []*ClonePair) []*CodeFragmen
 	return order
 }
 
-// Helper: build similarity cache from given pairs
-func (s *StarMedoidGrouping) buildSimilarityMap(pairs []*ClonePair) map[string]float64 {
-	sims := make(map[string]float64, len(pairs)*2)
-	for _, p := range pairs {
-		if p.Fragment1 == nil || p.Fragment2 == nil {
-			continue
-		}
-		k := pairKey(p.Fragment1, p.Fragment2)
-		if old, ok := sims[k]; !ok || p.Similarity > old {
-			sims[k] = p.Similarity // keep the highest if duplicates exist
-		}
-	}
-	return sims
-}
-
 func (s *StarMedoidGrouping) buildSimilarityGraph(pairs []*ClonePair) map[*CodeFragment][]fragmentSimilarity {
 	best := make(map[*CodeFragment]map[*CodeFragment]float64)
 	for _, p := range pairs {

--- a/internal/analyzer/star_medoid_grouping_test.go
+++ b/internal/analyzer/star_medoid_grouping_test.go
@@ -13,7 +13,11 @@ func newFrag(path string, sl, el int) *CodeFragment {
 }
 
 func newPair(a, b *CodeFragment, sim float64) *ClonePair {
-	return &ClonePair{Fragment1: a, Fragment2: b, Similarity: sim}
+	return newPairWithType(a, b, sim, Type4Clone)
+}
+
+func newPairWithType(a, b *CodeFragment, sim float64, cloneType CloneType) *ClonePair {
+	return &ClonePair{Fragment1: a, Fragment2: b, Similarity: sim, CloneType: cloneType}
 }
 
 func TestStarMedoidGrouping_SimpleCase(t *testing.T) {
@@ -122,6 +126,21 @@ func TestStarMedoidGrouping_AssignsIDsAfterStableSort(t *testing.T) {
 	}
 	assert.Same(t, B1, groups[0].Fragments[0])
 	assert.Same(t, A1, groups[1].Fragments[0])
+}
+
+func TestStarMedoidGrouping_PreservesPairCloneType(t *testing.T) {
+	A := newFrag("a.py", 1, 10)
+	B := newFrag("b.py", 1, 10)
+
+	groups := NewStarMedoidGrouping(0.85).GroupClones([]*ClonePair{
+		newPairWithType(A, B, 1.0, Type4Clone),
+	})
+
+	if !assert.Len(t, groups, 1) {
+		t.Fatalf("unexpected groups len: %d", len(groups))
+	}
+	assert.Equal(t, Type4Clone, groups[0].CloneType)
+	assert.Equal(t, 1.0, groups[0].Similarity)
 }
 
 func TestStarMedoidGrouping_NoGroups(t *testing.T) {

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -418,7 +418,7 @@ func (s *CloneService) convertCloneType(cloneType analyzer.CloneType) domain.Clo
 	case analyzer.Type4Clone:
 		return domain.Type4Clone
 	default:
-		return domain.Type1Clone
+		return domain.Type4Clone
 	}
 }
 

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/analyzer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -503,22 +504,20 @@ func TestCloneService_CreateDetectorConfig(t *testing.T) {
 func TestCloneService_ConvertCloneType(t *testing.T) {
 	testCases := []struct {
 		name               string
-		analyzerType       int // Using int since analyzer types are in internal package
+		analyzerType       analyzer.CloneType
 		expectedDomainType domain.CloneType
 	}{
-		{"Type1", 1, domain.Type1Clone},
-		{"Type2", 2, domain.Type2Clone},
-		{"Type3", 3, domain.Type3Clone},
-		{"Type4", 4, domain.Type4Clone},
-		{"Unknown", 99, domain.Type1Clone}, // Default case
+		{"Type1", analyzer.Type1Clone, domain.Type1Clone},
+		{"Type2", analyzer.Type2Clone, domain.Type2Clone},
+		{"Type3", analyzer.Type3Clone, domain.Type3Clone},
+		{"Type4", analyzer.Type4Clone, domain.Type4Clone},
+		{"Unknown", analyzer.CloneType(99), domain.Type4Clone},
 	}
 
-	// Note: We can't directly test the convertCloneType method since it uses internal types
-	// but we can test the domain.CloneType.String() method instead
+	service := NewCloneService()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			str := tc.expectedDomainType.String()
-			assert.Contains(t, str, "Type-")
+			assert.Equal(t, tc.expectedDomainType, service.convertCloneType(tc.analyzerType))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve pair-derived clone types when building `star`/medoid clone groups.
- Ignore unknown analyzer clone types in group majority calculation and fall back conservatively to Type-4.
- Convert unknown analyzer clone types to Type-4 instead of Type-1 in service output.
- Add regression coverage for star grouping and direct clone type conversion.

## Rationale
During #481 follow-up, I found a path where grouped clone output can be labeled Type-1 without pair-level Type-1 evidence: `StarMedoidGrouping` was leaving `CloneType` unset, and service conversion mapped unknown analyzer types to Type-1. That makes a group look like an exact clone even when the underlying pair classification is a less strict clone type.

This change keeps group type metadata tied to detected pair types and makes unknown values conservative instead of reporting them as Type-1.

## Validation
- `go test ./internal/analyzer -run 'TestStarMedoidGrouping|TestMajorityCloneType'`
- `go test ./service -run TestCloneService_ConvertCloneType`
- `go test ./internal/analyzer`
- `go test ./service`
- `go test ./...`
- Re-ran the issue481 reduced repro from a config-free cwd: `skip_docstrings=true`, `total_clone_groups=0`.