### PR TITLE
refactor(complexity): consolidate cognitive complexity into analyzer layer

### DIFF
--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -155,25 +155,18 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		complexity = 1
 	}
 
-	// Calculate nesting depth if the original AST node is available.
+	// Calculate nesting depth and location from the original AST node if available.
+	// The same node feeds CalculateCognitiveComplexity above via complexitySourceNode.
 	nestingDepth := 0
 	startLine := 0
 	startCol := 0
 	endLine := 0
-	if cfg.FunctionNode != nil {
-		nestingResult := CalculateMaxNestingDepth(cfg.FunctionNode)
-		nestingDepth = nestingResult.MaxDepth
+	if sourceNode := complexitySourceNode(cfg); sourceNode != nil {
+		nestingDepth = CalculateMaxNestingDepth(sourceNode).MaxDepth
 
-		startLine = cfg.FunctionNode.Location.StartLine
-		startCol = cfg.FunctionNode.Location.StartCol
-		endLine = cfg.FunctionNode.Location.EndLine
-	} else if cfg.ModuleNode != nil {
-		nestingResult := CalculateMaxNestingDepth(cfg.ModuleNode)
-		nestingDepth = nestingResult.MaxDepth
-
-		startLine = cfg.ModuleNode.Location.StartLine
-		startCol = cfg.ModuleNode.Location.StartCol
-		endLine = cfg.ModuleNode.Location.EndLine
+		startLine = sourceNode.Location.StartLine
+		startCol = sourceNode.Location.StartCol
+		endLine = sourceNode.Location.EndLine
 	}
 
 	result := &ComplexityResult{


### PR DESCRIPTION
## Summary

Resolves #465. Consolidates the duplicated `FunctionNode`/`ModuleNode` selection branch in `CalculateComplexityWithConfig` into the existing `complexitySourceNode` helper.

When investigating, tasks 1 and 3 from the issue were already in place:
- `CognitiveComplexity int` already exists on `analyzer.ComplexityResult` and is populated within `CalculateComplexityWithConfig`.
- `service/complexity_service.go` already reads `result.CognitiveComplexity` with no direct call to `analyzer.CalculateCognitiveComplexity`.

The remaining work was **task 2**: the DRY violation in the analyzer. Nesting depth, location, and cognitive complexity now all derive from a single source-node selection via `complexitySourceNode(cfg)`.

## Changes
- `internal/analyzer/complexity.go`: replace the 15-line `if/else if` over `FunctionNode`/`ModuleNode` with the `complexitySourceNode` helper (already used to feed cognitive complexity).

No behavioral change — code organization only.

## Verification
- `go build ./...` — OK
- `go test ./service/ ./internal/analyzer/` — pass (incl. the #464 regression test `module-level complexity includes cognitive and nesting metrics`)
- `go vet` — clean

Closes #465