### PR TITLE
docs(architecture): document style presets (layered/hexagonal/clean/mvc) (#335)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ reference, configuration), see:
 | [`ANALYZE_SCORING.md`](ANALYZE_SCORING.md)     | Health Score design rationale. See also the user-facing spec page. |
 | [`MCP_INTEGRATION.md`](MCP_INTEGRATION.md)     | MCP server design. |
 | [`algorithms/`](algorithms/)                   | Per-analyzer algorithm descriptions (CFG, APTED, LSH, Main Sequence, etc.). |
+| [`algorithms/architecture-presets.md`](algorithms/architecture-presets.md) | Architecture style presets (layered/hexagonal/clean/mvc) and `allow`/`deny`/`warn` rule semantics. |
 
 For the user-facing **rule catalog** (problem-based rule names and fixes), see
 <https://ludo-technologies.github.io/pyscn/rules/>.

--- a/docs/algorithms/architecture-presets.md
+++ b/docs/algorithms/architecture-presets.md
@@ -1,0 +1,224 @@
+# Architecture Style Presets
+
+This document describes the **architecture style presets** that ship with pyscn:
+named bundles of layer definitions and dependency rules that a project can opt
+into with a single `style = "..."` setting instead of hand-writing the full
+`[architecture.layers]` / `[architecture.rules]` configuration.
+
+The feature was delivered across PRs #520–#523 (issue #335):
+
+| PR    | Scope |
+| ----- | ----- |
+| #520  | Preset plumbing + the `layered` preset (the long-standing default, extracted into a named preset). |
+| #521  | `hexagonal` and `clean` presets. |
+| #522 / #523 | `mvc` preset + the warning-severity mechanism (`Warn` rules). #523 re-applies #522 cleanly on `main`. |
+
+Implementation lives in `internal/config/architecture_presets.go` (the preset
+definitions) and `service/system_analysis_service.go` (resolution and rule
+evaluation). Domain types are in `domain/system_analysis.go`.
+
+## Why presets
+
+Layer-boundary analysis is only as good as the layer/rule configuration behind
+it. Writing that configuration by hand is verbose and error-prone, and most
+projects follow one of a handful of well-known architectural styles. Presets
+encode those styles once so a project can declare its intent in one line:
+
+```toml
+[architecture]
+style = "hexagonal"
+```
+
+A preset supplies both the **layers** (which package-name patterns map to which
+layer) and the **rules** (which layer may depend on which). Users can still
+override either: explicit `[[architecture.layers]]` / `[[architecture.rules]]`
+take precedence over the preset (see [Resolution order](#resolution-order)).
+
+## Available presets
+
+### `layered` (default)
+
+The backward-compatible default. An empty/unset `style` is treated as
+`layered`, and the preset mirrors the `[architecture]` section of
+`internal/config/default_config.toml.tmpl` exactly so that pre-preset projects
+see no behavior change.
+
+| Layer | Example packages |
+| --- | --- |
+| `presentation` | `router`, `handler`, `controller`, `view`, `api`, `web`, `rest`, `graphql` |
+| `application` | `service`, `usecase`, `workflow`, `command`, `query`, `manager` |
+| `domain` | `model`, `entity`, `schema`, `domain`, `core`, `aggregate`, `valueobject` |
+| `infrastructure` | `repository`, `db`, `adapter`, `persistence`, `storage`, `cache`, `client` |
+
+Rules (allow-based):
+
+```
+presentation   -> presentation, application, domain, infrastructure
+application    -> application, domain, infrastructure
+domain         -> domain, infrastructure        (deny: presentation, application)
+infrastructure -> infrastructure, domain, application
+```
+
+> **Note:** `layered` intentionally allows `domain -> infrastructure`. This
+> relaxes the strict Dependency Inversion Principle but preserves long-standing
+> default behavior. Use `hexagonal` or `clean` for stricter DIP enforcement.
+
+### `hexagonal`
+
+Hexagonal / Onion architecture. Ports (interfaces) sit on the domain side;
+adapters (implementations) sit on the infrastructure side. Enforces the
+Dependency Inversion Principle: the domain depends on nothing outward.
+
+| Layer | Example packages |
+| --- | --- |
+| `domain` | `domain`, `model`, `entity`, `core`, `aggregate`, `valueobject` |
+| `ports` | `port`, `interface`, `contract`, `usecase`, `service` |
+| `adapters` | `adapter`, `handler`, `controller`, `router`, `api`, `repository`, `db`, `client`, `web`, `rest`, `graphql` |
+
+```
+domain   -> domain                       (deny: ports, adapters)
+ports    -> ports, domain                (deny: adapters)
+adapters -> adapters, ports, domain
+```
+
+### `clean`
+
+Clean Architecture's four concentric layers, innermost to outermost. The
+dependency rule: source-code dependencies point only **inward** — each layer
+may depend on itself and any inner layer, never an outer one.
+
+| Layer | Example packages |
+| --- | --- |
+| `entities` | `entity`, `model`, `domain`, `core`, `aggregate`, `valueobject` |
+| `use_cases` | `usecase`, `interactor`, `service`, `workflow`, `command`, `query` |
+| `interface_adapters` | `adapter`, `controller`, `presenter`, `gateway`, `repository`, `router` |
+| `frameworks` | `framework`, `infrastructure`, `db`, `web`, `api`, `external`, `client`, `persistence`, `ui` |
+
+```
+entities           -> entities                                                (deny: use_cases, interface_adapters, frameworks)
+use_cases          -> use_cases, entities                                     (deny: interface_adapters, frameworks)
+interface_adapters -> interface_adapters, use_cases, entities                 (deny: frameworks)
+frameworks         -> frameworks, interface_adapters, use_cases, entities
+```
+
+### `mvc`
+
+MVC / MVT. Template engines (MVT) are treated as views. Unlike the other
+presets, `mvc` exercises the **warning** severity: a direct `view -> model`
+dependency is permitted but discouraged rather than denied outright.
+
+| Layer | Example packages |
+| --- | --- |
+| `model` | `model`, `entity`, `schema`, `domain` |
+| `view` | `view`, `template`, `serializer`, `form` |
+| `controller` | `controller`, `handler`, `router`, `route`, `viewset` |
+
+```
+model      -> model                      (deny: view, controller)
+view       -> view, controller           (warn: model)        <-- discouraged, not denied
+controller -> controller, model, view
+```
+
+## Rule semantics: `allow`, `deny`, `warn`
+
+Each `LayerRule` (see `domain.LayerRule`) lists, for a given source layer
+(`From`), the target layers it may reach. Three lists are checked in order by
+`evaluateLayerEdge` (`service/system_analysis_service.go`):
+
+1. **`Deny`** — takes precedence. A denied edge is an **error**-severity
+   violation. Rule marker: `from !> to`.
+2. **`Warn`** — checked *between* deny and allow. A warn-listed edge is
+   permitted but emits a **warning**-severity violation, and the check stops
+   here so the edge is not also reported as a disallowed error. Rule marker:
+   `from ~> to`.
+3. **`Allow`** — if a non-empty allow list is present and the target is not in
+   it (and not already handled by deny/warn), the edge is an **error**.
+   Rule marker: `from -> {allowed,...}`.
+
+The `Warn` list (`Warn []string` on `domain.LayerRule`, `config.LayerRule`, and
+`LayerRuleToml`) was added in PR #522/#523 specifically to model the "tolerated
+but suboptimal" `view -> model` case. The same field is available to
+hand-written configs, not just the `mvc` preset.
+
+### Effect on the compliance score
+
+Severity feeds the architecture compliance score via
+`calculateComplianceWeighted`: an **error** is weighted 5 points, a **warning**
+1 point, against the number of checked edges:
+
+```
+compliance = 1 - (5*errors + 1*warnings) / checked   (clamped to [0, 1])
+```
+
+So a `view ~> model` warning nudges the score down slightly rather than
+counting as a full boundary breach. (In the #523 end-to-end check, a single
+`view ~> model` warning yielded a compliance of `0.929`.)
+
+## Resolution order
+
+`resolveArchitectureRules` decides what layers/rules actually run:
+
+1. **No config at all** (no layers, no rules, no style) → fully auto-detect the
+   architecture from the dependency graph.
+2. **A recognized `style`** → apply its preset layers/rules, then:
+   - If the user defined their own `[[architecture.layers]]`, those win and the
+     preset rules are *filtered* to the user's layer names.
+   - If the user defined their own `[[architecture.rules]]`, they are *merged*
+     on top of the preset — user rules win for any matching `From` value.
+3. **An unrecognized `style` with no explicit config** → fall back to
+   auto-detection.
+4. **Explicit layers/rules without a style** → behave as before presets existed
+   (load default rules filtered to the user's layers, or auto-detect layers for
+   user-supplied rules).
+
+The resolver clones the caller's `ArchitectureRules` before mutating, so the
+incoming config object is never modified.
+
+`ArchitectureStylePreset(style)` returns `(nil, nil)` for an unrecognized
+style, which is how callers distinguish "fall back to auto-detect" from "apply
+this preset."
+
+## Configuration
+
+In `.pyscn.toml` (or `pyproject.toml` under `[tool.pyscn.architecture]`):
+
+```toml
+[architecture]
+enabled = true
+style = "clean"        # one of: layered (default), hexagonal, clean, mvc
+strict_mode = true
+```
+
+Mixing a preset with overrides — keep the `mvc` layers but tighten `view`:
+
+```toml
+[architecture]
+style = "mvc"
+
+# User rule wins for From = "view": now an error instead of a warning.
+[[architecture.rules]]
+from = "view"
+allow = ["view", "controller"]
+deny  = ["model"]
+```
+
+## Testing
+
+Preset behavior is covered by:
+
+- **Unit** (`internal/config`): `TestArchitectureStylePreset_*` —
+  `HexagonalDomainIsolated`, `CleanEntitiesIsolated`, `MVCViewWarnsOnModel`,
+  `AllStylesNonEmpty`.
+- **Unit** (`service`): `TestEvaluateLayerEdge` Warn subtests.
+- **Fixtures** (`testdata/`): `hexagonal_ports/`, `clean_layers/`, `mvc_app/`,
+  each with one intentional violation.
+- **Integration**: `TestArchitecture_HexagonalPreset`,
+  `TestArchitecture_CleanPreset`, `TestArchitecture_MVCPreset` — each asserts
+  the intended violation is flagged (the MVC case specifically as a *warning*)
+  while allowed edges are not.
+
+## See also
+
+- [`dependency.md`](dependency.md) — module dependency graph construction and
+  the metrics the architecture layer builds on.
+- `internal/config/architecture_presets.go` — the canonical preset definitions.

--- a/docs/algorithms/architecture-presets.md
+++ b/docs/algorithms/architecture-presets.md
@@ -38,10 +38,17 @@ take precedence over the preset (see [Resolution order](#resolution-order)).
 
 ### `layered` (default)
 
-The backward-compatible default. An empty/unset `style` is treated as
-`layered`, and the preset mirrors the `[architecture]` section of
-`internal/config/default_config.toml.tmpl` exactly so that pre-preset projects
-see no behavior change.
+The backward-compatible baseline. Selecting `style = "layered"` reproduces the
+behavior projects had before presets existed: the preset mirrors the
+`[architecture]` section of `internal/config/default_config.toml.tmpl` exactly,
+so the generated default config (which ships those layers/rules explicitly)
+sees no change.
+
+> **Note on the empty style.** `ArchitectureStylePreset("")` returns the
+> `layered` definitions, but the resolver only consults a preset when `style`
+> is non-empty. A project with **no** `style`, layers, or rules at all is
+> auto-detected from its dependency graph, not silently given the `layered`
+> preset — see [Resolution order](#resolution-order).
 
 | Layer | Example packages |
 | --- | --- |
@@ -185,7 +192,7 @@ In `.pyscn.toml` (or `pyproject.toml` under `[tool.pyscn.architecture]`):
 ```toml
 [architecture]
 enabled = true
-style = "clean"        # one of: layered (default), hexagonal, clean, mvc
+style = "clean"        # one of: layered, hexagonal, clean, mvc (empty → auto-detect)
 strict_mode = true
 ```
 

--- a/website/docs/configuration/reference.md
+++ b/website/docs/configuration/reference.md
@@ -190,6 +190,7 @@ Layer validation. All keys optional — if you don't define layers, architecture
 | Key                        | Type  | Default | Description |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | Run layer validation. |
+| `style`                    | string | `""`   | Apply a built-in preset of layers + rules: `layered` (default), `hexagonal`, `clean`, `mvc`. Explicit `layers`/`rules` below override the preset. |
 | `validate_layers`          | bool  | `true`  | Check layer-to-layer rules. |
 | `validate_cohesion`        | bool  | `true`  | Check package cohesion. |
 | `validate_responsibility`  | bool  | `true`  | Check module responsibility count. |
@@ -199,6 +200,24 @@ Layer validation. All keys optional — if you don't define layers, architecture
 | `max_coupling`             | int   | `10`    | Max inter-layer coupling. |
 | `max_responsibilities`     | int   | `3`     | Max concerns per module. |
 | `neutral_prefixes`         | string[] | `[]` | Top-level module segments to strip before matching layer packages. Useful when every module starts with the same project prefix (e.g. `app`, `src`). |
+
+### Style presets
+
+Set `style` to apply a ready-made bundle of layer definitions and rules instead of writing them by hand. The preset is the starting point; any `[[architecture.layers]]` or `[[architecture.rules]]` you add override it (user rules win per `from` layer).
+
+| Preset | Enforces | Notable rule |
+| --- | --- | --- |
+| `layered` (default) | Classic `presentation → application → domain → infrastructure`. | `domain` may still reach `infrastructure` (lenient DIP). |
+| `hexagonal` | Ports & Adapters / Onion: `domain` depends on nothing outward. | `domain → ports`/`adapters` denied. |
+| `clean` | Clean Architecture: dependencies point only inward across `entities → use_cases → interface_adapters → frameworks`. | Any outward dependency denied. |
+| `mvc` | MVC / MVT: `model` / `view` / `controller`. | A direct `view → model` is **discouraged** (warning), not denied. |
+
+```toml
+[architecture]
+style = "hexagonal"
+```
+
+Rules use three lists, checked in order: `deny` (error), `warn` (allowed but reported as a warning — used by `mvc` for `view → model`), then `allow` (anything not listed becomes an error). A warning lowers the architecture compliance score less than an error does.
 
 ### Layer definitions
 

--- a/website/docs/configuration/reference.md
+++ b/website/docs/configuration/reference.md
@@ -190,7 +190,7 @@ Layer validation. All keys optional — if you don't define layers, architecture
 | Key                        | Type  | Default | Description |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | Run layer validation. |
-| `style`                    | string | `""`   | Apply a built-in preset of layers + rules: `layered` (default), `hexagonal`, `clean`, `mvc`. Explicit `layers`/`rules` below override the preset. |
+| `style`                    | string | `""`   | Apply a built-in preset of layers + rules: `layered`, `hexagonal`, `clean`, `mvc`. Explicit `layers`/`rules` below override the preset. With no `style`, layers, or rules at all, pyscn auto-detects the architecture instead. |
 | `validate_layers`          | bool  | `true`  | Check layer-to-layer rules. |
 | `validate_cohesion`        | bool  | `true`  | Check package cohesion. |
 | `validate_responsibility`  | bool  | `true`  | Check module responsibility count. |
@@ -203,11 +203,11 @@ Layer validation. All keys optional — if you don't define layers, architecture
 
 ### Style presets
 
-Set `style` to apply a ready-made bundle of layer definitions and rules instead of writing them by hand. The preset is the starting point; any `[[architecture.layers]]` or `[[architecture.rules]]` you add override it (user rules win per `from` layer).
+Set `style` to apply a ready-made bundle of layer definitions and rules instead of writing them by hand. The preset is the starting point; any `[[architecture.layers]]` or `[[architecture.rules]]` you add override it (user rules win per `from` layer). `layered` reproduces the layers/rules of the generated default config; with no `style`, layers, or rules set at all, pyscn auto-detects the architecture rather than applying `layered`.
 
 | Preset | Enforces | Notable rule |
 | --- | --- | --- |
-| `layered` (default) | Classic `presentation → application → domain → infrastructure`. | `domain` may still reach `infrastructure` (lenient DIP). |
+| `layered` | Classic `presentation → application → domain → infrastructure` (the generated default config's baseline). | `domain` may still reach `infrastructure` (lenient DIP). |
 | `hexagonal` | Ports & Adapters / Onion: `domain` depends on nothing outward. | `domain → ports`/`adapters` denied. |
 | `clean` | Clean Architecture: dependencies point only inward across `entities → use_cases → interface_adapters → frameworks`. | Any outward dependency denied. |
 | `mvc` | MVC / MVT: `model` / `view` / `controller`. | A direct `view → model` is **discouraged** (warning), not denied. |
@@ -217,7 +217,7 @@ Set `style` to apply a ready-made bundle of layer definitions and rules instead 
 style = "hexagonal"
 ```
 
-Rules use three lists, checked in order: `deny` (error), `warn` (allowed but reported as a warning — used by `mvc` for `view → model`), then `allow` (anything not listed becomes an error). A warning lowers the architecture compliance score less than an error does.
+Rules use three lists, checked in order: `deny` (error), `warn` (allowed but reported as a warning — used by `mvc` for `view → model`), then `allow` (when a non-empty allow list is present, anything not listed becomes an error). A warning lowers the architecture compliance score less than an error does.
 
 ### Layer definitions
 

--- a/website/docs/fr/configuration/reference.md
+++ b/website/docs/fr/configuration/reference.md
@@ -190,6 +190,7 @@ Validation des couches. Toutes les clés sont facultatives — si vous ne défin
 | Clé                        | Type  | Défaut | Description |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | Exécute la validation des couches. |
+| `style`                    | string | `""`   | Applique un préréglage intégré de couches + règles : `layered` (par défaut), `hexagonal`, `clean`, `mvc`. Les `layers`/`rules` explicites ci-dessous remplacent le préréglage. |
 | `validate_layers`          | bool  | `true`  | Vérifie les règles inter-couches. |
 | `validate_cohesion`        | bool  | `true`  | Vérifie la cohésion des paquets. |
 | `validate_responsibility`  | bool  | `true`  | Vérifie le nombre de responsabilités des modules. |
@@ -199,6 +200,24 @@ Validation des couches. Toutes les clés sont facultatives — si vous ne défin
 | `max_coupling`             | int   | `10`    | Couplage inter-couches maximal. |
 | `max_responsibilities`     | int   | `3`     | Préoccupations maximales par module. |
 | `neutral_prefixes`         | string[] | `[]` | Segments de module de premier niveau à retirer avant la correspondance des paquets de couche. Utile lorsque chaque module commence par le même préfixe projet (ex. `app`, `src`). |
+
+### Préréglages de style
+
+Définissez `style` pour appliquer un ensemble prêt à l'emploi de définitions de couches et de règles plutôt que de les écrire à la main. Le préréglage est le point de départ ; tout `[[architecture.layers]]` ou `[[architecture.rules]]` que vous ajoutez le remplace (les règles utilisateur l'emportent par couche `from`).
+
+| Préréglage | Impose | Règle notable |
+| --- | --- | --- |
+| `layered` (par défaut) | `presentation → application → domain → infrastructure` classique. | `domain` peut encore atteindre `infrastructure` (DIP souple). |
+| `hexagonal` | Ports & Adapters / Onion : `domain` ne dépend de rien vers l'extérieur. | `domain → ports`/`adapters` refusé. |
+| `clean` | Clean Architecture : les dépendances ne pointent que vers l'intérieur sur `entities → use_cases → interface_adapters → frameworks`. | Toute dépendance vers l'extérieur refusée. |
+| `mvc` | MVC / MVT : `model` / `view` / `controller`. | Une dépendance directe `view → model` est **déconseillée** (avertissement), pas refusée. |
+
+```toml
+[architecture]
+style = "hexagonal"
+```
+
+Les règles utilisent trois listes, évaluées dans l'ordre : `deny` (erreur), `warn` (autorisé mais signalé comme avertissement — utilisé par `mvc` pour `view → model`), puis `allow` (tout ce qui n'est pas listé devient une erreur). Un avertissement réduit moins le score de conformité d'architecture qu'une erreur.
 
 ### Définitions de couches
 

--- a/website/docs/fr/configuration/reference.md
+++ b/website/docs/fr/configuration/reference.md
@@ -190,7 +190,7 @@ Validation des couches. Toutes les clés sont facultatives — si vous ne défin
 | Clé                        | Type  | Défaut | Description |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | Exécute la validation des couches. |
-| `style`                    | string | `""`   | Applique un préréglage intégré de couches + règles : `layered` (par défaut), `hexagonal`, `clean`, `mvc`. Les `layers`/`rules` explicites ci-dessous remplacent le préréglage. |
+| `style`                    | string | `""`   | Applique un préréglage intégré de couches + règles : `layered`, `hexagonal`, `clean`, `mvc`. Les `layers`/`rules` explicites ci-dessous remplacent le préréglage. Sans aucun `style`, `layers` ni `rules`, pyscn détecte automatiquement l'architecture au lieu d'appliquer un préréglage. |
 | `validate_layers`          | bool  | `true`  | Vérifie les règles inter-couches. |
 | `validate_cohesion`        | bool  | `true`  | Vérifie la cohésion des paquets. |
 | `validate_responsibility`  | bool  | `true`  | Vérifie le nombre de responsabilités des modules. |
@@ -203,11 +203,11 @@ Validation des couches. Toutes les clés sont facultatives — si vous ne défin
 
 ### Préréglages de style
 
-Définissez `style` pour appliquer un ensemble prêt à l'emploi de définitions de couches et de règles plutôt que de les écrire à la main. Le préréglage est le point de départ ; tout `[[architecture.layers]]` ou `[[architecture.rules]]` que vous ajoutez le remplace (les règles utilisateur l'emportent par couche `from`).
+Définissez `style` pour appliquer un ensemble prêt à l'emploi de définitions de couches et de règles plutôt que de les écrire à la main. Le préréglage est le point de départ ; tout `[[architecture.layers]]` ou `[[architecture.rules]]` que vous ajoutez le remplace (les règles utilisateur l'emportent par couche `from`). `layered` reproduit les couches/règles de la configuration par défaut générée ; sans aucun `style`, `layers` ni `rules`, pyscn détecte automatiquement l'architecture au lieu d'appliquer `layered`.
 
 | Préréglage | Impose | Règle notable |
 | --- | --- | --- |
-| `layered` (par défaut) | `presentation → application → domain → infrastructure` classique. | `domain` peut encore atteindre `infrastructure` (DIP souple). |
+| `layered` | `presentation → application → domain → infrastructure` classique (base de la configuration par défaut générée). | `domain` peut encore atteindre `infrastructure` (DIP souple). |
 | `hexagonal` | Ports & Adapters / Onion : `domain` ne dépend de rien vers l'extérieur. | `domain → ports`/`adapters` refusé. |
 | `clean` | Clean Architecture : les dépendances ne pointent que vers l'intérieur sur `entities → use_cases → interface_adapters → frameworks`. | Toute dépendance vers l'extérieur refusée. |
 | `mvc` | MVC / MVT : `model` / `view` / `controller`. | Une dépendance directe `view → model` est **déconseillée** (avertissement), pas refusée. |
@@ -217,7 +217,7 @@ Définissez `style` pour appliquer un ensemble prêt à l'emploi de définitions
 style = "hexagonal"
 ```
 
-Les règles utilisent trois listes, évaluées dans l'ordre : `deny` (erreur), `warn` (autorisé mais signalé comme avertissement — utilisé par `mvc` pour `view → model`), puis `allow` (tout ce qui n'est pas listé devient une erreur). Un avertissement réduit moins le score de conformité d'architecture qu'une erreur.
+Les règles utilisent trois listes, évaluées dans l'ordre : `deny` (erreur), `warn` (autorisé mais signalé comme avertissement — utilisé par `mvc` pour `view → model`), puis `allow` (lorsqu'une liste allow non vide est présente, tout ce qui n'est pas listé devient une erreur). Un avertissement réduit moins le score de conformité d'architecture qu'une erreur.
 
 ### Définitions de couches
 

--- a/website/docs/ja/configuration/reference.md
+++ b/website/docs/ja/configuration/reference.md
@@ -190,7 +190,7 @@ Lack of Cohesion of Methods（LCOM4）です。
 | キー                        | 型  | デフォルト | 説明 |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | レイヤーバリデーションを実行します。 |
-| `style`                    | string | `""`   | レイヤーとルールの組み込みプリセットを適用します: `layered`（デフォルト）, `hexagonal`, `clean`, `mvc`。下で明示した `layers`/`rules` がプリセットより優先されます。 |
+| `style`                    | string | `""`   | レイヤーとルールの組み込みプリセットを適用します: `layered`, `hexagonal`, `clean`, `mvc`。下で明示した `layers`/`rules` がプリセットより優先されます。`style`・`layers`・`rules` をいずれも指定しない場合は、プリセットではなくアーキテクチャの自動検出が行われます。 |
 | `validate_layers`          | bool  | `true`  | レイヤー間ルールをチェックします。 |
 | `validate_cohesion`        | bool  | `true`  | パッケージ凝集度をチェックします。 |
 | `validate_responsibility`  | bool  | `true`  | モジュールごとの責務数をチェックします。 |
@@ -203,11 +203,11 @@ Lack of Cohesion of Methods（LCOM4）です。
 
 ### スタイルプリセット
 
-`style` を指定すると、レイヤー定義とルールを手書きする代わりに、出来合いのセットを適用できます。プリセットは出発点であり、追加した `[[architecture.layers]]` や `[[architecture.rules]]` がプリセットを上書きします（`from` レイヤー単位でユーザールールが優先）。
+`style` を指定すると、レイヤー定義とルールを手書きする代わりに、出来合いのセットを適用できます。プリセットは出発点であり、追加した `[[architecture.layers]]` や `[[architecture.rules]]` がプリセットを上書きします（`from` レイヤー単位でユーザールールが優先）。`layered` は生成されるデフォルト設定のレイヤー／ルールを再現したものです。`style`・`layers`・`rules` をいずれも指定しない場合は、`layered` ではなくアーキテクチャの自動検出が行われます。
 
 | プリセット | 強制する内容 | 特徴的なルール |
 | --- | --- | --- |
-| `layered`（デフォルト） | 従来の `presentation → application → domain → infrastructure`。 | `domain` から `infrastructure` への依存は許容（DIP は緩め）。 |
+| `layered` | 従来の `presentation → application → domain → infrastructure`（生成されるデフォルト設定の基準）。 | `domain` から `infrastructure` への依存は許容（DIP は緩め）。 |
 | `hexagonal` | ポート＆アダプター / オニオン: `domain` は外側に一切依存しない。 | `domain → ports`/`adapters` は拒否。 |
 | `clean` | クリーンアーキテクチャ: `entities → use_cases → interface_adapters → frameworks` で依存は内側のみ。 | 外側への依存はすべて拒否。 |
 | `mvc` | MVC / MVT: `model` / `view` / `controller`。 | `view → model` への直接依存は**非推奨**（警告）であり拒否ではない。 |
@@ -217,7 +217,7 @@ Lack of Cohesion of Methods（LCOM4）です。
 style = "hexagonal"
 ```
 
-ルールは 3 つのリストを順に評価します: `deny`（エラー）、`warn`（許可されるが警告として報告。`mvc` の `view → model` で使用）、`allow`（列挙外はエラー）。警告はエラーよりもアーキテクチャ適合スコアの低下が小さくなります。
+ルールは 3 つのリストを順に評価します: `deny`（エラー）、`warn`（許可されるが警告として報告。`mvc` の `view → model` で使用）、`allow`（空でない allow リストがある場合、列挙外はエラー）。警告はエラーよりもアーキテクチャ適合スコアの低下が小さくなります。
 
 ### レイヤー定義
 

--- a/website/docs/ja/configuration/reference.md
+++ b/website/docs/ja/configuration/reference.md
@@ -190,6 +190,7 @@ Lack of Cohesion of Methods（LCOM4）です。
 | キー                        | 型  | デフォルト | 説明 |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | レイヤーバリデーションを実行します。 |
+| `style`                    | string | `""`   | レイヤーとルールの組み込みプリセットを適用します: `layered`（デフォルト）, `hexagonal`, `clean`, `mvc`。下で明示した `layers`/`rules` がプリセットより優先されます。 |
 | `validate_layers`          | bool  | `true`  | レイヤー間ルールをチェックします。 |
 | `validate_cohesion`        | bool  | `true`  | パッケージ凝集度をチェックします。 |
 | `validate_responsibility`  | bool  | `true`  | モジュールごとの責務数をチェックします。 |
@@ -199,6 +200,24 @@ Lack of Cohesion of Methods（LCOM4）です。
 | `max_coupling`             | int   | `10`    | レイヤー間結合度の最大値。 |
 | `max_responsibilities`     | int   | `3`     | モジュールごとの責務の最大数。 |
 | `neutral_prefixes`         | string[] | `[]` | レイヤー判定の前に取り除くトップレベルのモジュールセグメント。すべてのモジュールが同じプロジェクト接頭辞（例: `app`, `src`）から始まる場合に便利です。 |
+
+### スタイルプリセット
+
+`style` を指定すると、レイヤー定義とルールを手書きする代わりに、出来合いのセットを適用できます。プリセットは出発点であり、追加した `[[architecture.layers]]` や `[[architecture.rules]]` がプリセットを上書きします（`from` レイヤー単位でユーザールールが優先）。
+
+| プリセット | 強制する内容 | 特徴的なルール |
+| --- | --- | --- |
+| `layered`（デフォルト） | 従来の `presentation → application → domain → infrastructure`。 | `domain` から `infrastructure` への依存は許容（DIP は緩め）。 |
+| `hexagonal` | ポート＆アダプター / オニオン: `domain` は外側に一切依存しない。 | `domain → ports`/`adapters` は拒否。 |
+| `clean` | クリーンアーキテクチャ: `entities → use_cases → interface_adapters → frameworks` で依存は内側のみ。 | 外側への依存はすべて拒否。 |
+| `mvc` | MVC / MVT: `model` / `view` / `controller`。 | `view → model` への直接依存は**非推奨**（警告）であり拒否ではない。 |
+
+```toml
+[architecture]
+style = "hexagonal"
+```
+
+ルールは 3 つのリストを順に評価します: `deny`（エラー）、`warn`（許可されるが警告として報告。`mvc` の `view → model` で使用）、`allow`（列挙外はエラー）。警告はエラーよりもアーキテクチャ適合スコアの低下が小さくなります。
 
 ### レイヤー定義
 

--- a/website/docs/zh/configuration/reference.md
+++ b/website/docs/zh/configuration/reference.md
@@ -190,7 +190,7 @@
 | 键                         | 类型  | 默认值 | 说明 |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | 运行分层验证。 |
-| `style`                    | string | `""`   | 应用内置的层与规则预设：`layered`（默认）、`hexagonal`、`clean`、`mvc`。下方显式定义的 `layers`/`rules` 会覆盖预设。 |
+| `style`                    | string | `""`   | 应用内置的层与规则预设：`layered`、`hexagonal`、`clean`、`mvc`。下方显式定义的 `layers`/`rules` 会覆盖预设。若完全不设置 `style`、`layers` 或 `rules`，pyscn 会自动检测架构而非套用预设。 |
 | `validate_layers`          | bool  | `true`  | 检查层间规则。 |
 | `validate_cohesion`        | bool  | `true`  | 检查包内聚性。 |
 | `validate_responsibility`  | bool  | `true`  | 检查每个模块的职责数量。 |
@@ -203,11 +203,11 @@
 
 ### 风格预设
 
-设置 `style` 即可应用现成的层定义与规则组合，无需手写。预设是起点；你额外添加的 `[[architecture.layers]]` 或 `[[architecture.rules]]` 会覆盖预设（按 `from` 层，用户规则优先）。
+设置 `style` 即可应用现成的层定义与规则组合，无需手写。预设是起点；你额外添加的 `[[architecture.layers]]` 或 `[[architecture.rules]]` 会覆盖预设（按 `from` 层，用户规则优先）。`layered` 复刻了生成的默认配置的层与规则；若完全不设置 `style`、`layers` 或 `rules`，pyscn 会自动检测架构，而不会套用 `layered`。
 
 | 预设 | 强制约束 | 关键规则 |
 | --- | --- | --- |
-| `layered`（默认） | 经典的 `presentation → application → domain → infrastructure`。 | `domain` 仍可依赖 `infrastructure`（宽松的 DIP）。 |
+| `layered` | 经典的 `presentation → application → domain → infrastructure`（生成的默认配置所采用的基准）。 | `domain` 仍可依赖 `infrastructure`（宽松的 DIP）。 |
 | `hexagonal` | 端口与适配器 / 洋葱架构：`domain` 不向外依赖任何内容。 | 拒绝 `domain → ports`/`adapters`。 |
 | `clean` | 整洁架构：`entities → use_cases → interface_adapters → frameworks` 依赖只能向内。 | 拒绝任何向外的依赖。 |
 | `mvc` | MVC / MVT：`model` / `view` / `controller`。 | 直接的 `view → model` 被**不推荐**（警告），而非拒绝。 |
@@ -217,7 +217,7 @@
 style = "hexagonal"
 ```
 
-规则按顺序评估三个列表：`deny`（错误）、`warn`（允许但报告为警告，`mvc` 的 `view → model` 即用此）、`allow`（未列出的视为错误）。警告对架构合规分数的影响小于错误。
+规则按顺序评估三个列表：`deny`（错误）、`warn`（允许但报告为警告，`mvc` 的 `view → model` 即用此）、`allow`（当 allow 列表非空时，未列出的视为错误）。警告对架构合规分数的影响小于错误。
 
 ### 层定义
 

--- a/website/docs/zh/configuration/reference.md
+++ b/website/docs/zh/configuration/reference.md
@@ -190,6 +190,7 @@
 | 键                         | 类型  | 默认值 | 说明 |
 | -------------------------- | ----- | ------- | --- |
 | `enabled`                  | bool  | `true`  | 运行分层验证。 |
+| `style`                    | string | `""`   | 应用内置的层与规则预设：`layered`（默认）、`hexagonal`、`clean`、`mvc`。下方显式定义的 `layers`/`rules` 会覆盖预设。 |
 | `validate_layers`          | bool  | `true`  | 检查层间规则。 |
 | `validate_cohesion`        | bool  | `true`  | 检查包内聚性。 |
 | `validate_responsibility`  | bool  | `true`  | 检查每个模块的职责数量。 |
@@ -199,6 +200,24 @@
 | `max_coupling`             | int   | `10`    | 最大层间耦合度。 |
 | `max_responsibilities`     | int   | `3`     | 每个模块最大职责数。 |
 | `neutral_prefixes`         | string[] | `[]` | 在匹配层包名之前需要剥离的顶层模块段。当所有模块都以同一个项目前缀（例如 `app`、`src`）开头时很有用。 |
+
+### 风格预设
+
+设置 `style` 即可应用现成的层定义与规则组合，无需手写。预设是起点；你额外添加的 `[[architecture.layers]]` 或 `[[architecture.rules]]` 会覆盖预设（按 `from` 层，用户规则优先）。
+
+| 预设 | 强制约束 | 关键规则 |
+| --- | --- | --- |
+| `layered`（默认） | 经典的 `presentation → application → domain → infrastructure`。 | `domain` 仍可依赖 `infrastructure`（宽松的 DIP）。 |
+| `hexagonal` | 端口与适配器 / 洋葱架构：`domain` 不向外依赖任何内容。 | 拒绝 `domain → ports`/`adapters`。 |
+| `clean` | 整洁架构：`entities → use_cases → interface_adapters → frameworks` 依赖只能向内。 | 拒绝任何向外的依赖。 |
+| `mvc` | MVC / MVT：`model` / `view` / `controller`。 | 直接的 `view → model` 被**不推荐**（警告），而非拒绝。 |
+
+```toml
+[architecture]
+style = "hexagonal"
+```
+
+规则按顺序评估三个列表：`deny`（错误）、`warn`（允许但报告为警告，`mvc` 的 `view → model` 即用此）、`allow`（未列出的视为错误）。警告对架构合规分数的影响小于错误。
 
 ### 层定义
 


### PR DESCRIPTION
## What

Documents the architecture **style preset** feature shipped across #520–#523 (issue #335). No code changes — docs only.

### Contributor / algorithm docs (English, `docs/`)
- New `docs/algorithms/architecture-presets.md`: per-preset layer/rule definitions (`layered`/`hexagonal`/`clean`/`mvc`), `allow`/`deny`/`warn` rule semantics + rule markers (`!>` / `~>` / `-> {...}`), the compliance-score weighting (error=5, warning=1), and the `resolveArchitectureRules` resolution order.
- Linked from `docs/README.md` index.

### User-facing reference (mkdocs, 4 languages)
- Added the `[architecture]` `style` key and a **Style presets** section to `website/docs/configuration/reference.md` in **en / ja / zh / fr**: preset comparison table, a `style = "hexagonal"` example, and the deny/warn/allow ordering (incl. the `mvc` `view → model` warning).

## Notes
- `docs/` is English-only by design (per `docs/README.md`); the 4-language treatment lives under `website/docs/`.
- mkdocs nav unchanged — additions are within the existing `reference.md` page. Site build is left to CI.

Refs #335