### PR TITLE
fix(analysis): exclude Django migration files from analysis defaults

### DIFF
--- a/cmd/pyscn/check.go
+++ b/cmd/pyscn/check.go
@@ -347,7 +347,7 @@ func (c *CheckCommand) checkComplexity(cmd *cobra.Command, args []string) (int, 
 		SortBy:          domain.SortByComplexity,
 		Recursive:       true,
 		IncludePatterns: []string{"**/*.py"},
-		ExcludePatterns: []string{"__pycache__/*", "*.pyc"},
+		ExcludePatterns: domain.DefaultAnalysisExcludePatterns(),
 		ConfigPath:      c.configFile,
 	}
 
@@ -410,7 +410,7 @@ func (c *CheckCommand) checkDeadCode(cmd *cobra.Command, args []string) (int, er
 		SortBy:                    domain.DeadCodeSortBySeverity,
 		Recursive:                 true,
 		IncludePatterns:           []string{"**/*.py"},
-		ExcludePatterns:           []string{"__pycache__/*", "*.pyc"},
+		ExcludePatterns:           domain.DefaultAnalysisExcludePatterns(),
 		IgnorePatterns:            []string{},
 		DetectAfterReturn:         domain.BoolPtr(true),
 		DetectAfterBreak:          domain.BoolPtr(true),
@@ -500,7 +500,7 @@ func (c *CheckCommand) checkClones(cmd *cobra.Command, args []string) (int, erro
 		CloneTypes:          domain.DefaultEnabledCloneTypes,
 		Recursive:           true,
 		IncludePatterns:     []string{"**/*.py"},
-		ExcludePatterns:     []string{"__pycache__/*", "*.pyc"},
+		ExcludePatterns:     domain.DefaultAnalysisExcludePatterns(),
 		ConfigPath:          c.configFile,
 	}
 
@@ -622,7 +622,7 @@ func (c *CheckCommand) checkMockdata(cmd *cobra.Command, args []string) (int, er
 		SortBy:          domain.MockDataSortBySeverity,
 		Recursive:       true,
 		IncludePatterns: []string{"**/*.py"},
-		ExcludePatterns: []string{"__pycache__/*", "*.pyc"},
+		ExcludePatterns: domain.DefaultAnalysisExcludePatterns(),
 		IgnoreTests:     domain.BoolPtr(true),
 		Keywords:        domain.DefaultMockDataKeywords(),
 		Domains:         domain.DefaultMockDataDomains(),

--- a/domain/clone.go
+++ b/domain/clone.go
@@ -338,7 +338,7 @@ func DefaultCloneRequest() *CloneRequest {
 		Paths:               []string{"."},
 		Recursive:           true,
 		IncludePatterns:     []string{"**/*.py"},
-		ExcludePatterns:     []string{"test_*.py", "*_test.py"},
+		ExcludePatterns:     DefaultAnalysisExcludePatterns(),
 		MinLines:            5,
 		MinNodes:            10,
 		SimilarityThreshold: DefaultCloneSimilarityThreshold,

--- a/domain/dead_code.go
+++ b/domain/dead_code.go
@@ -226,7 +226,7 @@ func DefaultDeadCodeRequest() *DeadCodeRequest {
 		SortBy:          DeadCodeSortBySeverity,
 		Recursive:       true,
 		IncludePatterns: []string{"**/*.py"},
-		ExcludePatterns: []string{"test_*.py", "*_test.py"},
+		ExcludePatterns: DefaultAnalysisExcludePatterns(),
 		IgnorePatterns:  []string{},
 
 		// Dead code detection options (all enabled by default)

--- a/domain/defaults.go
+++ b/domain/defaults.go
@@ -317,6 +317,17 @@ func DefaultMockDataDomains() []string {
 	}
 }
 
+// DefaultAnalysisExcludePatterns returns the canonical default file-glob
+// patterns excluded from all analyses (CBO, complexity, dead code, clones,
+// LCOM, system analysis). Callers must copy before mutating.
+func DefaultAnalysisExcludePatterns() []string {
+	return []string{
+		"test_*.py",
+		"*_test.py",
+		"**/migrations/**",
+	}
+}
+
 // DefaultMockDataTestPatterns returns the default patterns for test files to ignore.
 func DefaultMockDataTestPatterns() []string {
 	return []string{

--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -515,7 +515,7 @@ func DefaultSystemAnalysisRequest() *SystemAnalysisRequest {
 		CohesionViolationSeverity:       ViolationSeverityWarning,
 		ResponsibilityViolationSeverity: ViolationSeverityWarning,
 		IncludePatterns:                 []string{"**/*.py"},
-		ExcludePatterns:                 []string{"test_*.py", "*_test.py"},
+		ExcludePatterns:                 DefaultAnalysisExcludePatterns(),
 		ComplexityData:                  make(map[string]int),
 		ClonesData:                      make(map[string]float64),
 		DeadCodeData:                    make(map[string]int),

--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
@@ -46,7 +47,7 @@ type ModuleAnalysisOptions struct {
 func DefaultModuleAnalysisOptions() *ModuleAnalysisOptions {
 	return &ModuleAnalysisOptions{
 		IncludePatterns:   []string{"**/*.py"},
-		ExcludePatterns:   []string{"test_*.py", "*_test.py", "__pycache__", "*.pyc"},
+		ExcludePatterns:   domain.DefaultAnalysisExcludePatterns(),
 		IncludeStdLib:     false,
 		IncludeThirdParty: true,
 		FollowRelative:    true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,7 +238,7 @@ func DefaultConfig() *Config {
 		},
 		Analysis: AnalysisConfig{
 			IncludePatterns: []string{"**/*.py"},
-			ExcludePatterns: []string{"test_*.py", "*_test.py"},
+			ExcludePatterns: domain.DefaultAnalysisExcludePatterns(),
 			Recursive:       true,
 			FollowSymlinks:  false,
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -46,8 +46,8 @@ func TestDefaultConfig(t *testing.T) {
 	if len(config.Analysis.IncludePatterns) != 1 || config.Analysis.IncludePatterns[0] != "**/*.py" {
 		t.Errorf("Expected include patterns ['*.py'], got %v", config.Analysis.IncludePatterns)
 	}
-	if len(config.Analysis.ExcludePatterns) != 2 {
-		t.Errorf("Expected 2 exclude patterns, got %d", len(config.Analysis.ExcludePatterns))
+	if len(config.Analysis.ExcludePatterns) != 3 {
+		t.Errorf("Expected 3 exclude patterns, got %d", len(config.Analysis.ExcludePatterns))
 	}
 	if !config.Analysis.Recursive {
 		t.Error("Expected recursive to be true by default")

--- a/internal/config/default_config.toml.tmpl
+++ b/internal/config/default_config.toml.tmpl
@@ -128,7 +128,8 @@ exclude_patterns = [             # File patterns to exclude
     "venv/",
     "env/",
     ".venv/",
-    ".env/"
+    ".env/",
+    "**/migrations/**"           # Django/Alembic auto-generated migration files
 ]
 # =============================================================================
 # ARCHITECTURE VALIDATION

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -300,7 +300,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 			Paths:           []string{"."},
 			Recursive:       domain.BoolPtr(true),
 			IncludePatterns: []string{"**/*.py"},
-			ExcludePatterns: []string{"test_*.py", "*_test.py"},
+			ExcludePatterns: domain.DefaultAnalysisExcludePatterns(),
 		},
 		Output: CloneOutputConfig{
 			Format:      "text",
@@ -360,7 +360,7 @@ func DefaultPyscnConfig() *PyscnConfig {
 
 		// Analysis defaults (from [analysis] section - general analysis settings)
 		AnalysisIncludePatterns: []string{"**/*.py"},
-		AnalysisExcludePatterns: []string{"test_*.py", "*_test.py"},
+		AnalysisExcludePatterns: domain.DefaultAnalysisExcludePatterns(),
 		AnalysisRecursive:       domain.BoolPtr(true),
 		AnalysisFollowSymlinks:  domain.BoolPtr(false),
 

--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -129,7 +129,7 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) LoadDefaultConfig() *domain.Sys
 		ResponsibilityViolationSeverity: domain.ViolationSeverityWarning,
 		Recursive:                       domain.BoolPtr(true),
 		IncludePatterns:                 []string{"**/*.py"},
-		ExcludePatterns:                 []string{},
+		ExcludePatterns:                 domain.DefaultAnalysisExcludePatterns(),
 	}
 }
 

--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -314,7 +314,7 @@ analyze_dependencies = true
 analyze_architecture = true
 recursive = true
 include_patterns = ["**/*.py"]
-exclude_patterns = ["test_*.py", "*_test.py"]
+exclude_patterns = ["test_*.py", "*_test.py", "**/migrations/**"]
 
 [dependencies]
 include_stdlib = false


### PR DESCRIPTION
## Summary
- Add `**/migrations/**` to the default analysis exclude patterns so Django auto-generated migration files (`myapp/migrations/0001_initial.py`, etc.) are no longer counted in CBO/complexity/dead-code/clones/LCOM/system analysis. Their `Migration` classes only reference framework metadata (`migrations.AddField`, `migrations.CreateModel`, …), which inflates CBO and skews summary statistics on Django repos.
- Centralize the canonical default list in `domain.DefaultAnalysisExcludePatterns()` and have every runtime call site (`domain/clone.go`, `domain/dead_code.go`, `domain/system_analysis.go`, `internal/config/config.go`, `internal/config/pyscn_config.go` ×2, `internal/analyzer/module_analyzer.go`) reference it. Previously the same `["test_*.py", "*_test.py"]` slice was duplicated in 6+ places — a drift hazard.
- Update the `pyscn init` template (`default_config.toml.tmpl`) and the example doc string in `service/system_analysis_config_loader.go` for consistency. Users can still opt back in by overriding `exclude_patterns` in their config.


Fixes #479