### PR TITLE
docs: add duplicate code detection guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GREEN := \033[0;32m
 YELLOW := \033[1;33m
 NC := \033[0m # No Color
 
-.PHONY: all build test clean install run version help build-python python-wheel python-test python-clean build-mcp install-mcp clean-mcp
+.PHONY: all build test clean install run version help build-python python-wheel python-test python-clean build-mcp install-mcp clean-mcp docs-serve docs-build
 
 ## help: Show this help message
 help:
@@ -111,6 +111,16 @@ release:
 	git tag -a $(VERSION) -m "Release $(VERSION)"
 	git push origin $(VERSION)
 	@printf "$(GREEN)Release $(VERSION) created and pushed!$(NC)\n"
+
+## docs-serve: Serve the documentation site locally with live reload (requires uv)
+docs-serve:
+	@which uvx > /dev/null || (printf "$(YELLOW)uv is required: https://docs.astral.sh/uv/getting-started/installation/$(NC)\n" && exit 1)
+	cd website && uvx --with-requirements requirements.txt --from mkdocs mkdocs serve
+
+## docs-build: Build the documentation site in strict mode (requires uv)
+docs-build:
+	@which uvx > /dev/null || (printf "$(YELLOW)uv is required: https://docs.astral.sh/uv/getting-started/installation/$(NC)\n" && exit 1)
+	cd website && uvx --with-requirements requirements.txt --from mkdocs mkdocs build --strict
 
 ## dev: Development build with hot reload (requires air)
 dev:

--- a/website/docs/fr/guides/find-duplicate-code-python.md
+++ b/website/docs/fr/guides/find-duplicate-code-python.md
@@ -1,0 +1,214 @@
+---
+description: Un guide pratique pour détecter le code dupliqué en Python. Découvrez ce que sont les clones de code (Types 1 à 4), quels outils les détectent et comment automatiser la détection en CI.
+---
+
+# Comment détecter le code dupliqué en Python
+
+Le code dupliqué pose de vrais problèmes. Un bug corrigé dans une copie survit dans les autres. Chaque modification doit être répercutée à plusieurs endroits. Les relecteurs perdent du temps à lire une logique qu'ils ont déjà vue. Et maintenant que les assistants IA écrivent une grande partie de notre code, des blocs quasi identiques apparaissent dans les bases de code plus vite que les humains ne les copiaient-collaient.
+
+Ce guide explique ce qui constitue du code « dupliqué », quels outils permettent de le détecter en Python, et comment lancer la détection en local et en CI.
+
+## Réponse rapide
+
+Pour analyser un projet immédiatement, lancez :
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+Cette commande exécute la détection de clones de [pyscn](https://github.com/ludo-technologies/pyscn) sans rien installer. Elle ouvre un rapport HTML listant tous les groupes de code dupliqué, avec les scores de similarité et les emplacements dans les fichiers.
+
+## Qu'est-ce que du code « dupliqué » ? Les quatre types de clones
+
+La plupart des développeurs imaginent le code dupliqué comme un simple copier-coller. Dans la recherche, les duplicats sont appelés *clones de code* et se répartissent en quatre types. La distinction est importante, car la plupart des outils ne détectent que les un ou deux premiers.
+
+Voici la même fonction déclinée en quatre variantes.
+
+**Type 1 : code identique.** Un copier-coller où seuls l'espacement et les commentaires diffèrent :
+
+```python
+def calculate_order_total(items, discount_rate):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+Si ce bloc est collé dans un autre fichier, peut-être avec un commentaire ajouté, c'est un clone de Type 1. C'est le type le plus facile à détecter et à corriger : il suffit d'extraire une fonction commune. ([règle : duplicate-code-identical](../rules/duplicate-code-identical.md))
+
+**Type 2 : identifiants renommés.** La structure est intacte, seuls les noms ont changé :
+
+```python
+def compute_cart_amount(products, rebate):
+    amount = 0.0
+    for product in products:
+        cost = product["price"]
+        count = product["quantity"]
+        if count <= 0:
+            continue
+        amount += cost * count
+    if rebate > 0:
+        amount = amount * (1 - rebate)
+    levy = amount * 0.1
+    result = amount + levy
+    return round(result, 2)
+```
+
+Les outils basés sur les lignes ratent ce cas, car aucune ligne n'est textuellement identique. Mais si l'on compare les arbres syntaxiques avec les noms normalisés, les deux fonctions ont exactement la même forme. ([règle : duplicate-code-renamed](../rules/duplicate-code-renamed.md))
+
+**Type 3 : copies modifiées.** Quelqu'un a copié la fonction, puis ajouté ou supprimé quelques instructions :
+
+```python
+def calculate_quote_total(items, discount_rate, shipping=0.0):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    subtotal += shipping        # <- nouveau
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+C'est le type de clone le plus courant dans les vraies bases de code. Quelqu'un a copié une fonction, l'a adaptée à un nouveau cas et est passé à autre chose. La détecter implique de mesurer l'écart entre deux arbres (tree edit distance), pas seulement de vérifier s'ils correspondent. ([règle : duplicate-code-modified](../rules/duplicate-code-modified.md))
+
+**Type 4 : même comportement, implémentation différente.** Le code a été réécrit de zéro mais calcule la même chose :
+
+```python
+def total_for_order(items, discount_rate):
+    valid_items = []
+    for item in items:
+        if item["quantity"] > 0:
+            valid_items.append(item)
+    subtotal = sum(
+        item["price"] * item["quantity"]
+        for item in valid_items
+    )
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    total_with_tax = subtotal * 1.1
+    return round(total_with_tax, 2)
+```
+
+Aucune correspondance textuelle ou structurelle ne reliera ce code à l'original. La comparaison de la structure du flux de contrôle le peut. ([règle : duplicate-code-semantic](../rules/duplicate-code-semantic.md))
+
+## Outils de détection du code dupliqué en Python
+
+Voici les principales options et ce que chacune peut détecter :
+
+| Outil | Détecte | Remarques |
+| --- | --- | --- |
+| [pylint](https://pylint.readthedocs.io/) (`R0801`) | Type 1 | Vérification de similarité basée sur les lignes, inclus dans pylint. Détecte le copier-coller. Les renommages le trompent. |
+| [jscpd](https://github.com/kucherenko/jscpd) | Type 1, Type 2 partiel | Basé sur les tokens, supporte plus de 150 langages. Adapté si un seul détecteur doit couvrir un dépôt multilangage. |
+| [SonarQube](https://www.sonarsource.com/products/sonarqube/) | Type 1, Type 2 partiel | Plateforme complète avec tableaux de bord et historique. Plus lourd à configurer et à héberger. |
+| [PMD CPD](https://pmd.github.io/pmd/pmd_userdocs_cpd.html) | Type 1, Type 2 | Le détecteur de copier-coller classique. Nécessite une JVM. |
+| [pyscn](https://github.com/ludo-technologies/pyscn) | Types 1 à 4 | Spécifique à Python. Utilise le hachage AST pour les Types 1-2, la tree edit distance (APTED) pour le Type 3 et la comparaison de flux de contrôle pour le Type 4. |
+
+Un point de confusion fréquent : **[ruff](https://docs.astral.sh/ruff/) ne détecte pas le code dupliqué.** Ruff est un linter et un formateur. Il vérifie la façon dont les lignes et instructions individuelles sont écrites, ce qui est un travail différent de la comparaison de fonctions entre elles à travers les fichiers. Les deux types d'outils se complètent plutôt qu'ils ne se concurrencent.
+
+## Tutoriel : détecter les clones avec pyscn
+
+Reprenez les quatre variantes ci-dessus et répartissez-les dans deux fichiers, `orders.py` et `invoices.py`, avec l'original collé dans les deux. Ensuite, lancez :
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+pyscn analyse tous les fichiers Python, extrait les fragments de code et les compare par paires. Sur les grandes bases de code, il utilise [LSH](https://en.wikipedia.org/wiki/Locality-sensitive_hashing) pour rester rapide, à plus de 100 000 lignes par seconde. Le résumé s'affiche dans le terminal :
+
+```text
+📊 Analysis Summary:
+Health Score: 80/100 (Grade: B)
+
+📈 Detailed Scores:
+  Duplication:      0/100 ❌  (10.0% duplication, 1 groups)
+```
+
+Le rapport HTML regroupe les cinq fragments en un seul groupe de clones, avec chaque paire classifiée et scorée :
+
+| Paire | Classifié comme | Similarité |
+| --- | --- | --- |
+| copie exacte entre les deux fichiers | Type 1 | 1,00 |
+| original vs. copie modifiée | Type 2 | 0,85 |
+| original vs. version réécrite | Type 4 | 0,94 |
+
+Notez la dernière ligne. La version réécrite `total_for_order` est la variante qu'aucun outil basé sur le texte ne peut relier à l'original. pyscn la détecte avec une similarité de 0,94 à partir de sa structure de flux de contrôle.
+
+### Ajuster le seuil
+
+Le flag `--clone-threshold` (valeur par défaut `0.65`) définit la similarité minimale pour qu'une paire soit signalée :
+
+```bash
+pyscn analyze --select clones --clone-threshold 0.8 .   # plus strict : moins de correspondances, plus proches
+```
+
+Pour des réglages permanents, créez un fichier `.pyscn.toml` (ou utilisez `[tool.pyscn]` dans `pyproject.toml`) :
+
+```toml
+[clones]
+similarity_threshold = 0.8
+min_lines = 15        # ignore fragments smaller than this
+```
+
+Les fonctions très courtes sont ignorées par défaut (`min_lines`). En dessous d'une certaine taille, la similarité perd de son sens : chaque getter de deux lignes ressemble à tous les autres. Consultez la [référence de configuration](../configuration/reference.md#clones) pour toutes les options, y compris l'activation et la désactivation des types de clones individuels.
+
+## Automatiser la détection en CI
+
+`pyscn check` est la version CI de `analyze`. Il ne produit pas de rapport, seulement un code de sortie succès/échec :
+
+```bash
+pyscn check --select clones .
+```
+
+Comme étape GitHub Actions :
+
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.12"
+- run: pipx run pyscn check --select clones .
+```
+
+Le job échoue lorsque la duplication dépasse vos seuils. C'est précisément l'intérêt : une détection qu'il faut penser à lancer est une détection qui finit par ne plus avoir lieu. Consultez [Intégration CI/CD](../integrations/ci-cd.md) pour des workflows complets, et [Pyscn Bot](https://github.com/marketplace/pyscn-bot) pour recevoir des analyses automatiques sur les pull requests.
+
+## Que faire des résultats
+
+Tous les clones n'ont pas besoin d'être supprimés. Un ordre d'attaque utile :
+
+1. **Les clones de Type 1 et Type 2 dans le code de production.** Extrayez une fonction commune. La correction est mécanique et peu risquée, précisément parce que les copies sont quasi identiques.
+2. **Les clones de Type 3.** Examinez ce qui diffère entre les copies. Si les différences sont des données, extrayez une fonction qui prend des paramètres. Si les différences sont comportementales, les copies divergent peut-être intentionnellement. Parfois, deux points d'appel ont genuinement besoin d'évoluer séparément, et les fusionner couplerait des éléments qui devraient rester indépendants.
+3. **Les clones de Type 4.** Traitez-les comme des signaux plutôt que comme des actions à mener. Deux implémentations indépendantes de la même logique signifient souvent que deux personnes ignoraient les travaux de l'autre. Choisissez l'une des deux, ou documentez pourquoi les deux coexistent.
+4. **Les clones dans le code de test.** Soyez plus tolérant ici. Les tests privilégient l'explicite au détriment du DRY, et une certaine répétition qui rend chaque test lisible en lui-même en vaut généralement la peine.
+
+En pratique, il vaut mieux fixer un seuil strict pour que le rapport reste court, corriger le groupe en tête de liste et relancer l'analyse. Tenter d'éliminer un rapport de 40 groupes en un seul grand refactoring aboutit rarement bien.
+
+## FAQ
+
+**Est-ce que ruff détecte le code dupliqué ?**
+Non. Ruff est un linter et un formateur et ne possède pas de règles de détection de clones. Trouver des duplicats nécessite de comparer des fragments de code entre eux à travers les fichiers, ce qui dépasse le périmètre d'un linter. Utilisez ruff pour les vérifications de style et de correction, et un détecteur de clones pour la duplication. Les deux fonctionnent bien ensemble.
+
+**Quel niveau de duplication est acceptable ?**
+Il n'existe pas de chiffre universel. À titre indicatif, moins de 5 % de lignes dupliquées est typique d'une base de code bien entretenue, et tout ce qui dépasse 15 % signifie généralement un développement systématique par copier-coller. La tendance importe plus que le chiffre lui-même. Une duplication qui croît release après release est le vrai signal d'alarme.
+
+**Puis-je détecter des duplicats sur plusieurs dépôts ?**
+Oui. Pointez l'analyseur vers un répertoire contenant les deux checkouts : `pyscn analyze --select clones repo-a/ repo-b/`. Les fragments sont comparés sur tout ce qui est dans le périmètre, donc les clones inter-dépôts apparaissent comme n'importe quelle autre paire.
+
+**Pourquoi mon fragment dupliqué n'est-il pas signalé ?**
+Il est très probablement inférieur à la taille minimale de fragment (`min_lines` / `min_nodes` dans la configuration). Les détecteurs ignorent intentionnellement les fragments trop petits. À cinq lignes, la moitié de la base de code ressemble à l'autre moitié. Réduisez les limites dans `.pyscn.toml` si vous souhaitez que les fragments courts soient également comparés.
+
+---
+
+*Suite : parcourez le [catalogue des règles de code dupliqué](../rules/index.md) pour voir comment chaque type de clone est scoré, ou la [documentation du score de santé](../output/health-score.md) pour comprendre comment la duplication influe sur la note de votre projet.*

--- a/website/docs/guides/find-duplicate-code-python.md
+++ b/website/docs/guides/find-duplicate-code-python.md
@@ -1,0 +1,214 @@
+---
+description: A practical guide to finding duplicate code in Python. Learn what code clones are (Type 1-4), which tools detect them, and how to automate detection in CI.
+---
+
+# How to Find Duplicate Code in Python
+
+Duplicate code causes real problems. A bug fixed in one copy survives in the others. Every change has to be made in several places. Reviewers waste time re-reading logic they have already seen. And now that AI assistants write a lot of our code, near-identical blocks appear in codebases faster than humans ever copy-pasted them.
+
+This guide explains what counts as "duplicate" code, which tools can find it in Python, and how to run detection locally and in CI.
+
+## Quick answer
+
+To scan a project right now, run:
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+This runs [pyscn](https://github.com/ludo-technologies/pyscn)'s clone detection without installing anything. It opens an HTML report that lists every group of duplicated code, with similarity scores and file locations.
+
+## What counts as "duplicate"? The four clone types
+
+Most developers picture duplicate code as literal copy-paste. In research, duplicates are called *code clones*, and they come in four types. The difference matters because most tools only catch the first one or two.
+
+Here is the same function in four variants.
+
+**Type-1: identical code.** A copy-paste, where only whitespace and comments differ:
+
+```python
+def calculate_order_total(items, discount_rate):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+If this block is pasted into another file, perhaps with a comment added, that is a Type-1 clone. It is the easiest type to detect and the easiest to fix: extract a shared function. ([rule: duplicate-code-identical](../rules/duplicate-code-identical.md))
+
+**Type-2: renamed identifiers.** The structure is untouched. Only the names changed:
+
+```python
+def compute_cart_amount(products, rebate):
+    amount = 0.0
+    for product in products:
+        cost = product["price"]
+        count = product["quantity"]
+        if count <= 0:
+            continue
+        amount += cost * count
+    if rebate > 0:
+        amount = amount * (1 - rebate)
+    levy = amount * 0.1
+    result = amount + levy
+    return round(result, 2)
+```
+
+Line-based tools miss this, because no two lines are textually equal. But if you compare the syntax trees with names normalized away, the two functions have exactly the same shape. ([rule: duplicate-code-renamed](../rules/duplicate-code-renamed.md))
+
+**Type-3: modified copies.** Someone copied the function, then added or removed a few statements:
+
+```python
+def calculate_quote_total(items, discount_rate, shipping=0.0):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    subtotal += shipping        # <- new
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+This is the most common clone in real codebases. Someone copied a function, tweaked it for a new case, and moved on. Detecting it means measuring how far apart two trees are (tree edit distance), not just whether they match. ([rule: duplicate-code-modified](../rules/duplicate-code-modified.md))
+
+**Type-4: same behavior, different implementation.** The code was rewritten from scratch but computes the same thing:
+
+```python
+def total_for_order(items, discount_rate):
+    valid_items = []
+    for item in items:
+        if item["quantity"] > 0:
+            valid_items.append(item)
+    subtotal = sum(
+        item["price"] * item["quantity"]
+        for item in valid_items
+    )
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    total_with_tax = subtotal * 1.1
+    return round(total_with_tax, 2)
+```
+
+No text matching or tree matching will connect this to the original. Comparing control-flow structure can. ([rule: duplicate-code-semantic](../rules/duplicate-code-semantic.md))
+
+## Tools that detect duplicate code in Python
+
+Here are the main options and what each one can catch:
+
+| Tool | Detects | Notes |
+| --- | --- | --- |
+| [pylint](https://pylint.readthedocs.io/) (`R0801`) | Type-1 | Line-based similarity check, bundled with pylint. Catches copy-paste. Renames defeat it. |
+| [jscpd](https://github.com/kucherenko/jscpd) | Type-1, partial Type-2 | Token-based, supports 150+ languages. A good fit if one detector has to cover a multi-language repo. |
+| [SonarQube](https://www.sonarsource.com/products/sonarqube/) | Type-1, partial Type-2 | A full platform with dashboards and history. Heavier to set up and host. |
+| [PMD CPD](https://pmd.github.io/pmd/pmd_userdocs_cpd.html) | Type-1, Type-2 | The classic copy-paste detector. Requires a JVM. |
+| [pyscn](https://github.com/ludo-technologies/pyscn) | Type-1 through Type-4 | Python-specific. Uses AST hashing for Types 1-2, tree edit distance (APTED) for Type-3, and control-flow comparison for Type-4. |
+
+One common point of confusion: **[ruff](https://docs.astral.sh/ruff/) does not detect duplicate code.** Ruff is a linter and formatter. It checks how individual lines and statements are written, which is a different job from comparing functions against each other across files. The two kinds of tools complement each other rather than compete.
+
+## Walkthrough: detecting clones with pyscn
+
+Take the four variants above and spread them across two files, `orders.py` and `invoices.py`, with the original pasted into both. Then run:
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+pyscn parses every Python file, extracts code fragments, and compares them pairwise. On large codebases it uses [LSH](https://en.wikipedia.org/wiki/Locality-sensitive_hashing) to keep this fast, at over 100,000 lines per second. The summary appears in the terminal:
+
+```text
+📊 Analysis Summary:
+Health Score: 80/100 (Grade: B)
+
+📈 Detailed Scores:
+  Duplication:      0/100 ❌  (10.0% duplication, 1 groups)
+```
+
+The HTML report shows all five fragments collected into one clone group, with each pair classified and scored:
+
+| Pair | Classified as | Similarity |
+| --- | --- | --- |
+| exact copy across the two files | Type-1 | 1.00 |
+| original vs. modified copy | Type-2 | 0.85 |
+| original vs. rewritten version | Type-4 | 0.94 |
+
+Note the last row. The rewritten `total_for_order` is the variant no text-based tool can connect to the original. pyscn catches it at 0.94 similarity from its control-flow structure.
+
+### Tuning the threshold
+
+The `--clone-threshold` flag (default `0.65`) sets the minimum similarity for a pair to be reported:
+
+```bash
+pyscn analyze --select clones --clone-threshold 0.8 .   # stricter: fewer, closer matches
+```
+
+For permanent settings, create a `.pyscn.toml` file (or use `[tool.pyscn]` in `pyproject.toml`):
+
+```toml
+[clones]
+similarity_threshold = 0.8
+min_lines = 15        # ignore fragments smaller than this
+```
+
+Very short functions are skipped by default (`min_lines`). Below a certain size, similarity stops meaning much, because every two-line getter looks like every other. See the [configuration reference](../configuration/reference.md#clones) for all options, including turning individual clone types on or off.
+
+## Automating detection in CI
+
+`pyscn check` is the CI version of `analyze`. It produces no report, just a pass/fail exit code:
+
+```bash
+pyscn check --select clones .
+```
+
+As a GitHub Actions step:
+
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.12"
+- run: pipx run pyscn check --select clones .
+```
+
+The job fails when new duplication crosses your thresholds. That is the point: detection you have to remember to run is detection that stops happening. See [CI/CD integration](../integrations/ci-cd.md) for complete workflows, and [Pyscn Bot](https://github.com/marketplace/pyscn-bot) if you want reviews posted on pull requests automatically.
+
+## What to do with the findings
+
+Not every clone needs to be removed. A useful order of attack:
+
+1. **Type-1 and Type-2 clones in production code.** Extract a shared function. The fix is mechanical and low-risk precisely because the copies are nearly identical.
+2. **Type-3 clones.** Look at what differs between the copies. If the differences are data, extract a function that takes parameters. If the differences are behavior, the copies may be diverging on purpose. Sometimes two call sites genuinely want to evolve separately, and merging them would couple things that should stay independent.
+3. **Type-4 clones.** Treat these as signals rather than action items. Two independent implementations of the same logic often mean two people did not know about each other's work. Pick one, or document why both exist.
+4. **Clones in test code.** Be more tolerant here. Tests value explicitness over DRY-ness, and some repetition that keeps each test readable on its own is usually worth it.
+
+In practice, it works better to set a strict threshold so the report stays short, fix the top group, and run again. Trying to clear a 40-group report in one big refactor rarely ends well.
+
+## FAQ
+
+**Does ruff detect duplicate code?**
+No. Ruff is a linter and formatter and has no clone detection rules. Finding duplicates requires comparing code fragments against each other across files, which is outside what a linter does. Use ruff for style and correctness checks, and a clone detector for duplication. They work well together.
+
+**How much duplication is acceptable?**
+There is no universal number. As a rough guide, under 5% duplicated lines is typical for a well-maintained codebase, and anything above 15% usually means systematic copy-paste development. The trend matters more than the number itself. Duplication that grows release after release is the real warning sign.
+
+**Can I detect duplicates across multiple repositories?**
+Yes. Point the analyzer at a directory containing both checkouts: `pyscn analyze --select clones repo-a/ repo-b/`. Fragments are compared across everything in scope, so cross-repo clones show up like any other pair.
+
+**Why isn't my duplicated snippet being reported?**
+Most likely it is below the minimum fragment size (`min_lines` / `min_nodes` in the configuration). Detectors skip tiny fragments on purpose. At five lines, half the codebase resembles the other half. Lower the limits in `.pyscn.toml` if you want short fragments compared too.
+
+---
+
+*Next: browse the [duplicate code rule catalog](../rules/index.md) to see how each clone type is scored, or the [health score documentation](../output/health-score.md) to see how duplication affects your project grade.*

--- a/website/docs/ja/guides/find-duplicate-code-python.md
+++ b/website/docs/ja/guides/find-duplicate-code-python.md
@@ -1,0 +1,214 @@
+---
+description: Python で重複コードを見つけるための実践ガイドです。コードクローンの種類（Type 1〜4）、対応ツール、CI での自動検出方法を解説します。
+---
+
+# Python で重複コードを見つける方法
+
+重複コードは実際の問題を引き起こします。一方のコピーで修正したバグが、もう一方に残り続けます。変更のたびに複数の箇所を同時に直さなければなりません。レビュアーは既に読んだロジックを何度も読み返す羽目になります。しかも今やAIアシスタントが大量のコードを生成するため、ほぼ同一のブロックが人間のコピー&ペーストをはるかに上回るペースでコードベースに増殖します。
+
+このガイドでは、「重複」コードの定義、Python でそれを検出するツールの種類、そしてローカルおよび CI での検出手順を説明します。
+
+## 手っ取り早く試す
+
+今すぐプロジェクトをスキャンするには、次のコマンドを実行してください:
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+これは何もインストールせずに [pyscn](https://github.com/ludo-technologies/pyscn) のクローン検出を実行します。重複コードのグループを類似度スコアとファイル位置付きで一覧表示する HTML レポートが開きます。
+
+## 「重複」の定義: 4 種類のクローン
+
+多くの開発者は重複コードをコピー&ペーストそのものとして捉えています。研究分野では重複コードを*コードクローン*と呼び、4 つのタイプに分類されます。この違いが重要なのは、ほとんどのツールが最初の 1〜2 種類しか検出できないからです。
+
+以下は同じ関数の 4 つのバリアントです。
+
+**Type-1: 完全一致。** 空白とコメントだけが異なるコピー&ペーストです:
+
+```python
+def calculate_order_total(items, discount_rate):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+このブロックを別のファイルに貼り付け、コメントを追加しただけのものが Type-1 クローンです。最も検出しやすく、修正も簡単です。共通の関数に切り出せばよいだけです。（[ルール: duplicate-code-identical](../rules/duplicate-code-identical.md)）
+
+**Type-2: 識別子のリネーム。** 構造はそのままで、名前だけが変わっています:
+
+```python
+def compute_cart_amount(products, rebate):
+    amount = 0.0
+    for product in products:
+        cost = product["price"]
+        count = product["quantity"]
+        if count <= 0:
+            continue
+        amount += cost * count
+    if rebate > 0:
+        amount = amount * (1 - rebate)
+    levy = amount * 0.1
+    result = amount + levy
+    return round(result, 2)
+```
+
+行ベースのツールはこれを見逃します。どの行もテキストとして一致しないからです。しかし名前を正規化した上で構文木を比較すると、2 つの関数はまったく同じ形をしています。（[ルール: duplicate-code-renamed](../rules/duplicate-code-renamed.md)）
+
+**Type-3: 変更されたコピー。** 関数をコピーした後、いくつかの文を追加・削除しています:
+
+```python
+def calculate_quote_total(items, discount_rate, shipping=0.0):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    subtotal += shipping        # <- 追加
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+これは実際のコードベースで最もよく見られるクローンです。関数をコピーして新しいケース向けに少し手を加え、そのまま放置するパターンです。検出には 2 つの木の距離を測る（木編集距離）必要があり、単純なマッチングでは対応できません。（[ルール: duplicate-code-modified](../rules/duplicate-code-modified.md)）
+
+**Type-4: 同じ動作、異なる実装。** ゼロから書き直したにもかかわらず、同じ処理を行っています:
+
+```python
+def total_for_order(items, discount_rate):
+    valid_items = []
+    for item in items:
+        if item["quantity"] > 0:
+            valid_items.append(item)
+    subtotal = sum(
+        item["price"] * item["quantity"]
+        for item in valid_items
+    )
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    total_with_tax = subtotal * 1.1
+    return round(total_with_tax, 2)
+```
+
+テキスト照合でも木の照合でも、このコードを元の関数と結びつけることはできません。制御フローの構造を比較することで初めて関連性がわかります。（[ルール: duplicate-code-semantic](../rules/duplicate-code-semantic.md)）
+
+## Python で重複コードを検出するツール
+
+主なツールとそれぞれが検出できる範囲をまとめます:
+
+| ツール | 検出対象 | 備考 |
+| --- | --- | --- |
+| [pylint](https://pylint.readthedocs.io/)（`R0801`） | Type-1 | 行ベースの類似チェック。pylint に同梱。コピー&ペーストを検出。リネームには対応不可。 |
+| [jscpd](https://github.com/kucherenko/jscpd) | Type-1、Type-2 の一部 | トークンベース。150 以上の言語をサポート。複数言語の混在リポジトリに向く。 |
+| [SonarQube](https://www.sonarsource.com/products/sonarqube/) | Type-1、Type-2 の一部 | ダッシュボードと履歴を持つフルプラットフォーム。セットアップとホスティングに手間がかかる。 |
+| [PMD CPD](https://pmd.github.io/pmd/pmd_userdocs_cpd.html) | Type-1、Type-2 | 定番のコピー&ペースト検出器。JVM が必要。 |
+| [pyscn](https://github.com/ludo-technologies/pyscn) | Type-1〜Type-4 | Python 専用。Type 1〜2 に AST ハッシュ、Type-3 に木編集距離（APTED）、Type-4 に制御フロー比較を使用。 |
+
+よくある誤解を一点補足します。**[ruff](https://docs.astral.sh/ruff/) は重複コードを検出しません。** ruff はリンター兼フォーマッターで、個々の行や文の書き方をチェックするツールです。ファイルをまたいでコードフラグメントを比較する処理とは役割が異なります。2 種類のツールは競合するのではなく、互いを補い合う関係です。
+
+## ウォークスルー: pyscn でクローンを検出する
+
+上記の 4 つのバリアントを `orders.py` と `invoices.py` の 2 ファイルに分散させ、元の関数を両方に貼り付けておきます。次のコマンドを実行してください:
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+pyscn はすべての Python ファイルをパースし、コードフラグメントを抽出してペアごとに比較します。大規模なコードベースでは [LSH](https://en.wikipedia.org/wiki/Locality-sensitive_hashing) を活用して 100,000 行/秒以上の速度を維持します。ターミナルには次のようなサマリーが表示されます:
+
+```text
+📊 Analysis Summary:
+Health Score: 80/100 (Grade: B)
+
+📈 Detailed Scores:
+  Duplication:      0/100 ❌  (10.0% duplication, 1 groups)
+```
+
+HTML レポートでは、5 つのフラグメントがすべて 1 つのクローングループにまとめられ、各ペアの分類とスコアが確認できます:
+
+| ペア | 分類 | 類似度 |
+| --- | --- | --- |
+| 2 ファイル間の完全一致コピー | Type-1 | 1.00 |
+| 元の関数と変更されたコピー | Type-2 | 0.85 |
+| 元の関数と書き直したバージョン | Type-4 | 0.94 |
+
+最後の行に注目してください。書き直した `total_for_order` は、テキストベースのツールでは元の関数と結びつけられないバリアントです。pyscn は制御フローの構造から 0.94 の類似度として検出します。
+
+### 閾値のチューニング
+
+`--clone-threshold` フラグ（デフォルト `0.65`）で、ペアを報告するための最小類似度を設定できます:
+
+```bash
+pyscn analyze --select clones --clone-threshold 0.8 .   # stricter: fewer, closer matches
+```
+
+設定を永続化するには `.pyscn.toml` ファイルを作成するか（または `pyproject.toml` の `[tool.pyscn]` セクションを使用）、以下のように記述してください:
+
+```toml
+[clones]
+similarity_threshold = 0.8
+min_lines = 15        # ignore fragments smaller than this
+```
+
+非常に短い関数はデフォルトでスキップされます（`min_lines`）。一定サイズ以下では類似度があまり意味を持たず、2 行の getter はどれも似たようなものになるためです。個別のクローンタイプをオン・オフにする方法を含む全オプションは [設定リファレンス](../configuration/reference.md#clones) を参照してください。
+
+## CI での検出を自動化する
+
+`pyscn check` は `analyze` の CI 向けバージョンです。レポートは生成せず、パス/フェイルの終了コードだけを返します:
+
+```bash
+pyscn check --select clones .
+```
+
+GitHub Actions のステップとして記述する場合:
+
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.12"
+- run: pipx run pyscn check --select clones .
+```
+
+新たな重複が設定した閾値を超えるとジョブが失敗します。それがこの仕組みのポイントです。手動で実行することを覚えていなければならない検出は、やがて実行されなくなります。完全なワークフローは [CI/CD 連携](../integrations/ci-cd.md) を、プルリクエストに自動でレビューを投稿したい場合は [Pyscn Bot](https://github.com/marketplace/pyscn-bot) を参照してください。
+
+## 検出結果の対処法
+
+すべてのクローンを除去する必要はありません。推奨する対処の優先順位は次のとおりです:
+
+1. **本番コードの Type-1・Type-2 クローン。** 共通の関数に抽出してください。コピーがほぼ同一のため、修正は機械的かつリスクが低いです。
+2. **Type-3 クローン。** コピー間で何が異なるかを確認してください。差分がデータなら、パラメータを受け取る関数に切り出します。差分が振る舞いなら、コピーが意図的に分岐している可能性があります。2 つの呼び出し元が本当に独立して進化すべき場合、無理に統合するとかえって不要な結合を生みます。
+3. **Type-4 クローン。** アクションアイテムというよりシグナルとして扱ってください。同じロジックの独立した実装が 2 つ存在する場合、多くは互いの作業を知らなかったことを意味します。どちらか一方を採用するか、両方が存在する理由をドキュメントに残してください。
+4. **テストコードのクローン。** ここではより寛容に構えてください。テストは DRY 性よりも明示性を重視します。各テストを単独で読みやすくするための適度な繰り返しは、たいていの場合で許容できます。
+
+実際には、厳しめの閾値でレポートを短く保ち、上位グループを修正してから再実行するサイクルが効果的です。40 グループものレポートを一度の大規模リファクタリングで解消しようとしても、うまくいくことはほとんどありません。
+
+## FAQ
+
+**ruff は重複コードを検出しますか?**
+検出しません。ruff はリンター兼フォーマッターであり、クローン検出のルールを持っていません。重複の発見にはファイルをまたいでコードフラグメントを比較する処理が必要で、これはリンターの役割の外です。スタイルや正確性のチェックには ruff を、重複の検出にはクローン検出ツールを使ってください。2 つはうまく組み合わせて使えます。
+
+**どの程度の重複は許容範囲ですか?**
+普遍的な基準はありません。おおよその目安として、重複行が 5% 未満なら適切に管理されたコードベースとして典型的な水準です。15% を超えると、組織的なコピー&ペースト開発が行われていることを示すことが多いです。絶対値よりもトレンドのほうが重要です。リリースごとに重複が増え続けることが本当の警戒サインです。
+
+**複数のリポジトリをまたいで重複を検出できますか?**
+できます。両方のチェックアウトを含むディレクトリをアナライザーに指定してください: `pyscn analyze --select clones repo-a/ repo-b/`。スコープ内のすべてのコードが比較対象になるため、リポジトリをまたいだクローンも通常のペアと同様に検出されます。
+
+**重複している箇所が報告されないのはなぜですか?**
+ほとんどの場合、フラグメントの最小サイズ（設定の `min_lines` / `min_nodes`）を下回っているためです。検出器は意図的に短いフラグメントをスキップします。5 行程度だとコードベースの半分が互いに似通ってしまうからです。短いフラグメントも比較したい場合は、`.pyscn.toml` で制限値を下げてください。
+
+---
+
+*次のステップ: 各クローンタイプのスコアリングを確認するには [重複コードルールカタログ](../rules/index.md) を、重複がプロジェクトグレードに与える影響を確認するには [ヘルススコアのドキュメント](../output/health-score.md) をご覧ください。*

--- a/website/docs/zh/guides/find-duplicate-code-python.md
+++ b/website/docs/zh/guides/find-duplicate-code-python.md
@@ -1,0 +1,214 @@
+---
+description: 如何在 Python 项目中发现重复代码的实用指南。介绍代码克隆的四种类型（Type 1-4）、可用工具，以及如何在 CI 中自动化检测。
+---
+
+# 如何在 Python 中发现重复代码
+
+重复代码会带来实际问题。在一处副本中修复的 bug，往往在其他副本中继续存在。每次改动都要在多处同步修改。代码审查者也会浪费时间反复阅读已经看过的逻辑。如今 AI 助手大量参与代码编写，近乎相同的代码块在代码库中出现的速度，远比人工复制粘贴快得多。
+
+本指南将说明什么样的代码算作"重复"，哪些工具可以在 Python 中检测重复代码，以及如何在本地和 CI 中运行检测。
+
+## 快速上手
+
+如需立即扫描项目，运行：
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+这会在不安装任何依赖的情况下运行 [pyscn](https://github.com/ludo-technologies/pyscn) 的克隆检测。命令完成后会打开一份 HTML 报告，列出所有重复代码组，并附有相似度评分和文件位置。
+
+## 什么算"重复"？四种克隆类型
+
+大多数开发者对重复代码的印象是字面意义上的复制粘贴。在研究领域，重复代码被称为*代码克隆*，分为四种类型。这一区别很重要，因为大多数工具只能捕获前一两种。
+
+下面用同一个函数的四个变体来说明。
+
+**Type-1：完全相同的代码。** 复制粘贴，仅空白和注释有所不同：
+
+```python
+def calculate_order_total(items, discount_rate):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+如果这段代码被粘贴到另一个文件（也许加了一条注释），就是 Type-1 克隆。这是最容易检测、也最容易修复的类型：提取为共享函数即可。（[规则：duplicate-code-identical](../rules/duplicate-code-identical.md)）
+
+**Type-2：重命名标识符。** 结构完全相同，只有名称发生了变化：
+
+```python
+def compute_cart_amount(products, rebate):
+    amount = 0.0
+    for product in products:
+        cost = product["price"]
+        count = product["quantity"]
+        if count <= 0:
+            continue
+        amount += cost * count
+    if rebate > 0:
+        amount = amount * (1 - rebate)
+    levy = amount * 0.1
+    result = amount + levy
+    return round(result, 2)
+```
+
+基于行的工具会忽略这种情况，因为没有任何两行在文本上完全相同。但如果将语法树的名称归一化后再比较，这两个函数的结构完全一致。（[规则：duplicate-code-renamed](../rules/duplicate-code-renamed.md)）
+
+**Type-3：修改后的副本。** 有人复制了该函数，随后增加或删除了几条语句：
+
+```python
+def calculate_quote_total(items, discount_rate, shipping=0.0):
+    subtotal = 0.0
+    for item in items:
+        price = item["price"]
+        quantity = item["quantity"]
+        if quantity <= 0:
+            continue
+        subtotal += price * quantity
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    subtotal += shipping        # <- 新增
+    tax = subtotal * 0.1
+    total = subtotal + tax
+    return round(total, 2)
+```
+
+这是实际代码库中最常见的克隆类型。有人复制了一个函数，为新场景做了调整，然后继续开发。检测这类克隆需要度量两棵语法树之间的距离（树编辑距离），而不只是判断是否匹配。（[规则：duplicate-code-modified](../rules/duplicate-code-modified.md)）
+
+**Type-4：行为相同，实现不同。** 代码从头重写，但计算结果相同：
+
+```python
+def total_for_order(items, discount_rate):
+    valid_items = []
+    for item in items:
+        if item["quantity"] > 0:
+            valid_items.append(item)
+    subtotal = sum(
+        item["price"] * item["quantity"]
+        for item in valid_items
+    )
+    if discount_rate > 0:
+        subtotal = subtotal * (1 - discount_rate)
+    total_with_tax = subtotal * 1.1
+    return round(total_with_tax, 2)
+```
+
+文本匹配或树匹配都无法将这段代码与原始版本关联起来，但通过比较控制流结构可以发现。（[规则：duplicate-code-semantic](../rules/duplicate-code-semantic.md)）
+
+## 检测 Python 重复代码的工具
+
+以下是主要工具及各自的检测能力：
+
+| 工具 | 检测范围 | 说明 |
+| --- | --- | --- |
+| [pylint](https://pylint.readthedocs.io/)（`R0801`） | Type-1 | 基于行的相似度检查，随 pylint 一同提供。能捕获复制粘贴，重命名后失效。 |
+| [jscpd](https://github.com/kucherenko/jscpd) | Type-1，部分 Type-2 | 基于 token，支持 150 多种语言。适合需要一个检测器覆盖多语言仓库的场景。 |
+| [SonarQube](https://www.sonarsource.com/products/sonarqube/) | Type-1，部分 Type-2 | 完整平台，含仪表盘和历史记录。配置和托管成本较高。 |
+| [PMD CPD](https://pmd.github.io/pmd/pmd_userdocs_cpd.html) | Type-1，Type-2 | 经典的复制粘贴检测器，需要 JVM。 |
+| [pyscn](https://github.com/ludo-technologies/pyscn) | Type-1 至 Type-4 | Python 专用。Type 1-2 使用 AST 哈希，Type-3 使用树编辑距离（APTED），Type-4 使用控制流比较。 |
+
+一个常见的误解：**[ruff](https://docs.astral.sh/ruff/) 不检测重复代码。** Ruff 是 lint 工具和格式化工具，负责检查单行和语句的写法，这与跨文件比较函数是两件完全不同的事。两类工具相辅相成，而非互相竞争。
+
+## 演练：使用 pyscn 检测克隆
+
+将上面四个变体分散到两个文件 `orders.py` 和 `invoices.py` 中，并将原始版本粘贴到两个文件里，然后运行：
+
+```bash
+uvx pyscn@latest analyze --select clones .
+```
+
+pyscn 会解析所有 Python 文件，提取代码片段，并两两比较。对于大型代码库，它使用 [LSH](https://en.wikipedia.org/wiki/Locality-sensitive_hashing) 加速，分析速度超过 100,000 行/秒。终端会显示摘要：
+
+```text
+📊 Analysis Summary:
+Health Score: 80/100 (Grade: B)
+
+📈 Detailed Scores:
+  Duplication:      0/100 ❌  (10.0% duplication, 1 groups)
+```
+
+HTML 报告会将五个片段归入同一个克隆组，并对每对代码进行分类和评分：
+
+| 代码对 | 分类 | 相似度 |
+| --- | --- | --- |
+| 两个文件中的完全相同副本 | Type-1 | 1.00 |
+| 原始版本与修改副本 | Type-2 | 0.85 |
+| 原始版本与重写版本 | Type-4 | 0.94 |
+
+注意最后一行。重写后的 `total_for_order` 是任何基于文本的工具都无法与原始版本关联的变体，pyscn 通过控制流结构检测到了 0.94 的相似度。
+
+### 调整阈值
+
+`--clone-threshold` 参数（默认值 `0.65`）设置报告一对代码所需的最低相似度：
+
+```bash
+pyscn analyze --select clones --clone-threshold 0.8 .   # 更严格：匹配数量更少、相似度更高
+```
+
+如需固化设置，创建 `.pyscn.toml` 文件（或在 `pyproject.toml` 中使用 `[tool.pyscn]`）：
+
+```toml
+[clones]
+similarity_threshold = 0.8
+min_lines = 15        # ignore fragments smaller than this
+```
+
+默认会跳过非常短的函数（`min_lines`）。低于某个大小，相似度就失去了意义，因为每个两行的 getter 看起来都差不多。所有选项（包括单独开关各克隆类型）详见[配置参考](../configuration/reference.md#clones)。
+
+## 在 CI 中自动化检测
+
+`pyscn check` 是 `analyze` 的 CI 版本，不生成报告，只输出通过/失败的退出码：
+
+```bash
+pyscn check --select clones .
+```
+
+作为 GitHub Actions 步骤：
+
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.12"
+- run: pipx run pyscn check --select clones .
+```
+
+当新增重复代码超出阈值时，任务失败。这正是关键所在：需要手动触发的检测，迟早会被遗忘而停止执行。完整工作流详见 [CI/CD 集成](../integrations/ci-cd.md)，如需在 Pull Request 上自动发布审查评论，请参阅 [Pyscn Bot](https://github.com/marketplace/pyscn-bot)。
+
+## 如何处理检测结果
+
+并非所有克隆都需要消除。建议按以下优先级处理：
+
+1. **生产代码中的 Type-1 和 Type-2 克隆。** 提取为共享函数。由于副本几乎完全相同，修复方式机械化，风险极低。
+2. **Type-3 克隆。** 仔细查看各副本之间的差异。如果差异体现在数据上，提取一个接受参数的函数；如果差异体现在行为上，这些副本可能是有意分化的。有时两处调用确实需要独立演进，强行合并反而会耦合本该独立的模块。
+3. **Type-4 克隆。** 将其视为信号，而非必须立即处理的任务。同一逻辑的两套独立实现，往往意味着两位开发者互不知情。选择其中一套保留，或记录说明两者共存的原因。
+4. **测试代码中的克隆。** 对这类情况可以宽松一些。测试代码注重显式表达，而非 DRY 原则，适当的重复有助于每个测试用例保持独立可读性。
+
+实践中，设置一个较严格的阈值以保持报告简短，修复排名最靠前的克隆组，再重新运行，效果往往好于一次性清理 40 组克隆的大规模重构。
+
+## 常见问题
+
+**ruff 能检测重复代码吗？**
+不能。Ruff 是 lint 工具和格式化工具，没有克隆检测规则。发现重复代码需要跨文件比较代码片段，这超出了 linter 的职责范围。请用 ruff 做风格和正确性检查，用克隆检测工具处理重复问题，两者配合使用效果更佳。
+
+**多少重复是可以接受的？**
+没有统一的标准。粗略来说，维护良好的代码库重复行占比通常低于 5%，超过 15% 一般意味着存在系统性的复制粘贴开发习惯。趋势比数字本身更重要。每个版本发布后重复率持续上升，才是真正需要警惕的信号。
+
+**能跨多个仓库检测重复吗？**
+可以。将分析器指向包含多个仓库检出目录的父目录即可：`pyscn analyze --select clones repo-a/ repo-b/`。所有在扫描范围内的片段都会两两比较，跨仓库克隆与普通克隆一样会出现在报告中。
+
+**为什么我的重复代码片段没有被报告？**
+最可能的原因是片段低于最小大小限制（配置中的 `min_lines` / `min_nodes`）。检测器故意跳过极短的片段。在五行的情况下，代码库中的大半代码都会彼此相似。如需比较短片段，请在 `.pyscn.toml` 中降低限制值。
+
+---
+
+*延伸阅读：查看[重复代码规则目录](../rules/index.md)了解各克隆类型的评分方式，或查看[健康评分文档](../output/health-score.md)了解重复代码如何影响项目评级。*

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -77,6 +77,8 @@ plugins:
             Getting Started: はじめに
             Installation: インストール
             Quick Start: クイックスタート
+            Guides: ガイド
+            Find Duplicate Code in Python: Pythonの重複コードを検出する
             Rules: ルール
             Overview: 概要
             Unreachable Code: 到達不能コード
@@ -109,6 +111,8 @@ plugins:
             Getting Started: 入门
             Installation: 安装
             Quick Start: 快速开始
+            Guides: 指南
+            Find Duplicate Code in Python: 检测 Python 中的重复代码
             Rules: 规则
             Overview: 概览
             Unreachable Code: 不可达代码
@@ -139,6 +143,8 @@ plugins:
             Getting Started: Démarrage
             Installation: Installation
             Quick Start: Démarrage rapide
+            Guides: Guides
+            Find Duplicate Code in Python: Trouver le code dupliqué en Python
             Rules: Règles
             Overview: Vue d'ensemble
             Unreachable Code: Code inatteignable
@@ -214,6 +220,8 @@ nav:
   - Getting Started:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quick-start.md
+  - Guides:
+      - Find Duplicate Code in Python: guides/find-duplicate-code-python.md
   - Rules:
       - Overview: rules/index.md
       - Unreachable Code:


### PR DESCRIPTION
## Summary

Adds a new **Guides** section to the documentation site, starting with a problem-focused guide: **How to Find Duplicate Code in Python** (`website/docs/guides/find-duplicate-code-python.md`).

Search queries like "python duplicate code detection" currently surface only abandoned or simplistic tools (clonedigger, ActiveState recipes), so this is a content gap the docs site can own. The guide targets readers who do not know pyscn yet and acts as a hub linking into the existing rule catalog, configuration reference, and CI/CD pages.

## Contents

- The four clone types (Type 1-4) explained with Python examples
- A tool survey (pylint R0801, jscpd, SonarQube, PMD CPD, pyscn), including a note that ruff does not cover this layer
- A walkthrough with real pyscn output, plus threshold tuning and CI integration
- Triage guidance for findings and an FAQ

All code examples were verified against pyscn: the exact copy is detected as Type-1 (sim 1.00), the modified copy at 0.85, and the rewritten variant as Type-4 at 0.94. The terminal output and pair table in the article are taken from those runs.

## Other changes

- `mkdocs.yml`: new Guides nav tab with ja/zh/fr nav translations (the article body is English-only for now; i18n falls back to English)
- `Makefile`: new `docs-serve` and `docs-build` targets that run mkdocs via uvx, so no local install is needed

## Verification

- `make docs-build` (mkdocs build --strict, same as CI) passes
- No em-dashes; plain prose style