### PR TITLE
fix(dead-code): skip trailing-semicolon empty statements

### DIFF
--- a/internal/analyzer/dead_code.go
+++ b/internal/analyzer/dead_code.go
@@ -194,6 +194,16 @@ func (dcd *DeadCodeDetector) analyzeDeadBlock(block *BasicBlock) []*DeadCodeFind
 		return findings
 	}
 
+	// Skip blocks whose only "statements" are empty separators (a bare `;`).
+	// In Python a trailing semicolon (`raise X;` or `return y;`) parses as the
+	// terminating statement followed by an empty statement. That empty statement
+	// is technically unreachable, but reporting it as `unreachable_branch` with
+	// `code: ";"` and a `0-0` column range is noise — there's nothing for the
+	// user to act on beyond a stylistic trailing semicolon.
+	if isOnlyEmptyStatements(block) {
+		return findings
+	}
+
 	// Determine the reason for the dead code
 	reason, severity := dcd.determineDeadCodeReason(block)
 
@@ -537,4 +547,21 @@ func GroupFindingsByReason(findings []*DeadCodeFinding) map[DeadCodeReason][]*De
 	}
 
 	return groups
+}
+
+// isOnlyEmptyStatements reports whether every statement in the block is an
+// empty separator node (a bare `;`). Tree-sitter emits a node with
+// `Type == ";"` for the no-op produced by a trailing semicolon. Such blocks
+// are unreachable but carry no actionable signal, so they should not produce
+// dead-code findings.
+func isOnlyEmptyStatements(block *BasicBlock) bool {
+	if block == nil || len(block.Statements) == 0 {
+		return false
+	}
+	for _, stmt := range block.Statements {
+		if stmt == nil || string(stmt.Type) != ";" {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/analyzer/dead_code_test.go
+++ b/internal/analyzer/dead_code_test.go
@@ -674,3 +674,60 @@ def complex_function():
 	expectedRatio := float64(reachableCount) / float64(totalBlocks)
 	assert.InDelta(t, expectedRatio, ratio, 0.01, "Ratio calculation should be consistent")
 }
+
+// TestDeadCodeSkipsTrailingSemicolonNoise ensures the dead-code detector does
+// not emit `unreachable_branch` findings for the empty statement produced by a
+// trailing `;` after a terminating statement (raise/return). Regression test
+// for https://github.com/ludo-technologies/pyscn/issues/499.
+func TestDeadCodeSkipsTrailingSemicolonNoise(t *testing.T) {
+	code := `
+def f(x):
+    if x is None:
+        raise ValueError("nope");
+    return x
+
+
+def g(y):
+    return y;
+`
+
+	p := parser.New()
+	ctx := context.Background()
+	parseResult, err := p.Parse(ctx, []byte(code))
+	require.NoError(t, err)
+
+	builder := NewCFGBuilder()
+	cfgs, err := builder.BuildAll(parseResult.AST)
+	require.NoError(t, err)
+
+	for _, fnName := range []string{"f", "g"} {
+		cfg, ok := cfgs[fnName]
+		require.True(t, ok, "expected CFG for %s", fnName)
+
+		result := DetectInFunction(cfg)
+		require.NotNil(t, result)
+
+		for _, finding := range result.Findings {
+			assert.NotEqual(t, ";", finding.Code,
+				"function %s: dead-code finding for a bare ';' (trailing-semicolon empty statement) should be filtered out; got %+v",
+				fnName, finding)
+		}
+	}
+}
+
+func TestIsOnlyEmptyStatements(t *testing.T) {
+	assert.False(t, isOnlyEmptyStatements(nil), "nil block")
+	assert.False(t, isOnlyEmptyStatements(&BasicBlock{}), "empty block")
+
+	semi := &parser.Node{Type: parser.NodeType(";")}
+	ret := &parser.Node{Type: parser.NodeReturn}
+
+	assert.True(t, isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{semi}}),
+		"block with only a separator")
+	assert.True(t, isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{semi, semi}}),
+		"block with multiple separators")
+	assert.False(t, isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{ret}}),
+		"block with a real statement")
+	assert.False(t, isOnlyEmptyStatements(&BasicBlock{Statements: []*parser.Node{semi, ret}}),
+		"block mixing separators and a real statement")
+}


### PR DESCRIPTION
Closes #499

## Summary
A trailing \`;\` in Python (\`raise X;\` or \`return y;\`) parses as the terminating statement followed by an empty statement. tree-sitter emits the empty stmt as a node with \`Type == \";\"\`. That node is technically unreachable, but reporting it as a warning-severity \`unreachable_branch\` finding with \`code: \";\"\` and a \`0-0\` column range is pure noise — there is no actionable defect, only a stylistic trailing semicolon.

## Fix
- Add \`isOnlyEmptyStatements()\` helper in \`internal/analyzer/dead_code.go\` that returns true when every statement in a block is a separator node (\`Type == \";\"\`).
- Short-circuit in \`analyzeDeadBlock\` so blocks containing only empty statements do not produce findings.
- Real dead code (\`return x; y = 2\`) is unaffected — only the synthetic empty-stmt-only block is filtered.

## Verification
Using the repro from the issue (\`semi_repro.py\`):

**Before:**
\`\`\`
Dead Code: 95/100 ✅  (2 issues, 0 critical)
{"code": ";", "reason": "unreachable_branch", "severity": "warning", "location": {"start_column": 0, "end_column": 0}}
{"code": ";", "reason": "unreachable_branch", "severity": "warning", "location": {"start_column": 0, "end_column": 0}}
\`\`\`

**After:**
\`\`\`
Dead Code: 100/100 ✅  (0 issues, 0 critical)
\`\`\`

## Test plan
- [x] \`go test ./internal/analyzer/\` — full analyzer suite passes (42s)
- [x] New \`TestDeadCodeSkipsTrailingSemicolonNoise\` — regression test using the issue repro
- [x] New \`TestIsOnlyEmptyStatements\` — unit test for the helper covering nil / empty / pure separators / mixed / non-separator cases
- [x] End-to-end: rebuild + \`pyscn analyze --json\` on the repro shows 0 dead-code findings instead of 2