### PR TITLE
fix(clone): penalize Type-4 similarity for disjoint string literal vocabularies

### DIFF
--- a/internal/analyzer/semantic_literal_evidence_test.go
+++ b/internal/analyzer/semantic_literal_evidence_test.go
@@ -1,0 +1,170 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/parser"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression fixtures for issue #482: two apispec-style field converters from
+// flask-smorest. Identical control-flow template (isinstance check + version
+// branch filling a dict), but the field types and spec keys are entirely
+// different, so they are not semantic clones.
+const delimitedListConverterSrc = `def delimited_list2param(self, field, **kwargs):
+    """Document DelimitedList field as a query parameter."""
+    ret = {}
+    if isinstance(field, DelimitedList):
+        if self.openapi_version.major < 3:
+            ret["collectionFormat"] = "csv"
+        else:
+            ret["explode"] = False
+            ret["style"] = "form"
+    return ret
+`
+
+const uploadFieldConverterSrc = `def uploadfield2properties(self, field, **kwargs):
+    """Document Upload field properties in the API spec."""
+    ret = {}
+    if isinstance(field, Upload):
+        if self.openapi_version.major < 3:
+            ret["type"] = "file"
+        else:
+            ret["type"] = "string"
+            ret["format"] = field.format
+    return ret
+`
+
+// TestLiteralEvidence_DisjointLiteralsSuppressType4 verifies that fragments
+// whose string-literal vocabularies are completely disjoint score below the
+// default Type-4 threshold even when their CFGs match exactly (issue #482).
+func TestLiteralEvidence_DisjointLiteralsSuppressType4(t *testing.T) {
+	f1 := fragmentFor(t, delimitedListConverterSrc, parser.NodeFunctionDef)
+	f2 := fragmentFor(t, uploadFieldConverterSrc, parser.NodeFunctionDef)
+
+	for name, analyzer := range map[string]*SemanticSimilarityAnalyzer{
+		"cfg_only": NewSemanticSimilarityAnalyzer(),
+		"with_dfa": NewSemanticSimilarityAnalyzerWithDFA(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			similarity := analyzer.ComputeSimilarity(f1, f2)
+			require.Less(t, similarity, domain.DefaultType4CloneThreshold,
+				"disjoint literal vocabularies must suppress Type-4 classification")
+			require.Greater(t, similarity, 0.0,
+				"penalty should reduce, not zero out, the similarity")
+		})
+	}
+}
+
+// TestLiteralEvidence_StandaloneIfBlocks covers the exact fragment shape
+// reported in issue #482: the standalone `if isinstance(...)` blocks rather
+// than the enclosing functions.
+func TestLiteralEvidence_StandaloneIfBlocks(t *testing.T) {
+	f1 := fragmentFor(t, delimitedListConverterSrc, parser.NodeIf)
+	f2 := fragmentFor(t, uploadFieldConverterSrc, parser.NodeIf)
+
+	analyzer := NewSemanticSimilarityAnalyzerWithDFA()
+	similarity := analyzer.ComputeSimilarity(f1, f2)
+	require.Less(t, similarity, domain.DefaultType4CloneThreshold,
+		"isinstance blocks with disjoint spec keys must not reach the Type-4 threshold")
+}
+
+// TestLiteralEvidence_SharedLiteralsKeepScore verifies that a single shared
+// literal disables the penalty: overlap means the fragments emit at least
+// partially the same vocabulary.
+func TestLiteralEvidence_SharedLiteralsKeepScore(t *testing.T) {
+	src1 := `def converter_a(self, field, **kwargs):
+    ret = {}
+    if isinstance(field, Upload):
+        if self.openapi_version.major < 3:
+            ret["type"] = "file"
+        else:
+            ret["type"] = "string"
+            ret["format"] = "binary"
+    return ret
+`
+	// Same vocabulary, slightly different wiring.
+	src2 := `def converter_b(self, field, **kwargs):
+    ret = {}
+    if isinstance(field, Upload):
+        if self.openapi_version.major < 3:
+            ret["format"] = "binary"
+        else:
+            ret["type"] = "string"
+            ret["format"] = "binary"
+    return ret
+`
+	f1 := fragmentFor(t, src1, parser.NodeFunctionDef)
+	f2 := fragmentFor(t, src2, parser.NodeFunctionDef)
+
+	analyzer := NewSemanticSimilarityAnalyzer()
+	similarity := analyzer.ComputeSimilarity(f1, f2)
+	require.GreaterOrEqual(t, similarity, domain.DefaultType4CloneThreshold,
+		"overlapping literal vocabularies must not be penalized")
+}
+
+// TestLiteralEvidence_DocstringsAreNotEvidence verifies that differing
+// docstrings alone never trigger the penalty: bare string statements are
+// excluded from literal evidence.
+func TestLiteralEvidence_DocstringsAreNotEvidence(t *testing.T) {
+	src1 := `def sum_numbers(numbers):
+    """Calculate sum using a for loop over the input."""
+    "stray string statement"
+    total = 0
+    for num in numbers:
+        total = total + num
+    return total
+`
+	src2 := `def add_all(values):
+    """Recursively accumulate every value."""
+    "another stray string"
+    acc = 0
+    for v in values:
+        acc = acc + v
+    return acc
+`
+	f1 := fragmentFor(t, src1, parser.NodeFunctionDef)
+	f2 := fragmentFor(t, src2, parser.NodeFunctionDef)
+
+	signals1 := extractSemanticSignals(f1.ASTNode)
+	signals2 := extractSemanticSignals(f2.ASTNode)
+	require.Empty(t, signals1.stringLiterals, "docstrings and bare string statements must be ignored")
+	require.Empty(t, signals2.stringLiterals, "docstrings and bare string statements must be ignored")
+
+	analyzer := NewSemanticSimilarityAnalyzer()
+	similarity := analyzer.ComputeSimilarity(f1, f2)
+	require.GreaterOrEqual(t, similarity, domain.DefaultType4CloneThreshold,
+		"equivalent loops must stay above the threshold despite differing docstrings")
+}
+
+// TestLiteralEvidence_InsufficientLiteralsNoPenalty verifies the evidence
+// minimum: one literal per side is not enough to conclude anything.
+func TestLiteralEvidence_InsufficientLiteralsNoPenalty(t *testing.T) {
+	src1 := `def log_positive(items):
+    count = 0
+    for item in items:
+        if item > 0:
+            count = count + 1
+    return "found: " + str(count)
+`
+	src2 := `def tally_above_zero(values):
+    n = 0
+    for v in values:
+        if v > 0:
+            n = n + 1
+    return "total: " + str(n)
+`
+	f1 := fragmentFor(t, src1, parser.NodeFunctionDef)
+	f2 := fragmentFor(t, src2, parser.NodeFunctionDef)
+
+	signals1 := extractSemanticSignals(f1.ASTNode)
+	signals2 := extractSemanticSignals(f2.ASTNode)
+	require.Len(t, signals1.stringLiterals, 1)
+	require.Len(t, signals2.stringLiterals, 1)
+
+	analyzer := NewSemanticSimilarityAnalyzer()
+	similarity := analyzer.ComputeSimilarity(f1, f2)
+	require.GreaterOrEqual(t, similarity, domain.DefaultType4CloneThreshold,
+		"a single differing literal per side must not suppress an otherwise equivalent pair")
+}

--- a/internal/analyzer/semantic_similarity.go
+++ b/internal/analyzer/semantic_similarity.go
@@ -117,9 +117,25 @@ func (s *SemanticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) flo
 
 const semanticMismatchPenalty = 0.75
 
+// literalMismatchPenalty is applied when both fragments carry enough string
+// literals to compare and the sets are completely disjoint. Matching control
+// flow combined with a fully different literal vocabulary (dict keys, format
+// names, config values) is strong counter-evidence for semantic equivalence:
+// true Type-4 clones compute the same result, so the constants they emit
+// overlap. Calibrated to pull a saturated CFG score (1.0) below the default
+// Type-4 threshold (see issue #482).
+const literalMismatchPenalty = 0.5
+
+// minStringLiteralEvidence is the number of distinct meaningful string
+// literals each fragment must contain before disjoint literal sets are
+// treated as counter-evidence. Docstrings and other bare string statements
+// are excluded from the count.
+const minStringLiteralEvidence = 2
+
 type semanticSignals struct {
 	strongSignals    map[string]struct{}
 	returnCategories map[string]struct{}
+	stringLiterals   map[string]struct{}
 }
 
 func (s *SemanticSimilarityAnalyzer) applySemanticEvidence(baseSimilarity float64, f1, f2 *CodeFragment) float64 {
@@ -129,6 +145,9 @@ func (s *SemanticSimilarityAnalyzer) applySemanticEvidence(baseSimilarity float6
 
 	signals1 := extractSemanticSignals(f1.ASTNode)
 	signals2 := extractSemanticSignals(f2.ASTNode)
+	if hasDisjointStringLiterals(signals1.stringLiterals, signals2.stringLiterals) {
+		return baseSimilarity * literalMismatchPenalty
+	}
 	if !hasSharedSemanticSignal(signals1.strongSignals, signals2.strongSignals) {
 		return baseSimilarity * semanticMismatchPenalty
 	}
@@ -142,12 +161,30 @@ func extractSemanticSignals(node *parser.Node) semanticSignals {
 	signals := semanticSignals{
 		strongSignals:    make(map[string]struct{}),
 		returnCategories: make(map[string]struct{}),
+		stringLiterals:   make(map[string]struct{}),
 	}
 	if node == nil {
 		return signals
 	}
 
+	// Bare string statements (docstrings, string "comments") carry no
+	// executable semantics, so they must not count as literal evidence.
+	// Walk is pre-order, so a statement's parent is always visited first
+	// and marking here is sufficient.
+	inertStrings := make(map[*parser.Node]struct{})
+	markInertStrings := func(stmts []*parser.Node) {
+		for _, stmt := range stmts {
+			if isStringConstant(stmt) {
+				inertStrings[stmt] = struct{}{}
+			}
+		}
+	}
+
 	node.Walk(func(current *parser.Node) bool {
+		markInertStrings(current.Body)
+		markInertStrings(current.Orelse)
+		markInertStrings(current.Finalbody)
+
 		switch current.Type {
 		case parser.NodeBinOp, parser.NodeAugAssign:
 			addSignal(signals.strongSignals, "binop", current.Op)
@@ -163,11 +200,26 @@ func extractSemanticSignals(node *parser.Node) semanticSignals {
 			}
 		case parser.NodeReturn:
 			signals.returnCategories[returnCategory(current)] = struct{}{}
+		case parser.NodeConstant:
+			if _, inert := inertStrings[current]; inert {
+				break
+			}
+			if value, ok := current.Value.(string); ok && value != "" {
+				signals.stringLiterals[value] = struct{}{}
+			}
 		}
 		return true
 	})
 
 	return signals
+}
+
+func isStringConstant(node *parser.Node) bool {
+	if node == nil || node.Type != parser.NodeConstant {
+		return false
+	}
+	_, ok := node.Value.(string)
+	return ok
 }
 
 func addSignal(signals map[string]struct{}, kind, value string) {
@@ -226,6 +278,22 @@ func hasSharedSemanticSignal(signals1, signals2 map[string]struct{}) bool {
 		}
 	}
 	return false
+}
+
+// hasDisjointStringLiterals reports whether both fragments contain enough
+// distinct string literals to compare (minStringLiteralEvidence each) while
+// sharing none of them. Partial overlap or insufficient evidence on either
+// side is given the benefit of the doubt.
+func hasDisjointStringLiterals(literals1, literals2 map[string]struct{}) bool {
+	if len(literals1) < minStringLiteralEvidence || len(literals2) < minStringLiteralEvidence {
+		return false
+	}
+	for literal := range literals1 {
+		if _, ok := literals2[literal]; ok {
+			return false
+		}
+	}
+	return true
 }
 
 func hasCompatibleReturnCategories(categories1, categories2 map[string]struct{}) bool {

--- a/internal/analyzer/type4_detector_test.go
+++ b/internal/analyzer/type4_detector_test.go
@@ -64,6 +64,14 @@ func TestType4CloneDetection(t *testing.T) {
 		require.NotNil(t, pair, "direct comparison missed %s <-> %s", expected[0], expected[1])
 		assert.Equal(t, Type4Clone, pair.CloneType)
 	}
+
+	// Issue #482: same control-flow template, disjoint literal vocabulary.
+	// The pair may legitimately surface as a syntactic (Type-2/3) clone, but
+	// must never be classified as a semantic Type-4 clone.
+	if pair := pairByID[type4PairID("field_converter_a.py::delimited_list2param", "field_converter_b.py::uploadfield2properties")]; pair != nil {
+		assert.NotEqual(t, Type4Clone, pair.CloneType,
+			"field converters with disjoint spec keys must not be Type-4 clones")
+	}
 }
 
 func loadType4FunctionFragments(t *testing.T, detector *CloneDetector) ([]*CodeFragment, map[string]*CodeFragment) {

--- a/internal/analyzer/type4_similarity_test.go
+++ b/internal/analyzer/type4_similarity_test.go
@@ -38,6 +38,7 @@ func TestType4SimilarityScores(t *testing.T) {
 		{"sum_iterative.py::sum_numbers", "find_max_b.py::find_maximum"},
 		{"sum_iterative.py::sum_range", "find_max_b.py::find_min_max"},
 		{"find_max_a.py::find_maximum", "find_max_b.py::find_min_max"},
+		{"field_converter_a.py::delimited_list2param", "field_converter_b.py::uploadfield2properties"},
 	}
 	for _, negative := range negativePairs {
 		first := functions[negative[0]]

--- a/testdata/python/clones/type4/field_converter_a.py
+++ b/testdata/python/clones/type4/field_converter_a.py
@@ -1,0 +1,16 @@
+# Non-clone example: apispec-style field converter (issue #482)
+# Shares its control-flow template with field_converter_b.py but documents a
+# different field type with entirely different spec keys, so the pair must
+# not be reported as a Type-4 clone.
+
+
+def delimited_list2param(self, field, **kwargs):
+    """Document DelimitedList field as a query parameter."""
+    ret = {}
+    if isinstance(field, DelimitedList):
+        if self.openapi_version.major < 3:
+            ret["collectionFormat"] = "csv"
+        else:
+            ret["explode"] = False
+            ret["style"] = "form"
+    return ret

--- a/testdata/python/clones/type4/field_converter_b.py
+++ b/testdata/python/clones/type4/field_converter_b.py
@@ -1,0 +1,16 @@
+# Non-clone example: apispec-style field converter (issue #482)
+# Shares its control-flow template with field_converter_a.py but documents a
+# different field type with entirely different spec keys, so the pair must
+# not be reported as a Type-4 clone.
+
+
+def uploadfield2properties(self, field, **kwargs):
+    """Document Upload field properties in the API spec."""
+    ret = {}
+    if isinstance(field, Upload):
+        if self.openapi_version.major < 3:
+            ret["type"] = "file"
+        else:
+            ret["type"] = "string"
+            ret["format"] = field.format
+    return ret


### PR DESCRIPTION
## Summary

Fixes #482.

Type-4 (CFG/DFA-based) similarity is purely shape-based, so small functions that follow a common control-flow template saturate at similarity 1.00 even when they encode entirely different domain logic. The reported case: two apispec-style field converters (`delimited_list2param` / `uploadfield2properties`) that share the `isinstance check → version branch → fill dict` template but document different field types with entirely different spec keys.

The existing semantic-evidence gate did not help here because both functions share `call:isinstance` and `compare:<` signals, and even when the gate fires its 0.75 penalty cannot pull a saturated score (1.00) below the default Type-4 threshold (0.65).

## Fix

Add a literal-evidence check to `applySemanticEvidence`:

- Collect distinct string literals from each fragment, excluding docstrings and other bare string statements (which carry no executable semantics).
- If **both** fragments have ≥ 2 literals and the sets are **completely disjoint**, multiply the similarity by 0.5.

Rationale: true Type-4 clones compute the same result, so the constants they emit (dict keys, format names, config values) overlap. Matching control flow combined with a fully disjoint literal vocabulary is strong counter-evidence for semantic equivalence. Partial overlap or insufficient evidence on either side is given the benefit of the doubt, keeping the check conservative.

## Verification

- New unit tests (`semantic_literal_evidence_test.go`) covering the issue repro (function and standalone-if shapes, CFG-only and DFA paths), shared-literal and insufficient-evidence escapes, and docstring exclusion.
- New negative fixtures `field_converter_a.py` / `field_converter_b.py` wired into `TestType4CloneDetection` and `TestType4SimilarityScores`; all existing true Type-4 fixture pairs still classify as Type-4.
- End-to-end on `marshmallow-code/flask-smorest@2eec1ea` (the audited repo): Type-4 pairs drop **349 → 165 (-53%)**, Type-2 pairs unchanged (6). Type-4 pairs involving the reported converter drop 13 → 3; the remaining 3 partners carry fewer than 2 meaningful string literals, so the conservative evidence minimum correctly leaves them untouched.
- `go test ./...` passes, `make lint` reports 0 issues.

Note: the reported function pair still surfaces as a Type-2 clone (similarity 0.81) on main, which is defensible — the two functions are near-identical ASTs modulo identifiers/literals (a copy-paste-modify template). This PR targets the Type-4 misclassification described in the issue.