### PR TITLE
Fix DFA compound statement use contracts

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -324,11 +324,8 @@ func (a *CBOAnalyzer) analyzeMethodTypeHints(methodNode *parser.Node, dependenci
 	// Analyze parameter types
 	for _, arg := range methodNode.Args {
 		if arg != nil && arg.Type == parser.NodeArg {
-			// Look for type annotation in argument children
-			for _, child := range arg.Children {
-				if child != nil && a.isTypeAnnotation(child) {
-					a.extractTypeAnnotationDependencies(child, dependencies, result)
-				}
+			if arg.Right != nil && a.isTypeAnnotation(arg.Right) {
+				a.extractTypeAnnotationDependencies(arg.Right, dependencies, result)
 			}
 		}
 	}
@@ -599,12 +596,7 @@ func (a *CBOAnalyzer) isWithinTypeAnnotation(node *parser.Node) bool {
 			}
 			return false
 		case parser.NodeArg:
-			for _, child := range current.Children {
-				if child != nil && a.isTypeAnnotation(child) && nodeDescendsFrom(node, child) {
-					return true
-				}
-			}
-			return false
+			return current.Right != nil && nodeDescendsFrom(node, current.Right)
 		case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
 			return current.Right != nil && nodeDescendsFrom(node, current.Right)
 		case parser.NodeTypeNode, parser.NodeGenericType, parser.NodeTypeParameter:

--- a/internal/analyzer/cfg_builder.go
+++ b/internal/analyzer/cfg_builder.go
@@ -18,6 +18,10 @@ const (
 	LabelEntry        = "ENTRY"
 	LabelExit         = "EXIT"
 
+	// Conditional labels
+	LabelIfThen  = "if_then"
+	LabelIfMerge = "if_merge"
+
 	// Loop-related labels
 	LabelLoopHeader = "loop_header"
 	LabelLoopBody   = "loop_body"
@@ -34,6 +38,7 @@ const (
 	LabelWithSetup    = "with_setup"
 	LabelWithBody     = "with_body"
 	LabelWithTeardown = "with_teardown"
+	LabelMatchEval    = "match_eval"
 	LabelMatchCase    = "match_case"
 	LabelMatchMerge   = "match_merge"
 )
@@ -488,11 +493,11 @@ func (b *CFGBuilder) processIfStatement(stmt *parser.Node) {
 	conditionBlock.AddStatement(stmt)
 
 	// Create blocks for the then branch
-	thenBlock := b.createBlock("if_then")
+	thenBlock := b.createBlock(LabelIfThen)
 
 	// Create merge block only for the outermost if
 	// elif chains will share the same final merge block
-	mergeBlock := b.createBlock("if_merge")
+	mergeBlock := b.createBlock(LabelIfMerge)
 
 	// Connect condition block to then block (true branch)
 	b.cfg.ConnectBlocks(conditionBlock, thenBlock, EdgeCondTrue)
@@ -1216,7 +1221,7 @@ func (b *CFGBuilder) processWithStatement(stmt *parser.Node) {
 // processMatchStatement handles match statements (Python 3.10+)
 func (b *CFGBuilder) processMatchStatement(stmt *parser.Node) {
 	// Create match evaluation block
-	matchBlock := b.createBlock("match_eval")
+	matchBlock := b.createBlock(LabelMatchEval)
 	b.cfg.ConnectBlocks(b.currentBlock, matchBlock, EdgeNormal)
 
 	// Add the match statement (subject evaluation) to match block

--- a/internal/analyzer/concrete_dependency_detector.go
+++ b/internal/analyzer/concrete_dependency_detector.go
@@ -250,28 +250,9 @@ func (d *ConcreteDependencyDetector) isBuiltinType(name string) bool {
 
 // extractTypeHintName extracts the type name from an argument's type annotation
 func (d *ConcreteDependencyDetector) extractTypeHintName(arg *parser.Node) string {
-	// Check children for type annotation (tree-sitter AST structure)
-	for _, child := range arg.Children {
-		if child == nil {
-			continue
-		}
-
-		// Recursively look for type annotations
-		if d.isTypeAnnotation(child) {
-			typeName := d.extractTypeNameRecursive(child)
-			if typeName != "" {
-				return typeName
-			}
-		}
+	if arg.Right != nil && d.isTypeAnnotation(arg.Right) {
+		return d.extractTypeNameRecursive(arg.Right)
 	}
-
-	// Fall back to the raw type annotation text when the AST shape is unsupported.
-	if arg.Value != nil {
-		if typeStr, ok := arg.Value.(string); ok && typeStr != "" {
-			return d.extractTypeNameFromString(typeStr)
-		}
-	}
-
 	return ""
 }
 
@@ -344,51 +325,6 @@ func (d *ConcreteDependencyDetector) extractGenericInnerType(subscriptNode *pars
 	}
 
 	return ""
-}
-
-func (d *ConcreteDependencyDetector) extractTypeNameFromString(typeName string) string {
-	typeName = strings.TrimSpace(typeName)
-	if typeName == "" {
-		return ""
-	}
-
-	if strings.Contains(typeName, "|") {
-		parts := strings.Split(typeName, "|")
-		for _, part := range parts {
-			if extracted := d.extractTypeNameFromString(part); extracted != "" {
-				return extracted
-			}
-		}
-		return ""
-	}
-
-	if open := strings.Index(typeName, "["); open >= 0 && strings.HasSuffix(typeName, "]") {
-		outer := strings.TrimSpace(typeName[:open])
-		inner := strings.TrimSpace(typeName[open+1 : len(typeName)-1])
-		if d.isGenericTypeName(d.lastTypeSegment(outer)) {
-			for _, part := range strings.Split(inner, ",") {
-				if extracted := d.extractTypeNameFromString(part); extracted != "" {
-					return extracted
-				}
-			}
-			return ""
-		}
-	}
-
-	return d.lastTypeSegment(typeName)
-}
-
-func (d *ConcreteDependencyDetector) lastTypeSegment(typeName string) string {
-	typeName = strings.TrimSpace(typeName)
-	if typeName == "" {
-		return ""
-	}
-
-	if idx := strings.LastIndex(typeName, "."); idx >= 0 {
-		return strings.TrimSpace(typeName[idx+1:])
-	}
-
-	return typeName
 }
 
 func (d *ConcreteDependencyDetector) isGenericTypeName(typeName string) bool {

--- a/internal/analyzer/dfa.go
+++ b/internal/analyzer/dfa.go
@@ -15,6 +15,7 @@ const (
 	DefKindImport                         // import x / from m import x
 	DefKindWithTarget                     // with ... as x:
 	DefKindExceptTarget                   // except E as x:
+	DefKindPattern                        // case x:
 	DefKindAugmented                      // x += 1 (both def and use)
 
 	// Use kinds
@@ -39,6 +40,8 @@ func (k DefUseKind) String() string {
 		return "with_target"
 	case DefKindExceptTarget:
 		return "except_target"
+	case DefKindPattern:
+		return "pattern"
 	case DefKindAugmented:
 		return "augmented"
 	case UseKindRead:

--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -248,10 +248,9 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 		return nil
 	}
 
-	var uses []*VarReference
-
 	switch stmt.Type {
 	case parser.NodeAssign, parser.NodeAnnAssign:
+		var uses []*VarReference
 		// For assignment statements, only the right-hand side is a read.
 		if valueNode, ok := stmt.Value.(*parser.Node); ok {
 			uses = append(uses, b.extractUsesFromExpression(valueNode, block, stmt, pos)...)
@@ -259,6 +258,7 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 		return uses
 
 	case parser.NodeAugAssign:
+		var uses []*VarReference
 		// For augmented assignment, the target is both a def and a use.
 		if len(stmt.Targets) > 0 && stmt.Targets[0] != nil && stmt.Targets[0].Type == parser.NodeName {
 			ref := NewVarReference(stmt.Targets[0].Name, UseKindRead, block, stmt, pos)
@@ -268,7 +268,15 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 			uses = append(uses, b.extractUsesFromExpression(valueNode, block, stmt, pos)...)
 		}
 		return uses
+	}
 
+	return b.extractStatementHeaderUses(stmt, block, pos)
+}
+
+func (b *DFABuilder) extractStatementHeaderUses(stmt *parser.Node, block *BasicBlock, pos int) []*VarReference {
+	var uses []*VarReference
+
+	switch stmt.Type {
 	case parser.NodeIf, parser.NodeElifClause, parser.NodeWhile:
 		uses = append(uses, b.extractUsesFromExpression(stmt.Test, block, stmt, pos)...)
 
@@ -293,14 +301,11 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 		}
 
 	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
-		for _, decorator := range stmt.Decorator {
-			uses = append(uses, b.extractUsesFromExpression(decorator, block, stmt, pos)...)
-		}
+		uses = append(uses, b.extractDecoratorUses(stmt, block, pos)...)
+		uses = append(uses, b.extractFunctionDefaultUses(stmt, block, pos)...)
 
 	case parser.NodeClassDef:
-		for _, decorator := range stmt.Decorator {
-			uses = append(uses, b.extractUsesFromExpression(decorator, block, stmt, pos)...)
-		}
+		uses = append(uses, b.extractDecoratorUses(stmt, block, pos)...)
 		for _, base := range stmt.Bases {
 			uses = append(uses, b.extractUsesFromExpression(base, block, stmt, pos)...)
 		}
@@ -309,6 +314,27 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 		uses = append(uses, b.extractUsesFromExpression(stmt, block, stmt, pos)...)
 	}
 
+	return uses
+}
+
+func (b *DFABuilder) extractDecoratorUses(stmt *parser.Node, block *BasicBlock, pos int) []*VarReference {
+	var uses []*VarReference
+	for _, decorator := range stmt.Decorator {
+		uses = append(uses, b.extractUsesFromExpression(decorator, block, stmt, pos)...)
+	}
+	return uses
+}
+
+func (b *DFABuilder) extractFunctionDefaultUses(stmt *parser.Node, block *BasicBlock, pos int) []*VarReference {
+	var uses []*VarReference
+	for _, arg := range stmt.Args {
+		if arg == nil {
+			continue
+		}
+		if defaultExpr, ok := arg.Value.(*parser.Node); ok {
+			uses = append(uses, b.extractUsesFromExpression(defaultExpr, block, stmt, pos)...)
+		}
+	}
 	return uses
 }
 

--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -215,8 +215,12 @@ func (b *DFABuilder) extractDefinitions(stmt *parser.Node, block *BasicBlock, po
 		defs = append(defs, b.extractForTargetDefs(stmt, block, pos)...)
 
 	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
-		// def f(x, y): (parameters are definitions)
-		defs = append(defs, b.extractParameterDefs(stmt, block, pos)...)
+		// def f(...): binds f in the containing CFG. Parameters belong to the function CFG.
+		defs = append(defs, b.extractNamedBindingDef(stmt, block, pos)...)
+
+	case parser.NodeClassDef:
+		// class C(...): binds C in the containing CFG.
+		defs = append(defs, b.extractNamedBindingDef(stmt, block, pos)...)
 
 	case parser.NodeImport:
 		// import x, y
@@ -535,6 +539,13 @@ func (b *DFABuilder) extractForTargetDefs(stmt *parser.Node, block *BasicBlock, 
 	}
 
 	return defs
+}
+
+func (b *DFABuilder) extractNamedBindingDef(stmt *parser.Node, block *BasicBlock, pos int) []*VarReference {
+	if stmt.Name == "" {
+		return nil
+	}
+	return []*VarReference{NewVarReference(stmt.Name, DefKindAssign, block, stmt, pos)}
 }
 
 // extractParameterDefs extracts parameter definitions from a function

--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -131,13 +131,17 @@ func (b *DFABuilder) findReachingDef(varName string, use *VarReference) *VarRefe
 func (b *DFABuilder) findDefInBlockBefore(defs []*VarReference, blockID string, usePos int) *VarReference {
 	var lastDef *VarReference
 	for _, def := range defs {
-		if def.Block != nil && def.Block.ID == blockID && def.Position < usePos {
+		if def.Block != nil && def.Block.ID == blockID && defReachesUseAtPosition(def, usePos) {
 			if lastDef == nil || def.Position > lastDef.Position {
 				lastDef = def
 			}
 		}
 	}
 	return lastDef
+}
+
+func defReachesUseAtPosition(def *VarReference, usePos int) bool {
+	return def.Position < usePos || (def.Kind == DefKindPattern && def.Position == usePos)
 }
 
 // findDefInPredecessors finds a definition in predecessor blocks using BFS
@@ -238,6 +242,10 @@ func (b *DFABuilder) extractDefinitions(stmt *parser.Node, block *BasicBlock, po
 		// except E as x:
 		defs = append(defs, b.extractExceptTargetDefs(stmt, block, pos)...)
 
+	case parser.NodeMatchCase:
+		// case x: binds x for the case body and guard.
+		defs = append(defs, b.extractMatchPatternDefs(stmt.Test, block, stmt, pos)...)
+
 	case parser.NodeNamedExpr:
 		// x := value (walrus operator)
 		defs = append(defs, b.extractNamedExprDefs(stmt, block, pos)...)
@@ -294,7 +302,7 @@ func (b *DFABuilder) extractStatementHeaderUses(stmt *parser.Node, block *BasicB
 		uses = append(uses, b.extractUsesFromExpression(stmt.Test, block, stmt, pos)...)
 
 	case parser.NodeMatchCase:
-		uses = append(uses, b.extractUsesFromExpression(stmt.Test, block, stmt, pos)...)
+		uses = append(uses, b.extractMatchPatternUses(stmt.Test, block, stmt, pos)...)
 		if guard := nodeValue(stmt); guard != nil {
 			uses = append(uses, b.extractUsesFromExpression(guard, block, stmt, pos)...)
 		}
@@ -353,6 +361,123 @@ func (b *DFABuilder) extractWithContextUses(stmt *parser.Node, block *BasicBlock
 		}
 	}
 	return uses
+}
+
+func (b *DFABuilder) extractMatchPatternUses(pattern *parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	if pattern == nil {
+		return nil
+	}
+
+	var uses []*VarReference
+	switch pattern.Type {
+	case parser.NodeName, parser.NodeConstant, parser.NodeMatchSingleton, parser.NodeMatchStar:
+		return nil
+	case parser.NodeAttribute, parser.NodeSubscript, parser.NodeMatchValue:
+		uses = append(uses, b.extractPatternValueUses(pattern, block, stmt, pos)...)
+	case parser.NodeCall, parser.NodeMatchClass:
+		if funcNode := nodeValue(pattern); funcNode != nil {
+			uses = append(uses, b.extractClassPatternHeadUses(funcNode, block, stmt, pos)...)
+		}
+		uses = append(uses, b.extractMatchPatternUsesFromNodes(pattern.Args, block, stmt, pos)...)
+		for _, keyword := range pattern.Keywords {
+			if keyword == nil {
+				continue
+			}
+			if value := nodeValue(keyword); value != nil {
+				uses = append(uses, b.extractMatchPatternUses(value, block, stmt, pos)...)
+			}
+		}
+	case parser.NodeTuple, parser.NodeList, parser.NodeDict, parser.NodeStarred,
+		parser.NodeMatchSequence, parser.NodeMatchMapping, parser.NodeMatchAs,
+		parser.NodeMatchOr:
+		uses = append(uses, b.extractMatchPatternUsesFromNodes(pattern.GetChildren(), block, stmt, pos)...)
+	default:
+		switch string(pattern.Type) {
+		case "attribute":
+			uses = append(uses, b.extractDottedPatternUses(pattern, block, stmt, pos)...)
+		case "dotted_name":
+			if len(pattern.Children) > 1 {
+				uses = append(uses, b.extractDottedPatternUses(pattern, block, stmt, pos)...)
+			}
+		case "class_pattern":
+			if len(pattern.Children) > 0 {
+				uses = append(uses, b.extractClassPatternHeadUses(pattern.Children[0], block, stmt, pos)...)
+				uses = append(uses, b.extractMatchPatternUsesFromNodes(pattern.Children[1:], block, stmt, pos)...)
+			}
+		case "value_pattern":
+			uses = append(uses, b.extractPatternValueUsesFromNodes(pattern.GetChildren(), block, stmt, pos)...)
+		case "keyword_pattern":
+			if len(pattern.Children) > 0 {
+				uses = append(uses, b.extractMatchPatternUses(pattern.Children[len(pattern.Children)-1], block, stmt, pos)...)
+			}
+		case "wildcard_pattern", "_":
+			return nil
+		default:
+			uses = append(uses, b.extractMatchPatternUsesFromNodes(pattern.GetChildren(), block, stmt, pos)...)
+		}
+	}
+
+	return uses
+}
+
+func (b *DFABuilder) extractMatchPatternUsesFromNodes(nodes []*parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	var uses []*VarReference
+	for _, node := range nodes {
+		uses = append(uses, b.extractMatchPatternUses(node, block, stmt, pos)...)
+	}
+	return uses
+}
+
+func (b *DFABuilder) extractPatternValueUsesFromNodes(nodes []*parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	var uses []*VarReference
+	for _, node := range nodes {
+		uses = append(uses, b.extractPatternValueUses(node, block, stmt, pos)...)
+	}
+	return uses
+}
+
+func (b *DFABuilder) extractPatternValueUses(expr *parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	if expr == nil {
+		return nil
+	}
+	if expr.Type == parser.NodeName {
+		return []*VarReference{NewVarReference(expr.Name, UseKindRead, block, stmt, pos)}
+	}
+	if expr.Type == parser.NodeAttribute || string(expr.Type) == "attribute" || string(expr.Type) == "dotted_name" {
+		return b.extractDottedPatternUses(expr, block, stmt, pos)
+	}
+	return b.extractUsesFromExpression(expr, block, stmt, pos)
+}
+
+func (b *DFABuilder) extractClassPatternHeadUses(expr *parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	if expr == nil {
+		return nil
+	}
+	if expr.Type == parser.NodeName {
+		return []*VarReference{NewVarReference(expr.Name, UseKindCall, block, stmt, pos)}
+	}
+	return b.extractPatternValueUses(expr, block, stmt, pos)
+}
+
+func (b *DFABuilder) extractDottedPatternUses(expr *parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	if expr == nil {
+		return nil
+	}
+	if expr.Type == parser.NodeAttribute {
+		return b.extractUsesFromExpression(expr, block, stmt, pos)
+	}
+	for _, child := range expr.GetChildren() {
+		if child == nil {
+			continue
+		}
+		if child.Type == parser.NodeName {
+			return []*VarReference{NewVarReference(child.Name, UseKindAttribute, block, stmt, pos)}
+		}
+		if uses := b.extractDottedPatternUses(child, block, stmt, pos); len(uses) > 0 {
+			return uses
+		}
+	}
+	return nil
 }
 
 // extractUsesFromExpression recursively extracts variable uses from an expression
@@ -560,6 +685,70 @@ func (b *DFABuilder) extractParameterDefs(stmt *parser.Node, block *BasicBlock, 
 	}
 
 	return defs
+}
+
+func (b *DFABuilder) extractMatchPatternDefs(pattern *parser.Node, block *BasicBlock, stmt *parser.Node, pos int) []*VarReference {
+	var defs []*VarReference
+	b.collectMatchPatternDefs(pattern, block, stmt, pos, &defs)
+	return defs
+}
+
+func (b *DFABuilder) collectMatchPatternDefs(pattern *parser.Node, block *BasicBlock, stmt *parser.Node, pos int, defs *[]*VarReference) {
+	if pattern == nil {
+		return
+	}
+
+	switch pattern.Type {
+	case parser.NodeName:
+		if isPatternCaptureName(pattern.Name) {
+			*defs = append(*defs, NewVarReference(pattern.Name, DefKindPattern, block, stmt, pos))
+		}
+	case parser.NodeAttribute, parser.NodeSubscript, parser.NodeMatchValue, parser.NodeMatchSingleton:
+		return
+	case parser.NodeCall:
+		b.collectMatchPatternDefsFromNodes(pattern.Args, block, stmt, pos, defs)
+		for _, keyword := range pattern.Keywords {
+			if keyword == nil {
+				continue
+			}
+			if value := nodeValue(keyword); value != nil {
+				b.collectMatchPatternDefs(value, block, stmt, pos, defs)
+			}
+		}
+	case parser.NodeTuple, parser.NodeList, parser.NodeDict, parser.NodeStarred,
+		parser.NodeMatchSequence, parser.NodeMatchMapping, parser.NodeMatchAs,
+		parser.NodeMatchOr, parser.NodeMatchStar:
+		b.collectMatchPatternDefsFromNodes(pattern.GetChildren(), block, stmt, pos, defs)
+	default:
+		switch string(pattern.Type) {
+		case "attribute", "wildcard_pattern", "_":
+			return
+		case "dotted_name":
+			if len(pattern.Children) == 1 {
+				b.collectMatchPatternDefs(pattern.Children[0], block, stmt, pos, defs)
+			}
+		case "class_pattern":
+			if len(pattern.Children) > 1 {
+				b.collectMatchPatternDefsFromNodes(pattern.Children[1:], block, stmt, pos, defs)
+			}
+		case "keyword_pattern":
+			if len(pattern.Children) > 0 {
+				b.collectMatchPatternDefs(pattern.Children[len(pattern.Children)-1], block, stmt, pos, defs)
+			}
+		default:
+			b.collectMatchPatternDefsFromNodes(pattern.GetChildren(), block, stmt, pos, defs)
+		}
+	}
+}
+
+func (b *DFABuilder) collectMatchPatternDefsFromNodes(nodes []*parser.Node, block *BasicBlock, stmt *parser.Node, pos int, defs *[]*VarReference) {
+	for _, node := range nodes {
+		b.collectMatchPatternDefs(node, block, stmt, pos, defs)
+	}
+}
+
+func isPatternCaptureName(name string) bool {
+	return name != "" && name != "_"
 }
 
 func nodeValue(node *parser.Node) *parser.Node {

--- a/internal/analyzer/dfa_builder.go
+++ b/internal/analyzer/dfa_builder.go
@@ -250,30 +250,78 @@ func (b *DFABuilder) extractUses(stmt *parser.Node, block *BasicBlock, pos int) 
 
 	var uses []*VarReference
 
-	// For assignment statements, only the right-hand side is a read.
-	if stmt.Type == parser.NodeAssign || stmt.Type == parser.NodeAnnAssign {
+	switch stmt.Type {
+	case parser.NodeAssign, parser.NodeAnnAssign:
+		// For assignment statements, only the right-hand side is a read.
 		if valueNode, ok := stmt.Value.(*parser.Node); ok {
 			uses = append(uses, b.extractUsesFromExpression(valueNode, block, stmt, pos)...)
 		}
 		return uses
-	}
 
-	// For augmented assignment, the target is both a def and a use
-	if stmt.Type == parser.NodeAugAssign {
+	case parser.NodeAugAssign:
+		// For augmented assignment, the target is both a def and a use.
 		if len(stmt.Targets) > 0 && stmt.Targets[0] != nil && stmt.Targets[0].Type == parser.NodeName {
 			ref := NewVarReference(stmt.Targets[0].Name, UseKindRead, block, stmt, pos)
 			uses = append(uses, ref)
 		}
-		// Also extract uses from the right-hand side
 		if valueNode, ok := stmt.Value.(*parser.Node); ok {
 			uses = append(uses, b.extractUsesFromExpression(valueNode, block, stmt, pos)...)
 		}
 		return uses
+
+	case parser.NodeIf, parser.NodeElifClause, parser.NodeWhile:
+		uses = append(uses, b.extractUsesFromExpression(stmt.Test, block, stmt, pos)...)
+
+	case parser.NodeFor, parser.NodeAsyncFor:
+		uses = append(uses, b.extractUsesFromExpression(stmt.Iter, block, stmt, pos)...)
+
+	case parser.NodeWith, parser.NodeAsyncWith:
+		uses = append(uses, b.extractWithContextUses(stmt, block, pos)...)
+
+	case parser.NodeMatch:
+		uses = append(uses, b.extractUsesFromExpression(stmt.Test, block, stmt, pos)...)
+
+	case parser.NodeMatchCase:
+		uses = append(uses, b.extractUsesFromExpression(stmt.Test, block, stmt, pos)...)
+		if guard := nodeValue(stmt); guard != nil {
+			uses = append(uses, b.extractUsesFromExpression(guard, block, stmt, pos)...)
+		}
+
+	case parser.NodeExceptHandler:
+		if exceptionType := nodeValue(stmt); exceptionType != nil {
+			uses = append(uses, b.extractUsesFromExpression(exceptionType, block, stmt, pos)...)
+		}
+
+	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
+		for _, decorator := range stmt.Decorator {
+			uses = append(uses, b.extractUsesFromExpression(decorator, block, stmt, pos)...)
+		}
+
+	case parser.NodeClassDef:
+		for _, decorator := range stmt.Decorator {
+			uses = append(uses, b.extractUsesFromExpression(decorator, block, stmt, pos)...)
+		}
+		for _, base := range stmt.Bases {
+			uses = append(uses, b.extractUsesFromExpression(base, block, stmt, pos)...)
+		}
+
+	default:
+		uses = append(uses, b.extractUsesFromExpression(stmt, block, stmt, pos)...)
 	}
 
-	// For other statements, walk the entire statement tree
-	uses = append(uses, b.extractUsesFromExpression(stmt, block, stmt, pos)...)
+	return uses
+}
 
+func (b *DFABuilder) extractWithContextUses(stmt *parser.Node, block *BasicBlock, pos int) []*VarReference {
+	var uses []*VarReference
+	for _, child := range stmt.Children {
+		if child == nil || child.Type != parser.NodeWithItem {
+			continue
+		}
+		if contextExpr := nodeValue(child); contextExpr != nil {
+			uses = append(uses, b.extractUsesFromExpression(contextExpr, block, stmt, pos)...)
+		}
+	}
 	return uses
 }
 

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -558,6 +558,51 @@ def nested(arg=default_value):
 		assertUsesOnlyInBlockLabel(t, chain, 1, LabelEntry)
 	})
 
+	t.Run("Build_FunctionDef_UsesTypedDefaultArgumentsInOuterBlock", func(t *testing.T) {
+		source := `
+default_value = 1
+def nested(arg: int = default_value):
+    return arg
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		chain := requireDFAChain(t, info, "default_value")
+		require.Len(t, chain.Defs, 1)
+		assertUsesOnlyInBlockLabel(t, chain, 1, LabelEntry)
+	})
+
+	t.Run("Build_FunctionDef_BindsFunctionNameWithoutLeakingParameters", func(t *testing.T) {
+		source := `
+def nested(arg):
+    return arg
+alias = nested
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		nested := requireDFAChain(t, info, "nested")
+		require.Len(t, nested.Defs, 1)
+		assert.Equal(t, DefKindAssign, nested.Defs[0].Kind)
+		assertUsesOnlyInBlockLabel(t, nested, 1, LabelEntry)
+		assert.Nil(t, info.Chains["arg"], "function parameters belong to the function CFG, not the parent CFG")
+	})
+
+	t.Run("Build_ClassDef_BindsClassName", func(t *testing.T) {
+		source := `
+class Thing:
+    value = 1
+alias = Thing
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		thing := requireDFAChain(t, info, "Thing")
+		require.Len(t, thing.Defs, 1)
+		assert.Equal(t, DefKindAssign, thing.Defs[0].Kind)
+		assertUsesOnlyInBlockLabel(t, thing, 1, LabelClassBody)
+	})
+
 	t.Run("Build_NestedFunctionCFG_RetainsBodyUses", func(t *testing.T) {
 		source := `
 outer_value = 1

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -445,7 +445,7 @@ if cond:
 		require.NoError(t, err)
 
 		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "cond"), 1, LabelEntry)
-		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, "if_then")
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelIfThen)
 	})
 
 	t.Run("Build_ForStatement_UsesIterableWithoutReadingTargetOrBodyInHeader", func(t *testing.T) {
@@ -512,7 +512,7 @@ match subject:
 		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
 		require.NoError(t, err)
 
-		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "subject"), 1, "match_eval")
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "subject"), 1, LabelMatchEval)
 		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelMatchCase)
 	})
 
@@ -542,6 +542,39 @@ def nested():
 		chain := requireDFAChain(t, info, "outer_value")
 		require.Len(t, chain.Defs, 1)
 		assert.Empty(t, chain.Uses, "function body uses belong to the nested function CFG")
+	})
+
+	t.Run("Build_FunctionDef_UsesDefaultArgumentsInOuterBlock", func(t *testing.T) {
+		source := `
+default_value = 1
+def nested(arg=default_value):
+    return arg
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		chain := requireDFAChain(t, info, "default_value")
+		require.Len(t, chain.Defs, 1)
+		assertUsesOnlyInBlockLabel(t, chain, 1, LabelEntry)
+	})
+
+	t.Run("Build_NestedFunctionCFG_RetainsBodyUses", func(t *testing.T) {
+		source := `
+outer_value = 1
+def nested():
+    sink(outer_value)
+`
+		ast := parseSourceForDFA(t, source)
+		cfgs, err := NewCFGBuilder().BuildAll(ast)
+		require.NoError(t, err)
+
+		nestedCFG, ok := cfgs["nested"]
+		require.True(t, ok, "expected nested function CFG")
+
+		info, err := NewDFABuilder().Build(nestedCFG)
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "outer_value"), 1, LabelFunctionBody)
 	})
 }
 

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/internal/parser"
@@ -42,6 +43,25 @@ func assertChainHasUseKind(t *testing.T, chain *DefUseChain, kind DefUseKind) {
 		}
 	}
 	t.Fatalf("Expected %s to have use kind %s, got %v", chain.Variable, kind, chain.Uses)
+}
+
+func requireDFAChain(t *testing.T, info *DFAInfo, variable string) *DefUseChain {
+	t.Helper()
+
+	chain := info.Chains[variable]
+	require.NotNil(t, chain, "%q should be in variable chains", variable)
+	return chain
+}
+
+func assertUsesOnlyInBlockLabel(t *testing.T, chain *DefUseChain, wantUses int, label string) {
+	t.Helper()
+
+	require.Len(t, chain.Uses, wantUses, "unexpected uses for %q", chain.Variable)
+	for _, use := range chain.Uses {
+		require.NotNil(t, use.Block, "use for %q has nil block", chain.Variable)
+		assert.Truef(t, strings.HasPrefix(use.Block.Label, label),
+			"use for %q is in block %q, want prefix %q", chain.Variable, use.Block.Label, label)
+	}
 }
 
 func TestDFABuilder(t *testing.T) {
@@ -412,6 +432,116 @@ with cm() as [a, *rest]:
 			assert.Len(t, chain.Defs, 1)
 			assert.Equal(t, DefKindWithTarget, chain.Defs[0].Kind)
 		}
+	})
+
+	t.Run("Build_IfStatement_UsesBodyOnlyInBodyBlock", func(t *testing.T) {
+		source := `
+cond = True
+body_value = 1
+if cond:
+    sink(body_value)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "cond"), 1, LabelEntry)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, "if_then")
+	})
+
+	t.Run("Build_ForStatement_UsesIterableWithoutReadingTargetOrBodyInHeader", func(t *testing.T) {
+		source := `
+items = [1, 2, 3]
+body_value = 1
+for item in items:
+    sink(body_value)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		item := requireDFAChain(t, info, "item")
+		require.Len(t, item.Defs, 1)
+		assert.Equal(t, DefKindForTarget, item.Defs[0].Kind)
+		assert.Empty(t, item.Uses, "loop targets should not be phantom reads")
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "items"), 1, LabelLoopHeader)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelLoopBody)
+	})
+
+	t.Run("Build_WhileStatement_UsesConditionWithoutReadingBodyInHeader", func(t *testing.T) {
+		source := `
+cond = True
+body_value = 1
+while cond:
+    sink(body_value)
+    cond = False
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelLoopBody)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "cond"), 1, LabelLoopHeader)
+	})
+
+	t.Run("Build_WithStatement_UsesContextExprWithoutReadingBodyInSetup", func(t *testing.T) {
+		source := `
+path = "data.txt"
+body_value = 1
+with open(path) as handle:
+    sink(body_value)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "path"), 1, LabelWithSetup)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelWithBody)
+
+		handle := requireDFAChain(t, info, "handle")
+		require.Len(t, handle.Defs, 1)
+		assert.Equal(t, DefKindWithTarget, handle.Defs[0].Kind)
+		assert.Empty(t, handle.Uses, "with targets should not be phantom reads")
+	})
+
+	t.Run("Build_MatchStatement_UsesSubjectWithoutDoubleCountingCaseBody", func(t *testing.T) {
+		source := `
+subject = 1
+body_value = 1
+match subject:
+    case _:
+        sink(body_value)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "subject"), 1, "match_eval")
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelMatchCase)
+	})
+
+	t.Run("Build_ExceptHandler_DoesNotDoubleCountHandlerBody", func(t *testing.T) {
+		source := `
+body_value = 1
+try:
+    raise ValueError()
+except ValueError as exc:
+    sink(body_value)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "body_value"), 1, LabelExceptBlock)
+	})
+
+	t.Run("Build_FunctionDef_DoesNotAttributeBodyUsesToOuterBlock", func(t *testing.T) {
+		source := `
+outer_value = 1
+def nested():
+    sink(outer_value)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		chain := requireDFAChain(t, info, "outer_value")
+		require.Len(t, chain.Defs, 1)
+		assert.Empty(t, chain.Uses, "function body uses belong to the nested function CFG")
 	})
 }
 

--- a/internal/analyzer/dfa_builder_test.go
+++ b/internal/analyzer/dfa_builder_test.go
@@ -64,6 +64,13 @@ func assertUsesOnlyInBlockLabel(t *testing.T, chain *DefUseChain, wantUses int, 
 	}
 }
 
+func assertSingleDefKind(t *testing.T, chain *DefUseChain, kind DefUseKind) {
+	t.Helper()
+
+	require.Len(t, chain.Defs, 1, "unexpected defs for %q", chain.Variable)
+	assert.Equal(t, kind, chain.Defs[0].Kind)
+}
+
 func TestDFABuilder(t *testing.T) {
 	t.Run("Build_NilCFG", func(t *testing.T) {
 		builder := NewDFABuilder()
@@ -620,6 +627,95 @@ def nested():
 		require.NoError(t, err)
 
 		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "outer_value"), 1, LabelFunctionBody)
+	})
+
+	t.Run("Build_MatchCase_BindsCapturePatternWithoutPhantomRead", func(t *testing.T) {
+		source := `
+subject = object()
+guard_value = 1
+match subject:
+    case captured if captured == guard_value:
+        sink(captured)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		captured := requireDFAChain(t, info, "captured")
+		assertSingleDefKind(t, captured, DefKindPattern)
+		assertUsesOnlyInBlockLabel(t, captured, 2, LabelMatchCase)
+		assert.Len(t, captured.Pairs, 2)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "subject"), 1, LabelMatchEval)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "guard_value"), 1, LabelMatchCase)
+	})
+
+	t.Run("Build_MatchCase_UsesDottedValuePatternBaseOnly", func(t *testing.T) {
+		source := `
+subject = object()
+match subject:
+    case constants.OK:
+        pass
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "constants"), 1, LabelMatchCase)
+		assert.Nil(t, info.Chains["OK"], "attribute names are not standalone variable reads")
+	})
+
+	t.Run("Build_MatchCase_BindsClassPatternCaptures", func(t *testing.T) {
+		source := `
+subject = object()
+match subject:
+    case Point(x, y):
+        sink(x, y)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "Point"), 1, LabelMatchCase)
+		assertSingleDefKind(t, requireDFAChain(t, info, "x"), DefKindPattern)
+		assertSingleDefKind(t, requireDFAChain(t, info, "y"), DefKindPattern)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "x"), 1, LabelMatchCase)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "y"), 1, LabelMatchCase)
+	})
+
+	t.Run("Build_MatchCase_BindsMappingPatternCaptures", func(t *testing.T) {
+		source := `
+subject = object()
+match subject:
+    case {"id": user_id, "items": [first, *rest]} if rest:
+        sink(user_id, first, rest)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		for _, name := range []string{"user_id", "first", "rest"} {
+			chain := requireDFAChain(t, info, name)
+			assertSingleDefKind(t, chain, DefKindPattern)
+		}
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "user_id"), 1, LabelMatchCase)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "first"), 1, LabelMatchCase)
+		assertUsesOnlyInBlockLabel(t, requireDFAChain(t, info, "rest"), 2, LabelMatchCase)
+	})
+
+	t.Run("Build_MatchCase_BindsSequenceStarPatternCaptures", func(t *testing.T) {
+		source := `
+subject = object()
+match subject:
+    case [first, *rest]:
+        sink(first, rest)
+`
+		info, err := NewDFABuilder().Build(buildCFGForDFA(t, source))
+		require.NoError(t, err)
+
+		first := requireDFAChain(t, info, "first")
+		assertSingleDefKind(t, first, DefKindPattern)
+		assertUsesOnlyInBlockLabel(t, first, 1, LabelMatchCase)
+
+		rest := requireDFAChain(t, info, "rest")
+		assertSingleDefKind(t, rest, DefKindPattern)
+		assertUsesOnlyInBlockLabel(t, rest, 1, LabelMatchCase)
 	})
 }
 

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -1729,15 +1729,11 @@ func (b *ASTBuilder) buildParameters(tsNode *sitter.Node) []*Node {
 				if arg.Name == "" {
 					arg.Name = b.extractParameterName(child)
 				}
-				// Store type annotation both as text (for backward compatibility) and as AST node
 				if typeNode := b.getChildByFieldName(child, "type"); typeNode != nil {
-					arg.Value = b.getNodeText(typeNode)
-					// Also build the type annotation as an AST node and add to Children
-					// This allows proper analysis of complex types like Union (X | Y)
-					typeASTNode := b.buildNode(typeNode)
-					if typeASTNode != nil {
-						arg.Children = append(arg.Children, typeASTNode)
-					}
+					arg.Right = b.buildNode(typeNode)
+				}
+				if valueNode := b.getChildByFieldName(child, "value"); valueNode != nil {
+					arg.Value = b.buildNode(valueNode)
 				}
 				params = append(params, arg)
 			case "list_splat_pattern":
@@ -1975,11 +1971,12 @@ func (b *ASTBuilder) buildMatchCase(tsNode *sitter.Node) *Node {
 
 	if pattern := b.getChildByFieldName(tsNode, "pattern"); pattern != nil {
 		node.Test = b.buildNode(pattern)
+	} else if pattern := b.getFirstChildByType(tsNode, "case_pattern"); pattern != nil {
+		node.Test = b.buildNode(pattern)
 	}
 
 	if guard := b.getChildByFieldName(tsNode, "guard"); guard != nil {
-		// Store guard in Value field
-		node.Value = b.buildNode(guard)
+		node.Value = b.buildCaseGuard(guard)
 	}
 
 	if consequence := b.getChildByFieldName(tsNode, "consequence"); consequence != nil {
@@ -1989,6 +1986,18 @@ func (b *ASTBuilder) buildMatchCase(tsNode *sitter.Node) *Node {
 	}
 
 	return node
+}
+
+func (b *ASTBuilder) buildCaseGuard(tsNode *sitter.Node) *Node {
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child == nil || child.Type() == "if" || b.isTrivia(child) {
+			continue
+		}
+		return b.buildNode(child)
+	}
+	return nil
 }
 
 // buildDecorator builds a decorator node
@@ -2068,6 +2077,17 @@ func (b *ASTBuilder) hasChildOfType(tsNode *sitter.Node, childType string) bool 
 		}
 	}
 	return false
+}
+
+func (b *ASTBuilder) getFirstChildByType(tsNode *sitter.Node, childType string) *sitter.Node {
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		child := tsNode.Child(i)
+		if child != nil && child.Type() == childType {
+			return child
+		}
+	}
+	return nil
 }
 
 // isTrivia checks if a node is trivia (comments, whitespace)

--- a/internal/parser/ast_test.go
+++ b/internal/parser/ast_test.go
@@ -722,6 +722,73 @@ def unpack(cm):
 	}
 }
 
+func TestASTBuilderTypedDefaultParameterPreservesDefaultExpression(t *testing.T) {
+	result, err := New().Parse(context.Background(), []byte(`
+def configure(limit: int = default_limit):
+    return limit
+`))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	functions := result.AST.FindByType(NodeFunctionDef)
+	if len(functions) != 1 {
+		t.Fatalf("Expected 1 function, got %d", len(functions))
+	}
+	if len(functions[0].Args) != 1 {
+		t.Fatalf("Expected 1 argument, got %d", len(functions[0].Args))
+	}
+
+	arg := functions[0].Args[0]
+	if arg.Name != "limit" {
+		t.Fatalf("Arg name = %q, want %q", arg.Name, "limit")
+	}
+	typeNames := collectNameLeaves(arg.Right)
+	if got, want := typeNames, []string{"int"}; !equalStringSlices(got, want) {
+		t.Fatalf("Arg type annotation names = %v, want %v", got, want)
+	}
+	defaultExpr, ok := arg.Value.(*Node)
+	if !ok {
+		t.Fatalf("Arg default is %T, want *Node", arg.Value)
+	}
+	if defaultExpr.Type != NodeName || defaultExpr.Name != "default_limit" {
+		t.Fatalf("Arg default = %s(%s), want Name(default_limit)", defaultExpr.Type, defaultExpr.Name)
+	}
+}
+
+func TestASTBuilderMatchCasePreservesPatternAndGuard(t *testing.T) {
+	result, err := New().Parse(context.Background(), []byte(`
+match subject:
+    case captured if captured == guard_value:
+        sink(captured)
+`))
+	if err != nil {
+		t.Fatalf("Parse() unexpected error: %v", err)
+	}
+
+	matches := result.AST.FindByType(NodeMatch)
+	if len(matches) != 1 {
+		t.Fatalf("Expected 1 match statement, got %d", len(matches))
+	}
+	if len(matches[0].Body) != 1 {
+		t.Fatalf("Expected 1 match case, got %d", len(matches[0].Body))
+	}
+
+	matchCase := matches[0].Body[0]
+	patternNames := collectNameLeaves(matchCase.Test)
+	if got, want := patternNames, []string{"captured"}; !equalStringSlices(got, want) {
+		t.Fatalf("Pattern names = %v, want %v", got, want)
+	}
+	guard, ok := matchCase.Value.(*Node)
+	if !ok {
+		t.Fatalf("Guard is %T, want *Node", matchCase.Value)
+	}
+	guardNames := collectNameLeaves(guard)
+	if got, want := guardNames, []string{"captured", "guard_value"}; !equalStringSet(got, want) {
+		t.Fatalf("Guard names = %v, want %v", got, want)
+	}
+}
+
 func TestComprehensionIteratorAndTargetFields(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -805,6 +872,23 @@ func equalStringSlices(a, b []string) bool {
 	}
 	for i := range a {
 		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, item := range a {
+		counts[item]++
+	}
+	for _, item := range b {
+		counts[item]--
+		if counts[item] < 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
Fixes DFA extraction for compound statements so header uses, scoped definitions, defaults, and match patterns are attributed to the correct CFG blocks.

Keeps typed parameter annotations on Arg.Right and default expressions on Arg.Value, with CBO and dependency checks using the same contract.

Validated with go test ./..., go vet ./..., go test -race ./internal/analyzer -count=1, and golangci-lint v1.64.8.
