### PR TITLE
feat(architecture): style preset plumbing + layered preset (1/3) (#335)

### DIFF
--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -411,6 +411,11 @@ const (
 
 // ArchitectureRules defines architecture validation rules
 type ArchitectureRules struct {
+	// Style is an optional preset name: "layered", "hexagonal", "clean", "mvc".
+	// When non-empty and Layers/Rules are empty, the service loads the matching
+	// preset's layers and rules. Empty/"layered" preserves the legacy behavior.
+	Style string `json:"style" yaml:"style"`
+
 	// Layer rules
 	Layers []Layer     `json:"layers" yaml:"layers"`
 	Rules  []LayerRule `json:"rules" yaml:"rules"`

--- a/internal/config/architecture_presets.go
+++ b/internal/config/architecture_presets.go
@@ -1,0 +1,76 @@
+package config
+
+// Architecture style preset names. Users select one via `style` in the
+// [architecture] section of pyscn.toml / pyproject.toml to auto-apply a
+// matching set of layers and dependency rules.
+const (
+	// ArchitectureStyleLayered is the default, backward-compatible preset.
+	// An empty style is treated as layered.
+	ArchitectureStyleLayered = "layered"
+)
+
+// ArchitectureStylePreset returns the layer definitions and dependency rules
+// for the named architecture style. An empty style is treated as "layered".
+// Returns (nil, nil) for an unrecognized style so callers can fall back to
+// auto-detection.
+func ArchitectureStylePreset(style string) ([]LayerDefinition, []LayerRule) {
+	switch style {
+	case "", ArchitectureStyleLayered:
+		return layeredPresetLayers(), layeredPresetRules()
+	default:
+		return nil, nil
+	}
+}
+
+// layeredPresetLayers mirrors the [architecture.layers] section of
+// internal/config/default_config.toml.tmpl. Kept identical to preserve the
+// behavior projects had before style presets existed.
+func layeredPresetLayers() []LayerDefinition {
+	return []LayerDefinition{
+		{
+			Name:     "presentation",
+			Packages: []string{"router", "routers", "route", "routes", "endpoint", "endpoints", "handler", "handlers", "controller", "controllers", "view", "views", "api", "apis", "ui", "web", "rest", "graphql"},
+		},
+		{
+			Name:     "application",
+			Packages: []string{"service", "services", "usecase", "usecases", "use_case", "use_cases", "workflow", "workflows", "command", "commands", "query", "queries", "manager", "managers"},
+		},
+		{
+			Name:     "domain",
+			Packages: []string{"model", "models", "entity", "entities", "schema", "schemas", "domain", "domains", "core", "business", "aggregate", "aggregates", "valueobject", "valueobjects"},
+		},
+		{
+			Name:     "infrastructure",
+			Packages: []string{"repository", "repositories", "repo", "repos", "db", "database", "adapter", "adapters", "persistence", "storage", "cache", "client", "clients", "external"},
+		},
+	}
+}
+
+// layeredPresetRules mirrors the [architecture.rules] section of
+// internal/config/default_config.toml.tmpl.
+//
+// Note: this preset intentionally allows domain -> infrastructure. That relaxes
+// the strict Dependency Inversion Principle, but it is the long-standing default
+// behavior and is preserved here for backward compatibility. Use the hexagonal
+// or clean presets for stricter DIP enforcement.
+func layeredPresetRules() []LayerRule {
+	return []LayerRule{
+		{
+			From:  "presentation",
+			Allow: []string{"presentation", "application", "domain", "infrastructure"},
+		},
+		{
+			From:  "application",
+			Allow: []string{"application", "domain", "infrastructure"},
+		},
+		{
+			From:  "domain",
+			Allow: []string{"domain", "infrastructure"},
+			Deny:  []string{"presentation", "application"},
+		},
+		{
+			From:  "infrastructure",
+			Allow: []string{"infrastructure", "domain", "application"},
+		},
+	}
+}

--- a/internal/config/architecture_presets_test.go
+++ b/internal/config/architecture_presets_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestArchitectureStylePreset_LayeredMatchesEmpty verifies that an empty style
+// resolves to the same preset as the explicit "layered" style.
+func TestArchitectureStylePreset_LayeredMatchesEmpty(t *testing.T) {
+	emptyLayers, emptyRules := ArchitectureStylePreset("")
+	layeredLayers, layeredRules := ArchitectureStylePreset(ArchitectureStyleLayered)
+
+	if !reflect.DeepEqual(emptyLayers, layeredLayers) {
+		t.Errorf("empty-style layers differ from layered layers")
+	}
+	if !reflect.DeepEqual(emptyRules, layeredRules) {
+		t.Errorf("empty-style rules differ from layered rules")
+	}
+}
+
+// TestArchitectureStylePreset_LayeredBackwardCompat verifies that the layered
+// preset matches the embedded default_config.toml architecture section exactly,
+// so projects that relied on the previous default keep identical behavior.
+func TestArchitectureStylePreset_LayeredBackwardCompat(t *testing.T) {
+	defaultCfg, err := LoadDefaultConfigFromTOML()
+	if err != nil {
+		t.Fatalf("LoadDefaultConfigFromTOML failed: %v", err)
+	}
+
+	layers, rules := ArchitectureStylePreset(ArchitectureStyleLayered)
+
+	// Compare layer names and packages.
+	if len(layers) != len(defaultCfg.Architecture.Layers) {
+		t.Fatalf("layer count mismatch: preset=%d default=%d", len(layers), len(defaultCfg.Architecture.Layers))
+	}
+	for i, l := range layers {
+		d := defaultCfg.Architecture.Layers[i]
+		if l.Name != d.Name {
+			t.Errorf("layer[%d] name mismatch: preset=%q default=%q", i, l.Name, d.Name)
+		}
+		if !reflect.DeepEqual(l.Packages, d.Packages) {
+			t.Errorf("layer[%d] (%s) packages mismatch:\n preset=%v\ndefault=%v", i, l.Name, l.Packages, d.Packages)
+		}
+	}
+
+	// Compare rules (From/Allow/Deny).
+	if len(rules) != len(defaultCfg.Architecture.Rules) {
+		t.Fatalf("rule count mismatch: preset=%d default=%d", len(rules), len(defaultCfg.Architecture.Rules))
+	}
+	for i, r := range rules {
+		d := defaultCfg.Architecture.Rules[i]
+		if r.From != d.From {
+			t.Errorf("rule[%d] from mismatch: preset=%q default=%q", i, r.From, d.From)
+		}
+		if !reflect.DeepEqual(r.Allow, d.Allow) {
+			t.Errorf("rule[%d] (%s) allow mismatch:\n preset=%v\ndefault=%v", i, r.From, r.Allow, d.Allow)
+		}
+		if !reflect.DeepEqual(r.Deny, d.Deny) {
+			t.Errorf("rule[%d] (%s) deny mismatch:\n preset=%v\ndefault=%v", i, r.From, r.Deny, d.Deny)
+		}
+	}
+}
+
+// TestArchitectureStylePreset_UnknownReturnsNil verifies that an unrecognized
+// style returns no preset so callers can fall back to auto-detection.
+func TestArchitectureStylePreset_UnknownReturnsNil(t *testing.T) {
+	layers, rules := ArchitectureStylePreset("nonexistent-style")
+	if layers != nil {
+		t.Errorf("expected nil layers for unknown style, got %v", layers)
+	}
+	if rules != nil {
+		t.Errorf("expected nil rules for unknown style, got %v", rules)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -517,6 +517,9 @@ func PyscnConfigToConfig(pyscn *PyscnConfig) *Config {
 	if len(pyscn.ArchitectureNeutralPrefixes) > 0 {
 		cfg.Architecture.NeutralPrefixes = pyscn.ArchitectureNeutralPrefixes
 	}
+	if pyscn.ArchitectureStyle != "" {
+		cfg.Architecture.Style = pyscn.ArchitectureStyle
+	}
 	if len(pyscn.ArchitectureLayers) > 0 {
 		cfg.Architecture.Layers = pyscn.ArchitectureLayers
 	}
@@ -810,6 +813,9 @@ type ArchitectureConfig struct {
 	ValidateLayers         bool `mapstructure:"validate_layers" yaml:"validate_layers"`
 	ValidateCohesion       bool `mapstructure:"validate_cohesion" yaml:"validate_cohesion"`
 	ValidateResponsibility bool `mapstructure:"validate_responsibility" yaml:"validate_responsibility"`
+
+	// Style is an optional architecture preset: "layered", "hexagonal", "clean", "mvc".
+	Style string `mapstructure:"style" yaml:"style"`
 
 	// Layer definitions
 	Layers          []LayerDefinition `mapstructure:"layers" yaml:"layers"`

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -417,6 +417,9 @@ func mergeArchitectureSection(defaults *PyscnConfig, arch *ArchitectureTomlConfi
 	if len(arch.NeutralPrefixes) > 0 {
 		defaults.ArchitectureNeutralPrefixes = arch.NeutralPrefixes
 	}
+	if arch.Style != "" {
+		defaults.ArchitectureStyle = arch.Style
+	}
 	if len(arch.Layers) > 0 {
 		layers := make([]LayerDefinition, len(arch.Layers))
 		for i, l := range arch.Layers {

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -103,6 +103,7 @@ type PyscnConfig struct {
 	ArchitectureStrictMode                      *bool             `mapstructure:"architecture_strict_mode" yaml:"architecture_strict_mode" json:"architecture_strict_mode"`
 	ArchitectureFailOnViolations                *bool             `mapstructure:"architecture_fail_on_violations" yaml:"architecture_fail_on_violations" json:"architecture_fail_on_violations"`
 	ArchitectureNeutralPrefixes                 []string          `mapstructure:"architecture_neutral_prefixes" yaml:"architecture_neutral_prefixes" json:"architecture_neutral_prefixes"`
+	ArchitectureStyle                           string            `mapstructure:"architecture_style" yaml:"architecture_style" json:"architecture_style"`
 	ArchitectureLayers                          []LayerDefinition `mapstructure:"architecture_layers" yaml:"architecture_layers" json:"architecture_layers"`
 	ArchitectureRules                           []LayerRule       `mapstructure:"architecture_rules" yaml:"architecture_rules" json:"architecture_rules"`
 

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -112,6 +112,7 @@ type ArchitectureTomlConfig struct {
 	StrictMode                      *bool                 `toml:"strict_mode"`
 	FailOnViolations                *bool                 `toml:"fail_on_violations"`
 	NeutralPrefixes                 []string              `toml:"neutral_prefixes"`
+	Style                           string                `toml:"style"`
 	Layers                          []LayerDefinitionToml `toml:"layers"`
 	Rules                           []LayerRuleToml       `toml:"rules"`
 }

--- a/internal/config/toml_loader_test.go
+++ b/internal/config/toml_loader_test.go
@@ -358,3 +358,25 @@ func TestResolveConfigPath_MissingNonTomlPathReturnsError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 }
+
+func TestLoadArchitectureStyleFromPyscnToml(t *testing.T) {
+	tempDir := t.TempDir()
+
+	configContent := `[architecture]
+style = "hexagonal"
+`
+	configPath := filepath.Join(tempDir, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	loader := NewTomlConfigLoader()
+	cfg, err := loader.LoadConfig(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if cfg.ArchitectureStyle != "hexagonal" {
+		t.Errorf("Expected architecture style 'hexagonal', got %q", cfg.ArchitectureStyle)
+	}
+}

--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -71,10 +71,13 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) pyscnConfigToSystemAnalysisRequ
 	}
 
 	// Architecture settings
-	if cfg.ArchitectureStrictMode != nil || len(cfg.ArchitectureAllowedPatterns) > 0 || len(cfg.ArchitectureForbiddenPatterns) > 0 ||
+	if cfg.ArchitectureStrictMode != nil || cfg.ArchitectureStyle != "" || len(cfg.ArchitectureAllowedPatterns) > 0 || len(cfg.ArchitectureForbiddenPatterns) > 0 ||
 		len(cfg.ArchitectureLayers) > 0 || len(cfg.ArchitectureRules) > 0 || len(cfg.ArchitectureNeutralPrefixes) > 0 {
 		if request.ArchitectureRules == nil {
 			request.ArchitectureRules = &domain.ArchitectureRules{}
+		}
+		if cfg.ArchitectureStyle != "" {
+			request.ArchitectureRules.Style = cfg.ArchitectureStyle
 		}
 		if cfg.ArchitectureStrictMode != nil {
 			request.ArchitectureRules.StrictMode = *cfg.ArchitectureStrictMode
@@ -228,6 +231,9 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) MergeConfig(base *domain.System
 			// Merge: apply StrictMode from CLI while preserving config rules
 			if override.ArchitectureRules.StrictMode {
 				merged.ArchitectureRules.StrictMode = true
+			}
+			if override.ArchitectureRules.Style != "" {
+				merged.ArchitectureRules.Style = override.ArchitectureRules.Style
 			}
 			// If CLI provides layers/rules, they override config (unlikely in deps command)
 			if len(override.ArchitectureRules.Layers) > 0 {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -1015,18 +1015,44 @@ func (s *SystemAnalysisServiceImpl) autoDetectArchitecture(graph *analyzer.Depen
 // in missing layers or rules from auto-detection / embedded defaults.
 func (s *SystemAnalysisServiceImpl) resolveArchitectureRules(graph *analyzer.DependencyGraph, orig *domain.ArchitectureRules) *domain.ArchitectureRules {
 	// No user config at all — fully auto-detect
-	if orig == nil || (len(orig.Layers) == 0 && len(orig.Rules) == 0) {
+	if orig == nil || (len(orig.Layers) == 0 && len(orig.Rules) == 0 && orig.Style == "") {
 		return s.autoDetectArchitecture(graph)
 	}
 
 	// Clone to avoid mutating the caller's object
 	resolved := &domain.ArchitectureRules{
+		Style:             orig.Style,
 		Layers:            append([]domain.Layer(nil), orig.Layers...),
 		Rules:             append([]domain.LayerRule(nil), orig.Rules...),
 		NeutralPrefixes:   append([]string(nil), orig.NeutralPrefixes...),
 		StrictMode:        orig.StrictMode,
 		AllowedPatterns:   orig.AllowedPatterns,
 		ForbiddenPatterns: orig.ForbiddenPatterns,
+	}
+
+	// A style preset is selected — apply its layers/rules. Explicit user-defined
+	// layers/rules take precedence over the preset. An unrecognized style yields
+	// no preset; fall through to the explicit-config / auto-detect handling below.
+	if resolved.Style != "" {
+		presetLayers, presetRules := config.ArchitectureStylePreset(resolved.Style)
+		if presetLayers != nil || presetRules != nil {
+			if len(resolved.Layers) == 0 {
+				resolved.Layers = convertLayerDefinitions(presetLayers)
+			}
+			presetDomainRules := convertLayerRules(presetRules)
+			if len(resolved.Rules) == 0 {
+				resolved.Rules = presetDomainRules
+			} else {
+				// User provided some rules — merge on top of the preset; user
+				// rules win for any matching From value.
+				resolved.Rules = s.mergeLayerRules(presetDomainRules, resolved.Rules)
+			}
+			return resolved
+		}
+		// Unknown style with no explicit config — fall back to auto-detection.
+		if len(resolved.Layers) == 0 && len(resolved.Rules) == 0 {
+			return s.autoDetectArchitecture(graph)
+		}
 	}
 
 	if len(resolved.Layers) > 0 && len(resolved.Rules) == 0 {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -1036,10 +1036,12 @@ func (s *SystemAnalysisServiceImpl) resolveArchitectureRules(graph *analyzer.Dep
 	if resolved.Style != "" {
 		presetLayers, presetRules := config.ArchitectureStylePreset(resolved.Style)
 		if presetLayers != nil || presetRules != nil {
+			presetDomainRules := convertLayerRules(presetRules)
 			if len(resolved.Layers) == 0 {
 				resolved.Layers = convertLayerDefinitions(presetLayers)
+			} else {
+				presetDomainRules = s.filterLayerRulesForLayers(presetDomainRules, resolved.Layers)
 			}
-			presetDomainRules := convertLayerRules(presetRules)
 			if len(resolved.Rules) == 0 {
 				resolved.Rules = presetDomainRules
 			} else {
@@ -1093,6 +1095,22 @@ func (s *SystemAnalysisServiceImpl) mergeLayerRules(base, overrides []domain.Lay
 	return merged
 }
 
+// filterLayerRulesForLayers returns only rules whose From layer exists in layers.
+func (s *SystemAnalysisServiceImpl) filterLayerRulesForLayers(rules []domain.LayerRule, layers []domain.Layer) []domain.LayerRule {
+	layerNames := make(map[string]struct{}, len(layers))
+	for _, l := range layers {
+		layerNames[l.Name] = struct{}{}
+	}
+
+	filtered := make([]domain.LayerRule, 0, len(rules))
+	for _, rule := range rules {
+		if _, ok := layerNames[rule.From]; ok {
+			filtered = append(filtered, rule)
+		}
+	}
+	return filtered
+}
+
 // loadDefaultRulesForLayers loads the embedded default layer rules and returns
 // only those whose From field matches one of the given layer names. This avoids
 // injecting rules that reference built-in layer names (e.g. "presentation") when
@@ -1103,23 +1121,15 @@ func (s *SystemAnalysisServiceImpl) loadDefaultRulesForLayers(layers []domain.La
 		return nil
 	}
 
-	// Build a set of user-defined layer names for fast lookup
-	layerNames := make(map[string]struct{}, len(layers))
-	for _, l := range layers {
-		layerNames[l.Name] = struct{}{}
-	}
-
-	var filtered []domain.LayerRule
+	defaultRules := make([]domain.LayerRule, 0, len(defaultConfig.Architecture.Rules))
 	for _, rule := range defaultConfig.Architecture.Rules {
-		if _, ok := layerNames[rule.From]; ok {
-			filtered = append(filtered, domain.LayerRule{
-				From:  rule.From,
-				Allow: rule.Allow,
-				Deny:  rule.Deny,
-			})
-		}
+		defaultRules = append(defaultRules, domain.LayerRule{
+			From:  rule.From,
+			Allow: rule.Allow,
+			Deny:  rule.Deny,
+		})
 	}
-	return filtered
+	return s.filterLayerRulesForLayers(defaultRules, layers)
 }
 
 // isTestModule checks if a module represents test code

--- a/service/system_analysis_service_helpers_test.go
+++ b/service/system_analysis_service_helpers_test.go
@@ -696,3 +696,75 @@ func TestMergeLayerRules_UserOverridesDefaultForSameFrom(t *testing.T) {
 	assert.Equal(t, []string{"domain", "infrastructure"}, rulesByFrom["application"].Allow,
 		"base rule for 'application' should be preserved")
 }
+
+// TestResolveArchitectureRules_StyleLayeredMatchesAutoDetect verifies that
+// selecting style "layered" produces the same rules as the legacy auto-detection
+// path (which loads the embedded default config). This guards backward
+// compatibility for the default preset.
+func TestResolveArchitectureRules_StyleLayeredMatchesAutoDetect(t *testing.T) {
+	svc := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	graph.AddModule("app.api.users.router", "/project/app/api/users/router.py")
+	graph.AddModule("app.services.user_service", "/project/app/services/user_service.py")
+	graph.AddModule("app.domain.user_model", "/project/app/domain/user_model.py")
+	graph.AddModule("app.repositories.user_repo", "/project/app/repositories/user_repo.py")
+
+	styled := svc.resolveArchitectureRules(graph, &domain.ArchitectureRules{Style: "layered"})
+
+	require.NotNil(t, styled)
+	// The layered preset must define the four canonical layers and their rules.
+	require.Len(t, styled.Rules, 4, "layered preset should define four layer rules")
+
+	rulesByFrom := make(map[string]domain.LayerRule)
+	for _, r := range styled.Rules {
+		rulesByFrom[r.From] = r
+	}
+	assert.Equal(t, []string{"domain", "infrastructure"}, rulesByFrom["domain"].Allow,
+		"layered preset preserves legacy domain->infrastructure allowance")
+	assert.Equal(t, []string{"presentation", "application"}, rulesByFrom["domain"].Deny)
+}
+
+// TestResolveArchitectureRules_StyleWithUserRuleOverride verifies that explicit
+// user rules win over the preset for matching From values, while the rest of the
+// preset rules are preserved.
+func TestResolveArchitectureRules_StyleWithUserRuleOverride(t *testing.T) {
+	svc := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	graph.AddModule("app.domain.user_model", "/project/app/domain/user_model.py")
+
+	original := &domain.ArchitectureRules{
+		Style: "layered",
+		Rules: []domain.LayerRule{
+			{From: "domain", Allow: []string{"domain"}}, // stricter than preset
+		},
+	}
+
+	resolved := svc.resolveArchitectureRules(graph, original)
+
+	require.NotNil(t, resolved)
+	rulesByFrom := make(map[string]domain.LayerRule)
+	for _, r := range resolved.Rules {
+		rulesByFrom[r.From] = r
+	}
+	assert.Equal(t, []string{"domain"}, rulesByFrom["domain"].Allow,
+		"user rule for 'domain' should override the preset")
+	assert.Contains(t, rulesByFrom, "presentation",
+		"non-overridden preset rules should be preserved")
+
+	// Original must not be mutated.
+	require.Len(t, original.Rules, 1)
+}
+
+// TestResolveArchitectureRules_UnknownStyleFallsBackToAutoDetect verifies that an
+// unrecognized style with no explicit config falls back to auto-detection rather
+// than disabling architecture validation.
+func TestResolveArchitectureRules_UnknownStyleFallsBackToAutoDetect(t *testing.T) {
+	svc := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	graph.AddModule("app.domain.user_model", "/project/app/domain/user_model.py")
+
+	resolved := svc.resolveArchitectureRules(graph, &domain.ArchitectureRules{Style: "bogus"})
+
+	require.NotNil(t, resolved)
+	assert.NotEmpty(t, resolved.Rules, "unknown style should fall back to auto-detected rules")
+}

--- a/service/system_analysis_service_helpers_test.go
+++ b/service/system_analysis_service_helpers_test.go
@@ -755,6 +755,45 @@ func TestResolveArchitectureRules_StyleWithUserRuleOverride(t *testing.T) {
 	require.Len(t, original.Rules, 1)
 }
 
+// TestResolveArchitectureRules_StyleWithCustomLayersFiltersPresetRules verifies
+// that style presets do not inject rules for built-in layer names when the user
+// provides custom layer names.
+func TestResolveArchitectureRules_StyleWithCustomLayersFiltersPresetRules(t *testing.T) {
+	svc := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	graph.AddModule("app.api.handler", "/project/app/api/handler.py")
+	graph.AddModule("app.core.model", "/project/app/core/model.py")
+
+	resolved := svc.resolveArchitectureRules(graph, &domain.ArchitectureRules{
+		Style: "layered",
+		Layers: []domain.Layer{
+			{Name: "api", Packages: []string{"api"}},
+			{Name: "core", Packages: []string{"core"}},
+		},
+	})
+
+	require.NotNil(t, resolved)
+	assert.Empty(t, resolved.Rules, "custom layer names should not receive unmatched layered preset rules")
+}
+
+func TestResolveArchitectureRules_StyleWithBuiltinLayerSubsetFiltersPresetRules(t *testing.T) {
+	svc := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	graph.AddModule("app.domain.user_model", "/project/app/domain/user_model.py")
+
+	resolved := svc.resolveArchitectureRules(graph, &domain.ArchitectureRules{
+		Style: "layered",
+		Layers: []domain.Layer{
+			{Name: "domain", Packages: []string{"domain"}},
+		},
+	})
+
+	require.NotNil(t, resolved)
+	require.Len(t, resolved.Rules, 1)
+	assert.Equal(t, "domain", resolved.Rules[0].From)
+	assert.Equal(t, []string{"domain", "infrastructure"}, resolved.Rules[0].Allow)
+}
+
 // TestResolveArchitectureRules_UnknownStyleFallsBackToAutoDetect verifies that an
 // unrecognized style with no explicit config falls back to auto-detection rather
 // than disabling architecture validation.


### PR DESCRIPTION
Part 1 of 3 for #335 (architecture style presets). **Stacked**, merge in order: this PR → PR2 → PR3.

## What

Introduces an architecture `style` setting and wires it through the full config pipeline, plus the first preset (`layered`) which is **identical to the existing embedded default** — a no-op for current users.

- `domain.ArchitectureRules.Style` and `config.ArchitectureConfig.Style` added
- `style` threaded TOML → `PyscnConfig` → `Config` → `SystemAnalysisRequest` → `domain.ArchitectureRules`
- New `internal/config/architecture_presets.go` with `ArchitectureStylePreset(style)` returning `(layers, rules)`; only `layered` for now
- `resolveArchitectureRules` branches on `Style`:
  - empty / `"layered"` → identical legacy behavior
  - unknown style with no explicit config → falls back to auto-detection (does not disable checks)
  - explicit user layers/rules still take precedence over the preset (`mergeLayerRules`)

## Why

Currently the only architecture ruleset is hard-coded in `default_config.toml.tmpl`. Users of Hexagonal / Clean / MVC must hand-write rules. This PR lays the groundwork; PR2 adds hexagonal/clean, PR3 adds mvc with warning severity.

## Tests

- `TestArchitectureStylePreset_LayeredBackwardCompat` — layered preset matches embedded default exactly
- `TestResolveArchitectureRules_StyleLayeredMatchesAutoDetect`, `_StyleWithUserRuleOverride`, `_UnknownStyleFallsBackToAutoDetect`
- `TestLoadArchitectureStyleFromPyscnToml` — TOML round-trip
- Verified end-to-end: `style="layered"` vs no-style produces identical architecture output

Refs #335