### PR TITLE
fix: suppress clone groups covered by another group's larger windows

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -1122,9 +1122,13 @@ func (cd *CloneDetector) groupClonesWithStrategy(strategy GroupingStrategy) {
 		cd.cloneGroups = []*CloneGroup{}
 		return
 	}
-	dedupeResult := dedupeStrictSubsetGroupMembers(strategy.GroupClones(cd.clonePairs), cd.clonePairs)
-	cd.cloneGroups = dedupeResult.groups
-	cd.clonePairs = filterClonePairsWithSuppressedMembers(cd.clonePairs, dedupeResult.suppressed)
+	memberResult := dedupeStrictSubsetGroupMembers(strategy.GroupClones(cd.clonePairs), cd.clonePairs)
+	groupResult := dedupeCoveredGroups(memberResult.groups)
+	cd.cloneGroups = groupResult.groups
+	for fragment := range memberResult.suppressed {
+		groupResult.suppressed[fragment] = struct{}{}
+	}
+	cd.clonePairs = filterClonePairsWithSuppressedMembers(cd.clonePairs, groupResult.suppressed)
 }
 
 // isSameLocation checks if two locations refer to the same code

--- a/internal/analyzer/group_dedup.go
+++ b/internal/analyzer/group_dedup.go
@@ -67,6 +67,158 @@ func dedupeStrictSubsetGroupMembers(groups []*CloneGroup, pairs []*ClonePair) gr
 	return result
 }
 
+// coveredGroupSimilarityTolerance bounds how much weaker (in average
+// similarity) a covering group may be while still subsuming a covered group.
+// Overlapping windows of the same duplication shift similarity only slightly
+// (issue #518: 0.9692 vs 0.9613); a covered group that matches much more
+// strongly than its covering group is a distinct, sharper finding (e.g., a
+// near-identical inner block inside loosely similar functions) and is kept.
+const coveredGroupSimilarityTolerance = 0.05
+
+// dedupeCoveredGroups suppresses whole clone groups that are covered by
+// another group: every member of the covered group fits inside a distinct
+// member of the covering group (same file, containing line range), and the
+// covering group's similarity is comparable or better. Such groups describe
+// the same duplication relationship through slightly smaller windows — e.g.,
+// the same two blocks reported once with and once without their enclosing
+// `with` header line (issue #518) — and double-count it.
+//
+// Why dedupeStrictSubsetGroupMembers does not catch this: that pass compares
+// members *within* one group. Here the overlapping windows sit in *different*
+// groups, which stay disconnected because isOverlappingLocation forbids the
+// direct same-file pair that would have linked them.
+//
+// The group with the larger (covering) windows is kept, mirroring the
+// maximal-window policy of filterMaximalPerFile. When two groups cover each
+// other (identical member ranges), the earlier one in the slice wins.
+func dedupeCoveredGroups(groups []*CloneGroup) groupDedupeResult {
+	result := groupDedupeResult{
+		groups:     groups,
+		suppressed: make(map[*CodeFragment]struct{}),
+	}
+	if len(groups) < 2 {
+		return result
+	}
+
+	suppressed := make([]bool, len(groups))
+	for i, gi := range groups {
+		if gi == nil {
+			continue
+		}
+		// Compare against every other group, including already-suppressed
+		// ones: coverage is transitive, so a chain g1 ⊂ g2 ⊂ g3 still
+		// resolves to keeping only g3.
+		for j, gj := range groups {
+			if i == j || gj == nil {
+				continue
+			}
+			if !groupCoveredBy(gi, gj) {
+				continue
+			}
+			if groupCoveredBy(gj, gi) {
+				if j > i {
+					continue // mutual coverage: the earlier group survives
+				}
+			} else if gi.Similarity > gj.Similarity+coveredGroupSimilarityTolerance {
+				continue // gi is a distinctly stronger match than its cover
+			}
+			suppressed[i] = true
+			break
+		}
+	}
+
+	out := make([]*CloneGroup, 0, len(groups))
+	keptFragments := make(map[*CodeFragment]struct{})
+	for i, g := range groups {
+		if g == nil || suppressed[i] {
+			continue
+		}
+		out = append(out, g)
+		for _, f := range g.Fragments {
+			keptFragments[f] = struct{}{}
+		}
+	}
+	for i, g := range groups {
+		if g == nil || !suppressed[i] {
+			continue
+		}
+		for _, f := range g.Fragments {
+			if f == nil {
+				continue
+			}
+			// A fragment shared with a surviving group keeps its pairs.
+			if _, ok := keptFragments[f]; ok {
+				continue
+			}
+			result.suppressed[f] = struct{}{}
+		}
+	}
+	result.groups = out
+	return result
+}
+
+// groupCoveredBy reports whether every member of inner can be matched to a
+// distinct member of outer that covers it (same file, containing range,
+// equality included). Distinctness matters: two disjoint inner blocks inside
+// one outer member describe duplication *within* that member, which the outer
+// group does not report.
+func groupCoveredBy(inner, outer *CloneGroup) bool {
+	n := len(inner.Fragments)
+	if n == 0 || n > len(outer.Fragments) {
+		return false
+	}
+	candidates := make([][]int, n)
+	for i, f := range inner.Fragments {
+		if f == nil || f.Location == nil {
+			return false
+		}
+		for j, of := range outer.Fragments {
+			if of == nil || of.Location == nil {
+				continue
+			}
+			if locationCovers(of.Location, f.Location) {
+				candidates[i] = append(candidates[i], j)
+			}
+		}
+		if len(candidates[i]) == 0 {
+			return false
+		}
+	}
+	// Bipartite matching via augmenting paths; group sizes are small.
+	matchedInner := make([]int, len(outer.Fragments))
+	for j := range matchedInner {
+		matchedInner[j] = -1
+	}
+	var assign func(i int, visited []bool) bool
+	assign = func(i int, visited []bool) bool {
+		for _, j := range candidates[i] {
+			if visited[j] {
+				continue
+			}
+			visited[j] = true
+			if matchedInner[j] == -1 || assign(matchedInner[j], visited) {
+				matchedInner[j] = i
+				return true
+			}
+		}
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if !assign(i, make([]bool, len(outer.Fragments))) {
+			return false
+		}
+	}
+	return true
+}
+
+// locationCovers reports whether outer contains inner (same file, inclusive
+// line ranges; equal ranges count as covered).
+func locationCovers(outer, inner *CodeLocation) bool {
+	return outer.FilePath == inner.FilePath &&
+		outer.StartLine <= inner.StartLine &&
+		outer.EndLine >= inner.EndLine
+}
+
 // filterMaximalPerFile returns the subset of fragments that are maximal under
 // the same-file containment order. A fragment is suppressed if any other
 // kept fragment in the same file strictly covers it, or if it duplicates an

--- a/internal/analyzer/group_dedup_test.go
+++ b/internal/analyzer/group_dedup_test.go
@@ -242,6 +242,183 @@ func TestGroupClonesWithStrategy_FiltersSuppressedClonePairs(t *testing.T) {
 	}
 }
 
+// TestCoveredGroups_Issue518Repro reproduces issue #518: the same duplication
+// emitted as two near-identical groups whose member windows differ by exactly
+// one line (the enclosing `with` header). The group with the smaller windows
+// must be suppressed.
+func TestCoveredGroups_Issue518Repro(t *testing.T) {
+	inner := makeGroup(6, gf("smoke.py", 299, 315), gf("smoke.py", 318, 334))
+	inner.Similarity = 0.9692
+	outer := makeGroup(14, gf("smoke.py", 298, 315), gf("smoke.py", 317, 334))
+	outer.Similarity = 0.9613
+
+	out := dedupeCoveredGroups([]*CloneGroup{inner, outer})
+
+	if len(out.groups) != 1 {
+		t.Fatalf("expected 1 group after covered-group dedup, got %d", len(out.groups))
+	}
+	if out.groups[0] != outer {
+		t.Fatalf("expected the larger-window group to survive, got %v", rangesOf(out.groups[0]))
+	}
+	if len(out.suppressed) != 2 {
+		t.Fatalf("expected both members of the covered group suppressed, got %d", len(out.suppressed))
+	}
+}
+
+// TestCoveredGroups_IdenticalGroupsKeepFirst verifies the deterministic
+// tiebreak for mutual coverage: groups with identical member ranges collapse
+// to the earlier one in the slice.
+func TestCoveredGroups_IdenticalGroupsKeepFirst(t *testing.T) {
+	g1 := makeGroup(1, gf("x.py", 1, 10), gf("y.py", 1, 10))
+	g2 := makeGroup(2, gf("x.py", 1, 10), gf("y.py", 1, 10))
+
+	out := dedupeCoveredGroups([]*CloneGroup{g1, g2})
+
+	if len(out.groups) != 1 || out.groups[0] != g1 {
+		t.Fatalf("expected only the first of two identical groups to survive, got %+v", out.groups)
+	}
+}
+
+// TestCoveredGroups_ChainCollapsesToOutermost verifies transitivity: with
+// g1 ⊂ g2 ⊂ g3 member-wise, only the outermost group survives even though g2
+// is itself suppressed.
+func TestCoveredGroups_ChainCollapsesToOutermost(t *testing.T) {
+	g1 := makeGroup(1, gf("x.py", 3, 8), gf("y.py", 3, 8))
+	g2 := makeGroup(2, gf("x.py", 2, 9), gf("y.py", 2, 9))
+	g3 := makeGroup(3, gf("x.py", 1, 10), gf("y.py", 1, 10))
+
+	out := dedupeCoveredGroups([]*CloneGroup{g1, g2, g3})
+
+	if len(out.groups) != 1 || out.groups[0] != g3 {
+		t.Fatalf("expected only outermost group to survive, got %+v", out.groups)
+	}
+}
+
+// TestCoveredGroups_PartialCoverageKeptBoth verifies a group is kept when any
+// member falls outside the other group's windows: it carries information the
+// covering group does not.
+func TestCoveredGroups_PartialCoverageKeptBoth(t *testing.T) {
+	g1 := makeGroup(1, gf("x.py", 2, 9), gf("z.py", 1, 8))
+	g2 := makeGroup(2, gf("x.py", 1, 10), gf("y.py", 1, 10))
+
+	out := dedupeCoveredGroups([]*CloneGroup{g1, g2})
+
+	if len(out.groups) != 2 {
+		t.Fatalf("expected both groups kept, got %d", len(out.groups))
+	}
+	if len(out.suppressed) != 0 {
+		t.Fatalf("expected no suppressed fragments, got %d", len(out.suppressed))
+	}
+}
+
+// TestCoveredGroups_DistinctMembersRequired verifies the injective-matching
+// constraint: two disjoint blocks inside ONE member of another group describe
+// duplication within that member, which the outer group does not report, so
+// the inner group must be kept.
+func TestCoveredGroups_DistinctMembersRequired(t *testing.T) {
+	inner := makeGroup(1, gf("x.py", 10, 20), gf("x.py", 30, 40))
+	outer := makeGroup(2, gf("x.py", 1, 100), gf("y.py", 1, 100))
+
+	out := dedupeCoveredGroups([]*CloneGroup{inner, outer})
+
+	if len(out.groups) != 2 {
+		t.Fatalf("expected both groups kept (no injective cover), got %d", len(out.groups))
+	}
+}
+
+// TestCoveredGroups_NestedDistinctFilesSuppressed verifies the general nested
+// case: a group of inner blocks each inside a distinct cloned member of a
+// larger group, with comparable similarity, is redundant with it.
+func TestCoveredGroups_NestedDistinctFilesSuppressed(t *testing.T) {
+	inner := makeGroup(1, gf("x.py", 20, 30), gf("y.py", 20, 30))
+	inner.Similarity = 0.93
+	outer := makeGroup(2, gf("x.py", 1, 100), gf("y.py", 1, 100))
+	outer.Similarity = 0.91
+
+	out := dedupeCoveredGroups([]*CloneGroup{inner, outer})
+
+	if len(out.groups) != 1 || out.groups[0] != outer {
+		t.Fatalf("expected nested group suppressed in favor of covering group, got %+v", out.groups)
+	}
+}
+
+// TestCoveredGroups_StrongerInnerFindingKept verifies the similarity guard:
+// an inner group that matches much more strongly than its covering group
+// (e.g., a near-identical block inside loosely similar functions) is a
+// distinct finding and must survive.
+func TestCoveredGroups_StrongerInnerFindingKept(t *testing.T) {
+	inner := makeGroup(1, gf("x.py", 2, 5), gf("y.py", 2, 5))
+	inner.Similarity = 0.95
+	outer := makeGroup(2, gf("x.py", 1, 6), gf("y.py", 1, 6))
+	outer.Similarity = 0.65
+
+	out := dedupeCoveredGroups([]*CloneGroup{inner, outer})
+
+	if len(out.groups) != 2 {
+		t.Fatalf("expected both groups kept when inner is the stronger finding, got %d", len(out.groups))
+	}
+	if len(out.suppressed) != 0 {
+		t.Fatalf("expected no suppressed fragments, got %d", len(out.suppressed))
+	}
+}
+
+// TestCoveredGroups_SharedFragmentKeepsPairs verifies that a fragment also
+// present in a surviving group is not marked suppressed, so its clone pairs
+// stay in the output.
+func TestCoveredGroups_SharedFragmentKeepsPairs(t *testing.T) {
+	shared := gf("x.py", 5, 9)
+	covered := makeGroup(1, shared, gf("y.py", 5, 9))
+	covering := makeGroup(2, gf("x.py", 1, 10), gf("y.py", 1, 10))
+	keeper := makeGroup(3, shared, gf("z.py", 50, 90))
+
+	out := dedupeCoveredGroups([]*CloneGroup{covered, covering, keeper})
+
+	if len(out.groups) != 2 {
+		t.Fatalf("expected covering+keeper groups to survive, got %d", len(out.groups))
+	}
+	if _, ok := out.suppressed[shared]; ok {
+		t.Fatalf("fragment shared with a surviving group must not be suppressed")
+	}
+	if len(out.suppressed) != 1 {
+		t.Fatalf("expected only the non-shared member suppressed, got %d", len(out.suppressed))
+	}
+}
+
+// TestCoveredGroups_E2EThroughGroupClonesWithStrategy verifies the full
+// pipeline: two duplications reported through overlapping windows produce two
+// groups via connected grouping, and the covered one is dropped along with its
+// clone pairs.
+func TestCoveredGroups_E2EThroughGroupClonesWithStrategy(t *testing.T) {
+	innerA := gf("smoke.py", 299, 315)
+	innerB := gf("smoke.py", 318, 334)
+	outerA := gf("smoke.py", 298, 315)
+	outerB := gf("smoke.py", 317, 334)
+	cd := &CloneDetector{
+		clonePairs: []*ClonePair{
+			gpType(innerA, innerB, 0.9692, Type2Clone),
+			gpType(outerA, outerB, 0.9613, Type2Clone),
+		},
+	}
+
+	cd.groupClonesWithStrategy(NewConnectedGrouping(0.85))
+
+	if len(cd.cloneGroups) != 1 {
+		t.Fatalf("expected 1 group after covered-group dedup, got %d", len(cd.cloneGroups))
+	}
+	got := rangesOf(cd.cloneGroups[0])
+	want := []string{outerA.Location.String(), outerB.Location.String()}
+	sort.Strings(want)
+	if !equalStringSlices(got, want) {
+		t.Fatalf("expected larger-window group %v to survive, got %v", want, got)
+	}
+	if len(cd.clonePairs) != 1 {
+		t.Fatalf("expected covered group's pair to be filtered, got %d pairs", len(cd.clonePairs))
+	}
+	if cd.clonePairs[0].Fragment1 != outerA || cd.clonePairs[0].Fragment2 != outerB {
+		t.Fatalf("surviving pair should be the larger-window pair")
+	}
+}
+
 // TestDedupe_E2EThroughConnectedGrouping is the end-to-end integration test:
 // pairs (A, C) and (B, C) where A and B are overlapping same-file fragments
 // — isOverlappingLocation prevents a direct (A, B) pair, but Union-Find unites


### PR DESCRIPTION
## Summary

Fixes #518 (duplicate-overlapping-clone-groups): the clone detector could emit two separate groups describing the same duplication between the same two fragments, with member windows shifted by exactly one line (the enclosing `with` header).

## Root cause

`isOverlappingLocation` forbids a direct same-file pair between two overlapping windows (e.g. `smoke.py:298-315` and `smoke.py:299-315`), so the shifted windows can never be linked by a pair. Connected grouping then leaves them in two disconnected groups that report the same duplication relationship twice, inflating `clone_groups` count and the duplication percentage.

This is the cross-group sibling of #416: `dedupeStrictSubsetGroupMembers` (#432) collapses overlapping windows *within* one group, but cannot see overlapping windows split across *different* groups.

## Fix

Add `dedupeCoveredGroups` as a second post-grouping pass in `groupClonesWithStrategy`. A group is suppressed when:

- every member fits inside a *distinct* member of another group (same file, containing line range), matched injectively via bipartite matching — distinctness matters because two disjoint blocks inside one member of another group describe duplication that group does not report; and
- the covering group's similarity is comparable or better (tolerance 0.05) — a covered group that matches much more strongly than its cover (e.g. a near-identical inner block inside loosely similar functions) is a distinct, sharper finding and is kept.

The larger-window group survives, mirroring the maximal-window policy of `filterMaximalPerFile`. Mutual coverage (identical member ranges) keeps the earlier group deterministically, and coverage chains collapse to the outermost group. Clone pairs of suppressed members are removed through the existing suppressed-fragment mechanism, except for fragments shared with a surviving group.

## Testing

- New unit tests including the exact #518 shape (line numbers and similarities from the issue), the similarity guard, injective-matching constraint, chains, mutual coverage, partial coverage, and an end-to-end test through `groupClonesWithStrategy` + connected grouping.
- Full `go test ./...` passes; `make lint` reports 0 issues.
- Ran `pyscn analyze --select clones` on `Instagram/Fixit@bf8e1f5` (the issue's reproducer) with binaries from `main` and this branch: identical groups and pairs, i.e. no over-suppression on real data. The exact v1.22.9 duplicate pair no longer reproduces on current main defaults (type-4 detection changes since then absorbed those windows into one group), so the regression is locked in by the e2e unit test instead.