### PR TITLE
ci: upgrade golangci-lint-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.25'
         cache: true  # Re-enable cache now that race detection is disabled
-    
+
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v7
       with:
         version: latest
         args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,29 @@
-linters-settings:
-  staticcheck:
-    checks:
-      - "all"
-      - "-SA5011" # Disable false positives for nil checks before dereferencing
-
+version: "2"
 linters:
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -SA5011 # Disable false positives for nil checks before dereferencing
+        - -ST1*   # Style checks (separate stylecheck linter in v1, not enabled here)
+        - -QF1*   # Quickfix suggestions (not enabled in v1)
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
   enable:
-    - staticcheck
-    - unused
     - gofmt
-    - govet
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Why

golangci-lint v1 (the last release, built with go1.24) refuses to lint a module whose `go` directive targets go1.25+:

```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.5)
```

This is exactly what breaks the `lint` job on #504, where the dependency bumps push the `go` directive to 1.25.5. `build` and `test` pass there — only `lint` fails, and purely on this tooling mismatch.

## What

- Bump `golangci/golangci-lint-action@v3` → `@v7`, which runs golangci-lint **v2** (built with go1.25+).
- Migrate `.golangci.yml` to the v2 schema (`gofmt` moves to `formatters`; v1 default exclusions preserved explicitly).
- v2 unifies `staticcheck` with the former `stylecheck`/quickfix checks, so `checks: all` would newly flag ~20 `ST*`/`QF*` issues. Constrained to `-ST1*`/`-QF1*` to **preserve the previous v1 lint scope** rather than expand it in a CI-fix PR. Verified locally with golangci-lint v2.12.2: **0 issues**.
- Bump the lint job's Go to 1.25 to match the new module floor.

This unblocks #504 once merged (rebase #504 afterward).