### PR TITLE
perf(clone): reuse APTED DP matrices and parallelize pair comparison

### DIFF
--- a/internal/analyzer/apted.go
+++ b/internal/analyzer/apted.go
@@ -2,7 +2,6 @@ package analyzer
 
 import (
 	"math"
-	"sort"
 	"strings"
 )
 
@@ -10,17 +9,35 @@ const maxSameShapeAlignmentCells = 20000
 
 // APTEDAnalyzer implements the APTED (All Path Tree Edit Distance) algorithm
 // Based on Pawlik & Augsten's optimal O(n² log n) algorithm
+//
+// An APTEDAnalyzer is NOT safe for concurrent use: it reuses internal scratch
+// buffers across ComputeDistance calls. Create one analyzer per goroutine.
 type APTEDAnalyzer struct {
 	costModel CostModel
-	cache     map[string]float64 // Memoization cache for subproblems
+
+	// Scratch buffers reused across distance computations to avoid
+	// re-allocating the DP matrices for every tree pair.
+	td        []float64
+	fd        []float64
+	nodesBuf1 []*TreeNode
+	nodesBuf2 []*TreeNode
 }
 
 // NewAPTEDAnalyzer creates a new APTED analyzer with the given cost model
 func NewAPTEDAnalyzer(costModel CostModel) *APTEDAnalyzer {
 	return &APTEDAnalyzer{
 		costModel: costModel,
-		cache:     make(map[string]float64),
 	}
+}
+
+// scratchFloats returns a length-n slice backed by *buf, growing it if needed.
+// Contents are unspecified; callers must initialize the cells they read.
+func scratchFloats(buf *[]float64, n int) []float64 {
+	if cap(*buf) < n {
+		*buf = make([]float64, n)
+	}
+	*buf = (*buf)[:n]
+	return *buf
 }
 
 // ComputeDistance computes the tree edit distance between two trees
@@ -39,19 +56,13 @@ func (a *APTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64 {
 	// Use optimized version for large trees
 	size1, size2 := tree1.Size(), tree2.Size()
 	if size1 > 500 || size2 > 500 {
-		return a.computeDistanceOptimized(tree1, tree2)
+		return a.computeDistanceOptimized(tree1, tree2, size1, size2)
 	}
 
-	// Clear cache for new computation
-	a.cache = make(map[string]float64)
-
-	// Prepare both trees for APTED
-	keyRoots1 := PrepareTreeForAPTED(tree1)
-	keyRoots2 := PrepareTreeForAPTED(tree2)
-
-	// Sort key roots in ascending order (leaves before parents)
-	sort.Ints(keyRoots1)
-	sort.Ints(keyRoots2)
+	// Reuse the prepared tree indices (key roots are cached sorted ascending,
+	// leaves before parents). Trees prepared once can be compared concurrently.
+	keyRoots1 := ensurePreparedForAPTED(tree1)
+	keyRoots2 := ensurePreparedForAPTED(tree2)
 
 	// Compute distance using APTED algorithm
 	return a.apted(tree1, tree2, keyRoots1, keyRoots2)
@@ -67,9 +78,8 @@ func (a *APTEDAnalyzer) ComputeDistanceAndSimilarity(tree1, tree2 *TreeNode) (fl
 // computeDistanceOptimized keeps the large-tree clone-detection path fast
 // without letting the optimization erase real label or shape differences. This
 // is a bounded heuristic for large inputs, not an exact APTED replacement.
-func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode) float64 {
+func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode, size1, size2 int) float64 {
 	// Early termination based on size difference
-	size1, size2 := tree1.Size(), tree2.Size()
 	sizeDiff := math.Abs(float64(size1 - size2))
 
 	// If size difference is too large, return early upper bound
@@ -93,25 +103,20 @@ func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode) float64
 		return profileDistance
 	}
 
-	// Clear cache and use the capped optimized algorithm. The profile distance
-	// below is a lower bound that keeps capped key roots from undercounting.
-	a.cache = make(map[string]float64)
+	// Use the capped optimized algorithm. The profile distance below is a
+	// lower bound that keeps capped key roots from undercounting.
+	keyRoots1 := ensurePreparedForAPTED(tree1)
+	keyRoots2 := ensurePreparedForAPTED(tree2)
 
-	// Prepare both trees for APTED
-	keyRoots1 := PrepareTreeForAPTED(tree1)
-	keyRoots2 := PrepareTreeForAPTED(tree2)
-
-	// Limit key roots to reduce computation
+	// Limit key roots to reduce computation. Key roots are sorted ascending,
+	// so keep the tail: the largest post-order IDs cover the root and the
+	// upper tree structure, which dominate the distance for this heuristic.
 	if len(keyRoots1) > 100 {
-		keyRoots1 = keyRoots1[:100]
+		keyRoots1 = keyRoots1[len(keyRoots1)-100:]
 	}
 	if len(keyRoots2) > 100 {
-		keyRoots2 = keyRoots2[:100]
+		keyRoots2 = keyRoots2[len(keyRoots2)-100:]
 	}
-
-	// Sort key roots in ascending order (leaves before parents)
-	sort.Ints(keyRoots1)
-	sort.Ints(keyRoots2)
 
 	optimizedDistance := a.aptedOptimized(tree1, tree2, keyRoots1, keyRoots2, maxDistance*0.5)
 	return math.Max(optimizedDistance, profileDistance)
@@ -671,60 +676,80 @@ func (a *APTEDAnalyzer) cachedInsertCost(node *TreeNode, state *sameShapeDistanc
 // aptedOptimized implements the optimized APTED algorithm with early termination
 func (a *APTEDAnalyzer) aptedOptimized(tree1, tree2 *TreeNode, keyRoots1, keyRoots2 []int, maxDistance float64) float64 {
 	// Get all nodes in post-order
-	nodes1 := a.getPostOrderNodes(tree1)
-	nodes2 := a.getPostOrderNodes(tree2)
+	nodes1 := a.getPostOrderNodes(tree1, &a.nodesBuf1)
+	nodes2 := a.getPostOrderNodes(tree2, &a.nodesBuf2)
 
 	size1 := len(nodes1)
 	size2 := len(nodes2)
+	stride := size2 + 1
 
-	// Initialize distance matrix
-	td := make([][]float64, size1+1)
-	for i := range td {
-		td[i] = make([]float64, size2+1)
+	// Tree distance matrix, flat (size1+1) x (size2+1). Must start zeroed:
+	// subtree distances are filled in as key roots are processed.
+	td := scratchFloats(&a.td, (size1+1)*stride)
+	for k := range td {
+		td[k] = 0
 	}
+	fd := scratchFloats(&a.fd, (size1+1)*stride)
 
 	// Main APTED loop with early termination
 	for _, i := range keyRoots1 {
 		for _, j := range keyRoots2 {
-			a.computeForestDistanceOptimized(nodes1, nodes2, i, j, td, maxDistance)
+			a.computeForestDistanceOptimized(nodes1, nodes2, i, j, td, fd, stride, maxDistance)
 
 			// Early termination if distance exceeds threshold
-			if td[size1][size2] > maxDistance {
-				return td[size1][size2]
+			if td[size1*stride+size2] > maxDistance {
+				return td[size1*stride+size2]
 			}
 		}
 	}
 
-	return td[size1][size2]
+	return td[size1*stride+size2]
 }
 
 // apted implements the main APTED algorithm
 func (a *APTEDAnalyzer) apted(tree1, tree2 *TreeNode, keyRoots1, keyRoots2 []int) float64 {
 	// Get all nodes in post-order
-	nodes1 := a.getPostOrderNodes(tree1)
-	nodes2 := a.getPostOrderNodes(tree2)
+	nodes1 := a.getPostOrderNodes(tree1, &a.nodesBuf1)
+	nodes2 := a.getPostOrderNodes(tree2, &a.nodesBuf2)
 
 	size1 := len(nodes1)
 	size2 := len(nodes2)
+	stride := size2 + 1
 
-	// Initialize distance matrix
-	td := make([][]float64, size1+1)
-	for i := range td {
-		td[i] = make([]float64, size2+1)
+	// Tree distance matrix, flat (size1+1) x (size2+1). Must start zeroed:
+	// subtree distances are filled in as key roots are processed.
+	td := scratchFloats(&a.td, (size1+1)*stride)
+	for k := range td {
+		td[k] = 0
 	}
+	fd := scratchFloats(&a.fd, (size1+1)*stride)
 
 	// Main APTED loop
 	for _, i := range keyRoots1 {
 		for _, j := range keyRoots2 {
-			a.computeForestDistance(nodes1, nodes2, i, j, td)
+			a.computeForestDistance(nodes1, nodes2, i, j, td, fd, stride)
 		}
 	}
 
-	return td[size1][size2]
+	return td[size1*stride+size2]
 }
 
-// computeForestDistanceOptimized computes the distance between two forests with early termination
-func (a *APTEDAnalyzer) computeForestDistanceOptimized(nodes1, nodes2 []*TreeNode, i, j int, td [][]float64, maxDistance float64) {
+// zeroForestRegion clears the cells of the flat forest-distance matrix that
+// the (i, j) key-root computation reads and writes: rows lml_i..i+1, columns
+// lml_j..j+1. Equivalent to allocating a fresh zeroed matrix, without the
+// allocation.
+func zeroForestRegion(fd []float64, stride, lml_i, i, lml_j, j int) {
+	for x := lml_i; x <= i+1; x++ {
+		row := fd[x*stride+lml_j : x*stride+j+2]
+		for k := range row {
+			row[k] = 0
+		}
+	}
+}
+
+// computeForestDistanceOptimized computes the distance between two forests with early termination.
+// td and fd are flat (len(nodes1)+1) x stride matrices with stride = len(nodes2)+1.
+func (a *APTEDAnalyzer) computeForestDistanceOptimized(nodes1, nodes2 []*TreeNode, i, j int, td, fd []float64, stride int, maxDistance float64) {
 	// Bounds checking to prevent array access violations
 	if i < 0 || i >= len(nodes1) || j < 0 || j >= len(nodes2) {
 		return
@@ -734,80 +759,65 @@ func (a *APTEDAnalyzer) computeForestDistanceOptimized(nodes1, nodes2 []*TreeNod
 	lml_i := nodes1[i].LeftMostLeaf
 	lml_j := nodes2[j].LeftMostLeaf
 
-	// Initialize forest distance matrix
-	fd := make([][]float64, i+2)
-	for k := range fd {
-		fd[k] = make([]float64, j+2)
-	}
+	zeroForestRegion(fd, stride, lml_i, i, lml_j, j)
 
-	// Base cases for forest distance with bounds checking
+	// Base cases for forest distance
 	for x := lml_i; x <= i; x++ {
-		// Ensure x is within bounds
-		if x < 0 || x >= len(nodes1) {
-			continue
-		}
-		fd[x+1][lml_j] = fd[x][lml_j] + a.costModel.Delete(nodes1[x])
+		fd[(x+1)*stride+lml_j] = fd[x*stride+lml_j] + a.costModel.Delete(nodes1[x])
 		// Early termination check
-		if fd[x+1][lml_j] > maxDistance {
+		if fd[(x+1)*stride+lml_j] > maxDistance {
 			return
 		}
 	}
 
 	for y := lml_j; y <= j; y++ {
-		// Ensure y is within bounds
-		if y < 0 || y >= len(nodes2) {
-			continue
-		}
-		fd[lml_i][y+1] = fd[lml_i][y] + a.costModel.Insert(nodes2[y])
+		fd[lml_i*stride+y+1] = fd[lml_i*stride+y] + a.costModel.Insert(nodes2[y])
 		// Early termination check
-		if fd[lml_i][y+1] > maxDistance {
+		if fd[lml_i*stride+y+1] > maxDistance {
 			return
 		}
 	}
 
-	// Main computation with bounds checking
+	// Main computation
 	for x := lml_i; x <= i; x++ {
-		// Ensure x is within bounds
-		if x < 0 || x >= len(nodes1) {
-			continue
-		}
+		node1 := nodes1[x]
+		lml_x := node1.LeftMostLeaf
 		for y := lml_j; y <= j; y++ {
-			// Ensure y is within bounds
-			if y < 0 || y >= len(nodes2) {
-				continue
-			}
-			lml_x := nodes1[x].LeftMostLeaf
-			lml_y := nodes2[y].LeftMostLeaf
+			node2 := nodes2[y]
+			lml_y := node2.LeftMostLeaf
 
+			var dist float64
 			if lml_x == lml_i && lml_y == lml_j {
 				// Both nodes are at the leftmost leaf of their respective forests
-				deleteCost := fd[x][y+1] + a.costModel.Delete(nodes1[x])
-				insertCost := fd[x+1][y] + a.costModel.Insert(nodes2[y])
-				renameCost := fd[x][y] + a.costModel.Rename(nodes1[x], nodes2[y])
+				deleteCost := fd[x*stride+y+1] + a.costModel.Delete(node1)
+				insertCost := fd[(x+1)*stride+y] + a.costModel.Insert(node2)
+				renameCost := fd[x*stride+y] + a.costModel.Rename(node1, node2)
 
-				fd[x+1][y+1] = math.Min(deleteCost, math.Min(insertCost, renameCost))
-				td[x+1][y+1] = fd[x+1][y+1]
+				dist = math.Min(deleteCost, math.Min(insertCost, renameCost))
+				td[(x+1)*stride+y+1] = dist
 			} else {
 				// At least one node is not at the leftmost leaf
-				deleteCost := fd[x][y+1] + a.costModel.Delete(nodes1[x])
-				insertCost := fd[x+1][y] + a.costModel.Insert(nodes2[y])
+				deleteCost := fd[x*stride+y+1] + a.costModel.Delete(node1)
+				insertCost := fd[(x+1)*stride+y] + a.costModel.Insert(node2)
 
 				// td[x+1][y+1] was already computed during a previous key root iteration
-				subtreeCost := fd[lml_x][lml_y] + td[x+1][y+1]
+				subtreeCost := fd[lml_x*stride+lml_y] + td[(x+1)*stride+y+1]
 
-				fd[x+1][y+1] = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
+				dist = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
 			}
+			fd[(x+1)*stride+y+1] = dist
 
 			// Early termination check
-			if fd[x+1][y+1] > maxDistance {
+			if dist > maxDistance {
 				return
 			}
 		}
 	}
 }
 
-// computeForestDistance computes the distance between two forests
-func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j int, td [][]float64) {
+// computeForestDistance computes the distance between two forests.
+// td and fd are flat (len(nodes1)+1) x stride matrices with stride = len(nodes2)+1.
+func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j int, td, fd []float64, stride int) {
 	// Bounds checking to prevent array access violations
 	if i < 0 || i >= len(nodes1) || j < 0 || j >= len(nodes2) {
 		return
@@ -817,80 +827,59 @@ func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j i
 	lml_i := nodes1[i].LeftMostLeaf
 	lml_j := nodes2[j].LeftMostLeaf
 
-	// Initialize forest distance matrix
-	fd := make([][]float64, i+2)
-	for k := range fd {
-		fd[k] = make([]float64, j+2)
-	}
+	zeroForestRegion(fd, stride, lml_i, i, lml_j, j)
 
-	// Base cases for forest distance with bounds checking
+	// Base cases for forest distance
 	for x := lml_i; x <= i; x++ {
-		// Ensure x is within bounds
-		if x < 0 || x >= len(nodes1) {
-			continue
-		}
-		fd[x+1][lml_j] = fd[x][lml_j] + a.costModel.Delete(nodes1[x])
+		fd[(x+1)*stride+lml_j] = fd[x*stride+lml_j] + a.costModel.Delete(nodes1[x])
 	}
 
 	for y := lml_j; y <= j; y++ {
-		// Ensure y is within bounds
-		if y < 0 || y >= len(nodes2) {
-			continue
-		}
-		fd[lml_i][y+1] = fd[lml_i][y] + a.costModel.Insert(nodes2[y])
+		fd[lml_i*stride+y+1] = fd[lml_i*stride+y] + a.costModel.Insert(nodes2[y])
 	}
 
-	// Main computation with bounds checking
+	// Main computation
 	for x := lml_i; x <= i; x++ {
-		// Ensure x is within bounds
-		if x < 0 || x >= len(nodes1) {
-			continue
-		}
+		node1 := nodes1[x]
+		lml_x := node1.LeftMostLeaf
 		for y := lml_j; y <= j; y++ {
-			// Ensure y is within bounds
-			if y < 0 || y >= len(nodes2) {
-				continue
-			}
-			lml_x := nodes1[x].LeftMostLeaf
-			lml_y := nodes2[y].LeftMostLeaf
+			node2 := nodes2[y]
+			lml_y := node2.LeftMostLeaf
 
 			if lml_x == lml_i && lml_y == lml_j {
 				// Both nodes are at the leftmost leaf of their respective forests
-				deleteCost := fd[x][y+1] + a.costModel.Delete(nodes1[x])
-				insertCost := fd[x+1][y] + a.costModel.Insert(nodes2[y])
-				renameCost := fd[x][y] + a.costModel.Rename(nodes1[x], nodes2[y])
+				deleteCost := fd[x*stride+y+1] + a.costModel.Delete(node1)
+				insertCost := fd[(x+1)*stride+y] + a.costModel.Insert(node2)
+				renameCost := fd[x*stride+y] + a.costModel.Rename(node1, node2)
 
-				fd[x+1][y+1] = math.Min(deleteCost, math.Min(insertCost, renameCost))
-				td[x+1][y+1] = fd[x+1][y+1]
+				dist := math.Min(deleteCost, math.Min(insertCost, renameCost))
+				fd[(x+1)*stride+y+1] = dist
+				td[(x+1)*stride+y+1] = dist
 			} else {
 				// At least one node is not at the leftmost leaf
-				deleteCost := fd[x][y+1] + a.costModel.Delete(nodes1[x])
-				insertCost := fd[x+1][y] + a.costModel.Insert(nodes2[y])
+				deleteCost := fd[x*stride+y+1] + a.costModel.Delete(node1)
+				insertCost := fd[(x+1)*stride+y] + a.costModel.Insert(node2)
 
 				// td[x+1][y+1] was already computed during a previous key root iteration
-				subtreeCost := fd[lml_x][lml_y] + td[x+1][y+1]
+				subtreeCost := fd[lml_x*stride+lml_y] + td[(x+1)*stride+y+1]
 
-				fd[x+1][y+1] = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
+				fd[(x+1)*stride+y+1] = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
 			}
 		}
 	}
 }
 
-// getPostOrderNodes returns all nodes in post-order traversal
-func (a *APTEDAnalyzer) getPostOrderNodes(root *TreeNode) []*TreeNode {
+// getPostOrderNodes returns all nodes in post-order traversal, reusing buf as
+// backing storage. The traversal emits nodes in the same order PostOrderTraversal
+// assigns PostOrderIDs, so the result is already sorted by PostOrderID.
+func (a *APTEDAnalyzer) getPostOrderNodes(root *TreeNode, buf *[]*TreeNode) []*TreeNode {
+	*buf = (*buf)[:0]
 	if root == nil {
-		return []*TreeNode{}
+		return *buf
 	}
 
-	var nodes []*TreeNode
-	a.postOrderTraversal(root, &nodes)
-
-	// Sort by post-order ID to ensure correct ordering
-	sort.Slice(nodes, func(i, j int) bool {
-		return nodes[i].PostOrderID < nodes[j].PostOrderID
-	})
-
-	return nodes
+	a.postOrderTraversal(root, buf)
+	return *buf
 }
 
 // postOrderTraversal performs post-order traversal

--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ludo-technologies/pyscn/internal/parser"
@@ -23,6 +24,12 @@ type TreeNode struct {
 	PostOrderID  int  // Post-order traversal position
 	LeftMostLeaf int  // Left-most leaf descendant
 	KeyRoot      bool // Whether this node is a key root
+
+	// cachedKeyRoots holds the sorted key roots computed by PrepareTreeForAPTED
+	// (set on the root node only). It lets concurrent readers reuse a prepared
+	// tree without re-running the mutating preparation. Callers that modify the
+	// tree structure must call PrepareTreeForAPTED again to refresh it.
+	cachedKeyRoots []int
 
 	// Optional metadata from original AST
 	OriginalNode *parser.Node
@@ -356,7 +363,8 @@ func computeKeyRootsRecursive(node *TreeNode, keyRoots *[]int, visited map[int]b
 	}
 }
 
-// PrepareTreeForAPTED prepares a tree for APTED algorithm by computing all necessary indices
+// PrepareTreeForAPTED prepares a tree for APTED algorithm by computing all necessary indices.
+// The returned key roots are sorted ascending (leaves before parents) and cached on the root.
 func PrepareTreeForAPTED(root *TreeNode) []int {
 	if root == nil {
 		return []int{}
@@ -370,8 +378,21 @@ func PrepareTreeForAPTED(root *TreeNode) []int {
 
 	// Step 3: Identify key roots
 	keyRoots := ComputeKeyRoots(root)
+	sort.Ints(keyRoots)
 
+	root.cachedKeyRoots = keyRoots
 	return keyRoots
+}
+
+// ensurePreparedForAPTED returns the cached key roots for an already-prepared
+// tree, preparing it once if needed. Reads of an already-prepared tree are
+// safe from multiple goroutines; preparation itself mutates the tree and must
+// happen before concurrent use (the clone detector does this in prepareFragments).
+func ensurePreparedForAPTED(root *TreeNode) []int {
+	if root.cachedKeyRoots == nil {
+		return PrepareTreeForAPTED(root)
+	}
+	return root.cachedKeyRoots
 }
 
 // GetNodeByPostOrderID finds a node by its post-order ID

--- a/internal/analyzer/apted_tree.go
+++ b/internal/analyzer/apted_tree.go
@@ -49,6 +49,15 @@ func (t *TreeNode) AddChild(child *TreeNode) {
 	if child != nil {
 		child.Parent = t
 		t.Children = append(t.Children, child)
+
+		// Mutating the structure invalidates any cached APTED preparation:
+		// post-order IDs of every root above the insertion point are stale,
+		// and the attached subtree's own IDs will be rewritten on the next
+		// preparation of its new root.
+		child.cachedKeyRoots = nil
+		for n := t; n != nil; n = n.Parent {
+			n.cachedKeyRoots = nil
+		}
 	}
 }
 

--- a/internal/analyzer/apted_tree_test.go
+++ b/internal/analyzer/apted_tree_test.go
@@ -1275,3 +1275,24 @@ func TestSkipDocstrings_Integration(t *testing.T) {
 			"Functions with different docstrings should have same tree size when skipping docstrings")
 	})
 }
+
+// TestComputeDistanceAfterTreeMutation verifies that mutating a tree after it
+// has been compared (and its APTED preparation cached) invalidates the cache,
+// so later distance computations see the new structure.
+func TestComputeDistanceAfterTreeMutation(t *testing.T) {
+	analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+	tree1 := NewTreeNode(0, "A")
+	tree1.AddChild(NewTreeNode(1, "B"))
+	tree2 := NewTreeNode(0, "A")
+	tree2.AddChild(NewTreeNode(1, "B"))
+
+	assert.Equal(t, 0.0, analyzer.ComputeDistance(tree1, tree2),
+		"Identical trees should have zero distance")
+
+	// Mutate tree1 after the comparison above cached its key roots
+	tree1.AddChild(NewTreeNode(2, "C"))
+
+	assert.Equal(t, 1.0, analyzer.ComputeDistance(tree1, tree2),
+		"Distance after mutation should reflect the inserted node")
+}

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -2,11 +2,14 @@ package analyzer
 
 import (
 	"bytes"
+	"container/heap"
 	"context"
 	"fmt"
 	"math"
 	"runtime"
 	"sort"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/parser"
@@ -175,6 +178,7 @@ type CloneDetectorConfig struct {
 	BatchSizeLarge     int // Batch size for normal projects
 	BatchSizeSmall     int // Batch size for large projects
 	LargeProjectSize   int // Fragment count threshold for large projects
+	MaxGoroutines      int // Goroutines for parallel pair comparison (0 = all CPUs)
 
 	// Grouping configuration
 	GroupingMode      GroupingMode // デフォルト: GroupingModeConnected
@@ -266,16 +270,14 @@ type CloneDetector struct {
 	cloneGroups       []*CloneGroup
 }
 
-// NewCloneDetector creates a new clone detector with the given configuration
-func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
-	// Create appropriate cost model based on configuration
-	var costModel CostModel
+// buildCloneCostModel creates the APTED cost model for the given configuration.
+func buildCloneCostModel(config *CloneDetectorConfig) CostModel {
 	switch config.CostModelType {
 	case "default":
-		costModel = NewDefaultCostModel()
+		return NewDefaultCostModel()
 	case "python":
 		// Use boilerplate-aware cost model if enabled
-		costModel = NewPythonCostModelWithBoilerplateConfig(
+		return NewPythonCostModelWithBoilerplateConfig(
 			config.IgnoreLiterals,
 			config.IgnoreIdentifiers,
 			config.ReduceBoilerplateSimilarity,
@@ -288,39 +290,41 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 			config.ReduceBoilerplateSimilarity,
 			config.BoilerplateMultiplier,
 		)
-		costModel = NewWeightedCostModel(1.0, 1.0, 0.8, baseCostModel)
+		return NewWeightedCostModel(1.0, 1.0, 0.8, baseCostModel)
 	default:
-		costModel = NewPythonCostModel()
+		return NewPythonCostModel()
 	}
+}
 
-	analyzer := NewAPTEDAnalyzer(costModel)
+// buildCloneClassifier creates the multi-dimensional classifier, or nil if disabled.
+func buildCloneClassifier(config *CloneDetectorConfig) *CloneClassifier {
+	if !config.EnableMultiDimensionalAnalysis {
+		return nil
+	}
+	return NewCloneClassifier(&CloneClassifierConfig{
+		Type1Threshold:         config.Type1Threshold,
+		Type2Threshold:         config.Type2Threshold,
+		Type3Threshold:         config.Type3Threshold,
+		Type4Threshold:         config.Type4Threshold,
+		EnableTextualAnalysis:  config.EnableTextualAnalysis,
+		EnableSemanticAnalysis: config.EnableSemanticAnalysis,
+		EnableDFAAnalysis:      config.EnableDFAAnalysis,
+	})
+}
 
+// NewCloneDetector creates a new clone detector with the given configuration
+func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 	// If DFA is enabled, automatically enable multi-dimensional analysis and semantic analysis
 	if config.EnableDFAAnalysis {
 		config.EnableMultiDimensionalAnalysis = true
 		config.EnableSemanticAnalysis = true
 	}
 
-	// Initialize multi-dimensional classifier if enabled
-	var classifier *CloneClassifier
-	if config.EnableMultiDimensionalAnalysis {
-		classifierConfig := &CloneClassifierConfig{
-			Type1Threshold:         config.Type1Threshold,
-			Type2Threshold:         config.Type2Threshold,
-			Type3Threshold:         config.Type3Threshold,
-			Type4Threshold:         config.Type4Threshold,
-			EnableTextualAnalysis:  config.EnableTextualAnalysis,
-			EnableSemanticAnalysis: config.EnableSemanticAnalysis,
-			EnableDFAAnalysis:      config.EnableDFAAnalysis,
-		}
-		classifier = NewCloneClassifier(classifierConfig)
-	}
-
 	return &CloneDetector{
 		cloneDetectorConfig: *config,
-		analyzer:            analyzer,
+		analyzer:            NewAPTEDAnalyzer(buildCloneCostModel(config)),
 		converter:           NewTreeConverterWithConfig(config.SkipDocstrings),
-		classifier:          classifier,
+		classifier:          buildCloneClassifier(config),
 		textualAnalyzer:     NewTextualSimilarityAnalyzer(),
 		syntacticAnalyzer:   NewSyntacticSimilarityAnalyzer(),
 		featureExtractor:    NewASTFeatureExtractor(),
@@ -328,6 +332,69 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 		clonePairs:          []*ClonePair{},
 		cloneGroups:         []*CloneGroup{},
 	}
+}
+
+// newWorkerDetector returns a shallow copy of cd with private instances of the
+// stateful analyzers (the APTED analyzer's scratch buffers, the classifier's
+// internal analyzers, and the syntactic analyzer's tree converter), so that
+// fragment comparisons can run concurrently across goroutines. Immutable state
+// (config, fragments, textual analyzer, feature extractor) is shared.
+func (cd *CloneDetector) newWorkerDetector() *CloneDetector {
+	w := *cd
+	w.analyzer = NewAPTEDAnalyzer(buildCloneCostModel(&cd.cloneDetectorConfig))
+	w.classifier = buildCloneClassifier(&cd.cloneDetectorConfig)
+	w.syntacticAnalyzer = NewSyntacticSimilarityAnalyzer()
+	return &w
+}
+
+// effectiveWorkers returns how many goroutines to use for n independent work
+// items, honoring MaxGoroutines (0 means use all available CPUs).
+func (cd *CloneDetector) effectiveWorkers(n int) int {
+	workers := cd.cloneDetectorConfig.MaxGoroutines
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+	if workers > n {
+		workers = n
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	return workers
+}
+
+// runParallelIndexed distributes indices [0, n) across workers goroutines.
+// Each goroutine receives a private worker detector plus its worker slot, so
+// callers can keep per-worker state without locking. With workers <= 1 the
+// indices run inline on cd itself.
+func (cd *CloneDetector) runParallelIndexed(ctx context.Context, workers, n int, fn func(wd *CloneDetector, worker, index int)) {
+	if workers <= 1 {
+		for i := 0; i < n; i++ {
+			if isCancelled(ctx) {
+				return
+			}
+			fn(cd, 0, i)
+		}
+		return
+	}
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wd := cd.newWorkerDetector()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= n || isCancelled(ctx) {
+					return
+				}
+				fn(wd, w, i)
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // SetUseLSH enables or disables LSH acceleration for clone detection
@@ -639,7 +706,11 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 		minhashThreshold = 1
 	}
 
+	// Collect deduplicated candidate pairs that survive the cheap pre-filters,
+	// then run the expensive APTED verification in parallel.
+	type candidatePair struct{ a, b int }
 	seenPairs := make(map[[2]int]struct{})
+	var candidates []candidatePair
 	for _, r := range records {
 		if isCancelled(ctx) {
 			break
@@ -668,21 +739,31 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 			}
 
 			// MinHash similarity pre-filter
-			sig1 := sigByIndex[a]
-			sig2 := sigByIndex[b]
-			est := hasher.EstimateJaccardSimilarity(sig1, sig2)
+			est := hasher.EstimateJaccardSimilarity(sigByIndex[a], sigByIndex[b])
 			if est < minhashThreshold {
 				continue
 			}
 
-			// APTED verification
 			if f1.TreeNode == nil || f2.TreeNode == nil {
 				continue
 			}
-			pair := cd.compareFragments(f1, f2)
-			if pair != nil && cd.isSignificantClone(pair) {
-				cd.clonePairs = append(cd.clonePairs, pair)
-			}
+			candidates = append(candidates, candidatePair{a: a, b: b})
+		}
+	}
+
+	// APTED verification on surviving candidates
+	verified := make([]*ClonePair, len(candidates))
+	workers := cd.effectiveWorkers(len(candidates))
+	cd.runParallelIndexed(ctx, workers, len(candidates), func(wd *CloneDetector, _, k int) {
+		c := candidates[k]
+		pair := wd.compareFragments(cd.fragments[c.a], cd.fragments[c.b])
+		if pair != nil && wd.isSignificantClone(pair) {
+			verified[k] = pair
+		}
+	})
+	for _, pair := range verified {
+		if pair != nil {
+			cd.clonePairs = append(cd.clonePairs, pair)
 		}
 	}
 
@@ -733,17 +814,6 @@ func (cd *CloneDetector) prepareFragments() {
 	}
 }
 
-// calculateBatchSize determines the optimal batch size based on fragment count
-func (cd *CloneDetector) calculateBatchSize(fragmentCount int) int {
-	if fragmentCount < cd.cloneDetectorConfig.BatchSizeThreshold {
-		return fragmentCount // No batching needed
-	}
-	if fragmentCount > cd.cloneDetectorConfig.LargeProjectSize {
-		return cd.cloneDetectorConfig.BatchSizeSmall
-	}
-	return cd.cloneDetectorConfig.BatchSizeLarge
-}
-
 // detectClonePairsWithContext detects pairs with context support
 func (cd *CloneDetector) detectClonePairsWithContext(ctx context.Context) {
 	n := len(cd.fragments)
@@ -753,112 +823,74 @@ func (cd *CloneDetector) detectClonePairsWithContext(ctx context.Context) {
 		return
 	}
 
-	// Determine if batching is needed based on fragment count and estimated pairs
-	estimatedPairs := (n * (n - 1)) / 2
-	needsBatching := n > cd.cloneDetectorConfig.BatchSizeThreshold || estimatedPairs > cd.cloneDetectorConfig.MaxClonePairs
-
-	if needsBatching {
-		batchSize := cd.calculateBatchSize(n)
-		cd.detectClonePairsWithBatchingContext(ctx, cd.cloneDetectorConfig.MaxClonePairs, batchSize)
-	} else {
-		cd.detectClonePairsStandardWithContext(ctx)
-	}
-
-	// Sort and limit final results
-	cd.limitAndSortClonePairs(cd.cloneDetectorConfig.MaxClonePairs)
-}
-
-// detectClonePairsStandardWithContext uses standard approach with context
-func (cd *CloneDetector) detectClonePairsStandardWithContext(ctx context.Context) {
-	n := len(cd.fragments)
-	const checkInterval = 10 // Check context every 10 comparisons
-
-	for i := 0; i < n; i++ {
-		for j := i + 1; j < n; j++ {
-
-			// Check for cancellation periodically (every 10 comparisons)
-			if (i*n+j)%checkInterval == 0 && isCancelled(ctx) {
-				return
-			}
-			fragment1 := cd.fragments[i]
-			fragment2 := cd.fragments[j]
-
-			// Skip if both fragments are from the same location or overlap in the same file
-			if cd.isOverlappingLocation(fragment1.Location, fragment2.Location) {
-				continue
-			}
-
-			// Compute similarity
-			pair := cd.compareFragments(fragment1, fragment2)
-			if pair != nil && cd.isSignificantClone(pair) {
-				cd.clonePairs = append(cd.clonePairs, pair)
-			}
-		}
-	}
-}
-
-// detectClonePairsWithBatchingContext processes batches with context support
-func (cd *CloneDetector) detectClonePairsWithBatchingContext(ctx context.Context, maxPairs, batchSize int) {
-	n := len(cd.fragments)
-
-	// Ensure maxPairs has a reasonable minimum value
+	maxPairs := cd.cloneDetectorConfig.MaxClonePairs
 	if maxPairs <= 0 {
 		maxPairs = 10000
 	}
-	if batchSize <= 0 {
-		batchSize = 100
-	}
 
-	// Priority queue to keep only the best pairs
-	topPairs := make([]*ClonePair, 0, maxPairs)
-	minSimilarity := cd.cloneDetectorConfig.Type4Threshold // Use the lowest threshold as minimum
+	cd.detectClonePairsParallel(ctx, maxPairs)
 
-	// Process in batches to limit memory usage
-	for batchStart := 0; batchStart < n; batchStart += batchSize {
-		// Check for cancellation at batch start
-		if isCancelled(ctx) {
-			cd.clonePairs = topPairs
-			return
-		}
-		batchEnd := batchStart + batchSize
-		if batchEnd > n {
-			batchEnd = n
-		}
+	// Sort and limit final results
+	cd.limitAndSortClonePairs(maxPairs)
+}
 
-		// Process current batch against all previous and current fragments
-		for i := batchStart; i < batchEnd; i++ {
-			// Compare with fragments in current batch
-			for j := i + 1; j < batchEnd; j++ {
-				if pair := cd.tryCreateClonePair(i, j, minSimilarity); pair != nil {
-					topPairs = cd.addPairWithLimit(topPairs, pair, maxPairs)
-					// Update minimum similarity threshold
-					if len(topPairs) >= maxPairs {
-						minSimilarity = topPairs[len(topPairs)-1].Similarity
-					}
-				}
+// clonePairMinHeap is a min-heap on Similarity: the root is the worst retained
+// pair, so a better candidate can replace it in O(log n). Used to keep the
+// best maxPairs candidates per worker with bounded memory.
+type clonePairMinHeap []*ClonePair
+
+func (h clonePairMinHeap) Len() int           { return len(h) }
+func (h clonePairMinHeap) Less(i, j int) bool { return h[i].Similarity < h[j].Similarity }
+func (h clonePairMinHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *clonePairMinHeap) Push(x any)        { *h = append(*h, x.(*ClonePair)) }
+func (h *clonePairMinHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
+}
+
+// detectClonePairsParallel enumerates all unordered fragment pairs row by row,
+// fanning rows out across workers. Each worker keeps a bounded min-heap of its
+// best pairs, so memory stays O(workers * maxPairs) regardless of input size.
+// The union of per-worker top-maxPairs always contains the global top-maxPairs.
+func (cd *CloneDetector) detectClonePairsParallel(ctx context.Context, maxPairs int) {
+	n := len(cd.fragments)
+	workers := cd.effectiveWorkers(n - 1)
+	heaps := make([]clonePairMinHeap, workers)
+
+	cd.runParallelIndexed(ctx, workers, n, func(wd *CloneDetector, worker, i int) {
+		h := &heaps[worker]
+		for j := i + 1; j < n; j++ {
+			// Once the heap is full, the worst retained similarity becomes a
+			// pruning floor for this worker.
+			floor := 0.0
+			if h.Len() >= maxPairs {
+				floor = (*h)[0].Similarity
 			}
-
-			// Compare with all previous fragments
-			for j := 0; j < batchStart; j++ {
-				if pair := cd.tryCreateClonePair(i, j, minSimilarity); pair != nil {
-					topPairs = cd.addPairWithLimit(topPairs, pair, maxPairs)
-					// Update minimum similarity threshold
-					if len(topPairs) >= maxPairs {
-						minSimilarity = topPairs[len(topPairs)-1].Similarity
-					}
-				}
+			pair := wd.tryCreateClonePair(i, j, floor)
+			if pair == nil {
+				continue
+			}
+			if h.Len() < maxPairs {
+				heap.Push(h, pair)
+			} else if pair.Similarity > (*h)[0].Similarity {
+				(*h)[0] = pair
+				heap.Fix(h, 0)
 			}
 		}
+	})
 
-		// Periodic garbage collection hint for large batches
-		if batchStart%5000 == 0 {
-			// Force garbage collection to prevent memory buildup
-			runtime.GC()
-		}
+	total := 0
+	for w := range heaps {
+		total += heaps[w].Len()
 	}
-
-	// Replace clone pairs with the best ones found
-	cd.clonePairs = topPairs
+	merged := make([]*ClonePair, 0, total)
+	for w := range heaps {
+		merged = append(merged, heaps[w]...)
+	}
+	cd.clonePairs = merged
 }
 
 // shouldCompareFragments performs early filtering to determine if two fragments should be compared
@@ -1144,31 +1176,6 @@ func (cd *CloneDetector) tryCreateClonePair(i, j int, minSimilarity float64) *Cl
 		return pair
 	}
 	return nil
-}
-
-// addPairWithLimit adds a pair to the collection while maintaining size limit
-func (cd *CloneDetector) addPairWithLimit(pairs []*ClonePair, newPair *ClonePair, maxPairs int) []*ClonePair {
-	// If under limit, just add
-	if len(pairs) < maxPairs {
-		pairs = append(pairs, newPair)
-		// Keep sorted by similarity (descending)
-		sort.Slice(pairs, func(i, j int) bool {
-			return pairs[i].Similarity > pairs[j].Similarity
-		})
-		return pairs
-	}
-
-	// If at limit, check if new pair is better than the worst
-	if newPair.Similarity > pairs[len(pairs)-1].Similarity {
-		// Replace worst pair
-		pairs[len(pairs)-1] = newPair
-		// Re-sort to maintain order
-		sort.Slice(pairs, func(i, j int) bool {
-			return pairs[i].Similarity > pairs[j].Similarity
-		})
-	}
-
-	return pairs
 }
 
 // limitAndSortClonePairs ensures final results are sorted and limited

--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -706,11 +706,37 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 		minhashThreshold = 1
 	}
 
-	// Collect deduplicated candidate pairs that survive the cheap pre-filters,
-	// then run the expensive APTED verification in parallel.
+	// Stream deduplicated candidate pairs that survive the cheap pre-filters
+	// to a pool of workers for the expensive APTED verification. Streaming
+	// keeps memory bounded: the full candidate list is never materialized.
 	type candidatePair struct{ a, b int }
 	seenPairs := make(map[[2]int]struct{})
-	var candidates []candidatePair
+
+	workers := cd.effectiveWorkers(len(records))
+	candCh := make(chan candidatePair, 4*workers)
+	verified := make([][]*ClonePair, workers)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wd := cd
+			if workers > 1 {
+				wd = cd.newWorkerDetector()
+			}
+			for c := range candCh {
+				// Keep draining on cancellation so the producer never blocks.
+				if isCancelled(ctx) {
+					continue
+				}
+				pair := wd.compareFragments(cd.fragments[c.a], cd.fragments[c.b])
+				if pair != nil && wd.isSignificantClone(pair) {
+					verified[w] = append(verified[w], pair)
+				}
+			}
+		}()
+	}
+
 	for _, r := range records {
 		if isCancelled(ctx) {
 			break
@@ -747,24 +773,14 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 			if f1.TreeNode == nil || f2.TreeNode == nil {
 				continue
 			}
-			candidates = append(candidates, candidatePair{a: a, b: b})
+			candCh <- candidatePair{a: a, b: b}
 		}
 	}
+	close(candCh)
+	wg.Wait()
 
-	// APTED verification on surviving candidates
-	verified := make([]*ClonePair, len(candidates))
-	workers := cd.effectiveWorkers(len(candidates))
-	cd.runParallelIndexed(ctx, workers, len(candidates), func(wd *CloneDetector, _, k int) {
-		c := candidates[k]
-		pair := wd.compareFragments(cd.fragments[c.a], cd.fragments[c.b])
-		if pair != nil && wd.isSignificantClone(pair) {
-			verified[k] = pair
-		}
-	})
-	for _, pair := range verified {
-		if pair != nil {
-			cd.clonePairs = append(cd.clonePairs, pair)
-		}
+	for _, pairs := range verified {
+		cd.clonePairs = append(cd.clonePairs, pairs...)
 	}
 
 	// Finalize results


### PR DESCRIPTION
## Summary

Clone detection (Type-3 APTED path) was slow for two compounding reasons: the forest-distance DP matrix was re-allocated for **every key-root pair** (137,607 allocs / 65MB per medium-tree comparison), and the pairwise comparison loop was single-threaded. The allocation pressure is also why a previous parallelization attempt regressed: concurrent workers saturated the allocator and GC instead of doing work.

This PR fixes the allocations first, then parallelizes on top.

### APTED allocation fixes (`apted.go`, `apted_tree.go`)

- Reuse flat `td`/`fd` scratch buffers on `APTEDAnalyzer` (grow-only), zeroing only the region each key-root computation touches. `APTEDAnalyzer` is now documented as single-goroutine; workers each get their own.
- Drop the redundant `sort.Slice` in `getPostOrderNodes` — the traversal already emits nodes in post-order.
- Remove the `cache` field that was allocated on every `ComputeDistance` but never read.
- Cache sorted key roots on the tree root (`cachedKeyRoots`), so `ComputeDistance` no longer re-runs the **mutating** `PrepareTreeForAPTED` on shared `TreeNode`s for every comparison. This was both wasted work and the one data race blocking parallelism (caught by `-race`).
- Note: the large-tree heuristic's key-root cap (100) now keeps the **largest** post-order IDs (root + upper structure) instead of the first 100 in pre-order; this path is an explicitly bounded approximation and all validation tests pass.

### Parallelization (`clone_detector.go`)

- Unify the standard/batched pair loops into a single row-parallel top-k implementation: rows are distributed via an atomic counter, each worker owns a private APTED analyzer/classifier and a bounded min-heap (`maxPairs`), merged once at the end — no locks in the hot path. The union of per-worker top-k always contains the global top-k.
- LSH path: candidate enumeration (cheap) stays sequential; APTED verification fans out the same way.
- Remove the explicit `runtime.GC()` calls and the O(k log k)-per-insert `addPairWithLimit` full sort.
- New `CloneDetectorConfig.MaxGoroutines` (0 = all CPUs, the default).
- Side effect of unification: when `SimilarityThreshold < Type4Threshold`, the old batched path silently dropped pairs between the two thresholds while the standard path kept them; behavior now matches the standard path everywhere.

## Results

Identical detection output pre/post — verified down to JSON pair counts (adk-python: 699 clones / 1,323 pairs / 219 groups on both binaries).

Wall-clock, `analyze --select clones`, Apple M4 (10 cores):

| Repo | Files | Before | After | Speedup |
|---|---|---|---|---|
| pydantic | 398 | 81.1s | **8.1s** | **10.0x** |
| adk-python | 1,110 | 88.3s | **12.0s** | **7.4x** |
| requests | small | 0.47s | 0.13s | 3.5x |

Total CPU time also drops ~3x (pydantic: 219s → 65s user), so this is faster even on a single core, with parallel scaling on top (CPU utilization ~270% → ~800%).

Microbenchmarks:

| Benchmark | Before | After |
|---|---|---|
| `BenchmarkAPTED_MediumTrees` | 8.52ms, 137,607 allocs, 65MB/op | **1.40ms, 0 allocs, 97B/op** |
| `BenchmarkCloneDetector_DetectClones/144/standard` | 1.29s | **217ms** |
| `BenchmarkCloneDetector_DetectClones/144/lsh` | 95.8ms | **20.7ms** |

## Testing

- `go test ./...` — all 12 packages pass
- `go test -race` on the clone/APTED/similarity tests — clean (the race it initially caught is fixed by the key-root cache)
- `make lint` — 0 issues