### PR TITLE
feat(analyzer): group namespace import members for CBO calculation

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -398,9 +398,10 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 					SortBy:          domain.SortByCoupling,
 					ConfigPath:      config.ConfigFile,
 					// Boolean options left as nil to allow config file values to take precedence
-					ShowZeros:       nil,
-					IncludeBuiltins: nil,
-					IncludeImports:  nil,
+					ShowZeros:             nil,
+					IncludeBuiltins:       nil,
+					IncludeImports:        nil,
+					GroupNamespaceImports: nil,
 				}
 				return uc.cboUseCase.analyzeSnapshotRequest(ctx, snapshot, request)
 			},

--- a/domain/cbo.go
+++ b/domain/cbo.go
@@ -36,8 +36,9 @@ type CBORequest struct {
 	ExcludePatterns []string
 
 	// Analysis scope
-	IncludeBuiltins *bool // Include dependencies on built-in types
-	IncludeImports  *bool // Include imported modules in dependency count
+	IncludeBuiltins       *bool // Include dependencies on built-in types
+	IncludeImports        *bool // Include imported modules in dependency count
+	GroupNamespaceImports *bool // Collapse alias.Member references to a single alias edge
 }
 
 // CBOMetrics represents detailed CBO metrics for a class
@@ -164,18 +165,19 @@ type CBOAnalysisOptions struct {
 // Threshold values are sourced from domain/defaults.go
 func DefaultCBORequest() *CBORequest {
 	return &CBORequest{
-		OutputFormat:    OutputFormatText,
-		ShowDetails:     false,
-		MinCBO:          0,
-		MaxCBO:          0,              // No limit
-		SortBy:          SortByCoupling, // Sort by CBO value
-		ShowZeros:       BoolPtr(false),
-		LowThreshold:    DefaultCBOLowThreshold,    // Industry standard: CBO <= 3 is low risk
-		MediumThreshold: DefaultCBOMediumThreshold, // Industry standard: 3 < CBO <= 7 is medium risk
-		Recursive:       BoolPtr(true),
-		IncludeBuiltins: BoolPtr(false),
-		IncludeImports:  BoolPtr(true),
-		IncludePatterns: DefaultAnalysisIncludePatterns(),
-		ExcludePatterns: []string{},
+		OutputFormat:          OutputFormatText,
+		ShowDetails:           false,
+		MinCBO:                0,
+		MaxCBO:                0,              // No limit
+		SortBy:                SortByCoupling, // Sort by CBO value
+		ShowZeros:             BoolPtr(false),
+		LowThreshold:          DefaultCBOLowThreshold,    // Industry standard: CBO <= 3 is low risk
+		MediumThreshold:       DefaultCBOMediumThreshold, // Industry standard: 3 < CBO <= 7 is medium risk
+		Recursive:             BoolPtr(true),
+		IncludeBuiltins:       BoolPtr(false),
+		IncludeImports:        BoolPtr(true),
+		GroupNamespaceImports: BoolPtr(true),
+		IncludePatterns:       DefaultAnalysisIncludePatterns(),
+		ExcludePatterns:       []string{},
 	}
 }

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -44,24 +44,26 @@ type CBOResult struct {
 
 // CBOOptions configures CBO analysis behavior
 type CBOOptions struct {
-	IncludeBuiltins   bool
-	IncludeImports    bool
-	PublicClassesOnly bool
-	ExcludePatterns   []string
-	LowThreshold      int // Default: 3 (industry standard)
-	MediumThreshold   int // Default: 7 (industry standard)
+	IncludeBuiltins       bool
+	IncludeImports        bool
+	PublicClassesOnly     bool
+	GroupNamespaceImports bool
+	ExcludePatterns       []string
+	LowThreshold          int // Default: 3 (industry standard)
+	MediumThreshold       int // Default: 7 (industry standard)
 }
 
 // DefaultCBOOptions returns default CBO analysis options
 // Threshold values are sourced from domain/defaults.go
 func DefaultCBOOptions() *CBOOptions {
 	return &CBOOptions{
-		IncludeBuiltins:   false,
-		IncludeImports:    true,
-		PublicClassesOnly: false,
-		ExcludePatterns:   []string{"test_*", "*_test", "__*__"},
-		LowThreshold:      domain.DefaultCBOLowThreshold,    // Industry standard: CBO <= 3 is low risk
-		MediumThreshold:   domain.DefaultCBOMediumThreshold, // Industry standard: 3 < CBO <= 7 is medium risk
+		IncludeBuiltins:       false,
+		IncludeImports:        true,
+		PublicClassesOnly:     false,
+		GroupNamespaceImports: true,
+		ExcludePatterns:       []string{"test_*", "*_test", "__*__"},
+		LowThreshold:          domain.DefaultCBOLowThreshold,    // Industry standard: CBO <= 3 is low risk
+		MediumThreshold:       domain.DefaultCBOMediumThreshold, // Industry standard: 3 < CBO <= 7 is medium risk
 	}
 }
 
@@ -72,6 +74,7 @@ type CBOAnalyzer struct {
 	builtinFunctions map[string]bool
 	standardLibs     map[string]bool
 	importedNames    map[string]string         // alias -> module.name mapping
+	namespaceAliases map[string]string         // module.name -> alias mapping (only for alias imports)
 	regexCache       map[string]*regexp.Regexp // pattern -> compiled regex cache
 }
 
@@ -84,6 +87,11 @@ const (
 	dependencyKindAttributeAccess
 	dependencyKindImport
 )
+
+type cboImportMaps struct {
+	importedNames    map[string]string
+	namespaceAliases map[string]string
+}
 
 type cboDependencies struct {
 	all               map[string]bool
@@ -117,6 +125,7 @@ func NewCBOAnalyzer(options *CBOOptions) *CBOAnalyzer {
 		builtinFunctions: make(map[string]bool),
 		standardLibs:     make(map[string]bool),
 		importedNames:    make(map[string]string),
+		namespaceAliases: make(map[string]string),
 		regexCache:       make(map[string]*regexp.Regexp),
 	}
 
@@ -136,9 +145,10 @@ func (a *CBOAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*CBOR
 	classes := a.collectClasses(ast)
 	imports := a.collectImports(ast)
 
-	// Import aliases are file-local. Reset the map on each AST so one analyzed file
+	// Import aliases are file-local. Reset the maps on each AST so one analyzed file
 	// cannot change dependency identity in the next file.
-	a.importedNames = imports
+	a.importedNames = imports.importedNames
+	a.namespaceAliases = imports.namespaceAliases
 
 	var results []*CBOResult
 
@@ -370,6 +380,15 @@ func (a *CBOAnalyzer) analyzeInstantiationAndAccess(classNode *parser.Node, depe
 				return true
 			}
 
+			// Handle imported namespace members (e.g. cst.Arg): if the dotted
+			// name resolves to a class reference, count it as coupling. The same
+			// heuristic used for calls avoids counting functions like os.getcwd.
+			attrName := a.extractClassName(node)
+			if dep := a.callDependencyName(attrName, allClasses); dep != "" && a.shouldIncludeDependencyForClass(dep, result.ClassName) {
+				a.addDependency(dependencies, dep, dependencyKindAttributeAccess)
+				break
+			}
+
 			objNode := node.Left
 			if objNode == nil {
 				if valueNode, ok := node.Value.(*parser.Node); ok {
@@ -403,9 +422,14 @@ func (a *CBOAnalyzer) collectClasses(ast *parser.Node) map[string]*parser.Node {
 	return classes
 }
 
-// collectImports collects import statements and their aliases
-func (a *CBOAnalyzer) collectImports(ast *parser.Node) map[string]string {
-	imports := make(map[string]string)
+// collectImports collects import statements and their aliases.
+// It returns both the alias -> module.name map and a reverse map of
+// module.name -> alias for namespace aliases created by "import ... as ...".
+func (a *CBOAnalyzer) collectImports(ast *parser.Node) cboImportMaps {
+	imports := cboImportMaps{
+		importedNames:    make(map[string]string),
+		namespaceAliases: make(map[string]string),
+	}
 
 	a.walkNode(ast, func(node *parser.Node) bool {
 		switch node.Type {
@@ -422,12 +446,17 @@ func (a *CBOAnalyzer) collectImports(ast *parser.Node) map[string]string {
 							aliasedNames[module] = true
 						}
 					}
-					imports[alias] = module
+					imports.importedNames[alias] = module
+					// Only true aliases (different from the module binding) form a
+					// namespace that should be collapsed.
+					if alias != module {
+						imports.namespaceAliases[module] = alias
+					}
 				}
 			}
 			for _, name := range node.Names {
 				if !aliasedNames[name] {
-					imports[importBindingName(name)] = name
+					imports.importedNames[importBindingName(name)] = name
 				}
 			}
 		case parser.NodeImportFrom:
@@ -444,12 +473,12 @@ func (a *CBOAnalyzer) collectImports(ast *parser.Node) map[string]string {
 							aliasedNames[name] = true
 						}
 					}
-					imports[alias] = module + "." + name
+					imports.importedNames[alias] = module + "." + name
 				}
 			}
 			for _, name := range node.Names {
 				if !aliasedNames[name] {
-					imports[name] = module + "." + name
+					imports.importedNames[name] = module + "." + name
 				}
 			}
 		}
@@ -717,6 +746,8 @@ func (a *CBOAnalyzer) addDependency(dependencies *cboDependencies, className str
 		return
 	}
 
+	className = a.canonicalDependencyName(className)
+
 	dependencies.all[className] = true
 
 	if a.isImportedDependency(className) {
@@ -736,6 +767,37 @@ func (a *CBOAnalyzer) addDependency(dependencies *cboDependencies, className str
 	case dependencyKindImport:
 		dependencies.imports[className] = true
 	}
+}
+
+// canonicalDependencyName collapses references through a namespace alias to the
+// alias itself when GroupNamespaceImports is enabled. This prevents a single
+// "import libcst as cst" from inflating CBO by one edge per cst.Member usage.
+func (a *CBOAnalyzer) canonicalDependencyName(className string) string {
+	if !a.options.GroupNamespaceImports {
+		return className
+	}
+	if className == "" {
+		return className
+	}
+
+	// If the name is a direct reference to an aliased module, prefer the alias.
+	if alias, exists := a.namespaceAliases[className]; exists {
+		return alias
+	}
+
+	// If the name is alias.Member and the leading part is a real namespace
+	// alias (created by "import ... as ..."), collapse to the alias.
+	if strings.Contains(className, ".") {
+		parts := strings.SplitN(className, ".", 2)
+		alias := parts[0]
+		if module, exists := a.importedNames[alias]; exists {
+			if canonicalAlias, aliased := a.namespaceAliases[module]; aliased && canonicalAlias == alias {
+				return alias
+			}
+		}
+	}
+
+	return className
 }
 
 func (a *CBOAnalyzer) sameDependencyIdentity(className, ownerClass string) bool {
@@ -936,14 +998,12 @@ func (a *CBOAnalyzer) walkNode(node *parser.Node, visitor func(*parser.Node) boo
 	node.Walk(visitor)
 }
 
-// inferObjectType tries to infer the type of an object from context
+// inferObjectType tries to infer the type of an object from context.
+// We return the local binding name so that namespace aliases like
+// "import libcst as cst" collapse consistently in addDependency.
 func (a *CBOAnalyzer) inferObjectType(node *parser.Node) string {
 	// Simple heuristic - try to extract type from variable name or method call
 	if node.Type == parser.NodeName {
-		// Look up in imported names
-		if fullName, exists := a.importedNames[node.Name]; exists {
-			return fullName
-		}
 		return node.Name
 	}
 

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -871,6 +871,101 @@ class Service:
 	assert.Contains(t, serviceResult.DependentClasses, "Logger")
 }
 
+func TestCBOAnalyzer_NamespaceImportMembersAreGrouped(t *testing.T) {
+	pythonCode := `
+import libcst as cst
+import libcst.matchers as m
+
+class Foo:
+    a = cst.Name
+    b = cst.Call
+    c = cst.Arg
+    d = m.Comparison
+    e = m.ComparisonTarget
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	t.Run("group namespace imports", func(t *testing.T) {
+		options := DefaultCBOOptions()
+		options.GroupNamespaceImports = true
+
+		results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "foo.py")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		foo := results[0]
+		assert.Equal(t, 2, foo.CouplingCount, "cst.* and m.* should collapse to two edges")
+		assert.Equal(t, []string{"cst", "m"}, foo.DependentClasses)
+		assert.Equal(t, 2, foo.ImportDependencies)
+	})
+
+	t.Run("keep per-member edges when disabled", func(t *testing.T) {
+		options := DefaultCBOOptions()
+		options.GroupNamespaceImports = false
+
+		results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "foo.py")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		foo := results[0]
+		assert.Equal(t, 5, foo.CouplingCount, "each alias.Member should be a separate edge")
+		assert.Equal(t, []string{"cst.Arg", "cst.Call", "cst.Name", "m.Comparison", "m.ComparisonTarget"}, foo.DependentClasses)
+	})
+}
+
+func TestCBOAnalyzer_NamespaceImportCallsAreGrouped(t *testing.T) {
+	pythonCode := `
+import libcst as cst
+
+class Builder:
+    def build(self):
+        name = cst.Name()
+        call = cst.Call()
+        arg = cst.Arg()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	options := DefaultCBOOptions()
+	options.GroupNamespaceImports = true
+
+	results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "builder.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	builder := results[0]
+	assert.Equal(t, 1, builder.CouplingCount)
+	assert.Equal(t, []string{"cst"}, builder.DependentClasses)
+	assert.Equal(t, 1, builder.ImportDependencies)
+}
+
+func TestCBOAnalyzer_NonAliasedModuleMembersAreNotGrouped(t *testing.T) {
+	pythonCode := `
+import datetime
+
+class Scheduler:
+    def now(self):
+        return datetime.datetime.now()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	options := DefaultCBOOptions()
+	options.GroupNamespaceImports = true
+
+	results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "scheduler.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	scheduler := results[0]
+	assert.Equal(t, []string{"datetime.datetime"}, scheduler.DependentClasses)
+	assert.Equal(t, 1, scheduler.CouplingCount)
+}
+
 func TestCBOAnalyzer_FunctionCallsAreNotClassDependencies(t *testing.T) {
 	// Regression test for #494: imported function calls (os.getcwd, suppress,
 	// escape) must not be counted as class dependencies.

--- a/internal/config/cbo_config_test.go
+++ b/internal/config/cbo_config_test.go
@@ -21,6 +21,7 @@ max_cbo = 20
 show_zeros = true
 include_builtins = true
 include_imports = false
+group_namespace_imports = false
 `
 	configPath := filepath.Join(tempDir, ".pyscn.toml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -43,6 +44,7 @@ include_imports = false
 	t.Logf("  CboShowZeros: %v", config.CboShowZeros)
 	t.Logf("  CboIncludeBuiltins: %v", config.CboIncludeBuiltins)
 	t.Logf("  CboIncludeImports: %v", config.CboIncludeImports)
+	t.Logf("  CboGroupNamespaceImports: %v", config.CboGroupNamespaceImports)
 
 	// Verify cbo settings were loaded
 	if config.CboLowThreshold != 5 {
@@ -65,6 +67,9 @@ include_imports = false
 	}
 	if domain.BoolValue(config.CboIncludeImports, true) {
 		t.Errorf("Expected include_imports false, got %v", config.CboIncludeImports)
+	}
+	if domain.BoolValue(config.CboGroupNamespaceImports, true) {
+		t.Errorf("Expected group_namespace_imports false, got %v", config.CboGroupNamespaceImports)
 	}
 }
 
@@ -113,6 +118,9 @@ medium_threshold = 8
 	if !domain.BoolValue(config.CboIncludeImports, true) {
 		t.Errorf("Expected default include_imports true, got %v", config.CboIncludeImports)
 	}
+	if !domain.BoolValue(config.CboGroupNamespaceImports, true) {
+		t.Errorf("Expected default group_namespace_imports true, got %v", config.CboGroupNamespaceImports)
+	}
 }
 
 func TestMergeCboSection(t *testing.T) {
@@ -121,13 +129,14 @@ func TestMergeCboSection(t *testing.T) {
 
 	// Create cbo settings
 	cbo := CboTomlConfig{
-		LowThreshold:    intPtr(4),
-		MediumThreshold: intPtr(9),
-		MinCbo:          intPtr(1),
-		MaxCbo:          intPtr(15),
-		ShowZeros:       boolPtr(true),
-		IncludeBuiltins: boolPtr(true),
-		IncludeImports:  boolPtr(false),
+		LowThreshold:          intPtr(4),
+		MediumThreshold:       intPtr(9),
+		MinCbo:                intPtr(1),
+		MaxCbo:                intPtr(15),
+		ShowZeros:             boolPtr(true),
+		IncludeBuiltins:       boolPtr(true),
+		IncludeImports:        boolPtr(false),
+		GroupNamespaceImports: boolPtr(false),
 	}
 
 	// Merge cbo settings
@@ -155,6 +164,9 @@ func TestMergeCboSection(t *testing.T) {
 	if domain.BoolValue(config.CboIncludeImports, true) {
 		t.Errorf("Expected include_imports false, got %v", config.CboIncludeImports)
 	}
+	if domain.BoolValue(config.CboGroupNamespaceImports, true) {
+		t.Errorf("Expected group_namespace_imports false, got %v", config.CboGroupNamespaceImports)
+	}
 }
 
 func TestMergeCboSectionNilValues(t *testing.T) {
@@ -164,13 +176,14 @@ func TestMergeCboSectionNilValues(t *testing.T) {
 
 	// Create cbo settings with nil values
 	cbo := CboTomlConfig{
-		LowThreshold:    nil,
-		MediumThreshold: nil,
-		MinCbo:          nil,
-		MaxCbo:          nil,
-		ShowZeros:       nil,
-		IncludeBuiltins: nil,
-		IncludeImports:  nil,
+		LowThreshold:          nil,
+		MediumThreshold:       nil,
+		MinCbo:                nil,
+		MaxCbo:                nil,
+		ShowZeros:             nil,
+		IncludeBuiltins:       nil,
+		IncludeImports:        nil,
+		GroupNamespaceImports: nil,
 	}
 
 	// Merge cbo settings

--- a/internal/config/default_config.toml.tmpl
+++ b/internal/config/default_config.toml.tmpl
@@ -108,6 +108,7 @@ medium_threshold = {{ .CBOMediumThreshold }}             # CBO values {{ .CBOLow
                                 # CBO values > {{ .CBOMediumThreshold }} are high risk
 include_builtins = false         # Include built-in type dependencies
 include_imports = true           # Include imported module dependencies
+group_namespace_imports = true   # Collapse alias.Member references to one edge per namespace
 min_cbo = 0                      # Minimum CBO to report
 show_zeros = false               # Include classes with CBO = 0
 

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -349,6 +349,9 @@ func mergeCboSection(defaults *PyscnConfig, cbo *CboTomlConfig) {
 	if cbo.IncludeImports != nil {
 		defaults.CboIncludeImports = cbo.IncludeImports
 	}
+	if cbo.GroupNamespaceImports != nil {
+		defaults.CboGroupNamespaceImports = cbo.GroupNamespaceImports
+	}
 }
 
 // mergeLcomSection merges settings from the [lcom] section

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -72,13 +72,14 @@ type PyscnConfig struct {
 	analysisIncludeExplicit bool     `mapstructure:"-" yaml:"-" json:"-"`
 
 	// CBO Configuration (from [cbo] section in TOML)
-	CboLowThreshold    int   `mapstructure:"cbo_low_threshold" yaml:"cbo_low_threshold" json:"cbo_low_threshold"`
-	CboMediumThreshold int   `mapstructure:"cbo_medium_threshold" yaml:"cbo_medium_threshold" json:"cbo_medium_threshold"`
-	CboMinCbo          int   `mapstructure:"cbo_min_cbo" yaml:"cbo_min_cbo" json:"cbo_min_cbo"`
-	CboMaxCbo          int   `mapstructure:"cbo_max_cbo" yaml:"cbo_max_cbo" json:"cbo_max_cbo"`
-	CboShowZeros       *bool `mapstructure:"cbo_show_zeros" yaml:"cbo_show_zeros" json:"cbo_show_zeros"`
-	CboIncludeBuiltins *bool `mapstructure:"cbo_include_builtins" yaml:"cbo_include_builtins" json:"cbo_include_builtins"`
-	CboIncludeImports  *bool `mapstructure:"cbo_include_imports" yaml:"cbo_include_imports" json:"cbo_include_imports"`
+	CboLowThreshold          int   `mapstructure:"cbo_low_threshold" yaml:"cbo_low_threshold" json:"cbo_low_threshold"`
+	CboMediumThreshold       int   `mapstructure:"cbo_medium_threshold" yaml:"cbo_medium_threshold" json:"cbo_medium_threshold"`
+	CboMinCbo                int   `mapstructure:"cbo_min_cbo" yaml:"cbo_min_cbo" json:"cbo_min_cbo"`
+	CboMaxCbo                int   `mapstructure:"cbo_max_cbo" yaml:"cbo_max_cbo" json:"cbo_max_cbo"`
+	CboShowZeros             *bool `mapstructure:"cbo_show_zeros" yaml:"cbo_show_zeros" json:"cbo_show_zeros"`
+	CboIncludeBuiltins       *bool `mapstructure:"cbo_include_builtins" yaml:"cbo_include_builtins" json:"cbo_include_builtins"`
+	CboIncludeImports        *bool `mapstructure:"cbo_include_imports" yaml:"cbo_include_imports" json:"cbo_include_imports"`
+	CboGroupNamespaceImports *bool `mapstructure:"cbo_group_namespace_imports" yaml:"cbo_group_namespace_imports" json:"cbo_group_namespace_imports"`
 
 	// LCOM Configuration (from [lcom] section in TOML)
 	LcomLowThreshold    int `mapstructure:"lcom_low_threshold" yaml:"lcom_low_threshold" json:"lcom_low_threshold"`
@@ -375,13 +376,14 @@ func DefaultPyscnConfig() *PyscnConfig {
 		AnalysisFollowSymlinks:  domain.BoolPtr(false),
 
 		// CBO defaults (from [cbo] section)
-		CboLowThreshold:    domain.DefaultCBOLowThreshold,
-		CboMediumThreshold: domain.DefaultCBOMediumThreshold,
-		CboMinCbo:          0,
-		CboMaxCbo:          0, // No limit
-		CboShowZeros:       domain.BoolPtr(false),
-		CboIncludeBuiltins: domain.BoolPtr(false),
-		CboIncludeImports:  domain.BoolPtr(true),
+		CboLowThreshold:          domain.DefaultCBOLowThreshold,
+		CboMediumThreshold:       domain.DefaultCBOMediumThreshold,
+		CboMinCbo:                0,
+		CboMaxCbo:                0, // No limit
+		CboShowZeros:             domain.BoolPtr(false),
+		CboIncludeBuiltins:       domain.BoolPtr(false),
+		CboIncludeImports:        domain.BoolPtr(true),
+		CboGroupNamespaceImports: domain.BoolPtr(true),
 
 		// LCOM defaults (from [lcom] section)
 		LcomLowThreshold:    domain.DefaultLCOMLowThreshold,

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -77,13 +77,14 @@ func (c *AnalysisTomlConfig) hasIncludePatterns() bool {
 
 // CboTomlConfig represents the [cbo] section
 type CboTomlConfig struct {
-	LowThreshold    *int  `toml:"low_threshold"`
-	MediumThreshold *int  `toml:"medium_threshold"`
-	MinCbo          *int  `toml:"min_cbo"`
-	MaxCbo          *int  `toml:"max_cbo"`
-	ShowZeros       *bool `toml:"show_zeros"`
-	IncludeBuiltins *bool `toml:"include_builtins"`
-	IncludeImports  *bool `toml:"include_imports"`
+	LowThreshold          *int  `toml:"low_threshold"`
+	MediumThreshold       *int  `toml:"medium_threshold"`
+	MinCbo                *int  `toml:"min_cbo"`
+	MaxCbo                *int  `toml:"max_cbo"`
+	ShowZeros             *bool `toml:"show_zeros"`
+	IncludeBuiltins       *bool `toml:"include_builtins"`
+	IncludeImports        *bool `toml:"include_imports"`
+	GroupNamespaceImports *bool `toml:"group_namespace_imports"`
 }
 
 // LcomTomlConfig represents the [lcom] section

--- a/service/cbo_config_loader.go
+++ b/service/cbo_config_loader.go
@@ -116,6 +116,9 @@ func (cl *CBOConfigurationLoaderImpl) MergeConfig(base *domain.CBORequest, overr
 	if override.IncludeImports != nil {
 		merged.IncludeImports = override.IncludeImports
 	}
+	if override.GroupNamespaceImports != nil {
+		merged.GroupNamespaceImports = override.GroupNamespaceImports
+	}
 
 	// Analysis options
 	if override.Recursive != nil {
@@ -137,36 +140,38 @@ func (cl *CBOConfigurationLoaderImpl) MergeConfig(base *domain.CBORequest, overr
 func (cl *CBOConfigurationLoaderImpl) configToRequest(pyscnCfg *config.PyscnConfig) *domain.CBORequest {
 	if pyscnCfg == nil {
 		return &domain.CBORequest{
-			LowThreshold:    domain.DefaultCBOLowThreshold,
-			MediumThreshold: domain.DefaultCBOMediumThreshold,
-			MinCBO:          0,
-			MaxCBO:          0,
-			ShowZeros:       domain.BoolPtr(false),
-			ShowDetails:     false,
-			IncludeBuiltins: domain.BoolPtr(false),
-			IncludeImports:  domain.BoolPtr(true),
-			SortBy:          domain.SortByComplexity,
-			OutputFormat:    domain.OutputFormatText,
-			Recursive:       domain.BoolPtr(true),
-			IncludePatterns: domain.DefaultAnalysisIncludePatterns(),
-			ExcludePatterns: []string{},
+			LowThreshold:          domain.DefaultCBOLowThreshold,
+			MediumThreshold:       domain.DefaultCBOMediumThreshold,
+			MinCBO:                0,
+			MaxCBO:                0,
+			ShowZeros:             domain.BoolPtr(false),
+			ShowDetails:           false,
+			IncludeBuiltins:       domain.BoolPtr(false),
+			IncludeImports:        domain.BoolPtr(true),
+			GroupNamespaceImports: domain.BoolPtr(true),
+			SortBy:                domain.SortByComplexity,
+			OutputFormat:          domain.OutputFormatText,
+			Recursive:             domain.BoolPtr(true),
+			IncludePatterns:       domain.DefaultAnalysisIncludePatterns(),
+			ExcludePatterns:       []string{},
 		}
 	}
 
 	return &domain.CBORequest{
-		OutputFormat:    domain.OutputFormat(pyscnCfg.Output.Format),
-		ShowDetails:     domain.BoolValue(pyscnCfg.Output.ShowDetails, false),
-		LowThreshold:    pyscnCfg.CboLowThreshold,
-		MediumThreshold: pyscnCfg.CboMediumThreshold,
-		MinCBO:          pyscnCfg.CboMinCbo,
-		MaxCBO:          pyscnCfg.CboMaxCbo,
-		ShowZeros:       pyscnCfg.CboShowZeros,
-		IncludeBuiltins: pyscnCfg.CboIncludeBuiltins,
-		IncludeImports:  pyscnCfg.CboIncludeImports,
-		SortBy:          domain.SortByComplexity, // Default, can be overridden
-		Recursive:       pyscnCfg.AnalysisRecursive,
-		IncludePatterns: pyscnCfg.AnalysisIncludePatterns,
-		ExcludePatterns: pyscnCfg.AnalysisExcludePatterns,
+		OutputFormat:          domain.OutputFormat(pyscnCfg.Output.Format),
+		ShowDetails:           domain.BoolValue(pyscnCfg.Output.ShowDetails, false),
+		LowThreshold:          pyscnCfg.CboLowThreshold,
+		MediumThreshold:       pyscnCfg.CboMediumThreshold,
+		MinCBO:                pyscnCfg.CboMinCbo,
+		MaxCBO:                pyscnCfg.CboMaxCbo,
+		ShowZeros:             pyscnCfg.CboShowZeros,
+		IncludeBuiltins:       pyscnCfg.CboIncludeBuiltins,
+		IncludeImports:        pyscnCfg.CboIncludeImports,
+		GroupNamespaceImports: pyscnCfg.CboGroupNamespaceImports,
+		SortBy:                domain.SortByComplexity, // Default, can be overridden
+		Recursive:             pyscnCfg.AnalysisRecursive,
+		IncludePatterns:       pyscnCfg.AnalysisIncludePatterns,
+		ExcludePatterns:       pyscnCfg.AnalysisExcludePatterns,
 	}
 }
 

--- a/service/cbo_config_loader_test.go
+++ b/service/cbo_config_loader_test.go
@@ -21,6 +21,7 @@ max_cbo = 20
 show_zeros = true
 include_builtins = true
 include_imports = false
+group_namespace_imports = false
 `
 	configPath := filepath.Join(tempDir, ".pyscn.toml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -56,6 +57,9 @@ include_imports = false
 	if domain.BoolValue(req.IncludeImports, true) {
 		t.Errorf("Expected IncludeImports false, got %v", req.IncludeImports)
 	}
+	if domain.BoolValue(req.GroupNamespaceImports, true) {
+		t.Errorf("Expected GroupNamespaceImports false, got %v", req.GroupNamespaceImports)
+	}
 }
 
 func TestCBOConfigurationLoader_LoadDefaultConfig(t *testing.T) {
@@ -87,6 +91,9 @@ func TestCBOConfigurationLoader_LoadDefaultConfig(t *testing.T) {
 	}
 	if !domain.BoolValue(req.IncludeImports, true) {
 		t.Errorf("Expected default IncludeImports true, got %v", req.IncludeImports)
+	}
+	if !domain.BoolValue(req.GroupNamespaceImports, true) {
+		t.Errorf("Expected default GroupNamespaceImports true, got %v", req.GroupNamespaceImports)
 	}
 }
 
@@ -123,19 +130,22 @@ func TestCBOConfigurationLoader_MergeConfig(t *testing.T) {
 		{
 			name: "override boolean flags",
 			base: &domain.CBORequest{
-				ShowZeros:       domain.BoolPtr(false),
-				IncludeBuiltins: domain.BoolPtr(false),
-				IncludeImports:  domain.BoolPtr(true),
+				ShowZeros:             domain.BoolPtr(false),
+				IncludeBuiltins:       domain.BoolPtr(false),
+				IncludeImports:        domain.BoolPtr(true),
+				GroupNamespaceImports: domain.BoolPtr(true),
 			},
 			override: &domain.CBORequest{
-				ShowZeros:       domain.BoolPtr(true),
-				IncludeBuiltins: domain.BoolPtr(true),
-				IncludeImports:  domain.BoolPtr(false),
+				ShowZeros:             domain.BoolPtr(true),
+				IncludeBuiltins:       domain.BoolPtr(true),
+				IncludeImports:        domain.BoolPtr(false),
+				GroupNamespaceImports: domain.BoolPtr(false),
 			},
 			expected: &domain.CBORequest{
-				ShowZeros:       domain.BoolPtr(true),
-				IncludeBuiltins: domain.BoolPtr(true),
-				IncludeImports:  domain.BoolPtr(false),
+				ShowZeros:             domain.BoolPtr(true),
+				IncludeBuiltins:       domain.BoolPtr(true),
+				IncludeImports:        domain.BoolPtr(false),
+				GroupNamespaceImports: domain.BoolPtr(false),
 			},
 		},
 		{
@@ -193,6 +203,18 @@ func TestCBOConfigurationLoader_MergeConfig(t *testing.T) {
 				if len(result.Paths) != len(tt.expected.Paths) {
 					t.Errorf("Expected %d paths, got %d", len(tt.expected.Paths), len(result.Paths))
 				}
+			}
+			if tt.expected.ShowZeros != nil && domain.BoolValue(result.ShowZeros, false) != domain.BoolValue(tt.expected.ShowZeros, false) {
+				t.Errorf("Expected ShowZeros %v, got %v", domain.BoolValue(tt.expected.ShowZeros, false), domain.BoolValue(result.ShowZeros, false))
+			}
+			if tt.expected.IncludeBuiltins != nil && domain.BoolValue(result.IncludeBuiltins, false) != domain.BoolValue(tt.expected.IncludeBuiltins, false) {
+				t.Errorf("Expected IncludeBuiltins %v, got %v", domain.BoolValue(tt.expected.IncludeBuiltins, false), domain.BoolValue(result.IncludeBuiltins, false))
+			}
+			if tt.expected.IncludeImports != nil && domain.BoolValue(result.IncludeImports, true) != domain.BoolValue(tt.expected.IncludeImports, true) {
+				t.Errorf("Expected IncludeImports %v, got %v", domain.BoolValue(tt.expected.IncludeImports, true), domain.BoolValue(result.IncludeImports, true))
+			}
+			if tt.expected.GroupNamespaceImports != nil && domain.BoolValue(result.GroupNamespaceImports, true) != domain.BoolValue(tt.expected.GroupNamespaceImports, true) {
+				t.Errorf("Expected GroupNamespaceImports %v, got %v", domain.BoolValue(tt.expected.GroupNamespaceImports, true), domain.BoolValue(result.GroupNamespaceImports, true))
 			}
 		})
 	}

--- a/service/cbo_service.go
+++ b/service/cbo_service.go
@@ -409,27 +409,29 @@ func (s *CBOServiceImpl) getCBORange(cbo int) string {
 // buildCBOOptions converts domain request to analyzer options
 func (s *CBOServiceImpl) buildCBOOptions(req domain.CBORequest) *analyzer.CBOOptions {
 	return &analyzer.CBOOptions{
-		IncludeBuiltins:   domain.BoolValue(req.IncludeBuiltins, false),
-		IncludeImports:    domain.BoolValue(req.IncludeImports, true),
-		PublicClassesOnly: false, // Could add this to domain.CBORequest later
-		ExcludePatterns:   req.ExcludePatterns,
-		LowThreshold:      req.LowThreshold,
-		MediumThreshold:   req.MediumThreshold,
+		IncludeBuiltins:       domain.BoolValue(req.IncludeBuiltins, false),
+		IncludeImports:        domain.BoolValue(req.IncludeImports, true),
+		GroupNamespaceImports: domain.BoolValue(req.GroupNamespaceImports, true),
+		PublicClassesOnly:     false, // Could add this to domain.CBORequest later
+		ExcludePatterns:       req.ExcludePatterns,
+		LowThreshold:          req.LowThreshold,
+		MediumThreshold:       req.MediumThreshold,
 	}
 }
 
 // buildConfigForResponse creates config info for response
 func (s *CBOServiceImpl) buildConfigForResponse(req domain.CBORequest) interface{} {
 	return map[string]interface{}{
-		"minCBO":          req.MinCBO,
-		"maxCBO":          req.MaxCBO,
-		"showZeros":       domain.BoolValue(req.ShowZeros, false),
-		"lowThreshold":    req.LowThreshold,
-		"mediumThreshold": req.MediumThreshold,
-		"includeBuiltins": domain.BoolValue(req.IncludeBuiltins, false),
-		"includeImports":  domain.BoolValue(req.IncludeImports, true),
-		"outputFormat":    req.OutputFormat,
-		"sortBy":          req.SortBy,
+		"minCBO":                req.MinCBO,
+		"maxCBO":                req.MaxCBO,
+		"showZeros":             domain.BoolValue(req.ShowZeros, false),
+		"lowThreshold":          req.LowThreshold,
+		"mediumThreshold":       req.MediumThreshold,
+		"includeBuiltins":       domain.BoolValue(req.IncludeBuiltins, false),
+		"includeImports":        domain.BoolValue(req.IncludeImports, true),
+		"groupNamespaceImports": domain.BoolValue(req.GroupNamespaceImports, true),
+		"outputFormat":          req.OutputFormat,
+		"sortBy":                req.SortBy,
 	}
 }
 

--- a/service/cbo_service_test.go
+++ b/service/cbo_service_test.go
@@ -543,11 +543,12 @@ func TestCBOService_BuildCBOOptions(t *testing.T) {
 	service := NewCBOService()
 
 	req := domain.CBORequest{
-		IncludeBuiltins: domain.BoolPtr(true),
-		IncludeImports:  domain.BoolPtr(false),
-		ExcludePatterns: []string{"test_*.py"},
-		LowThreshold:    3,
-		MediumThreshold: 8,
+		IncludeBuiltins:       domain.BoolPtr(true),
+		IncludeImports:        domain.BoolPtr(false),
+		GroupNamespaceImports: domain.BoolPtr(false),
+		ExcludePatterns:       []string{"test_*.py"},
+		LowThreshold:          3,
+		MediumThreshold:       8,
 	}
 
 	options := service.buildCBOOptions(req)
@@ -555,6 +556,7 @@ func TestCBOService_BuildCBOOptions(t *testing.T) {
 	assert.NotNil(t, options)
 	assert.Equal(t, true, options.IncludeBuiltins)
 	assert.Equal(t, false, options.IncludeImports)
+	assert.Equal(t, false, options.GroupNamespaceImports)
 	assert.Equal(t, false, options.PublicClassesOnly)
 	assert.Equal(t, []string{"test_*.py"}, options.ExcludePatterns)
 	assert.Equal(t, 3, options.LowThreshold)
@@ -565,15 +567,16 @@ func TestCBOService_BuildConfigForResponse(t *testing.T) {
 	service := NewCBOService()
 
 	req := domain.CBORequest{
-		MinCBO:          1,
-		MaxCBO:          20,
-		ShowZeros:       domain.BoolPtr(false),
-		LowThreshold:    5,
-		MediumThreshold: 10,
-		IncludeBuiltins: domain.BoolPtr(true),
-		IncludeImports:  domain.BoolPtr(false),
-		OutputFormat:    domain.OutputFormatJSON,
-		SortBy:          domain.SortByCoupling,
+		MinCBO:                1,
+		MaxCBO:                20,
+		ShowZeros:             domain.BoolPtr(false),
+		LowThreshold:          5,
+		MediumThreshold:       10,
+		IncludeBuiltins:       domain.BoolPtr(true),
+		IncludeImports:        domain.BoolPtr(false),
+		GroupNamespaceImports: domain.BoolPtr(false),
+		OutputFormat:          domain.OutputFormatJSON,
+		SortBy:                domain.SortByCoupling,
 	}
 
 	config := service.buildConfigForResponse(req)
@@ -588,6 +591,7 @@ func TestCBOService_BuildConfigForResponse(t *testing.T) {
 	assert.Equal(t, 10, configMap["mediumThreshold"])
 	assert.Equal(t, true, configMap["includeBuiltins"])
 	assert.Equal(t, false, configMap["includeImports"])
+	assert.Equal(t, false, configMap["groupNamespaceImports"])
 	assert.Equal(t, domain.OutputFormatJSON, configMap["outputFormat"])
 	assert.Equal(t, domain.SortByCoupling, configMap["sortBy"])
 }


### PR DESCRIPTION
## Summary

- Add a configurable "group namespace imports" heuristic for CBO analysis.
- Collapse all `alias.Member` references from a single `import ... as ...` statement into one coupling edge (the alias/module).
- Propagate the new option through `domain.CBORequest`, the service layer, and TOML/pyproject config files.
- Add regression tests covering grouped behavior, opt-out behavior, and non-aliased module imports.

## Rationale

Issue #517 reports that classes using namespace aliases such as `import libcst as cst` get CBO inflated 3–5x because every `cst.Arg`, `cst.Call`, etc. is counted as a separate dependency. This change makes CBO reflect the real coupling surface (the imported namespace) while preserving strict per-type counting via the `group_namespace_imports = false` config option.

Closes #517.

## Validation

- `go test ./...` — all packages pass
- `go vet ./...` — clean
- `gofmt` — changed files formatted

Note: `make lint` could not be run locally because the installed golangci-lint was built with an older Go toolchain than the project target; `go vet` and `gofmt` are clean.
