### PR TITLE
fix(score): soften CBO coupling scoring calibration

### DIFF
--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -69,13 +69,11 @@ const (
 	GroupDensityMinLines    = 1.0    // Minimum lines in thousands (for small projects)
 	GroupDensityCoefficient = 20.0   // Multiplier to convert density to percentage
 
-	// CBO coupling thresholds and penalties
-	CouplingRatioHigh     = 0.30 // 30% or more classes with high coupling
-	CouplingRatioMedium   = 0.15 // 15-30% classes with high coupling
-	CouplingRatioLow      = 0.05 // 5-15% classes with high coupling
-	CouplingPenaltyHigh   = 20   // Aligned with other high penalties
-	CouplingPenaltyMedium = 12   // Aligned with other medium penalties
-	CouplingPenaltyLow    = 6    // Aligned with other low penalties
+	// CBO coupling scoring curve (used by calculateCouplingPenalty)
+	// Penalty grows linearly with the weighted ratio of problematic classes
+	// and saturates (reaches the max penalty) at CouplingSaturationRatio.
+	CouplingMediumWeight    = 0.3  // Medium-risk classes count 0.3 vs High = 1.0
+	CouplingSaturationRatio = 0.40 // weighted ratio at which the penalty maxes out
 
 	// Maximum penalties
 	MaxDeadCodePenalty = 20
@@ -327,13 +325,13 @@ func (s *AnalyzeSummary) calculateCouplingPenalty() int {
 	}
 
 	// Calculate combined problematic classes ratio
-	// Weight: High Risk = 1.0, Medium Risk = 0.5
-	weightedProblematicClasses := float64(s.HighCouplingClasses) + (0.5 * float64(s.MediumCouplingClasses))
+	// Weight: High Risk = 1.0, Medium Risk = CouplingMediumWeight
+	weightedProblematicClasses := float64(s.HighCouplingClasses) + (CouplingMediumWeight * float64(s.MediumCouplingClasses))
 	ratio := weightedProblematicClasses / float64(s.CBOClasses)
 
-	// Linear penalty: starts at 0%, reaches max (20) at 25%
-	// Formula: penalty = ratio / 0.25 * 20
-	penalty := ratio / 0.25 * 20.0
+	// Linear penalty: starts at 0%, reaches max (20) at CouplingSaturationRatio
+	// Formula: penalty = ratio / CouplingSaturationRatio * 20
+	penalty := ratio / CouplingSaturationRatio * 20.0
 	if penalty > 20.0 {
 		penalty = 20.0
 	}

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -192,19 +192,19 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				AverageComplexity:         7.0,  // Continuous: (7-2)/13*20 = 7.69 → 8
 				CodeDuplication:           15.0, // Continuous: 15/10*20 = 30 → 20 (capped, 0-10% scale)
 				CBOClasses:                10,
-				HighCouplingClasses:       2, // 20% ratio: 0.20/0.25*20 = 16
+				HighCouplingClasses:       2, // 20% ratio: 0.20/0.40*20 = 10
 				DepsEnabled:               true,
 				DepsMainSequenceDeviation: 1.0, // 1.0*3 = 3 (new max MSD)
 				ArchEnabled:               true,
 				ArchCompliance:            0.125, // (1-0.125)*12 = 10.5 → 11 (new max arch)
 			},
-			expectedScore:             42,  // Updated: 100-8-20-16-3-11 = 42 (CBO threshold changed to 25%)
-			expectedGrade:             "F", // 42 < 45 = F
+			expectedScore:             48,  // Updated: 100-8-20-10-3-11 = 48 (CBO saturation 0.40)
+			expectedGrade:             "D", // 48 >= 45 = D
 			expectError:               false,
 			expectedComplexityScore:   60,  // 100 - (8/20)*100 = 60
 			expectedDeadCodeScore:     100, // No dead code
 			expectedDuplicationScore:  0,   // 100 - (20/20)*100 = 0 (0-10% scale: 20 penalty capped)
-			expectedCouplingScore:     20,  // 100 - (16/20)*100 = 20 (CBO threshold 25%)
+			expectedCouplingScore:     50,  // 100 - (10/20)*100 = 50 (CBO saturation 0.40)
 			expectedDependencyScore:   80,  // Normalized: (3/16)*20 = 3.75 → 4, Score: 100 - (4/20)*100 = 80
 			expectedArchitectureScore: 13,  // Compliance 0.125 * 100 = 12.5 → 13
 		},
@@ -273,15 +273,15 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				AverageComplexity:   4.0, // Continuous: (4-2)/13*20 = 3.08 → 3
 				CodeDuplication:     2.0, // 2/10*20 = 4 penalty (0-10% scale)
 				CBOClasses:          20,
-				HighCouplingClasses: 2, // 10% ratio: 0.10/0.25*20 = 8 (CBO threshold 25%)
+				HighCouplingClasses: 2, // 10% ratio: 0.10/0.40*20 = 5 (CBO saturation 0.40)
 				DepsEnabled:         true,
 				DepsTotalModules:    10,
 				DepsMaxDepth:        4, // Expected = max(3, ceil(log2(11))+1) = 5, excess = 4-5 = 0
 				ArchEnabled:         true,
 				ArchCompliance:      0.9, // (1-0.9)*12 = 1.2 → 1
 			},
-			expectedScore: 84,  // Updated: 100-3-4-8-0-1 = 84 (CBO threshold changed to 25%)
-			expectedGrade: "B", // 75 ≤ 84 < 90 = B
+			expectedScore: 87,  // Updated: 100-3-4-5-0-1 = 87 (CBO saturation 0.40)
+			expectedGrade: "B", // 75 ≤ 87 < 90 = B
 			expectError:   false,
 		},
 		{
@@ -290,13 +290,13 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				AverageComplexity:   15.0, // Continuous: (15-2)/13*20 = 20 (capped)
 				CodeDuplication:     25.0, // 25/20*20 = 25 → capped at 20 penalty (0-20% scale)
 				CBOClasses:          20,
-				HighCouplingClasses: 2, // 10% ratio: 0.10/0.25*20 = 8 (CBO threshold 25%)
+				HighCouplingClasses: 2, // 10% ratio: 0.10/0.40*20 = 5 (CBO saturation 0.40)
 				DeadCodeCount:       5,
 				CriticalDeadCode:    0, // No critical issues, so no dead code penalty
 				TotalFiles:          1,
 			},
-			expectedScore: 52,  // Updated: 100-20-20-8 = 52 (CBO threshold changed to 25%)
-			expectedGrade: "D", // 45 ≤ 52 < 60 = D
+			expectedScore: 55,  // Updated: 100-20-20-5 = 55 (CBO saturation 0.40)
+			expectedGrade: "D", // 45 ≤ 55 < 60 = D
 			expectError:   false,
 		},
 		{


### PR DESCRIPTION
## Background

The `analyze` Coupling (CBO) score floored to 0/100 too easily, even for repos with a healthy average CBO.

Example (`japan-fiscal-simulator`, 236 classes):
- Average CBO **3.9** (low = good), high-coupling only 27/236 (11.4%)
- Yet **Coupling 0/100 / Health 41 (F)**

## Cause

The scoring curve in `calculateCouplingPenalty()` was too strict:
- Medium-risk classes (`3 < CBO <= 7`) were weighted `0.5`
- The penalty saturated (score 0) at a weighted ratio of just **25%**

The medium threshold (CBO > 3) is low — classes with 4–7 dependencies are common in real code. Once those exceed ~1/4 of all classes, the score immediately bottomed out, leaving no resolution.

## Changes

Soften the scoring curve only (the industry-standard CBO risk thresholds Low=3 / Medium=7 are unchanged):

| Parameter | before | after |
|---|---|---|
| Medium weight | `0.5` | **`0.3`** (`CouplingMediumWeight`) |
| Saturation ratio (weighted) | `0.25` | **`0.40`** (`CouplingSaturationRatio`) |

Also replaced the `CouplingRatio*` / `CouplingPenalty*` constants (unused in production — referenced only in comments/tests, never in the penalty function) with the two named constants the function now actually uses, removing the magic-number / dead-constant smell.

## Effect

| | before | after |
|---|---|---|
| Coupling (CBO) | 0/100 | **50/100** |
| Health (the repo above) | 41 (F) | **51 (D)** |

## Tests

Updated the expected values of 4 health-score test cases in `domain` for the new curve. `domain` and `app` suites both pass.

## Related

LCOM (cohesion) scoring has the same over-strict curve shape. Tracked separately in #529.