### PR TITLE
fix(score): soften LCOM cohesion scoring calibration

### DIFF
--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -75,6 +75,12 @@ const (
 	CouplingMediumWeight    = 0.3  // Medium-risk classes count 0.3 vs High = 1.0
 	CouplingSaturationRatio = 0.40 // weighted ratio at which the penalty maxes out
 
+	// LCOM cohesion scoring curve (used by calculateCohesionPenalty)
+	// Penalty grows linearly with the weighted ratio of low-cohesion classes
+	// and saturates (reaches the max penalty) at CohesionSaturationRatio.
+	CohesionMediumWeight    = 0.3  // Medium-risk classes count 0.3 vs High = 1.0
+	CohesionSaturationRatio = 0.40 // weighted ratio at which the penalty maxes out
+
 	// Maximum penalties
 	MaxDeadCodePenalty = 20
 	MaxCriticalPenalty = 10
@@ -347,13 +353,13 @@ func (s *AnalyzeSummary) calculateCohesionPenalty() int {
 	}
 
 	// Calculate combined problematic classes ratio
-	// Weight: High Risk (LCOM4 > 5) = 1.0, Medium Risk (LCOM4 3-5) = 0.5
-	weightedProblematicClasses := float64(s.HighLCOMClasses) + (0.5 * float64(s.MediumLCOMClasses))
+	// Weight: High Risk (LCOM4 > 5) = 1.0, Medium Risk (LCOM4 3-5) = CohesionMediumWeight
+	weightedProblematicClasses := float64(s.HighLCOMClasses) + (CohesionMediumWeight * float64(s.MediumLCOMClasses))
 	ratio := weightedProblematicClasses / float64(s.LCOMClasses)
 
-	// Linear penalty: starts at 0%, reaches max (20) at 30%
-	// Formula: penalty = ratio / 0.30 * 20
-	penalty := ratio / 0.30 * 20.0
+	// Linear penalty: starts at 0%, reaches max (20) at CohesionSaturationRatio
+	// Formula: penalty = ratio / CohesionSaturationRatio * 20
+	penalty := ratio / CohesionSaturationRatio * 20.0
 	if penalty > 20.0 {
 		penalty = 20.0
 	}

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -165,6 +165,7 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 		expectedDeadCodeScore     int
 		expectedDuplicationScore  int
 		expectedCouplingScore     int
+		expectedCohesionScore     int
 		expectedDependencyScore   int
 		expectedArchitectureScore int
 	}{
@@ -300,6 +301,21 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			expectError:   false,
 		},
 		{
+			// Softened cohesion curve (#529): a repo with a healthy average LCOM
+			// and ~10% high-LCOM classes should not floor. Mirrors CBO fix #528.
+			name: "cohesion calibration - healthy repo not floored",
+			summary: domain.AnalyzeSummary{
+				LCOMClasses:       100,
+				HighLCOMClasses:   10, // 10%
+				MediumLCOMClasses: 20,
+				// weighted = 10 + 0.3*20 = 16; ratio = 0.16; penalty = 0.16/0.40*20 = 8
+			},
+			expectedScore:         92, // 100 - 8
+			expectedGrade:         "A",
+			expectedCohesionScore: 60, // 100 - (8/20)*100 = 60
+			expectError:           false,
+		},
+		{
 			name: "grade D threshold",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity:   22.0, // Capped at 20
@@ -406,6 +422,11 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				if tt.expectedCouplingScore > 0 {
 					if tt.summary.CouplingScore != tt.expectedCouplingScore {
 						t.Errorf("CouplingScore = %d, want %d", tt.summary.CouplingScore, tt.expectedCouplingScore)
+					}
+				}
+				if tt.expectedCohesionScore > 0 {
+					if tt.summary.CohesionScore != tt.expectedCohesionScore {
+						t.Errorf("CohesionScore = %d, want %d", tt.summary.CohesionScore, tt.expectedCohesionScore)
 					}
 				}
 				if tt.expectedDependencyScore > 0 {


### PR DESCRIPTION
## Summary

Softens the Cohesion (LCOM) scoring curve in `calculateCohesionPenalty()`, mirroring the CBO fix in #528. The previous curve saturated (cohesion score floored) at a weighted low-cohesion-class ratio of just **30%**, with medium-risk classes (3 ≤ LCOM4 ≤ 5) weighted **0.5** — so healthy codebases with a good average LCOM were over-penalized.

Risk thresholds (LCOM4 > 5 / 3–5) are **unchanged**; only the scoring curve is softened.

## Changes

- `CohesionMediumWeight`: `0.5` → `0.3`
- `CohesionSaturationRatio`: `0.30` → `0.40`
- Extracted the magic numbers into named constants (parallel to `CouplingMediumWeight` / `CouplingSaturationRatio`)
- Added a regression test asserting a healthy repo is no longer floored

## Effect

On `japan-fiscal-simulator` (avg LCOM **2.5**, high-LCOM 28/243 = 11.5%):

| | Before | After |
|---|---|---|
| Cohesion (LCOM) | 25/100 | **55/100** |

Now consistent with the calibrated Coupling score (50/100).

## Test

`go build ./...` and `go test ./domain/` pass.

Closes #529