### PR TITLE
fix(cbo): stop counting imported function calls as class dependencies

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -349,12 +349,10 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 				if valueNode, ok := node.Value.(*parser.Node); ok {
 					if valueNode.Type == parser.NodeCall {
 						className := a.extractClassNameFromCallNode(valueNode)
-						if className != "" && a.shouldIncludeDependencyForClass(className, result.ClassName) {
-							if a.isCallDependency(className, allClasses) {
-								a.addDependency(dependencies, className, dependencyKindInstantiation)
-							}
-							// Note: function calls are NOT added to dependencies
+						if dep := a.callDependencyName(className, allClasses); dep != "" && a.shouldIncludeDependencyForClass(dep, result.ClassName) {
+							a.addDependency(dependencies, dep, dependencyKindInstantiation)
 						}
+						// Note: function calls are NOT added to dependencies
 					}
 				}
 			}
@@ -362,12 +360,10 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 			// Function/class call - could be instantiation
 			// Use structural AST analysis instead of string parsing
 			className := a.extractClassNameFromCallNode(node)
-			if className != "" && a.shouldIncludeDependencyForClass(className, result.ClassName) {
-				if a.isCallDependency(className, allClasses) {
-					a.addDependency(dependencies, className, dependencyKindInstantiation)
-				}
-				// Note: function calls are NOT added to dependencies
+			if dep := a.callDependencyName(className, allClasses); dep != "" && a.shouldIncludeDependencyForClass(dep, result.ClassName) {
+				a.addDependency(dependencies, dep, dependencyKindInstantiation)
 			}
+			// Note: function calls are NOT added to dependencies
 		case parser.NodeAttribute:
 			// Attribute access: obj.method() or obj.attr
 			if a.shouldSkipAttributeAccess(node) {
@@ -550,18 +546,31 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 	return true
 }
 
-func (a *CBOAnalyzer) isCallDependency(className string, allClasses map[string]*parser.Node) bool {
-	if _, isClass := allClasses[className]; isClass {
-		return true
+// callDependencyName returns the portion of a called dotted name that refers
+// to a class, or "" when the call does not read as class coupling. The class
+// part is found by trying dotted prefixes from longest to shortest, so
+// class-method calls couple to the class itself: Path.cwd() -> Path,
+// datetime.datetime.now() -> datetime.datetime. Locally defined classes are
+// matched structurally; imported names carry no type information in
+// single-file analysis, so they only count when a prefix reads as a class —
+// otherwise function calls like os.getcwd() or suppress() would be reported
+// as class coupling.
+func (a *CBOAnalyzer) callDependencyName(className string, allClasses map[string]*parser.Node) string {
+	if className == "" {
+		return ""
 	}
-	// Imported names carry no type information in single-file analysis, so a
-	// called import only counts as instantiation when the name itself reads as
-	// a class; otherwise function calls like os.getcwd() or suppress() would
-	// be reported as class coupling.
-	if a.isImportedDependency(className) {
-		return a.looksLikeClassReference(className)
+	imported := a.isImportedDependency(className)
+	parts := strings.Split(className, ".")
+	for end := len(parts); end > 0; end-- {
+		prefix := strings.Join(parts[:end], ".")
+		if _, isClass := allClasses[prefix]; isClass {
+			return prefix
+		}
+		if imported && a.looksLikeClassReference(prefix) {
+			return prefix
+		}
 	}
-	return false
+	return ""
 }
 
 // knownLowercaseClasses lists well-known standard library classes that do not
@@ -620,7 +629,7 @@ func (a *CBOAnalyzer) isAttributeReceiverDependency(className string, allClasses
 	if _, isClass := allClasses[className]; isClass {
 		return true
 	}
-	// Same reasoning as isCallDependency: an imported receiver is only class
+	// Same reasoning as callDependencyName: an imported receiver is only class
 	// coupling when the name reads as a class; plain modules (os, json, ...)
 	// are not classes.
 	if a.isImportedDependency(className) {

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
@@ -550,11 +551,64 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 }
 
 func (a *CBOAnalyzer) isCallDependency(className string, allClasses map[string]*parser.Node) bool {
-	if a.isImportedDependency(className) {
-		return true
-	}
 	if _, isClass := allClasses[className]; isClass {
 		return true
+	}
+	// Imported names carry no type information in single-file analysis, so a
+	// called import only counts as instantiation when the name itself reads as
+	// a class; otherwise function calls like os.getcwd() or suppress() would
+	// be reported as class coupling.
+	if a.isImportedDependency(className) {
+		return a.looksLikeClassReference(className)
+	}
+	return false
+}
+
+// knownLowercaseClasses lists well-known standard library classes that do not
+// follow the PEP 8 CapWords convention and would otherwise be rejected by the
+// capitalization heuristic in looksLikeClassReference.
+var knownLowercaseClasses = map[string]bool{
+	"datetime.datetime":       true,
+	"datetime.date":           true,
+	"datetime.time":           true,
+	"datetime.timedelta":      true,
+	"datetime.timezone":       true,
+	"collections.defaultdict": true,
+	"collections.deque":       true,
+	"array.array":             true,
+	"socket.socket":           true,
+	"threading.local":         true,
+}
+
+// resolveImportedName expands an alias or module-qualified name to the full
+// imported path (e.g. "FilePath" -> "pathlib.Path", "os.getcwd" -> "os.getcwd").
+func (a *CBOAnalyzer) resolveImportedName(name string) string {
+	if full, exists := a.importedNames[name]; exists {
+		return full
+	}
+	if strings.Contains(name, ".") {
+		parts := strings.SplitN(name, ".", 2)
+		if full, exists := a.importedNames[parts[0]]; exists {
+			return full + "." + parts[1]
+		}
+	}
+	return name
+}
+
+// looksLikeClassReference applies the PEP 8 naming convention to decide
+// whether an imported name refers to a class (CapWords) rather than a
+// function (snake_case). Aliases resolve to their original imported name so
+// the convention is judged on the name the defining module chose.
+func (a *CBOAnalyzer) looksLikeClassReference(name string) bool {
+	resolved := a.resolveImportedName(name)
+	if knownLowercaseClasses[resolved] {
+		return true
+	}
+	leaf := strings.TrimLeft(dependencyLeafName(resolved), "_")
+	for _, r := range leaf {
+		// Only a clearly lower-case leading letter marks a function; uncased
+		// scripts keep counting as classes to stay conservative.
+		return !unicode.IsLower(r)
 	}
 	return false
 }
@@ -563,11 +617,14 @@ func (a *CBOAnalyzer) isAttributeReceiverDependency(className string, allClasses
 	if className == "" || className == "self" || className == "cls" {
 		return false
 	}
-	if a.isImportedDependency(className) {
-		return true
-	}
 	if _, isClass := allClasses[className]; isClass {
 		return true
+	}
+	// Same reasoning as isCallDependency: an imported receiver is only class
+	// coupling when the name reads as a class; plain modules (os, json, ...)
+	// are not classes.
+	if a.isImportedDependency(className) {
+		return a.looksLikeClassReference(className)
 	}
 	return a.options.IncludeBuiltins && a.builtinTypes[className]
 }

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -871,6 +871,128 @@ class Service:
 	assert.Contains(t, serviceResult.DependentClasses, "Logger")
 }
 
+func TestCBOAnalyzer_FunctionCallsAreNotClassDependencies(t *testing.T) {
+	// Regression test for #494: imported function calls (os.getcwd, suppress,
+	// escape) must not be counted as class dependencies.
+	pythonCode := `
+import os
+from contextlib import suppress
+from rich.markup import escape
+
+
+class Widget:
+    pass
+
+
+class MyThing:
+    def run(self):
+        cwd = os.getcwd()
+        path = os.path.realpath(cwd)
+        with suppress(KeyError):
+            x = escape("hi")
+        return Widget()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "mything.py")
+	require.NoError(t, err)
+
+	resultMap := make(map[string]*CBOResult)
+	for _, result := range results {
+		resultMap[result.ClassName] = result
+	}
+
+	myThing, found := resultMap["MyThing"]
+	require.True(t, found, "MyThing not found in results")
+	assert.Equal(t, []string{"Widget"}, myThing.DependentClasses)
+	assert.Equal(t, 1, myThing.CouplingCount)
+	assert.Equal(t, "low", myThing.RiskLevel)
+}
+
+func TestCBOAnalyzer_LowercaseLocalClassInstantiationStillCounts(t *testing.T) {
+	// Locally defined classes are known to be classes regardless of naming.
+	pythonCode := `
+class widget_factory:
+    pass
+
+class Consumer:
+    def build(self):
+        return widget_factory()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "consumer.py")
+	require.NoError(t, err)
+
+	var consumer *CBOResult
+	for _, result := range results {
+		if result.ClassName == "Consumer" {
+			consumer = result
+			break
+		}
+	}
+
+	require.NotNil(t, consumer)
+	assert.Equal(t, []string{"widget_factory"}, consumer.DependentClasses)
+	assert.Equal(t, 1, consumer.CouplingCount)
+}
+
+func TestCBOAnalyzer_KnownLowercaseStdlibClassesStillCount(t *testing.T) {
+	// Well-known stdlib classes that break the CapWords convention remain
+	// counted via the explicit allowlist.
+	pythonCode := `
+import datetime
+from collections import deque
+
+class Scheduler:
+    def setup(self):
+        self.queue = deque()
+        self.started = datetime.datetime(2024, 1, 1)
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "scheduler.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	scheduler := results[0]
+	assert.Equal(t, "Scheduler", scheduler.ClassName)
+	assert.Contains(t, scheduler.DependentClasses, "deque")
+	assert.Contains(t, scheduler.DependentClasses, "datetime.datetime")
+}
+
+func TestCBOAnalyzer_CallHeuristicJudgesOriginalImportedName(t *testing.T) {
+	// Aliases resolve to the original imported name before applying the
+	// CapWords heuristic: a function aliased to CapWords stays excluded and a
+	// class aliased to snake_case stays counted.
+	pythonCode := `
+from helpers import make_widget as WidgetFactory
+from models import Widget as widget_cls
+
+class Consumer:
+    def build(self):
+        a = WidgetFactory()
+        return widget_cls()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "consumer.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	consumer := results[0]
+	assert.Equal(t, []string{"widget_cls"}, consumer.DependentClasses)
+	assert.Equal(t, 1, consumer.CouplingCount)
+}
+
 // Helper function to parse Python code into AST
 func parseCode(code string) (*parser.Node, error) {
 	p := parser.New()

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -993,6 +993,86 @@ class Consumer:
 	assert.Equal(t, 1, consumer.CouplingCount)
 }
 
+func TestCBOAnalyzer_ImportedClassMethodCallsCountClassCoupling(t *testing.T) {
+	// Class-method/static-method calls on an imported class are real class
+	// coupling: the dependency is recorded as the class part of the dotted
+	// name, not the method and not nothing.
+	pythonCode := `
+from pathlib import Path
+import datetime
+
+class Worker:
+    def run(self):
+        here = Path.cwd()
+        now = datetime.datetime.now()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "worker.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	worker := results[0]
+	assert.Equal(t, "Worker", worker.ClassName)
+	assert.Equal(t, []string{"Path", "datetime.datetime"}, worker.DependentClasses)
+	assert.Equal(t, 2, worker.CouplingCount)
+}
+
+func TestCBOAnalyzer_LocalClassMethodCallsCountClassCoupling(t *testing.T) {
+	pythonCode := `
+class Widget:
+    @classmethod
+    def create(cls):
+        return cls()
+
+class Consumer:
+    def build(self):
+        return Widget.create()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "consumer.py")
+	require.NoError(t, err)
+
+	var consumer *CBOResult
+	for _, result := range results {
+		if result.ClassName == "Consumer" {
+			consumer = result
+			break
+		}
+	}
+
+	require.NotNil(t, consumer)
+	assert.Equal(t, []string{"Widget"}, consumer.DependentClasses)
+	assert.Equal(t, 1, consumer.CouplingCount)
+}
+
+func TestCBOAnalyzer_OwnClassMethodCallIsNotSelfCoupling(t *testing.T) {
+	pythonCode := `
+from models import Widget
+
+class Widget:
+    def clone(self):
+        return Widget.create()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "widget.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	widget := results[0]
+	assert.Equal(t, "Widget", widget.ClassName)
+	assert.Empty(t, widget.DependentClasses)
+	assert.Equal(t, 0, widget.CouplingCount)
+}
+
 // Helper function to parse Python code into AST
 func parseCode(code string) (*parser.Node, error) {
 	p := parser.New()


### PR DESCRIPTION
## Summary

Fixes #494.

`isCallDependency` treated **any called imported name** as a class instantiation, so plain function calls (`os.getcwd`, `os.path.realpath`, `contextlib.suppress`, `rich.markup.escape`, project-local helpers) were listed in `DependentClasses` and inflated `CouplingCount` — pushing structurally simple classes into the high-coupling risk bucket. The attribute-receiver path had the sibling problem: module receivers (`os` in `os.path.realpath(...)`) were counted as class coupling.

## Approach

pyscn analyzes one file at a time, so there is no type information for imported names. The fix gates call and attribute-receiver dependencies on the PEP 8 naming convention:

- An imported name counts as class coupling only when its leaf name reads as CapWords (`looksLikeClassReference`).
- Aliases resolve to the **original** imported name first (`from helpers import make_widget as WidgetFactory` stays excluded; `from models import Widget as widget_cls` stays counted).
- A small allowlist keeps well-known lowercase stdlib classes counted (`datetime.datetime`, `collections.deque`, `socket.socket`, ...).
- Only a clearly lowercase leading letter marks a function — uncased scripts keep counting, staying conservative.
- Locally defined classes are unaffected: they are matched structurally via the class registry regardless of naming.

## Repro from the issue

```json
// before
{"Name": "MyThing", "CouplingCount": 5, "DependentClasses": ["Widget", "escape", "os.getcwd", "os.path.realpath", "suppress"]}
// after
{"Name": "MyThing", "CouplingCount": 1, "DependentClasses": ["Widget"]}
```

(verified end-to-end with `pyscn analyze --json` on the issue's synthetic repro)

## Tests

- `TestCBOAnalyzer_FunctionCallsAreNotClassDependencies` — issue repro, expects only `Widget`
- `TestCBOAnalyzer_LowercaseLocalClassInstantiationStillCounts` — local snake_case class still counted
- `TestCBOAnalyzer_KnownLowercaseStdlibClassesStillCount` — `deque`/`datetime.datetime` via allowlist
- `TestCBOAnalyzer_CallHeuristicJudgesOriginalImportedName` — alias resolution both directions
- Full `go test ./...` and `make lint` pass

## Known trade-off

A third-party/project **class** with a snake_case name imported from another file is no longer counted (false negative). This is the inherent cost of a naming heuristic without cross-file resolution; PEP 8-violating class names are rare, and undercounting is preferable to the current systematic overcounting that misclassifies risk.

## Update: class-method calls (review follow-up)

The initial leaf-only heuristic dropped real class coupling for class/static-method calls (`Path.cwd()` → leaf `cwd` → rejected). `callDependencyName` now scans dotted prefixes from longest to shortest and records the **class part** of the name:

- `Path.cwd()` → `Path` (was `Path.cwd` on main — method name mislabeled as a class)
- `datetime.datetime.now()` → `datetime.datetime` (allowlist now also applies through method calls)
- `Widget.create()` on a locally defined class → `Widget` (was dropped even on main)
- `os.path.realpath()` → no class-like prefix → still excluded

Inclusion filters (self-reference, exclude patterns, stdlib) run on the recorded class name. Added tests: `ImportedClassMethodCallsCountClassCoupling`, `LocalClassMethodCallsCountClassCoupling`, `OwnClassMethodCallIsNotSelfCoupling`.
