### PR TITLE
fix(parser): preserve every elif in a chain so complexity isn't undercounted (#511)

### DIFF
--- a/internal/analyzer/complexity_elif_chain_test.go
+++ b/internal/analyzer/complexity_elif_chain_test.go
@@ -1,0 +1,54 @@
+package analyzer
+
+import "testing"
+
+// TestCalculateComplexityElifChain pins cyclomatic complexity for elif chains.
+//
+// Each if/elif condition is a decision point, so "if + N elif [+ else]" has
+// cyclomatic complexity N+2 (N+1 conditions plus the base of 1). Regression
+// guard for #511: the AST builder kept only the last elif of a chain, so every
+// elif but the last was dropped and complexity was undercounted on long
+// dispatch chains. The existing MultipleElif CFG test only asserted
+// cfg.Size() >= 5, so it stayed green while branches went missing.
+func TestCalculateComplexityElifChain(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "if_else",
+			src:  "\nif x > 1:\n    print(1)\nelse:\n    print(0)\n",
+			want: 2,
+		},
+		{
+			name: "if_one_elif_else",
+			src:  "\nif x > 1:\n    print(1)\nelif x > 2:\n    print(2)\nelse:\n    print(0)\n",
+			want: 3,
+		},
+		{
+			name: "if_three_elif_else",
+			src:  "\nif x > 100:\n    print(1)\nelif x > 50:\n    print(2)\nelif x > 10:\n    print(3)\nelif x > 0:\n    print(4)\nelse:\n    print(0)\n",
+			want: 5,
+		},
+		{
+			name: "if_five_elif_no_else",
+			src:  "\nif x == 1:\n    print(1)\nelif x == 2:\n    print(2)\nelif x == 3:\n    print(3)\nelif x == 4:\n    print(4)\nelif x == 5:\n    print(5)\nelif x == 6:\n    print(6)\n",
+			want: 7,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ast := parseSource(t, c.src)
+			cfg, err := NewCFGBuilder().Build(ast)
+			if err != nil {
+				t.Fatalf("Build CFG: %v", err)
+			}
+			got := CalculateComplexity(cfg).Complexity
+			if got != c.want {
+				t.Errorf("cyclomatic complexity = %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -314,9 +314,12 @@ func (b *ASTBuilder) buildIfStatement(tsNode *sitter.Node) *Node {
 		}
 	}
 
-	// Get alternatives (else/elif) - there may be multiple with the same field name
-	// Tree-sitter can have both elif_clause and else_clause as "alternative"
-	var elifNode *Node
+	// Get alternatives (else/elif). Tree-sitter exposes every elif_clause and
+	// the else_clause as separate "alternative" children of the same
+	// if_statement. Collect the elif clauses in order so the whole chain is
+	// preserved; keeping only the last one (the previous behavior) dropped the
+	// middle branches and undercounted complexity (#511).
+	var elifNodes []*Node
 	var elseNode *Node
 
 	childCount := int(tsNode.ChildCount())
@@ -326,7 +329,7 @@ func (b *ASTBuilder) buildIfStatement(tsNode *sitter.Node) *Node {
 			alt := b.buildNode(child)
 			if alt != nil {
 				if alt.Type == NodeIf || alt.Type == NodeElifClause {
-					elifNode = alt
+					elifNodes = append(elifNodes, alt)
 				} else if alt.Type == NodeElseClause {
 					elseNode = alt
 				}
@@ -334,30 +337,23 @@ func (b *ASTBuilder) buildIfStatement(tsNode *sitter.Node) *Node {
 		}
 	}
 
-	// If we have an elif, attach the else to it
-	if elifNode != nil {
-		if elseNode != nil {
-			// Attach else to the elif chain
-			b.attachElseToElifChain(elifNode, elseNode)
+	if len(elifNodes) > 0 {
+		// Link each elif to the next through Orelse so the parent if owns a
+		// nested elif/else chain that the CFG builder can walk end to end.
+		for i := 0; i+1 < len(elifNodes); i++ {
+			elifNodes[i].Orelse = []*Node{elifNodes[i+1]}
 		}
-		node.Orelse = []*Node{elifNode}
+		if elseNode != nil {
+			last := elifNodes[len(elifNodes)-1]
+			last.Orelse = b.extractBlockBody(elseNode, last)
+		}
+		node.Orelse = []*Node{elifNodes[0]}
 	} else if elseNode != nil {
 		// Just an else clause, no elif
 		node.Orelse = b.extractBlockBody(elseNode, node)
 	}
 
 	return node
-}
-
-// attachElseToElifChain attaches an else clause to the end of an elif chain
-func (b *ASTBuilder) attachElseToElifChain(elifNode *Node, elseNode *Node) {
-	current := elifNode
-	// Find the last elif in the chain
-	for len(current.Orelse) > 0 && current.Orelse[0].Type == NodeElifClause {
-		current = current.Orelse[0]
-	}
-	// Attach the else clause
-	current.Orelse = b.extractBlockBody(elseNode, current)
 }
 
 // buildElifClause builds an elif clause node (similar to if statement)


### PR DESCRIPTION
Fixes #511.

pyscn undercounts cyclomatic complexity for any `if/elif/.../else` chain past the first elif. a function that dispatches on several branches gets scored like it only has one.

repro:

```python
def classify(x):
    if x > 100:
        return "huge"
    elif x > 50:
        return "large"
    elif x > 10:
        return "medium"
    elif x > 0:
        return "small"
    else:
        return "non-positive"
```

four conditions, so cyclomatic complexity should be 5. pyscn reports 3.

## root cause

`buildIfStatement` in `internal/parser/ast_builder.go` walks the `alternative` children of an `if_statement` - tree-sitter exposes every `elif_clause` and the `else_clause` as a separate alternative. it did `elifNode = alt` on each pass, so only the last elif survived. the middle elifs were dropped before the CFG builder ran, and the CFG (which already walks an elif chain correctly via `Orelse`) only ever saw `if -> last elif`.

## the fix

collect the elif clauses in order and link each to the next through `Orelse`, so the parent `if` owns the full nested chain. the else attaches to the last elif. the `attachElseToElifChain` helper expected a chain that was never built, so it's now redundant and removed.

## tests

`internal/analyzer/complexity_elif_chain_test.go` asserts cyclomatic complexity across chain lengths, with and without an else. red before the change (the four-condition case reported 3), green after. the existing `MultipleElif` CFG test only checked `cfg.Size() >= 5`, which is why this slipped through. full `go test ./...`, `go vet ./...`, gofmt, and golangci-lint are all clean.
