### PR TITLE
fix(clones): populate fragment id and type in clone group output

### DIFF
--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -382,8 +382,10 @@ func (s *CloneService) convertCloneGroupsToDomain(cloneGroups []*analyzer.CloneG
 		}
 
 		// Convert fragments to clones
-		for _, fragment := range group.Fragments {
+		for i, fragment := range group.Fragments {
 			clone := &domain.Clone{
+				ID:   i + 1,
+				Type: s.convertCloneType(group.CloneType),
 				Location: &domain.CloneLocation{
 					FilePath:  fragment.Location.FilePath,
 					StartLine: fragment.Location.StartLine,
@@ -391,6 +393,7 @@ func (s *CloneService) convertCloneGroupsToDomain(cloneGroups []*analyzer.CloneG
 					StartCol:  fragment.Location.StartCol,
 					EndCol:    fragment.Location.EndCol,
 				},
+				Hash:      fragment.Hash,
 				Size:      fragment.Size,
 				LineCount: fragment.LineCount,
 			}

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -162,9 +162,9 @@ func (s *CloneService) buildCloneResponse(
 	clonePairs, cloneGroups := detector.DetectClonesWithLSH(ctx, allFragments)
 
 	// Convert to domain objects
-	domainClones := s.convertFragmentsToDomainClones(allFragments)
+	domainClones, fragmentIDs := s.convertFragmentsToDomainClones(allFragments)
 	domainClonePairs := s.convertClonePairsToDomain(clonePairs, req.ShowContent)
-	domainCloneGroups := s.convertCloneGroupsToDomain(cloneGroups, req.ShowContent)
+	domainCloneGroups := s.convertCloneGroupsToDomain(cloneGroups, req.ShowContent, fragmentIDs)
 
 	// Filter results based on request criteria
 	domainClonePairs = s.filterClonePairs(domainClonePairs, req)
@@ -297,13 +297,23 @@ func (s *CloneService) createDetectorConfig(req *domain.CloneRequest) *analyzer.
 	}
 }
 
-// convertFragmentsToDomainClones converts analyzer fragments to domain clones
-func (s *CloneService) convertFragmentsToDomainClones(fragments []*analyzer.CodeFragment) []*domain.Clone {
+// convertFragmentsToDomainClones converts analyzer fragments to domain clones.
+//
+// It also returns a fragment -> id map so that the same fragment receives the
+// same id everywhere it appears in the response (top-level clones[] and the
+// per-group clone_groups[].clones[]). The id is the fragment's 1-based index in
+// the analyzed fragment set, which is response-unique and stable.
+func (s *CloneService) convertFragmentsToDomainClones(
+	fragments []*analyzer.CodeFragment,
+) ([]*domain.Clone, map[*analyzer.CodeFragment]int) {
 	domainClones := make([]*domain.Clone, len(fragments))
+	fragmentIDs := make(map[*analyzer.CodeFragment]int, len(fragments))
 
 	for i, fragment := range fragments {
+		id := i + 1
+		fragmentIDs[fragment] = id
 		domainClones[i] = &domain.Clone{
-			ID: i + 1,
+			ID: id,
 			Location: &domain.CloneLocation{
 				FilePath:  fragment.Location.FilePath,
 				StartLine: fragment.Location.StartLine,
@@ -319,7 +329,7 @@ func (s *CloneService) convertFragmentsToDomainClones(fragments []*analyzer.Code
 		}
 	}
 
-	return domainClones
+	return domainClones, fragmentIDs
 }
 
 // convertClonePairsToDomain converts analyzer clone pairs to domain clone pairs.
@@ -369,7 +379,11 @@ func (s *CloneService) convertClonePairsToDomain(clonePairs []*analyzer.ClonePai
 }
 
 // convertCloneGroupsToDomain converts analyzer clone groups to domain clone groups.
-func (s *CloneService) convertCloneGroupsToDomain(cloneGroups []*analyzer.CloneGroup, includeContent bool) []*domain.CloneGroup {
+func (s *CloneService) convertCloneGroupsToDomain(
+	cloneGroups []*analyzer.CloneGroup,
+	includeContent bool,
+	fragmentIDs map[*analyzer.CodeFragment]int,
+) []*domain.CloneGroup {
 	domainGroups := make([]*domain.CloneGroup, len(cloneGroups))
 
 	for i, group := range cloneGroups {
@@ -382,9 +396,12 @@ func (s *CloneService) convertCloneGroupsToDomain(cloneGroups []*analyzer.CloneG
 		}
 
 		// Convert fragments to clones
-		for i, fragment := range group.Fragments {
+		for _, fragment := range group.Fragments {
 			clone := &domain.Clone{
-				ID:   i + 1,
+				// Reuse the fragment's response-wide id so a group fragment
+				// matches the same fragment in top-level clones[] and ids stay
+				// unique across the response (not reset per group).
+				ID:   fragmentIDs[fragment],
 				Type: s.convertCloneType(group.CloneType),
 				Location: &domain.CloneLocation{
 					FilePath:  fragment.Location.FilePath,

--- a/service/clone_service_content_test.go
+++ b/service/clone_service_content_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"testing"
 
+	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/analyzer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,4 +77,46 @@ func TestCloneService_convertCloneGroupsToDomain_Content(t *testing.T) {
 	require.Len(t, withoutContent[0].Clones, 2)
 	assert.Empty(t, withoutContent[0].Clones[0].Content)
 	assert.Empty(t, withoutContent[0].Clones[1].Content)
+}
+
+// Regression for #488: group fragments were emitted with id=0 and type=0 for
+// every fragment, leaving them indistinguishable and untyped even though the
+// parent group carried the correct id and clone type.
+func TestCloneService_convertCloneGroupsToDomain_FragmentIDAndType(t *testing.T) {
+	service := NewCloneService()
+	groups := []*analyzer.CloneGroup{
+		{
+			ID:         1,
+			CloneType:  analyzer.Type2Clone,
+			Similarity: 0.91,
+			Size:       2,
+			Fragments: []*analyzer.CodeFragment{
+				{
+					Location:  &analyzer.CodeLocation{FilePath: "a.py", StartLine: 1, EndLine: 2},
+					Content:   "value = 1\nprint(value)",
+					Size:      3,
+					LineCount: 2,
+				},
+				{
+					Location:  &analyzer.CodeLocation{FilePath: "b.py", StartLine: 5, EndLine: 6},
+					Content:   "count = 1\nprint(count)",
+					Size:      3,
+					LineCount: 2,
+				},
+			},
+		},
+	}
+
+	result := service.convertCloneGroupsToDomain(groups, false)
+	require.Len(t, result, 1)
+	require.Len(t, result[0].Clones, 2)
+
+	// Each fragment gets a stable id, unique within the group.
+	assert.Equal(t, 1, result[0].Clones[0].ID)
+	assert.Equal(t, 2, result[0].Clones[1].ID)
+
+	// Each fragment inherits the group's clone type instead of the zero value.
+	for _, clone := range result[0].Clones {
+		assert.Equal(t, domain.Type2Clone, clone.Type, "fragment type should match the group clone type")
+	}
 }

--- a/service/clone_service_content_test.go
+++ b/service/clone_service_content_test.go
@@ -66,54 +66,60 @@ func TestCloneService_convertCloneGroupsToDomain_Content(t *testing.T) {
 		},
 	}
 
-	withContent := service.convertCloneGroupsToDomain(groups, true)
+	withContent := service.convertCloneGroupsToDomain(groups, true, nil)
 	require.Len(t, withContent, 1)
 	require.Len(t, withContent[0].Clones, 2)
 	assert.Equal(t, "value = 1\nprint(value)", withContent[0].Clones[0].Content)
 	assert.Equal(t, "count = 1\nprint(count)", withContent[0].Clones[1].Content)
 
-	withoutContent := service.convertCloneGroupsToDomain(groups, false)
+	withoutContent := service.convertCloneGroupsToDomain(groups, false, nil)
 	require.Len(t, withoutContent, 1)
 	require.Len(t, withoutContent[0].Clones, 2)
 	assert.Empty(t, withoutContent[0].Clones[0].Content)
 	assert.Empty(t, withoutContent[0].Clones[1].Content)
 }
 
-// Regression for #488: group fragments were emitted with id=0 and type=0 for
-// every fragment, leaving them indistinguishable and untyped even though the
-// parent group carried the correct id and clone type.
+// Regression for #488 (fragment id/type were always 0) plus the #503 review:
+// a group fragment must surface its response-wide id (the same id it carries in
+// top-level clones[]) instead of a per-group counter, so ids stay unique across
+// the response and link back to clones[].
 func TestCloneService_convertCloneGroupsToDomain_FragmentIDAndType(t *testing.T) {
 	service := NewCloneService()
+	frag0 := &analyzer.CodeFragment{
+		Location:  &analyzer.CodeLocation{FilePath: "a.py", StartLine: 1, EndLine: 2},
+		Content:   "value = 1\nprint(value)",
+		Size:      3,
+		LineCount: 2,
+	}
+	frag1 := &analyzer.CodeFragment{
+		Location:  &analyzer.CodeLocation{FilePath: "b.py", StartLine: 5, EndLine: 6},
+		Content:   "count = 1\nprint(count)",
+		Size:      3,
+		LineCount: 2,
+	}
 	groups := []*analyzer.CloneGroup{
 		{
 			ID:         1,
 			CloneType:  analyzer.Type2Clone,
 			Similarity: 0.91,
 			Size:       2,
-			Fragments: []*analyzer.CodeFragment{
-				{
-					Location:  &analyzer.CodeLocation{FilePath: "a.py", StartLine: 1, EndLine: 2},
-					Content:   "value = 1\nprint(value)",
-					Size:      3,
-					LineCount: 2,
-				},
-				{
-					Location:  &analyzer.CodeLocation{FilePath: "b.py", StartLine: 5, EndLine: 6},
-					Content:   "count = 1\nprint(count)",
-					Size:      3,
-					LineCount: 2,
-				},
-			},
+			Fragments:  []*analyzer.CodeFragment{frag0, frag1},
 		},
 	}
 
-	result := service.convertCloneGroupsToDomain(groups, false)
+	// Non-sequential, response-wide ids (as if these were clones #3 and #7 in
+	// the top-level clones[]). The group must surface these exact ids, not a
+	// per-group 1,2 reset.
+	fragmentIDs := map[*analyzer.CodeFragment]int{frag0: 3, frag1: 7}
+
+	result := service.convertCloneGroupsToDomain(groups, false, fragmentIDs)
 	require.Len(t, result, 1)
 	require.Len(t, result[0].Clones, 2)
 
-	// Each fragment gets a stable id, unique within the group.
-	assert.Equal(t, 1, result[0].Clones[0].ID)
-	assert.Equal(t, 2, result[0].Clones[1].ID)
+	// Fragment ids match their response-wide ids (link to top-level clones[]),
+	// not a per-group reset.
+	assert.Equal(t, 3, result[0].Clones[0].ID)
+	assert.Equal(t, 7, result[0].Clones[1].ID)
 
 	// Each fragment inherits the group's clone type instead of the zero value.
 	for _, clone := range result[0].Clones {


### PR DESCRIPTION
## Summary

Clone-group fragments in the analysis output (`clone.clone_groups[*].clones[*]`) were emitted with `id: 0` and `type: 0` for **every** fragment, even though the parent group carried the correct `id` and clone `type`. That left fragments within a group indistinguishable from one another and untyped.

Root cause: `convertCloneGroupsToDomain` (`service/clone_service.go`) built each `domain.Clone` with only `Location`/`Size`/`LineCount` and never set `ID` or `Type`. The sibling converter `convertFragmentsToDomainClones` already sets `ID: i + 1`; this aligns the group path with it and inherits the group's clone type per fragment.

## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
Refs #488

> **Scope note:** #488 also reports `hash: ""` on fragments. That's a *separate* root cause — `analyzer.CodeFragment.Hash` is never populated anywhere in the detector (clone detection uses MinHash/LSH signatures, not a stored per-fragment hash), so the field is dead at the source. Populating it well needs a design decision (hash algorithm + whether Type-1 whitespace/comment normalization applies), which felt like a maintainer call rather than something to invent here. This PR forwards `fragment.Hash` (so output tracks the field once it's populated) but doesn't compute it — happy to follow up on hash separately. Used `Refs` rather than `Closes` so the hash part stays tracked on #488.

## Changes
- `service/clone_service.go`: in `convertCloneGroupsToDomain`, set per-fragment `ID` (`i + 1`, unique within the group, matching `convertFragmentsToDomainClones`) and `Type` (inherited from the group's clone type); forward `Hash`.
- `service/clone_service_content_test.go`: add `TestCloneService_convertCloneGroupsToDomain_FragmentIDAndType` asserting fragments get sequential ids and the group's clone type.

## Testing
- [x] `make test` (`go test ./...`) passes locally
- [x] `go test -race ./service/...` passes locally
- [x] `make lint` passes locally (`go vet ./...` + `golangci-lint run`, both clean)
- [x] Added a regression test

Manual before/after on a two-function Type-2 clone fixture:

```
# before
clones: [ {id:0, type:0}, {id:0, type:0} ]
# after  (group: id:0, type:2)
clones: [ {id:1, type:2}, {id:2, type:2} ]
```

## Documentation
- [x] No doc changes needed — the output schema fields already exist; this populates them.
