### PR TITLE
Reuse prepared clone features for LSH

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -66,7 +66,7 @@ type CodeFragment struct {
 	Size       int      // Number of AST nodes
 	LineCount  int      // Number of source lines
 	Complexity int      // Cyclomatic complexity (if applicable)
-	Features   []string // Pre-computed features for Jaccard similarity
+	Features   []string // Pre-computed features for Jaccard and LSH similarity
 }
 
 // NewCodeFragment creates a new code fragment
@@ -599,13 +599,7 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 		return cd.clonePairs, cd.cloneGroups
 	}
 
-	// Stage 1: Feature extraction and MinHash signatures
-	extractor := NewASTFeatureExtractor().WithOptions(
-		max(1, cd.cloneDetectorConfig.LSHRows), // reuse rows for subtree height if >0
-		max(2, 4),                              // keep default k=4
-		true,
-		false,
-	)
+	// Stage 1: MinHash signatures from prepared clone features
 	hasher := NewMinHasher(cd.cloneDetectorConfig.LSHMinHashCount)
 
 	type fragRec struct {
@@ -618,9 +612,7 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 		if f == nil || f.TreeNode == nil {
 			continue
 		}
-		// Very short fragments: still create minimal features
-		feats, _ := extractor.ExtractFeatures(f.TreeNode)
-		sig := hasher.ComputeSignature(feats)
+		sig := hasher.ComputeSignature(f.Features)
 		records = append(records, fragRec{idx: i, sig: sig})
 		sigByIndex[i] = sig
 	}
@@ -726,13 +718,19 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 // prepareFragments converts AST fragments to tree nodes and pre-computes features
 func (cd *CloneDetector) prepareFragments() {
 	for _, fragment := range cd.fragments {
-		if fragment.ASTNode != nil {
+		if fragment == nil {
+			continue
+		}
+		if fragment.TreeNode == nil && fragment.ASTNode != nil {
 			fragment.TreeNode = cd.converter.ConvertAST(fragment.ASTNode)
-			if fragment.TreeNode != nil {
-				PrepareTreeForAPTED(fragment.TreeNode)
-				features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
-				fragment.Features = features
-			}
+		}
+		if fragment.TreeNode == nil {
+			continue
+		}
+		PrepareTreeForAPTED(fragment.TreeNode)
+		if len(fragment.Features) == 0 {
+			features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
+			fragment.Features = features
 		}
 	}
 }

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -66,7 +66,7 @@ type CodeFragment struct {
 	Size       int      // Number of AST nodes
 	LineCount  int      // Number of source lines
 	Complexity int      // Cyclomatic complexity (if applicable)
-	Features   []string // Cached clone feature tokens for this fragment's tree
+	Features   []string // Detector-populated clone feature cache for this fragment's tree
 }
 
 // NewCodeFragment creates a new code fragment
@@ -250,12 +250,6 @@ func DefaultCloneDetectorConfig() *CloneDetectorConfig {
 // are missed while the vast majority of non-clone pairs are skipped.
 const jaccardRejectionThreshold = 0.10
 
-// newCloneFeatureExtractor owns the CodeFragment.Features contract shared by
-// the Jaccard pre-filter and LSH candidate generation.
-func newCloneFeatureExtractor() *ASTFeatureExtractor {
-	return NewASTFeatureExtractor()
-}
-
 // CloneDetector detects code clones using APTED algorithm
 type CloneDetector struct {
 	// Embed config fields (private to maintain encapsulation)
@@ -329,7 +323,7 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 		classifier:          classifier,
 		textualAnalyzer:     NewTextualSimilarityAnalyzer(),
 		syntacticAnalyzer:   NewSyntacticSimilarityAnalyzer(),
-		featureExtractor:    newCloneFeatureExtractor(),
+		featureExtractor:    NewASTFeatureExtractor(),
 		fragments:           []*CodeFragment{},
 		clonePairs:          []*ClonePair{},
 		cloneGroups:         []*CloneGroup{},
@@ -727,19 +721,15 @@ func (cd *CloneDetector) prepareFragments() {
 		if fragment == nil {
 			continue
 		}
-		treeBuiltFromAST := false
 		if fragment.TreeNode == nil && fragment.ASTNode != nil {
 			fragment.TreeNode = cd.converter.ConvertAST(fragment.ASTNode)
-			treeBuiltFromAST = fragment.TreeNode != nil
 		}
 		if fragment.TreeNode == nil {
 			continue
 		}
 		PrepareTreeForAPTED(fragment.TreeNode)
-		if treeBuiltFromAST || len(fragment.Features) == 0 {
-			features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
-			fragment.Features = features
-		}
+		features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
+		fragment.Features = features
 	}
 }
 

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -66,7 +66,7 @@ type CodeFragment struct {
 	Size       int      // Number of AST nodes
 	LineCount  int      // Number of source lines
 	Complexity int      // Cyclomatic complexity (if applicable)
-	Features   []string // Pre-computed features for Jaccard and LSH similarity
+	Features   []string // Cached clone feature tokens for this fragment's tree
 }
 
 // NewCodeFragment creates a new code fragment
@@ -250,6 +250,12 @@ func DefaultCloneDetectorConfig() *CloneDetectorConfig {
 // are missed while the vast majority of non-clone pairs are skipped.
 const jaccardRejectionThreshold = 0.10
 
+// newCloneFeatureExtractor owns the CodeFragment.Features contract shared by
+// the Jaccard pre-filter and LSH candidate generation.
+func newCloneFeatureExtractor() *ASTFeatureExtractor {
+	return NewASTFeatureExtractor()
+}
+
 // CloneDetector detects code clones using APTED algorithm
 type CloneDetector struct {
 	// Embed config fields (private to maintain encapsulation)
@@ -260,7 +266,7 @@ type CloneDetector struct {
 	classifier        *CloneClassifier // Multi-dimensional classifier (optional)
 	textualAnalyzer   *TextualSimilarityAnalyzer
 	syntacticAnalyzer *SyntacticSimilarityAnalyzer
-	featureExtractor  *ASTFeatureExtractor // Pre-filter feature extractor
+	featureExtractor  *ASTFeatureExtractor // Source for CodeFragment.Features
 	fragments         []*CodeFragment
 	clonePairs        []*ClonePair
 	cloneGroups       []*CloneGroup
@@ -323,7 +329,7 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 		classifier:          classifier,
 		textualAnalyzer:     NewTextualSimilarityAnalyzer(),
 		syntacticAnalyzer:   NewSyntacticSimilarityAnalyzer(),
-		featureExtractor:    NewASTFeatureExtractor(),
+		featureExtractor:    newCloneFeatureExtractor(),
 		fragments:           []*CodeFragment{},
 		clonePairs:          []*ClonePair{},
 		cloneGroups:         []*CloneGroup{},
@@ -715,20 +721,22 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 	return cd.clonePairs, cd.cloneGroups
 }
 
-// prepareFragments converts AST fragments to tree nodes and pre-computes features
+// prepareFragments converts AST fragments to tree nodes and populates clone features.
 func (cd *CloneDetector) prepareFragments() {
 	for _, fragment := range cd.fragments {
 		if fragment == nil {
 			continue
 		}
+		treeBuiltFromAST := false
 		if fragment.TreeNode == nil && fragment.ASTNode != nil {
 			fragment.TreeNode = cd.converter.ConvertAST(fragment.ASTNode)
+			treeBuiltFromAST = fragment.TreeNode != nil
 		}
 		if fragment.TreeNode == nil {
 			continue
 		}
 		PrepareTreeForAPTED(fragment.TreeNode)
-		if len(fragment.Features) == 0 {
+		if treeBuiltFromAST || len(fragment.Features) == 0 {
 			features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
 			fragment.Features = features
 		}

--- a/internal/analyzer/clone_detector_benchmark_fixture_test.go
+++ b/internal/analyzer/clone_detector_benchmark_fixture_test.go
@@ -20,7 +20,6 @@ func cloneBenchmarkConfig(useLSH bool) *CloneDetectorConfig {
 }
 
 func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) []*CodeFragment {
-	extractor := newCloneFeatureExtractor()
 	fragments := make([]*CodeFragment, 0, familyCount*copiesPerFamily+noiseCount)
 
 	for family := 0; family < familyCount; family++ {
@@ -29,7 +28,6 @@ func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) 
 		for copyIndex := 0; copyIndex < copiesPerFamily; copyIndex++ {
 			tree := buildCloneBenchmarkTree(family)
 			PrepareTreeForAPTED(tree)
-			features, _ := extractor.ExtractFeatures(tree)
 			fragments = append(fragments, &CodeFragment{
 				Location: &CodeLocation{
 					FilePath:  fmt.Sprintf("family_%02d_copy_%02d.py", family, copyIndex),
@@ -44,7 +42,6 @@ func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) 
 				LineCount:  8,
 				Complexity: complexity,
 				TreeNode:   tree,
-				Features:   features,
 			})
 		}
 	}
@@ -52,7 +49,6 @@ func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) 
 	for noise := 0; noise < noiseCount; noise++ {
 		tree := buildCloneBenchmarkNoiseTree(familyCount + noise)
 		PrepareTreeForAPTED(tree)
-		features, _ := extractor.ExtractFeatures(tree)
 
 		lineCount := 5 + (noise % 4)
 		fragments = append(fragments, &CodeFragment{
@@ -69,7 +65,6 @@ func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) 
 			LineCount:  lineCount,
 			Complexity: 1 + (noise % 5),
 			TreeNode:   tree,
-			Features:   features,
 		})
 	}
 

--- a/internal/analyzer/clone_detector_benchmark_fixture_test.go
+++ b/internal/analyzer/clone_detector_benchmark_fixture_test.go
@@ -20,7 +20,7 @@ func cloneBenchmarkConfig(useLSH bool) *CloneDetectorConfig {
 }
 
 func buildCloneBenchmarkFragments(familyCount, copiesPerFamily, noiseCount int) []*CodeFragment {
-	extractor := NewASTFeatureExtractor()
+	extractor := newCloneFeatureExtractor()
 	fragments := make([]*CodeFragment, 0, familyCount*copiesPerFamily+noiseCount)
 
 	for family := 0; family < familyCount; family++ {

--- a/internal/analyzer/lsh_integration_test.go
+++ b/internal/analyzer/lsh_integration_test.go
@@ -100,19 +100,24 @@ func TestCloneDetectorPrepareFragmentsBuildsTreeBackedFeatures(t *testing.T) {
 	}
 }
 
-func TestCloneDetectorPrepareFragmentsKeepsPrecomputedFeatures(t *testing.T) {
+func TestCloneDetectorPrepareFragmentsRefreshesTreeBackedFeatures(t *testing.T) {
+	staleFeatures := []string{"stale:feature"}
 	fragment := &CodeFragment{
 		Location:  &CodeLocation{FilePath: "tree.py", StartLine: 1, EndLine: 5},
 		TreeNode:  buildSimpleTree("FunctionDef", "If", "Return"),
 		Size:      3,
 		LineCount: 5,
-		Features:  []string{"precomputed:feature"},
+		Features:  staleFeatures,
 	}
 
 	prepareTestFragment(t, DefaultCloneDetectorConfig(), fragment)
 
-	if len(fragment.Features) != 1 || fragment.Features[0] != "precomputed:feature" {
-		t.Fatalf("expected precomputed features to be preserved, got %v", fragment.Features)
+	if slices.Equal(fragment.Features, staleFeatures) {
+		t.Fatalf("expected tree-backed fragment features to be refreshed")
+	}
+	expected, _ := NewASTFeatureExtractor().ExtractFeatures(fragment.TreeNode)
+	if !slices.Equal(fragment.Features, expected) {
+		t.Fatalf("expected tree-backed features %v, got %v", expected, fragment.Features)
 	}
 }
 
@@ -134,7 +139,7 @@ func TestCloneDetectorPrepareFragmentsRefreshesConvertedASTFeatures(t *testing.T
 	if slices.Equal(fragment.Features, staleFeatures) {
 		t.Fatalf("expected AST conversion to refresh stale features")
 	}
-	expected, _ := newCloneFeatureExtractor().ExtractFeatures(fragment.TreeNode)
+	expected, _ := NewASTFeatureExtractor().ExtractFeatures(fragment.TreeNode)
 	if !slices.Equal(fragment.Features, expected) {
 		t.Fatalf("expected converted AST features %v, got %v", expected, fragment.Features)
 	}
@@ -161,49 +166,41 @@ func TestCloneDetectorPrepareFragmentsFeatureContractIgnoresLSHRows(t *testing.T
 	}
 }
 
-func TestCloneDetectorDetectClonesWithLSHUsesFeatureCache(t *testing.T) {
-	sharedFeatures := []string{"shared:shape", "shared:flow"}
+func TestCloneDetectorDetectClonesWithLSHRefreshesStaleFeatureCache(t *testing.T) {
 	fragments := []*CodeFragment{
 		{
 			Location:  &CodeLocation{FilePath: "cached_a.py", StartLine: 1, EndLine: 5},
-			TreeNode:  buildSimpleTree("FunctionDef", "Return", "NameA"),
+			TreeNode:  buildSimpleTree("FunctionDef", "Return", "Name"),
 			Size:      3,
 			LineCount: 5,
-			Features:  append([]string(nil), sharedFeatures...),
+			Features:  []string{"stale:left"},
 		},
 		{
 			Location:  &CodeLocation{FilePath: "cached_b.py", StartLine: 1, EndLine: 5},
-			TreeNode:  buildSimpleTree("ClassDef", "Assign", "AttributeB"),
+			TreeNode:  buildSimpleTree("FunctionDef", "Return", "Name"),
 			Size:      3,
 			LineCount: 5,
-			Features:  append([]string(nil), sharedFeatures...),
+			Features:  []string{"stale:right"},
 		},
 	}
 
 	cfg := DefaultCloneDetectorConfig()
 	cfg.UseLSH = true
 	cfg.MinNodes = 1
-	cfg.Type1Threshold = 1
-	cfg.Type2Threshold = 1
-	cfg.Type3Threshold = 1
-	cfg.Type4Threshold = 0
 	cfg.LSHSimilarityThreshold = 1
 
-	extractor := newCloneFeatureExtractor()
-	freshA, _ := extractor.ExtractFeatures(fragments[0].TreeNode)
-	freshB, _ := extractor.ExtractFeatures(fragments[1].TreeNode)
 	hasher := NewMinHasher(cfg.LSHMinHashCount)
-	freshSimilarity := hasher.EstimateJaccardSimilarity(
-		hasher.ComputeSignature(freshA),
-		hasher.ComputeSignature(freshB),
+	staleSimilarity := hasher.EstimateJaccardSimilarity(
+		hasher.ComputeSignature(fragments[0].Features),
+		hasher.ComputeSignature(fragments[1].Features),
 	)
-	if freshSimilarity == 1 {
-		t.Fatalf("test setup needs tree-derived features below strict LSH threshold")
+	if staleSimilarity == 1 {
+		t.Fatalf("test setup needs stale features below strict LSH threshold")
 	}
 
 	pairs, _ := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
 	if len(pairs) != 1 {
-		t.Fatalf("expected LSH to use cached features for candidate generation, got %d pairs", len(pairs))
+		t.Fatalf("expected LSH to refresh stale cached features before candidate generation, got %d pairs", len(pairs))
 	}
 }
 

--- a/internal/analyzer/lsh_integration_test.go
+++ b/internal/analyzer/lsh_integration_test.go
@@ -2,9 +2,12 @@ package analyzer
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/ludo-technologies/pyscn/internal/parser"
 )
 
 // buildSimpleTree builds a small ordered tree with labels
@@ -21,6 +24,27 @@ func buildSimpleTree(labels ...string) *TreeNode {
 	}
 	PrepareTreeForAPTED(root)
 	return root
+}
+
+func buildSimpleAST(types ...parser.NodeType) *parser.Node {
+	if len(types) == 0 {
+		return nil
+	}
+	root := parser.NewNode(types[0])
+	cur := root
+	for i := 1; i < len(types); i++ {
+		child := parser.NewNode(types[i])
+		cur.AddChild(child)
+		cur = child
+	}
+	return root
+}
+
+func prepareTestFragment(t *testing.T, cfg *CloneDetectorConfig, fragment *CodeFragment) {
+	t.Helper()
+	detector := NewCloneDetector(cfg)
+	detector.fragments = []*CodeFragment{fragment}
+	detector.prepareFragments()
 }
 
 func TestCloneDetector_DetectClonesWithLSH_Simple(t *testing.T) {
@@ -69,9 +93,7 @@ func TestCloneDetectorPrepareFragmentsBuildsTreeBackedFeatures(t *testing.T) {
 		LineCount: 5,
 	}
 
-	detector := NewCloneDetector(DefaultCloneDetectorConfig())
-	detector.fragments = []*CodeFragment{fragment}
-	detector.prepareFragments()
+	prepareTestFragment(t, DefaultCloneDetectorConfig(), fragment)
 
 	if len(fragment.Features) == 0 {
 		t.Fatalf("expected prepareFragments to populate features for tree-backed fragment")
@@ -87,12 +109,101 @@ func TestCloneDetectorPrepareFragmentsKeepsPrecomputedFeatures(t *testing.T) {
 		Features:  []string{"precomputed:feature"},
 	}
 
-	detector := NewCloneDetector(DefaultCloneDetectorConfig())
-	detector.fragments = []*CodeFragment{fragment}
-	detector.prepareFragments()
+	prepareTestFragment(t, DefaultCloneDetectorConfig(), fragment)
 
 	if len(fragment.Features) != 1 || fragment.Features[0] != "precomputed:feature" {
 		t.Fatalf("expected precomputed features to be preserved, got %v", fragment.Features)
+	}
+}
+
+func TestCloneDetectorPrepareFragmentsRefreshesConvertedASTFeatures(t *testing.T) {
+	staleFeatures := []string{"stale:feature"}
+	fragment := &CodeFragment{
+		Location:  &CodeLocation{FilePath: "ast.py", StartLine: 1, EndLine: 5},
+		ASTNode:   buildSimpleAST(parser.NodeFunctionDef, parser.NodeIf, parser.NodeReturn),
+		Size:      3,
+		LineCount: 5,
+		Features:  staleFeatures,
+	}
+
+	prepareTestFragment(t, DefaultCloneDetectorConfig(), fragment)
+
+	if fragment.TreeNode == nil {
+		t.Fatalf("expected prepareFragments to convert AST to tree")
+	}
+	if slices.Equal(fragment.Features, staleFeatures) {
+		t.Fatalf("expected AST conversion to refresh stale features")
+	}
+	expected, _ := newCloneFeatureExtractor().ExtractFeatures(fragment.TreeNode)
+	if !slices.Equal(fragment.Features, expected) {
+		t.Fatalf("expected converted AST features %v, got %v", expected, fragment.Features)
+	}
+}
+
+func TestCloneDetectorPrepareFragmentsFeatureContractIgnoresLSHRows(t *testing.T) {
+	featuresForRows := func(rows int) []string {
+		cfg := DefaultCloneDetectorConfig()
+		cfg.LSHRows = rows
+		fragment := &CodeFragment{
+			Location:  &CodeLocation{FilePath: "rows.py", StartLine: 1, EndLine: 5},
+			TreeNode:  buildSimpleTree("FunctionDef", "If", "Return"),
+			Size:      3,
+			LineCount: 5,
+		}
+		prepareTestFragment(t, cfg, fragment)
+		return fragment.Features
+	}
+
+	rowsOneFeatures := featuresForRows(1)
+	rowsNineFeatures := featuresForRows(9)
+	if !slices.Equal(rowsOneFeatures, rowsNineFeatures) {
+		t.Fatalf("LSHRows must not change clone features: rows=1 %v rows=9 %v", rowsOneFeatures, rowsNineFeatures)
+	}
+}
+
+func TestCloneDetectorDetectClonesWithLSHUsesFeatureCache(t *testing.T) {
+	sharedFeatures := []string{"shared:shape", "shared:flow"}
+	fragments := []*CodeFragment{
+		{
+			Location:  &CodeLocation{FilePath: "cached_a.py", StartLine: 1, EndLine: 5},
+			TreeNode:  buildSimpleTree("FunctionDef", "Return", "NameA"),
+			Size:      3,
+			LineCount: 5,
+			Features:  append([]string(nil), sharedFeatures...),
+		},
+		{
+			Location:  &CodeLocation{FilePath: "cached_b.py", StartLine: 1, EndLine: 5},
+			TreeNode:  buildSimpleTree("ClassDef", "Assign", "AttributeB"),
+			Size:      3,
+			LineCount: 5,
+			Features:  append([]string(nil), sharedFeatures...),
+		},
+	}
+
+	cfg := DefaultCloneDetectorConfig()
+	cfg.UseLSH = true
+	cfg.MinNodes = 1
+	cfg.Type1Threshold = 1
+	cfg.Type2Threshold = 1
+	cfg.Type3Threshold = 1
+	cfg.Type4Threshold = 0
+	cfg.LSHSimilarityThreshold = 1
+
+	extractor := newCloneFeatureExtractor()
+	freshA, _ := extractor.ExtractFeatures(fragments[0].TreeNode)
+	freshB, _ := extractor.ExtractFeatures(fragments[1].TreeNode)
+	hasher := NewMinHasher(cfg.LSHMinHashCount)
+	freshSimilarity := hasher.EstimateJaccardSimilarity(
+		hasher.ComputeSignature(freshA),
+		hasher.ComputeSignature(freshB),
+	)
+	if freshSimilarity == 1 {
+		t.Fatalf("test setup needs tree-derived features below strict LSH threshold")
+	}
+
+	pairs, _ := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
+	if len(pairs) != 1 {
+		t.Fatalf("expected LSH to use cached features for candidate generation, got %d pairs", len(pairs))
 	}
 }
 

--- a/internal/analyzer/lsh_integration_test.go
+++ b/internal/analyzer/lsh_integration_test.go
@@ -61,6 +61,41 @@ func TestCloneDetector_DetectClonesWithLSH_Simple(t *testing.T) {
 	}
 }
 
+func TestCloneDetectorPrepareFragmentsBuildsTreeBackedFeatures(t *testing.T) {
+	fragment := &CodeFragment{
+		Location:  &CodeLocation{FilePath: "tree.py", StartLine: 1, EndLine: 5},
+		TreeNode:  buildSimpleTree("FunctionDef", "If", "Return"),
+		Size:      3,
+		LineCount: 5,
+	}
+
+	detector := NewCloneDetector(DefaultCloneDetectorConfig())
+	detector.fragments = []*CodeFragment{fragment}
+	detector.prepareFragments()
+
+	if len(fragment.Features) == 0 {
+		t.Fatalf("expected prepareFragments to populate features for tree-backed fragment")
+	}
+}
+
+func TestCloneDetectorPrepareFragmentsKeepsPrecomputedFeatures(t *testing.T) {
+	fragment := &CodeFragment{
+		Location:  &CodeLocation{FilePath: "tree.py", StartLine: 1, EndLine: 5},
+		TreeNode:  buildSimpleTree("FunctionDef", "If", "Return"),
+		Size:      3,
+		LineCount: 5,
+		Features:  []string{"precomputed:feature"},
+	}
+
+	detector := NewCloneDetector(DefaultCloneDetectorConfig())
+	detector.fragments = []*CodeFragment{fragment}
+	detector.prepareFragments()
+
+	if len(fragment.Features) != 1 || fragment.Features[0] != "precomputed:feature" {
+		t.Fatalf("expected precomputed features to be preserved, got %v", fragment.Features)
+	}
+}
+
 func TestCloneDetector_DetectClonesWithLSH_CandidateCapDoesNotDropExactFamily(t *testing.T) {
 	fragments := make([]*CodeFragment, 0, 9)
 	for i := 0; i < 9; i++ {


### PR DESCRIPTION
Reuses the clone feature cache prepared by prepareFragments when building LSH MinHash signatures.

This keeps tree-backed fragments on the same detector-owned feature contract as AST-backed fragments, and avoids stale caller-provided feature slices affecting LSH candidate selection.

Validation:
go test ./internal/analyzer -count=1 -run 'TestCloneDetector.*LSH|TestCloneDetectorPrepareFragments'
go test ./internal/analyzer -count=1
go test ./... -count=1
go test ./internal/analyzer -run '^$' -bench 'BenchmarkCloneDetector_DetectClones' -benchmem
