### PR TITLE
Fix module import branch traversal

### DIFF
--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -205,14 +205,15 @@ func (ma *ModuleAnalyzer) analyzeModuleDependencies(graph *DependencyGraph, file
 		return fmt.Errorf("module not found in graph: %s", moduleName)
 	}
 
-	// Extract module information
-	ma.extractModuleInfo(result.AST, module)
-
-	// Collect import statements
-	imports := ma.collectModuleImports(result.AST, filePath)
+	facts := ma.collectModuleFacts(result.AST)
+	module.FunctionCount = facts.functionCount
+	module.ClassCount = facts.classCount
+	module.AbstractClassCount = facts.abstractClassCount
+	module.PublicNames = facts.publicNames
+	module.LineCount = countSourceLines(content)
 
 	// Process each import
-	for _, imp := range imports {
+	for _, imp := range facts.imports {
 		// Skip TYPE_CHECKING imports for circular dependency detection
 		if imp.IsTypeChecking {
 			continue
@@ -299,91 +300,137 @@ func (ma *ModuleAnalyzer) shouldSkipPackageInitDependency(filePath, moduleName, 
 	return isPythonPackageInit(filePath) && strings.HasPrefix(targetModule, moduleName+".")
 }
 
-// collectModuleImports collects all import statements from AST
-func (ma *ModuleAnalyzer) collectModuleImports(ast *parser.Node, filePath string) []*ImportInfo {
-	var imports []*ImportInfo
+type moduleFacts struct {
+	imports            []*ImportInfo
+	functionCount      int
+	classCount         int
+	abstractClassCount int
+	publicNames        []string
+}
 
-	ma.walkNode(ast, func(node *parser.Node) bool {
+func (ma *ModuleAnalyzer) collectModuleFacts(ast *parser.Node) moduleFacts {
+	var facts moduleFacts
+	if ast == nil {
+		return facts
+	}
+
+	ast.Walk(func(node *parser.Node) bool {
 		switch node.Type {
-		case parser.NodeImport:
-			// Handle "import module" statements
-			isTypeChecking := ma.isInTypeCheckingBlock(node)
-
-			if len(node.Children) > 0 {
-				for _, child := range node.Children {
-					if child.Type == parser.NodeAlias {
-						imp := &ImportInfo{
-							Statement:      fmt.Sprintf("import %s", child.Name),
-							ImportedNames:  []string{child.Name},
-							IsRelative:     false,
-							Line:           node.Location.StartLine,
-							IsTypeChecking: isTypeChecking,
-						}
-						if child.Value != nil {
-							if alias, ok := child.Value.(string); ok {
-								imp.Alias = alias
-							}
-						}
-						imports = append(imports, imp)
-					}
-				}
-			} else if len(node.Names) > 0 {
-				for _, name := range node.Names {
-					imp := &ImportInfo{
-						Statement:      fmt.Sprintf("import %s", name),
-						ImportedNames:  []string{name},
-						IsRelative:     false,
-						Line:           node.Location.StartLine,
-						IsTypeChecking: isTypeChecking,
-					}
-					imports = append(imports, imp)
-				}
+		case parser.NodeImport, parser.NodeImportFrom:
+			facts.imports = append(facts.imports, ma.importsFromNode(node)...)
+		case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
+			facts.functionCount++
+			if isPublicName(node.Name) {
+				facts.publicNames = append(facts.publicNames, node.Name)
 			}
-
-		case parser.NodeImportFrom:
-			// Handle "from module import name" statements
-			isTypeChecking := ma.isInTypeCheckingBlock(node)
-			module := node.Module
-			level := node.Level
-
-			// Get imported names - use map to deduplicate since names may appear
-			// in both node.Names and child Alias nodes depending on parser version
-			nameSet := make(map[string]bool)
-			for _, name := range node.Names {
-				nameSet[name] = true
+		case parser.NodeClassDef:
+			facts.classCount++
+			if ma.isAbstractClass(node) {
+				facts.abstractClassCount++
 			}
-			for _, child := range node.Children {
-				if child.Type == parser.NodeAlias {
-					nameSet[child.Name] = true
-				}
+			if isPublicName(node.Name) {
+				facts.publicNames = append(facts.publicNames, node.Name)
 			}
-			importedNames := make([]string, 0, len(nameSet))
-			for name := range nameSet {
-				importedNames = append(importedNames, name)
-			}
-
-			imp := &ImportInfo{
-				Statement:      ma.buildImportStatement(node),
-				ImportedNames:  importedNames,
-				IsRelative:     level > 0,
-				Level:          level,
-				Line:           node.Location.StartLine,
-				IsTypeChecking: isTypeChecking,
-			}
-
-			// Clean module name for relative imports
-			if imp.IsRelative {
-				imp.Statement = strings.TrimLeft(module, ".")
-			} else {
-				imp.Statement = module
-			}
-
-			imports = append(imports, imp)
 		}
 		return true
 	})
 
-	return imports
+	return facts
+}
+
+func isPublicName(name string) bool {
+	return name != "" && !strings.HasPrefix(name, "_")
+}
+
+func countSourceLines(content []byte) int {
+	lines := 1
+	for _, b := range content {
+		if b == '\n' {
+			lines++
+		}
+	}
+	return lines
+}
+
+func (ma *ModuleAnalyzer) importsFromNode(node *parser.Node) []*ImportInfo {
+	isTypeChecking := ma.isInTypeCheckingBlock(node)
+
+	switch node.Type {
+	case parser.NodeImport:
+		var imports []*ImportInfo
+		if len(node.Children) > 0 {
+			for _, child := range node.Children {
+				if child.Type != parser.NodeAlias {
+					continue
+				}
+				imp := &ImportInfo{
+					Statement:      fmt.Sprintf("import %s", child.Name),
+					ImportedNames:  []string{child.Name},
+					IsRelative:     false,
+					Line:           node.Location.StartLine,
+					IsTypeChecking: isTypeChecking,
+				}
+				if alias, ok := child.Value.(string); ok {
+					imp.Alias = alias
+				}
+				imports = append(imports, imp)
+			}
+			return imports
+		}
+
+		imports = make([]*ImportInfo, 0, len(node.Names))
+		for _, name := range node.Names {
+			imports = append(imports, &ImportInfo{
+				Statement:      fmt.Sprintf("import %s", name),
+				ImportedNames:  []string{name},
+				IsRelative:     false,
+				Line:           node.Location.StartLine,
+				IsTypeChecking: isTypeChecking,
+			})
+		}
+		return imports
+
+	case parser.NodeImportFrom:
+		module := node.Module
+		level := node.Level
+
+		seenNames := make(map[string]bool, len(node.Names)+len(node.Children))
+		importedNames := make([]string, 0, len(node.Names)+len(node.Children))
+		addName := func(name string) {
+			if name == "" || seenNames[name] {
+				return
+			}
+			seenNames[name] = true
+			importedNames = append(importedNames, name)
+		}
+		for _, name := range node.Names {
+			addName(name)
+		}
+		for _, child := range node.Children {
+			if child.Type == parser.NodeAlias {
+				addName(child.Name)
+			}
+		}
+
+		imp := &ImportInfo{
+			Statement:      ma.buildImportStatement(node),
+			ImportedNames:  importedNames,
+			IsRelative:     level > 0,
+			Level:          level,
+			Line:           node.Location.StartLine,
+			IsTypeChecking: isTypeChecking,
+		}
+
+		if imp.IsRelative {
+			imp.Statement = strings.TrimLeft(module, ".")
+		} else {
+			imp.Statement = module
+		}
+
+		return []*ImportInfo{imp}
+	default:
+		return nil
+	}
 }
 
 // resolveImport resolves an import to a module name
@@ -661,42 +708,6 @@ func (ma *ModuleAnalyzer) pathToModuleName(path string) string {
 	return strings.ReplaceAll(relPath, string(filepath.Separator), ".")
 }
 
-// extractModuleInfo extracts information about the module from its AST
-func (ma *ModuleAnalyzer) extractModuleInfo(ast *parser.Node, module *ModuleNode) {
-	var functionCount, classCount, abstractClassCount int
-	var publicNames []string
-
-	ma.walkNode(ast, func(node *parser.Node) bool {
-		switch node.Type {
-		case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef:
-			functionCount++
-			if node.Name != "" && !strings.HasPrefix(node.Name, "_") {
-				publicNames = append(publicNames, node.Name)
-			}
-		case parser.NodeClassDef:
-			classCount++
-			if ma.isAbstractClass(node) {
-				abstractClassCount++
-			}
-			if node.Name != "" && !strings.HasPrefix(node.Name, "_") {
-				publicNames = append(publicNames, node.Name)
-			}
-		}
-		return true
-	})
-
-	// Update module information
-	module.FunctionCount = functionCount
-	module.ClassCount = classCount
-	module.AbstractClassCount = abstractClassCount
-	module.PublicNames = publicNames
-
-	// Count lines (approximation)
-	if _, err := os.Stat(module.FilePath); err == nil {
-		module.LineCount = ma.estimateLineCount(module.FilePath)
-	}
-}
-
 func (ma *ModuleAnalyzer) isAbstractClass(classNode *parser.Node) bool {
 	for _, base := range classNode.Bases {
 		if ma.isAbstractClassName(ma.nodeQualifiedName(base)) {
@@ -793,23 +804,6 @@ func (ma *ModuleAnalyzer) shouldIncludeDependency(moduleName string) bool {
 	}
 
 	return true
-}
-
-// Utility methods
-
-// walkNode recursively walks AST nodes
-func (ma *ModuleAnalyzer) walkNode(node *parser.Node, visitor func(*parser.Node) bool) {
-	if node == nil || !visitor(node) {
-		return
-	}
-
-	for _, child := range node.Children {
-		ma.walkNode(child, visitor)
-	}
-
-	for _, child := range node.Body {
-		ma.walkNode(child, visitor)
-	}
 }
 
 // buildImportStatement builds the original import statement string
@@ -976,78 +970,71 @@ func (ma *ModuleAnalyzer) isStandardLibrary(moduleName string) bool {
 	return false
 }
 
-// estimateLineCount estimates line count for a file
-func (ma *ModuleAnalyzer) estimateLineCount(filePath string) int {
-	content, err := os.ReadFile(filePath)
-	if err != nil {
-		return 0
-	}
-	return strings.Count(string(content), "\n") + 1
-}
-
 // isInTypeCheckingBlock checks if a node is inside a TYPE_CHECKING conditional block
 func (ma *ModuleAnalyzer) isInTypeCheckingBlock(node *parser.Node) bool {
-	// Walk up the parent chain to find if we're inside an if statement
+	child := node
 	current := node.Parent
 	for current != nil {
-		if current.Type == parser.NodeIf {
-			// Check if this is a TYPE_CHECKING condition
-			if ma.isTypeCheckingCondition(current.Test) {
+		if current.Type == parser.NodeIf || current.Type == parser.NodeElifClause {
+			if ma.isTypeCheckingCondition(current.Test) && containsDirectNode(current.Body, child) {
 				return true
 			}
 		}
+		child = current
 		current = current.Parent
 	}
 	return false
 }
 
-// isTypeCheckingCondition checks if an expression is a TYPE_CHECKING condition
+func containsDirectNode(nodes []*parser.Node, target *parser.Node) bool {
+	for _, node := range nodes {
+		if node == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (ma *ModuleAnalyzer) isTypeCheckingCondition(expr *parser.Node) bool {
 	if expr == nil {
 		return false
 	}
 
-	// Handle simple case: just TYPE_CHECKING
 	if expr.Type == parser.NodeName && expr.Name == "TYPE_CHECKING" {
 		return true
 	}
 
-	// Handle attribute access: typing.TYPE_CHECKING
 	if expr.Type == parser.NodeAttribute && expr.Name == "TYPE_CHECKING" {
 		return true
 	}
 
-	// Handle binary operations that include TYPE_CHECKING
-	// e.g., "TYPE_CHECKING and sys.version_info >= (3, 9)"
 	if expr.Type == parser.NodeBoolOp {
-		return ma.containsTypeChecking(expr)
-	}
-
-	// Handle comparisons and other complex expressions
-	if expr.Type == parser.NodeCompare {
-		return ma.containsTypeChecking(expr)
+		return ma.isTypeCheckingBoolOp(expr)
 	}
 
 	return false
 }
 
-// containsTypeChecking recursively checks if an expression contains TYPE_CHECKING
-func (ma *ModuleAnalyzer) containsTypeChecking(node *parser.Node) bool {
-	if node == nil {
+func (ma *ModuleAnalyzer) isTypeCheckingBoolOp(expr *parser.Node) bool {
+	children := expr.GetChildren()
+	if len(children) == 0 {
 		return false
 	}
 
-	// Check current node
-	if (node.Type == parser.NodeName && node.Name == "TYPE_CHECKING") ||
-		(node.Type == parser.NodeAttribute && node.Name == "TYPE_CHECKING") {
-		return true
-	}
-
-	// Recursively check all children
-	for _, child := range node.GetChildren() {
-		if ma.containsTypeChecking(child) {
-			return true
+	switch expr.Op {
+	case "and":
+		for _, child := range children {
+			if ma.isTypeCheckingCondition(child) {
+				return true
+			}
 		}
+	case "or":
+		for _, child := range children {
+			if !ma.isTypeCheckingCondition(child) {
+				return false
+			}
+		}
+		return true
 	}
 
 	return false

--- a/internal/analyzer/module_analyzer_import_test.go
+++ b/internal/analyzer/module_analyzer_import_test.go
@@ -139,6 +139,88 @@ func TestModuleAnalyzerResolvesImportWithAlias(t *testing.T) {
 	}
 }
 
+func TestModuleAnalyzerCollectsImportsFromCompoundBranches(t *testing.T) {
+	dir := t.TempDir()
+
+	consumer := filepath.Join(dir, "consumer.py")
+
+	source := []byte(`
+if ready:
+    pass
+else:
+    import else_target
+
+try:
+    pass
+except Exception:
+    import except_target
+finally:
+    import finally_target
+`)
+	if err := os.WriteFile(consumer, source, 0o644); err != nil {
+		t.Fatalf("failed to write consumer: %v", err)
+	}
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{ProjectRoot: dir})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	imports := collectImportsForTest(t, analyzer, consumer)
+	statements := make(map[string]bool, len(imports))
+	for _, imp := range imports {
+		statements[imp.Statement] = true
+	}
+
+	for _, statement := range []string{"import else_target", "import except_target", "import finally_target"} {
+		if !statements[statement] {
+			t.Fatalf("expected import %s, got %v", statement, statements)
+		}
+	}
+}
+
+func TestModuleAnalyzerDetectsCycleThroughCompoundBranchImport(t *testing.T) {
+	dir := t.TempDir()
+
+	moduleA := filepath.Join(dir, "a.py")
+	moduleB := filepath.Join(dir, "b.py")
+
+	sourceA := []byte(`
+if ready:
+    pass
+else:
+    import b
+`)
+	if err := os.WriteFile(moduleA, sourceA, 0o644); err != nil {
+		t.Fatalf("failed to write module a: %v", err)
+	}
+	if err := os.WriteFile(moduleB, []byte("import a\n"), 0o644); err != nil {
+		t.Fatalf("failed to write module b: %v", err)
+	}
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{ProjectRoot: dir})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	graph, err := analyzer.AnalyzeFiles([]string{moduleA, moduleB})
+	if err != nil {
+		t.Fatalf("AnalyzeFiles failed: %v", err)
+	}
+
+	result := DetectCircularDependencies(graph)
+	if !result.HasCircularDependencies {
+		aNode := graph.GetModule("a")
+		bNode := graph.GetModule("b")
+		if aNode == nil || bNode == nil {
+			t.Fatalf("expected modules a and b in graph")
+		}
+		t.Fatalf("expected cycle through else import, got dependencies a=%v b=%v",
+			aNode.Dependencies,
+			bNode.Dependencies)
+	}
+}
+
 func TestModuleAnalyzerResolvesSingleDotRelativeImportInCurrentPackage(t *testing.T) {
 	dir := t.TempDir()
 
@@ -654,5 +736,5 @@ func collectImportsForTest(t *testing.T, analyzer *ModuleAnalyzer, path string) 
 	if err != nil {
 		t.Fatalf("failed to parse %s: %v", path, err)
 	}
-	return analyzer.collectModuleImports(result.AST, path)
+	return analyzer.collectModuleFacts(result.AST).imports
 }

--- a/internal/analyzer/module_analyzer_type_checking_test.go
+++ b/internal/analyzer/module_analyzer_type_checking_test.go
@@ -91,7 +91,7 @@ if TYPE_CHECKING and sys.version_info >= (3, 9):
 		t.Fatalf("Failed to parse file: %v", err)
 	}
 
-	imports := analyzer.collectModuleImports(result.AST, testFile)
+	imports := analyzer.collectModuleFacts(result.AST).imports
 
 	// Verify the imports
 	typeCheckingImports := 0
@@ -259,5 +259,83 @@ class ClassB:
 	if graph.HasCycle() {
 		cyclicModules := graph.GetModulesInCycles()
 		t.Errorf("Found unexpected cycles with modules: %v", cyclicModules)
+	}
+}
+
+func TestModuleAnalyzerTreatsTypeCheckingElseAsRuntime(t *testing.T) {
+	dir := t.TempDir()
+
+	moduleA := filepath.Join(dir, "module_a.py")
+	moduleB := filepath.Join(dir, "module_b.py")
+	moduleC := filepath.Join(dir, "module_c.py")
+	moduleD := filepath.Join(dir, "module_d.py")
+	moduleE := filepath.Join(dir, "module_e.py")
+	moduleF := filepath.Join(dir, "module_f.py")
+
+	sourceA := []byte(`
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import module_b
+elif TYPE_CHECKING:
+    import module_c
+else:
+    import module_d
+
+if TYPE_CHECKING or enable_plugin:
+    import module_e
+
+if TYPE_CHECKING == False:
+    import module_f
+`)
+	if err := os.WriteFile(moduleA, sourceA, 0o644); err != nil {
+		t.Fatalf("failed to write module_a: %v", err)
+	}
+	writeSimpleModule(t, moduleB)
+	writeSimpleModule(t, moduleC)
+	writeSimpleModule(t, moduleD)
+	writeSimpleModule(t, moduleE)
+	writeSimpleModule(t, moduleF)
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{
+		ProjectRoot:       dir,
+		IncludeStdLib:     domain.BoolPtr(false),
+		IncludeThirdParty: domain.BoolPtr(true),
+		FollowRelative:    domain.BoolPtr(true),
+	})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	graph, err := analyzer.AnalyzeFiles([]string{moduleA, moduleB, moduleC, moduleD, moduleE, moduleF})
+	if err != nil {
+		t.Fatalf("AnalyzeFiles failed: %v", err)
+	}
+
+	node := graph.GetModule("module_a")
+	if node == nil {
+		t.Fatalf("module_a not found in graph")
+	}
+	if node.Dependencies["module_b"] {
+		t.Fatalf("did not expect TYPE_CHECKING body dependency, got %v", node.Dependencies)
+	}
+	if node.Dependencies["module_c"] {
+		t.Fatalf("did not expect TYPE_CHECKING elif dependency, got %v", node.Dependencies)
+	}
+	if !node.Dependencies["module_d"] {
+		t.Fatalf("expected runtime else dependency on module_d, got %v", node.Dependencies)
+	}
+	if !node.Dependencies["module_e"] {
+		t.Fatalf("expected runtime or dependency on module_e, got %v", node.Dependencies)
+	}
+	if !node.Dependencies["module_f"] {
+		t.Fatalf("expected runtime comparison dependency on module_f, got %v", node.Dependencies)
+	}
+}
+
+func writeSimpleModule(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("value = 1\n"), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
 	}
 }


### PR DESCRIPTION
Module dependency analysis missed imports stored outside the AST Body field, including imports in else, except, and finally branches. This makes module analysis use the parser traversal contract, collects module facts in one pass, and keeps TYPE_CHECKING filtering branch-aware.

Validation: go test ./internal/analyzer and go test ./...