### PR TITLE
fix(clones): populate fragment hash in clone output

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -65,7 +65,7 @@ type CodeFragment struct {
 	ASTNode    *parser.Node
 	TreeNode   *TreeNode
 	Content    string   // Original source code content
-	Hash       string   // Hash for quick comparison
+	Hash       string   // FNV-64a hex hash of Type-1 normalized content; "" when no source content
 	Size       int      // Number of AST nodes
 	LineCount  int      // Number of source lines
 	Complexity int      // Cyclomatic complexity (if applicable)
@@ -78,6 +78,7 @@ func NewCodeFragment(location *CodeLocation, astNode *parser.Node, content strin
 		Location:  location,
 		ASTNode:   astNode,
 		Content:   content,
+		Hash:      hashFragmentContent(content),
 		Size:      calculateASTSize(astNode),
 		LineCount: location.EndLine - location.StartLine + 1,
 	}

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -97,6 +97,41 @@ func TestCodeFragment_Creation(t *testing.T) {
 	assert.Equal(t, content, fragment.Content, "Content should be set")
 	assert.Equal(t, 10, fragment.LineCount, "Line count should be calculated correctly")
 	assert.Greater(t, fragment.Size, 0, "Size should be calculated")
+	assert.NotEmpty(t, fragment.Hash, "Hash should be computed from content")
+}
+
+func TestCodeFragment_Hash(t *testing.T) {
+	location := &CodeLocation{FilePath: "/test/file.py", StartLine: 1, EndLine: 2}
+	astNode := &parser.Node{Type: parser.NodeFunctionDef, Name: "f"}
+
+	newFragment := func(content string) *CodeFragment {
+		return NewCodeFragment(location, astNode, content)
+	}
+
+	t.Run("non-empty content produces 16-char hex hash", func(t *testing.T) {
+		fragment := newFragment("def f():\n    return 1")
+		assert.Regexp(t, "^[0-9a-f]{16}$", fragment.Hash)
+	})
+
+	t.Run("empty content produces empty hash", func(t *testing.T) {
+		fragment := newFragment("")
+		assert.Empty(t, fragment.Hash, "Fragments extracted without source content should have no hash")
+	})
+
+	t.Run("Type-1 variants share the same hash", func(t *testing.T) {
+		original := newFragment("def f():\n    return 1")
+		reformatted := newFragment("def f():\n        return  1")
+		commented := newFragment("def f():  # comment\n    return 1")
+
+		assert.Equal(t, original.Hash, reformatted.Hash, "Whitespace differences should not change the hash")
+		assert.Equal(t, original.Hash, commented.Hash, "Comments should not change the hash")
+	})
+
+	t.Run("different code produces different hashes", func(t *testing.T) {
+		f1 := newFragment("def f():\n    return 1")
+		f2 := newFragment("def f():\n    return 2")
+		assert.NotEqual(t, f1.Hash, f2.Hash)
+	})
 }
 
 func TestCalculateASTSize(t *testing.T) {

--- a/internal/analyzer/textual_similarity.go
+++ b/internal/analyzer/textual_similarity.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"fmt"
 	"hash/fnv"
 	"regexp"
 	"strings"
@@ -213,6 +214,23 @@ func (t *TextualSimilarityAnalyzer) hashContent(content string) uint64 {
 	h := fnv.New64a()
 	h.Write([]byte(content))
 	return h.Sum64()
+}
+
+// fragmentHashNormalizer applies the default Type-1 normalization (remove
+// comments, collapse whitespace) for fragment fingerprinting, independent of
+// any per-detector similarity configuration.
+var fragmentHashNormalizer = NewTextualSimilarityAnalyzer()
+
+// hashFragmentContent returns a hex-encoded FNV-64a hash of the Type-1
+// normalized content. Two fragments with the same hash are Type-1 clones of
+// each other. Returns "" when the content is empty after normalization (e.g.
+// the fragment was extracted without source content).
+func hashFragmentContent(content string) string {
+	normalized := fragmentHashNormalizer.normalizeContent(content)
+	if normalized == "" {
+		return ""
+	}
+	return fmt.Sprintf("%016x", fragmentHashNormalizer.hashContent(normalized))
 }
 
 // computeLevenshteinSimilarity computes similarity based on Levenshtein distance.

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -345,6 +345,7 @@ func (s *CloneService) convertClonePairsToDomain(clonePairs []*analyzer.ClonePai
 				StartCol:  pair.Fragment1.Location.StartCol,
 				EndCol:    pair.Fragment1.Location.EndCol,
 			},
+			Hash:      pair.Fragment1.Hash,
 			Size:      pair.Fragment1.Size,
 			LineCount: pair.Fragment1.LineCount,
 		}
@@ -356,6 +357,7 @@ func (s *CloneService) convertClonePairsToDomain(clonePairs []*analyzer.ClonePai
 				StartCol:  pair.Fragment2.Location.StartCol,
 				EndCol:    pair.Fragment2.Location.EndCol,
 			},
+			Hash:      pair.Fragment2.Hash,
 			Size:      pair.Fragment2.Size,
 			LineCount: pair.Fragment2.LineCount,
 		}

--- a/service/clone_service_content_test.go
+++ b/service/clone_service_content_test.go
@@ -126,3 +126,36 @@ func TestCloneService_convertCloneGroupsToDomain_FragmentIDAndType(t *testing.T)
 		assert.Equal(t, domain.Type2Clone, clone.Type, "fragment type should match the group clone type")
 	}
 }
+
+// Regression for #488: the fragment hash must be forwarded to both pair-level
+// and group-level clone output instead of being dropped.
+func TestCloneService_convertClonesToDomain_Hash(t *testing.T) {
+	service := NewCloneService()
+	frag0 := &analyzer.CodeFragment{
+		Location:  &analyzer.CodeLocation{FilePath: "a.py", StartLine: 1, EndLine: 2},
+		Hash:      "00000000aaaaaaaa",
+		Size:      3,
+		LineCount: 2,
+	}
+	frag1 := &analyzer.CodeFragment{
+		Location:  &analyzer.CodeLocation{FilePath: "b.py", StartLine: 5, EndLine: 6},
+		Hash:      "00000000bbbbbbbb",
+		Size:      3,
+		LineCount: 2,
+	}
+
+	pairs := service.convertClonePairsToDomain([]*analyzer.ClonePair{
+		{Fragment1: frag0, Fragment2: frag1, Similarity: 1.0, CloneType: analyzer.Type1Clone},
+	}, false)
+	require.Len(t, pairs, 1)
+	assert.Equal(t, "00000000aaaaaaaa", pairs[0].Clone1.Hash)
+	assert.Equal(t, "00000000bbbbbbbb", pairs[0].Clone2.Hash)
+
+	groups := service.convertCloneGroupsToDomain([]*analyzer.CloneGroup{
+		{ID: 1, CloneType: analyzer.Type1Clone, Similarity: 1.0, Size: 2, Fragments: []*analyzer.CodeFragment{frag0, frag1}},
+	}, false, nil)
+	require.Len(t, groups, 1)
+	require.Len(t, groups[0].Clones, 2)
+	assert.Equal(t, "00000000aaaaaaaa", groups[0].Clones[0].Hash)
+	assert.Equal(t, "00000000bbbbbbbb", groups[0].Clones[1].Hash)
+}


### PR DESCRIPTION
## Summary

Completes #488. PR #503 fixed the fragment `id`/`type` fields but deferred `hash`, which stayed `""` on every clone fragment because `analyzer.CodeFragment.Hash` was declared and forwarded but never assigned anywhere in the detector.

This populates it at the source: `NewCodeFragment` now computes a hex-encoded FNV-64a hash of the Type-1 normalized content (comments removed, whitespace collapsed), reusing the same normalization and FNV hashing the textual similarity analyzer already uses. The chosen semantics: **two fragments with equal hashes are Type-1 clones of each other** — formatting and comment differences don't change the hash, identifier or logic changes do. Fragments extracted without source content (the no-source extraction path) keep an empty hash.

## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
Closes #488

## Changes
- `internal/analyzer/textual_similarity.go`: add `hashFragmentContent` — Type-1 normalization (default config, independent of per-detector similarity settings) + FNV-64a, hex-encoded; returns `""` for content that is empty after normalization.
- `internal/analyzer/clone_detector.go`: set `Hash` in `NewCodeFragment`; update the field comment to document the semantics.
- `service/clone_service.go`: forward `Hash` to pair-level `Clone1`/`Clone2` output (group-level and top-level `clones[]` already forwarded it since #503).
- Tests: `TestCodeFragment_Hash` (hex shape, empty-content case, Type-1 variants share a hash, different code differs) and `TestCloneService_convertClonesToDomain_Hash` (hash forwarded in pair and group conversion).

## Testing
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Added tests for new functionality
- [x] Manual testing completed

Manual before/after on a fixture with two Type-1 variants of `alpha` (comment/whitespace differences) plus a renamed `beta`:

```json
"clones": [
  {"id": 1, "hash": "f8f37c9414249927", "file": "other.py"},
  {"id": 2, "hash": "f8f37c9414249927", "file": "sample.py"},
  {"id": 3, "hash": "5886275b18f60979", "file": "sample.py"}
]
```

Type-1 variants share the hash; the renamed function gets a distinct one. Before this change all three were `""`.

## Documentation
- [x] Updated godoc comments
- [ ] Updated README or other docs (if needed) — none needed; the output schema field already existed, this populates it.

## Additional Context
Per-fragment hashing happens once at fragment construction (regex whitespace collapse + comment strip over the fragment text), which is negligible next to the similarity computations downstream.