### PR TITLE
fix(dead-code): merge overlapping unreachable findings (#471)

### DIFF
--- a/internal/analyzer/dead_code.go
+++ b/internal/analyzer/dead_code.go
@@ -142,8 +142,18 @@ func (dcd *DeadCodeDetector) Detect() *DeadCodeResult {
 
 	// Sort findings by line number for consistent output
 	sort.Slice(result.Findings, func(i, j int) bool {
-		return result.Findings[i].StartLine < result.Findings[j].StartLine
+		if result.Findings[i].StartLine != result.Findings[j].StartLine {
+			return result.Findings[i].StartLine < result.Findings[j].StartLine
+		}
+		return result.Findings[i].EndLine < result.Findings[j].EndLine
 	})
+
+	// Merge overlapping/contiguous findings that share a reason. A compound
+	// statement (e.g. `if`) spans its body, so the body's own block produces a
+	// finding whose line range is nested inside the `if` finding's range. Left
+	// as-is, the same source line is reported—and tallied—more than once. Merging
+	// collapses each contiguous dead region into a single non-overlapping finding.
+	result.Findings = mergeContiguousFindings(result.Findings)
 
 	result.AnalysisTime = time.Since(startTime)
 	return result
@@ -547,6 +557,70 @@ func GroupFindingsByReason(findings []*DeadCodeFinding) map[DeadCodeReason][]*De
 	}
 
 	return groups
+}
+
+// mergeContiguousFindings collapses findings whose line ranges overlap or are
+// directly adjacent (no reachable line between them) and that share the same
+// reason into a single finding. Findings must be pre-sorted by StartLine (then
+// EndLine). This removes the overlapping/duplicate ranges that arise because a
+// compound statement's finding spans its body while the body's block emits its
+// own nested finding.
+func mergeContiguousFindings(findings []*DeadCodeFinding) []*DeadCodeFinding {
+	if len(findings) <= 1 {
+		return findings
+	}
+
+	severityRank := map[SeverityLevel]int{
+		SeverityLevelInfo:     1,
+		SeverityLevelWarning:  2,
+		SeverityLevelCritical: 3,
+	}
+
+	merged := make([]*DeadCodeFinding, 0, len(findings))
+	current := findings[0]
+
+	for _, next := range findings[1:] {
+		// Contiguous if the next finding starts at or before the line right after
+		// the current region's end (overlapping or back-to-back lines).
+		contiguous := next.StartLine <= current.EndLine+1
+		if contiguous && next.Reason == current.Reason {
+			if next.EndLine > current.EndLine {
+				current.EndLine = next.EndLine
+			}
+			current.Code = mergeCodeLines(current.Code, next.Code)
+			if severityRank[next.Severity] > severityRank[current.Severity] {
+				current.Severity = next.Severity
+				current.Description = next.Description
+			}
+			continue
+		}
+		merged = append(merged, current)
+		current = next
+	}
+	merged = append(merged, current)
+
+	return merged
+}
+
+// mergeCodeLines appends the lines of b to a, skipping a leading line of b that
+// duplicates the trailing line of a. This keeps the merged snippet readable when
+// a nested-body block repeats the line already shown by its enclosing statement.
+func mergeCodeLines(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	aLines := strings.Split(a, "\n")
+	bLines := strings.Split(b, "\n")
+	if len(aLines) > 0 && len(bLines) > 0 && aLines[len(aLines)-1] == bLines[0] {
+		bLines = bLines[1:]
+	}
+	if len(bLines) == 0 {
+		return a
+	}
+	return a + "\n" + strings.Join(bLines, "\n")
 }
 
 // isOnlyEmptyStatements reports whether every statement in the block is an

--- a/internal/analyzer/dead_code_test.go
+++ b/internal/analyzer/dead_code_test.go
@@ -715,6 +715,104 @@ def g(y):
 	}
 }
 
+func TestDeadCodeNoOverlappingFindings(t *testing.T) {
+	// A compound statement (if) spans its body, so the body's own block used to
+	// emit a finding whose range was nested inside the if's finding range,
+	// double-counting the same source line. The whole region after `raise` is
+	// one contiguous dead region and should produce non-overlapping findings.
+	code := `
+def do_flip(self, show_widgets=True):
+    raise NotImplementedError
+    self.widget_tooltip = None
+    if show_widgets:
+        self.render_widgets()
+    if self.notifications:
+        self.render_notifications()
+`
+
+	p := parser.New()
+	ctx := context.Background()
+	parseResult, err := p.Parse(ctx, []byte(code))
+	require.NoError(t, err)
+
+	builder := NewCFGBuilder()
+	cfgs, err := builder.BuildAll(parseResult.AST)
+	require.NoError(t, err)
+
+	cfg, ok := cfgs["do_flip"]
+	require.True(t, ok, "expected CFG for do_flip")
+
+	result := DetectInFunction(cfg)
+	require.NotNil(t, result)
+	require.NotEmpty(t, result.Findings)
+
+	// Findings must not have overlapping line ranges: each finding's start line
+	// must be strictly after the previous finding's end line.
+	for i := 1; i < len(result.Findings); i++ {
+		prev := result.Findings[i-1]
+		cur := result.Findings[i]
+		assert.Greater(t, cur.StartLine, prev.EndLine,
+			"findings overlap: %+v then %+v", prev, cur)
+	}
+
+	// The contiguous dead region collapses to a single finding.
+	assert.Len(t, result.Findings, 1, "contiguous dead region should be one finding")
+}
+
+func TestMergeContiguousFindings(t *testing.T) {
+	mk := func(start, end int, reason DeadCodeReason, sev SeverityLevel) *DeadCodeFinding {
+		return &DeadCodeFinding{StartLine: start, EndLine: end, Reason: reason, Severity: sev, Code: "x"}
+	}
+
+	t.Run("merges overlapping same-reason findings", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 6, ReasonUnreachableAfterRaise, SeverityLevelWarning),
+			mk(6, 6, ReasonUnreachableAfterRaise, SeverityLevelCritical),
+		}
+		out := mergeContiguousFindings(in)
+		require.Len(t, out, 1)
+		assert.Equal(t, 4, out[0].StartLine)
+		assert.Equal(t, 6, out[0].EndLine)
+		assert.Equal(t, SeverityLevelCritical, out[0].Severity, "keeps highest severity")
+	})
+
+	t.Run("merges adjacent same-reason findings", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 6, ReasonUnreachableAfterRaise, SeverityLevelCritical),
+			mk(7, 8, ReasonUnreachableAfterRaise, SeverityLevelCritical),
+		}
+		out := mergeContiguousFindings(in)
+		require.Len(t, out, 1)
+		assert.Equal(t, 8, out[0].EndLine)
+	})
+
+	t.Run("does not merge across a gap", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 4, ReasonUnreachableAfterRaise, SeverityLevelCritical),
+			mk(6, 6, ReasonUnreachableAfterRaise, SeverityLevelCritical),
+		}
+		out := mergeContiguousFindings(in)
+		assert.Len(t, out, 2)
+	})
+
+	t.Run("does not merge different reasons", func(t *testing.T) {
+		in := []*DeadCodeFinding{
+			mk(4, 6, ReasonUnreachableAfterRaise, SeverityLevelCritical),
+			mk(6, 6, ReasonUnreachableBranch, SeverityLevelWarning),
+		}
+		out := mergeContiguousFindings(in)
+		assert.Len(t, out, 2)
+	})
+}
+
+func TestMergeCodeLines(t *testing.T) {
+	assert.Equal(t, "b", mergeCodeLines("", "b"))
+	assert.Equal(t, "a", mergeCodeLines("a", ""))
+	assert.Equal(t, "a\nb", mergeCodeLines("a", "b"))
+	// Duplicate boundary line (nested body repeats enclosing line) is collapsed.
+	assert.Equal(t, "if\nCall", mergeCodeLines("if\nCall", "Call"))
+}
+
 func TestIsOnlyEmptyStatements(t *testing.T) {
 	assert.False(t, isOnlyEmptyStatements(nil), "nil block")
 	assert.False(t, isOnlyEmptyStatements(&BasicBlock{}), "empty block")


### PR DESCRIPTION
## Summary

Fixes #471. Dead-code findings contained **overlapping line ranges** for the same source statement: a compound statement (e.g. `if`) spans its body, so the body's own CFG block emitted a finding whose line range was nested inside the enclosing statement's finding. The same source line was reported—and tallied—more than once, making counts like `total_findings` misleading.

### Repro (before)

```python
def do_flip(self, show_widgets=True):
    raise NotImplementedError
    self.widget_tooltip = None
    if show_widgets:
        self.render_widgets()
    if self.notifications:
        self.render_notifications()
```

| start-end | code | reason |
| --- | --- | --- |
| 4-6 | `assignment\nif` | unreachable_after_raise |
| 6-6 | `Call` | unreachable_after_raise |
| 7-8 | `if` | unreachable_after_raise |
| 8-8 | `Call` | unreachable_after_raise |

Lines 6 and 8 each appear in two findings.

### After

A single non-overlapping finding for the contiguous dead region:

| start-end | code | reason |
| --- | --- | --- |
| 4-8 | `assignment\nif\nCall\nif\nCall` | unreachable_after_raise |

## Changes

- `Detect()` now sorts findings by `(StartLine, EndLine)` and runs them through `mergeContiguousFindings()`.
- `mergeContiguousFindings()` collapses findings whose ranges overlap or are directly adjacent (no reachable line between) **and share the same reason** into one finding. Keeps the widest range and the highest severity.
- `mergeCodeLines()` folds the duplicate boundary line when a nested body repeats its enclosing statement's line, keeping the merged snippet readable.

## Tests

- `TestDeadCodeNoOverlappingFindings` — asserts no overlapping ranges and that the contiguous region collapses to one finding.
- `TestMergeContiguousFindings` — overlap merge, adjacent merge, gap not merged, different-reason not merged, severity escalation.
- `TestMergeCodeLines` — boundary-line dedup.

`go test ./...` passes; `gofmt`/`go vet` clean.