### PR TITLE
fix(analyze): calibrate progress bar with actual task timings

### DIFF
--- a/app/analysis_progress.go
+++ b/app/analysis_progress.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"maps"
+	"math"
+	"sync"
+	"time"
+)
+
+// analysisProgressTracker estimates overall progress for concurrently running
+// analysis tasks. Tasks all start together, so the projected wall time is the
+// completion time of the largest still-pending task. Each task completion is
+// both a hard checkpoint and a calibration sample: the observed ratio of
+// actual to estimated time rescales the projection for the remaining tasks.
+type analysisProgressTracker struct {
+	mu          sync.Mutex
+	start       time.Time
+	pending     map[string]float64 // task name -> calibrated estimated seconds
+	doneWall    float64            // sum of completion wall times of finished tasks
+	doneEst     float64            // sum of estimated seconds of finished tasks
+	durations   map[string]float64 // task name -> completion wall time in seconds
+	lastPercent int
+}
+
+// minTimingSignal is the minimum accumulated estimated-seconds of completed
+// tasks before observed timings override the prior estimates; ratios derived
+// from near-instant tasks are too noisy to extrapolate from.
+const minTimingSignal = 0.3
+
+func newAnalysisProgressTracker(estimatedSeconds map[string]float64) *analysisProgressTracker {
+	pending := make(map[string]float64, len(estimatedSeconds))
+	for name, est := range estimatedSeconds {
+		if est < 0.05 {
+			est = 0.05
+		}
+		pending[name] = est
+	}
+	return &analysisProgressTracker{
+		start:     time.Now(),
+		pending:   pending,
+		durations: make(map[string]float64, len(estimatedSeconds)),
+	}
+}
+
+// TaskCompleted records that the named task finished, capturing its wall-clock
+// completion time as a calibration sample for the remaining tasks.
+func (t *analysisProgressTracker) TaskCompleted(name string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	est, ok := t.pending[name]
+	if !ok {
+		return
+	}
+	delete(t.pending, name)
+
+	wall := time.Since(t.start).Seconds()
+	t.durations[name] = wall
+	t.doneWall += wall
+	t.doneEst += est
+}
+
+// CompletedDurations returns the observed wall-clock completion time per task.
+func (t *analysisProgressTracker) CompletedDurations() map[string]float64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	out := make(map[string]float64, len(t.durations))
+	maps.Copy(out, t.durations)
+	return out
+}
+
+// Percent returns the current progress in [0, 99]. The value is monotonic; it
+// never reaches 100 here because completion is signalled explicitly by the
+// caller once all tasks have actually finished.
+func (t *analysisProgressTracker) Percent() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if len(t.pending) == 0 {
+		t.lastPercent = 99
+		return 99
+	}
+
+	// Rescale remaining estimates by the observed actual/estimated ratio once
+	// enough completed work has accumulated to be a meaningful sample.
+	ratio := 1.0
+	if t.doneEst >= minTimingSignal {
+		ratio = t.doneWall / t.doneEst
+		if ratio < 0.1 {
+			ratio = 0.1
+		} else if ratio > 20 {
+			ratio = 20
+		}
+	}
+
+	maxPending := 0.0
+	for _, est := range t.pending {
+		if est > maxPending {
+			maxPending = est
+		}
+	}
+	projected := maxPending * ratio
+	if projected < 0.1 {
+		projected = 0.1
+	}
+
+	elapsed := time.Since(t.start).Seconds()
+	frac := elapsed / projected
+	var percent float64
+	if frac <= 1.0 {
+		percent = frac * 95.0
+	} else {
+		// Past the projection: approach 99% asymptotically instead of
+		// freezing, so an underestimate still shows visible movement.
+		percent = 95.0 + 4.0*(1.0-math.Exp(-(frac-1.0)/0.5))
+	}
+
+	p := min(max(int(percent), t.lastPercent), 99)
+	t.lastPercent = p
+	return p
+}
+
+// applyTimingFactors scales estimated task durations by per-task calibration
+// factors observed in previous runs. Tasks without a recorded factor keep
+// their formula-based estimate.
+func applyTimingFactors(estimatedSeconds, factors map[string]float64) map[string]float64 {
+	calibrated := make(map[string]float64, len(estimatedSeconds))
+	for name, est := range estimatedSeconds {
+		if f, ok := factors[name]; ok && f > 0 {
+			est *= f
+		}
+		calibrated[name] = est
+	}
+	return calibrated
+}

--- a/app/analysis_progress_test.go
+++ b/app/analysis_progress_test.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProgressTrackerAdvancesWithElapsedTime(t *testing.T) {
+	tracker := newAnalysisProgressTracker(map[string]float64{
+		"small": 1.0,
+		"large": 10.0,
+	})
+	// Simulate 5s elapsed: projection is the largest pending task (10s)
+	tracker.start = time.Now().Add(-5 * time.Second)
+
+	p := tracker.Percent()
+	// 5/10 of the projection at 95% scale => ~47%
+	if p < 40 || p > 55 {
+		t.Errorf("expected progress around 47%%, got %d%%", p)
+	}
+}
+
+func TestProgressTrackerRecalibratesOnTaskCompletion(t *testing.T) {
+	tracker := newAnalysisProgressTracker(map[string]float64{
+		"small": 1.0,
+		"large": 10.0,
+	})
+	// The small task (estimated 1s) actually took 3s => machine is 3x slower
+	tracker.start = time.Now().Add(-3 * time.Second)
+	tracker.TaskCompleted("small")
+
+	p := tracker.Percent()
+	// Projection rescales to 10 * 3 = 30s; at 3s elapsed => ~9.5%
+	if p > 15 {
+		t.Errorf("expected recalibrated progress below 15%%, got %d%%", p)
+	}
+}
+
+func TestProgressTrackerApproachesCapOnOverrun(t *testing.T) {
+	tracker := newAnalysisProgressTracker(map[string]float64{"only": 1.0})
+	// Elapsed time far beyond the 1s estimate
+	tracker.start = time.Now().Add(-30 * time.Second)
+
+	p := tracker.Percent()
+	if p < 95 || p > 99 {
+		t.Errorf("expected progress in [95, 99] on overrun, got %d%%", p)
+	}
+}
+
+func TestProgressTrackerIsMonotonic(t *testing.T) {
+	tracker := newAnalysisProgressTracker(map[string]float64{
+		"small": 1.0,
+		"large": 10.0,
+	})
+	tracker.start = time.Now().Add(-8 * time.Second)
+	before := tracker.Percent()
+
+	// Completing the small task triples the projection, which would lower the
+	// raw time fraction; the displayed value must not move backwards
+	tracker.TaskCompleted("small")
+	after := tracker.Percent()
+
+	if after < before {
+		t.Errorf("progress moved backwards: %d%% -> %d%%", before, after)
+	}
+}
+
+func TestProgressTrackerReports99WhenAllTasksDone(t *testing.T) {
+	tracker := newAnalysisProgressTracker(map[string]float64{"only": 1.0})
+	tracker.TaskCompleted("only")
+
+	if p := tracker.Percent(); p != 99 {
+		t.Errorf("expected 99%% when all tasks completed, got %d%%", p)
+	}
+}
+
+func TestProgressTrackerIgnoresUnknownTask(t *testing.T) {
+	tracker := newAnalysisProgressTracker(map[string]float64{"only": 1.0})
+	tracker.TaskCompleted("nonexistent")
+
+	if d := tracker.CompletedDurations(); len(d) != 0 {
+		t.Errorf("expected no recorded durations, got %v", d)
+	}
+}
+
+func TestApplyTimingFactors(t *testing.T) {
+	estimates := map[string]float64{"a": 2.0, "b": 4.0}
+	factors := map[string]float64{"a": 3.0}
+
+	calibrated := applyTimingFactors(estimates, factors)
+
+	if calibrated["a"] != 6.0 {
+		t.Errorf("expected task a calibrated to 6.0, got %f", calibrated["a"])
+	}
+	if calibrated["b"] != 4.0 {
+		t.Errorf("expected task b unchanged at 4.0, got %f", calibrated["b"])
+	}
+}

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -182,6 +182,16 @@ func (b *AnalyzeUseCaseBuilder) Build() (*AnalyzeUseCase, error) {
 	}, nil
 }
 
+// Task names used both for display and as keys for progress estimation
+const (
+	taskNameComplexity = "Complexity Analysis"
+	taskNameDeadCode   = "Dead Code Detection"
+	taskNameClones     = "Clone Detection"
+	taskNameCBO        = "Class Coupling (CBO)"
+	taskNameLCOM       = "Class Cohesion (LCOM)"
+	taskNameSystem     = "System Analysis"
+)
+
 // AnalysisTask represents a single analysis task
 type AnalysisTask struct {
 	Name    string
@@ -226,8 +236,9 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 		return nil, fmt.Errorf("no Python files found in the specified paths")
 	}
 
-	// Calculate estimated time based on file count and enabled analyses
-	estimatedTime := uc.calculateEstimatedTime(len(files), useCaseCfg, executionCfg)
+	// Estimate per-task durations from file count, then calibrate with actual
+	// timings recorded by previous runs on this project (if any)
+	estimatedSeconds := uc.estimateTaskSeconds(len(files), useCaseCfg, executionCfg)
 
 	var snapshot *service.ProjectSnapshot
 	if uc.needsProjectSnapshot(useCaseCfg) {
@@ -236,11 +247,14 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 		})
 	}
 
-	// Start unified progress tracking with time-based estimation
+	// Start unified progress tracking; task completions feed back into the
+	// estimate so the bar recalibrates to actual machine/codebase speed
+	var tracker *analysisProgressTracker
 	var progressDone chan struct{}
 	if uc.progressManager != nil {
+		tracker = newAnalysisProgressTracker(applyTimingFactors(estimatedSeconds, service.LoadAnalysisTimingFactors()))
 		uc.progressManager.Initialize(100) // 100% based progress
-		progressDone = uc.startTimeBasedProgressUpdater(estimatedTime)
+		progressDone = uc.startProgressUpdater(tracker)
 	}
 
 	// Create analysis tasks
@@ -259,6 +273,9 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 			result, err := t.Execute(ctx)
 			t.Result = result
 			t.Error = err
+			if tracker != nil {
+				tracker.TaskCompleted(t.Name)
+			}
 		}(task)
 	}
 
@@ -270,6 +287,11 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 		close(progressDone)
 		uc.progressManager.Update(100, 100)
 		uc.progressManager.Complete(true)
+	}
+
+	// Persist observed timings to improve the initial estimate of future runs
+	if tracker != nil {
+		service.UpdateAnalysisTimingFactors(estimatedSeconds, tracker.CompletedDurations())
 	}
 
 	// Check for errors
@@ -305,7 +327,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	// Complexity analysis task
 	if uc.complexityUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
-			Name:    "Complexity Analysis",
+			Name:    taskNameComplexity,
 			Enabled: !config.SkipComplexity,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := uc.buildComplexityTaskRequest(config, files, executionCfg)
@@ -317,7 +339,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	// Dead code analysis task
 	if uc.deadCodeUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
-			Name:    "Dead Code Detection",
+			Name:    taskNameDeadCode,
 			Enabled: !config.SkipDeadCode,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.DeadCodeRequest{
@@ -348,7 +370,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	// Clone detection task
 	if uc.cloneUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
-			Name:    "Clone Detection",
+			Name:    taskNameClones,
 			Enabled: !config.SkipClones,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := uc.buildCloneTaskRequest(config, files)
@@ -360,7 +382,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	// CBO analysis task
 	if uc.cboUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
-			Name:    "Class Coupling (CBO)",
+			Name:    taskNameCBO,
 			Enabled: !config.SkipCBO,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.CBORequest{
@@ -388,7 +410,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	// LCOM analysis task
 	if uc.lcomUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
-			Name:    "Class Cohesion (LCOM)",
+			Name:    taskNameLCOM,
 			Enabled: !config.SkipLCOM,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.LCOMRequest{
@@ -411,7 +433,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 	// System analysis task
 	if uc.systemUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
-			Name:    "System Analysis",
+			Name:    taskNameSystem,
 			Enabled: !config.SkipSystem,
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.SystemAnalysisRequest{
@@ -657,30 +679,33 @@ func (uc *AnalyzeUseCase) loadExecutionConfig(configPath string, paths []string)
 	return uc.configLoader.LoadAnalyzeExecutionConfig(configPath, targetPath)
 }
 
-// calculateEstimatedTime estimates the total analysis time based on file count and enabled analyses
-func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUseCaseConfig, executionCfg domain.AnalyzeExecutionConfig) float64 {
+// estimateTaskSeconds estimates the duration of each enabled analysis task in
+// seconds, keyed by task name. The formulas capture how each analysis scales
+// with file count; absolute accuracy comes from calibration against actual
+// timings (see applyTimingFactors and UpdateAnalysisTimingFactors).
+func (uc *AnalyzeUseCase) estimateTaskSeconds(fileCount int, config AnalyzeUseCaseConfig, executionCfg domain.AnalyzeExecutionConfig) map[string]float64 {
 	n := float64(fileCount)
-	totalTime := 0.0
+	estimates := map[string]float64{}
 
 	// Linear analyses (fast)
-	if !config.SkipComplexity {
-		totalTime += 0.01 * n // Complexity: ~0.01s per file
+	if uc.complexityUseCase != nil && !config.SkipComplexity {
+		estimates[taskNameComplexity] = 0.01 * n // Complexity: ~0.01s per file
 	}
-	if !config.SkipDeadCode {
-		totalTime += 0.01 * n // Dead Code: ~0.01s per file
+	if uc.deadCodeUseCase != nil && !config.SkipDeadCode {
+		estimates[taskNameDeadCode] = 0.01 * n // Dead Code: ~0.01s per file
 	}
-	if !config.SkipCBO {
-		totalTime += 0.01 * n // CBO: ~0.01s per file
+	if uc.cboUseCase != nil && !config.SkipCBO {
+		estimates[taskNameCBO] = 0.01 * n // CBO: ~0.01s per file
 	}
-	if !config.SkipLCOM {
-		totalTime += 0.01 * n // LCOM: ~0.01s per file
+	if uc.lcomUseCase != nil && !config.SkipLCOM {
+		estimates[taskNameLCOM] = 0.01 * n // LCOM: ~0.01s per file
 	}
-	if !config.SkipSystem {
-		totalTime += 0.02 * n // System: ~0.02s per file (slightly heavier)
+	if uc.systemUseCase != nil && !config.SkipSystem {
+		estimates[taskNameSystem] = 0.02 * n // System: ~0.02s per file (slightly heavier)
 	}
 
 	// Clone detection - account for LSH configuration
-	if !config.SkipClones {
+	if uc.cloneUseCase != nil && !config.SkipClones {
 		// Estimate fragment count (empirical average: ~5.0 fragments per file)
 		estimatedFragments := n * 5.0
 
@@ -695,30 +720,21 @@ func (uc *AnalyzeUseCase) calculateEstimatedTime(fileCount int, config AnalyzeUs
 		if useLSH {
 			// LSH enabled: Near-linear O(n^1.1) complexity
 			// LSH candidate filtering significantly reduces the number of APTED comparisons
-			// Exponent 1.1 and coefficient 0.01 are empirically tuned
-			// Note: Actual performance varies by environment and code characteristics
-			totalTime += 0.01 * math.Pow(estimatedFragments, 1.1)
+			estimates[taskNameClones] = 0.01 * math.Pow(estimatedFragments, 1.1)
 		} else {
 			// LSH disabled: Quadratic O(n²) complexity - full pairwise comparison
 			// All fragment pairs are compared via expensive APTED tree edit distance
-			// This becomes the bottleneck for codebases with many fragments
-			// Coefficient 0.001 accounts for fragment count estimation
-			totalTime += 0.001 * estimatedFragments * estimatedFragments
+			estimates[taskNameClones] = 0.001 * estimatedFragments * estimatedFragments
 		}
 	}
 
-	// Minimum time to avoid division by zero
-	if totalTime < 0.1 {
-		totalTime = 0.1
-	}
-
-	return totalTime
+	return estimates
 }
 
-// startTimeBasedProgressUpdater starts a background goroutine that updates progress based on elapsed time
-func (uc *AnalyzeUseCase) startTimeBasedProgressUpdater(estimatedTime float64) chan struct{} {
+// startProgressUpdater starts a background goroutine that periodically renders
+// the tracker's current progress estimate
+func (uc *AnalyzeUseCase) startProgressUpdater(tracker *analysisProgressTracker) chan struct{} {
 	done := make(chan struct{})
-	startTime := time.Now()
 
 	// Start progress bar
 	uc.progressManager.Start()
@@ -730,14 +746,7 @@ func (uc *AnalyzeUseCase) startTimeBasedProgressUpdater(estimatedTime float64) c
 		for {
 			select {
 			case <-ticker.C:
-				elapsed := time.Since(startTime).Seconds()
-				// Progress increases with elapsed time, but caps at 99%
-				// (we'll set it to 100% when tasks actually complete)
-				progress := int((elapsed / estimatedTime) * 100)
-				if progress > 99 {
-					progress = 99
-				}
-				uc.progressManager.Update(progress, 100)
+				uc.progressManager.Update(tracker.Percent(), 100)
 
 			case <-done:
 				return

--- a/service/timing_cache.go
+++ b/service/timing_cache.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const analysisTimingsVersion = 1
+
+// analysisTimings stores per-task calibration factors (actual seconds divided by
+// estimated seconds) observed in previous runs for a given project directory.
+type analysisTimings struct {
+	Version int                `json:"version"`
+	Factors map[string]float64 `json:"factors"`
+}
+
+// analysisTimingsPath returns the per-project cache file path, keyed by the
+// current working directory so repeated runs on the same project share timings.
+func analysisTimingsPath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256([]byte(cwd))
+	name := hex.EncodeToString(sum[:8]) + ".json"
+	return filepath.Join(cacheDir, "pyscn", "timings", name), nil
+}
+
+// LoadAnalysisTimingFactors returns calibration factors recorded by previous
+// runs on this project. Returns an empty map when no usable cache exists.
+// Disabled under `go test` so test runs neither read nor pollute the cache.
+func LoadAnalysisTimingFactors() map[string]float64 {
+	if testing.Testing() {
+		return map[string]float64{}
+	}
+	path, err := analysisTimingsPath()
+	if err != nil {
+		return map[string]float64{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]float64{}
+	}
+	var timings analysisTimings
+	if err := json.Unmarshal(data, &timings); err != nil || timings.Version != analysisTimingsVersion || timings.Factors == nil {
+		return map[string]float64{}
+	}
+	return timings.Factors
+}
+
+// UpdateAnalysisTimingFactors records observed task durations against their
+// estimates, smoothing with previously stored factors. Failures are ignored:
+// the cache only improves progress estimation and must never affect analysis.
+func UpdateAnalysisTimingFactors(estimatedSeconds, actualSeconds map[string]float64) {
+	if testing.Testing() {
+		return
+	}
+	factors := LoadAnalysisTimingFactors()
+	for name, est := range estimatedSeconds {
+		actual, ok := actualSeconds[name]
+		if !ok || est <= 0 || actual <= 0 {
+			continue
+		}
+		factor := clampTimingFactor(actual / est)
+		if prev, ok := factors[name]; ok {
+			// Exponential moving average to absorb run-to-run noise
+			factor = 0.5*prev + 0.5*factor
+		}
+		factors[name] = factor
+	}
+	if len(factors) == 0 {
+		return
+	}
+
+	path, err := analysisTimingsPath()
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	data, err := json.Marshal(analysisTimings{Version: analysisTimingsVersion, Factors: factors})
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
+}
+
+// clampTimingFactor bounds a calibration factor so a single pathological run
+// (sleeping laptop, antivirus scan) cannot poison future estimates.
+func clampTimingFactor(f float64) float64 {
+	if f < 0.05 {
+		return 0.05
+	}
+	if f > 50 {
+		return 50
+	}
+	return f
+}


### PR DESCRIPTION
## Problem

The `analyze` progress bar was purely cosmetic and frequently diverged from reality:

- A background ticker interpolated `elapsed / estimatedTime` from **hardcoded per-file coefficients** (`calculateEstimatedTime`), and none of the analysis tasks ever reported progress back.
- The coefficients are off by 20x+ depending on machine speed and codebase characteristics (verified empirically: on this machine all calibration factors clamp at the 0.05 floor for the testdata fixtures).
- Result: the bar either froze at 99% for a long time (underestimate) or crawled and then jumped straight to 100% (overestimate).

## Approach

Keep it light — no changes inside the analyzers. Two mechanisms:

**1. Task-completion checkpoints with live recalibration** (`app/analysis_progress.go`)

Tasks all start concurrently, so projected wall time is modeled as the completion time of the largest still-pending task. Each task completion is both a checkpoint and a calibration sample: the observed actual/estimated ratio rescales the projection for the remaining tasks. The fast linear analyses (complexity, dead code, CBO, LCOM) finish within the first seconds and immediately recalibrate the estimate for the dominant clone-detection task to actual machine/codebase speed.

- On overrun the bar approaches 99% asymptotically instead of freezing.
- Displayed progress is monotonic (recalibration never moves the bar backwards).

**2. Per-project timing cache** (`service/timing_cache.go`)

On completion, per-task calibration factors (actual/estimated, EMA-smoothed, clamped to [0.05, 50]) are persisted under the user cache dir keyed by hashed project directory. Subsequent runs start with an accurate initial estimate instead of formula defaults. Cache I/O is best-effort (failures never affect analysis) and disabled under `go test` via `testing.Testing()` to keep test runs hermetic.

The existing formula-based estimates are retained as relative shape priors — they capture how each task scales with file count (including the LSH vs. pairwise clone complexity split); absolute accuracy now comes from calibration.

## Changes

- `app/analysis_progress.go` (new): `analysisProgressTracker` + `applyTimingFactors`
- `service/timing_cache.go` (new): load/update of per-project calibration factors
- `app/analyze_usecase.go`: `calculateEstimatedTime` → per-task `estimateTaskSeconds` map; task goroutines call `tracker.TaskCompleted()`; task names extracted to constants shared between display and estimation keys
- `app/analysis_progress_test.go` (new): 7 unit tests (advancement, recalibration, overrun asymptote, monotonicity, all-done, unknown task, factor application)

## Testing

- `go test ./app/ ./service/` — pass
- `make lint` — 0 issues
- Ran the built binary on `testdata/python` twice: first run writes the calibration cache, second run loads and EMA-updates it; tests no longer write to the user cache dir

Note: project snapshot construction (parsing) before the bar starts is still outside the tracked window — intentionally out of scope.