### PR TITLE
Fix nested function CFG collection

### DIFF
--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -270,7 +270,13 @@ func (b *CFGBuilder) buildNestedFunction(node *parser.Node) error {
 		return fmt.Errorf("failed to build nested function %s: %w", node.Name, err)
 	}
 
-	// Store the function CFG
+	// Store descendant CFGs produced while building this function before the
+	// function itself. Their names are already fully scoped by nestedBuilder.
+	for nestedName, nestedCFG := range nestedBuilder.functionCFGs {
+		b.functionCFGs[nestedName] = nestedCFG
+	}
+
+	// Store the function CFG.
 	fullName := b.getFullScopeName(node.Name)
 	b.functionCFGs[fullName] = funcCFG
 

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -171,27 +171,6 @@ func (b *CFGBuilder) BuildAll(node *parser.Node) (map[string]*CFG, error) {
 		allCFGs[name] = cfg
 	}
 
-	// Also process top-level functions directly
-	if node.Type == parser.NodeModule {
-		for _, stmt := range node.Body {
-			if stmt.Type == parser.NodeFunctionDef || stmt.Type == parser.NodeAsyncFunctionDef {
-				// Check if we already have this function
-				if _, exists := allCFGs[stmt.Name]; !exists {
-					funcBuilder := NewCFGBuilder()
-					funcCFG, err := funcBuilder.Build(stmt)
-					if err == nil {
-						allCFGs[stmt.Name] = funcCFG
-						// Add nested functions from this function
-						for nestedName, nestedCFG := range funcBuilder.functionCFGs {
-							fullName := stmt.Name + "." + nestedName
-							allCFGs[fullName] = nestedCFG
-						}
-					}
-				}
-			}
-		}
-	}
-
 	return allCFGs, nil
 }
 

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -112,6 +112,13 @@ func (b *CFGBuilder) Build(node *parser.Node) (*CFG, error) {
 		return nil, fmt.Errorf("cannot build CFG from nil node")
 	}
 
+	if len(b.scopeStack) == 0 {
+		b.functionCFGs = make(map[string]*CFG)
+	}
+	b.blockCounter = 0
+	b.loopStack = b.loopStack[:0]
+	b.exceptionStack = b.exceptionStack[:0]
+
 	// Initialize CFG based on node type
 	cfgName := domain.ModuleFunctionName
 	if node.Type == parser.NodeFunctionDef || node.Type == parser.NodeAsyncFunctionDef {

--- a/internal/analyzer/cfg_builder_test.go
+++ b/internal/analyzer/cfg_builder_test.go
@@ -196,10 +196,13 @@ def outer():
 		}
 
 		for _, name := range []string{domain.ModuleFunctionName, "outer", "outer.middle", "outer.middle.inner"} {
-			if _, ok := allCFGs[name]; !ok {
-				t.Fatalf("Missing %q CFG; got %v", name, mapKeys(allCFGs))
-			}
+			requireCFG(t, allCFGs, name)
 		}
+
+		assertFunctionCFG(t, allCFGs, "outer", "outer")
+		assertFunctionCFG(t, allCFGs, "outer.middle", "middle")
+		assertFunctionCFG(t, allCFGs, "outer.middle.inner", "inner")
+		assertHasReturnEdge(t, allCFGs["outer.middle.inner"])
 	})
 
 	t.Run("BuildNestedMethodFunctions", func(t *testing.T) {
@@ -220,10 +223,12 @@ class Factory:
 		}
 
 		for _, name := range []string{domain.ModuleFunctionName, "Factory.build", "Factory.build.make_value"} {
-			if _, ok := allCFGs[name]; !ok {
-				t.Fatalf("Missing %q CFG; got %v", name, mapKeys(allCFGs))
-			}
+			requireCFG(t, allCFGs, name)
 		}
+
+		assertFunctionCFG(t, allCFGs, "Factory.build", "build")
+		assertFunctionCFG(t, allCFGs, "Factory.build.make_value", "make_value")
+		assertHasReturnEdge(t, allCFGs["Factory.build.make_value"])
 	})
 
 	t.Run("BuildTopLevelFunctions", func(t *testing.T) {
@@ -252,17 +257,37 @@ def outer():
 			t.Errorf("Missing %q CFG", domain.ModuleFunctionName)
 		}
 
-		// Check for outer function
-		hasOuter := false
-		for name := range allCFGs {
-			if name == "outer" || strings.Contains(name, "outer") {
-				hasOuter = true
-				break
-			}
+		requireCFG(t, allCFGs, "outer")
+		requireCFG(t, allCFGs, "outer.inner")
+	})
+
+	t.Run("BuildAllResetsCollectedFunctions", func(t *testing.T) {
+		builder := NewCFGBuilder()
+
+		firstAST := parseSource(t, `
+def first():
+    def stale():
+        return 1
+    return stale()
+`)
+		firstCFGs, err := builder.BuildAll(firstAST)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		requireCFG(t, firstCFGs, "first.stale")
+
+		secondAST := parseSource(t, `
+def second():
+    return 2
+`)
+		secondCFGs, err := builder.BuildAll(secondAST)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
 		}
 
-		if !hasOuter {
-			t.Error("Function 'outer' not found in CFGs")
+		requireCFG(t, secondCFGs, "second")
+		if _, ok := secondCFGs["first.stale"]; ok {
+			t.Fatalf("BuildAll leaked stale CFGs across builds; got %v", mapKeys(secondCFGs))
 		}
 	})
 
@@ -478,6 +503,52 @@ func countStatements(cfg *CFG) int {
 		onEdge: func(e *Edge) bool { return true },
 	})
 	return count
+}
+
+func requireCFG(t *testing.T, cfgs map[string]*CFG, name string) *CFG {
+	t.Helper()
+
+	cfg, ok := cfgs[name]
+	if !ok {
+		t.Fatalf("Missing %q CFG; got %v", name, mapKeys(cfgs))
+	}
+	if cfg == nil {
+		t.Fatalf("CFG %q is nil", name)
+	}
+	return cfg
+}
+
+func assertFunctionCFG(t *testing.T, cfgs map[string]*CFG, key, functionName string) {
+	t.Helper()
+
+	cfg := requireCFG(t, cfgs, key)
+	if cfg.Name != functionName {
+		t.Fatalf("CFG %q has name %q, want %q", key, cfg.Name, functionName)
+	}
+	if cfg.FunctionNode == nil {
+		t.Fatalf("CFG %q has nil function node", key)
+	}
+	if cfg.FunctionNode.Name != functionName {
+		t.Fatalf("CFG %q function node name = %q, want %q", key, cfg.FunctionNode.Name, functionName)
+	}
+}
+
+func assertHasReturnEdge(t *testing.T, cfg *CFG) {
+	t.Helper()
+
+	hasReturnEdge := false
+	cfg.Walk(&testVisitor{
+		onBlock: func(b *BasicBlock) bool { return true },
+		onEdge: func(e *Edge) bool {
+			if e.Type == EdgeReturn && e.To == cfg.Exit {
+				hasReturnEdge = true
+			}
+			return true
+		},
+	})
+	if !hasReturnEdge {
+		t.Fatalf("CFG %q has no return edge to exit", cfg.Name)
+	}
 }
 
 func mapKeys(cfgs map[string]*CFG) []string {

--- a/internal/analyzer/cfg_builder_test.go
+++ b/internal/analyzer/cfg_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log"
+	"sort"
 	"strings"
 	"testing"
 
@@ -179,6 +180,55 @@ def early_return(x):
 	t.Run("BuildNestedFunctions", func(t *testing.T) {
 		source := `
 def outer():
+    def middle():
+        def inner():
+            return 42
+        return inner()
+    return middle()
+`
+		ast := parseSource(t, source)
+
+		builder := NewCFGBuilder()
+		allCFGs, err := builder.BuildAll(ast)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		for _, name := range []string{domain.ModuleFunctionName, "outer", "outer.middle", "outer.middle.inner"} {
+			if _, ok := allCFGs[name]; !ok {
+				t.Fatalf("Missing %q CFG; got %v", name, mapKeys(allCFGs))
+			}
+		}
+	})
+
+	t.Run("BuildNestedMethodFunctions", func(t *testing.T) {
+		source := `
+class Factory:
+    def build(self):
+        def make_value():
+            return 42
+        return make_value()
+`
+		ast := parseSource(t, source)
+
+		builder := NewCFGBuilder()
+		allCFGs, err := builder.BuildAll(ast)
+
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		for _, name := range []string{domain.ModuleFunctionName, "Factory.build", "Factory.build.make_value"} {
+			if _, ok := allCFGs[name]; !ok {
+				t.Fatalf("Missing %q CFG; got %v", name, mapKeys(allCFGs))
+			}
+		}
+	})
+
+	t.Run("BuildTopLevelFunctions", func(t *testing.T) {
+		source := `
+def outer():
     def inner():
         return 42
     return inner()
@@ -214,10 +264,6 @@ def outer():
 		if !hasOuter {
 			t.Error("Function 'outer' not found in CFGs")
 		}
-
-		// For now, nested functions inside other functions are a complex feature
-		// that will be fully handled in later improvements
-		// The important thing is that we handle top-level functions correctly
 	})
 
 	t.Run("BuildSequentialStatements", func(t *testing.T) {
@@ -432,6 +478,15 @@ func countStatements(cfg *CFG) int {
 		onEdge: func(e *Edge) bool { return true },
 	})
 	return count
+}
+
+func mapKeys(cfgs map[string]*CFG) []string {
+	keys := make([]string, 0, len(cfgs))
+	for key := range cfgs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // Removed custom contains function - now using strings.Contains from stdlib


### PR DESCRIPTION
This fixes CFG collection for nested functions deeper than one level and nested functions inside methods.

The builder now propagates descendant CFGs from nested builders, keeps BuildAll on one collection path, and resets root builder state between builds so stale function CFGs cannot leak across reused builders.

The tests now assert fully qualified CFG keys, function payloads, return edges, and builder reuse behavior.

Tests run:
go test ./internal/analyzer -count=1
go test ./...
go vet ./...
go test -race ./internal/analyzer -count=1