### PR TITLE
fix(score): change duplication metric from group density to fragment ratio

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -233,10 +233,7 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 
 	if len(files) == 0 {
-		// No Python files to analyze is not a failure: emit an empty report and
-		// exit successfully, consistent with clone detection's empty-input handling.
-		tasks := uc.createAnalysisTasks(useCaseCfg, files, nil, executionCfg)
-		return uc.buildResponse(tasks, startTime), nil
+		return nil, fmt.Errorf("no Python files found in the specified paths")
 	}
 
 	// Estimate per-task durations from file count, then calibrate with actual

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -233,7 +233,10 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no Python files found in the specified paths")
+		// No Python files to analyze is not a failure: emit an empty report and
+		// exit successfully, consistent with clone detection's empty-input handling.
+		tasks := uc.createAnalysisTasks(useCaseCfg, files, nil, executionCfg)
+		return uc.buildResponse(tasks, startTime), nil
 	}
 
 	// Estimate per-task durations from file count, then calibrate with actual
@@ -605,26 +608,13 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 		summary.ClonePairs = response.Clone.Statistics.TotalClonePairs
 		summary.CloneGroups = response.Clone.Statistics.TotalCloneGroups
 
-		// Calculate code duplication based on K-Core clone groups
-		// K-Core groups represent true duplication clusters where each fragment
-		// is similar to at least k other fragments (default k=2)
-		// This filters out false positives from structural similarity
-		totalLines := response.Clone.Statistics.LinesAnalyzed
-		groupCount := response.Clone.Statistics.TotalCloneGroups
+		// Calculate code duplication based on fragment ratio
+		// Measures what proportion of all code fragments are involved in duplication
+		totalFragments := response.Clone.Statistics.TotalFragments
+		totalClones := response.Clone.Statistics.TotalClones
 
-		if totalLines > 0 && groupCount > 0 {
-			// Calculate group density: groups per 1000 lines of code
-			// This normalizes for project size
-			linesInThousands := float64(totalLines) / domain.GroupDensityLinesUnit
-			if linesInThousands < domain.GroupDensityMinLines {
-				linesInThousands = domain.GroupDensityMinLines
-			}
-			groupDensity := float64(groupCount) / linesInThousands
-
-			// Convert density to percentage for penalty calculation
-			// 0.5 groups/1000 lines = 10% duplication (max penalty)
-			// This makes the scoring stricter for duplicate code clusters
-			summary.CodeDuplication = math.Min(domain.DuplicationThresholdHigh, groupDensity*domain.GroupDensityCoefficient)
+		if totalFragments > 0 && totalClones > 0 {
+			summary.CodeDuplication = math.Min(domain.DuplicationThresholdHigh, float64(totalClones)/float64(totalFragments)*100)
 		}
 	}
 

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -474,7 +474,7 @@ func (c *AnalyzeCommand) printSummary(cmd *cobra.Command, response *domain.Analy
 
 	if response.Summary.CloneEnabled {
 		icon := getScoreIcon(response.Summary.DuplicationScore)
-		fmt.Fprintf(cmd.ErrOrStderr(), "  Duplication:    %3d/100 %s  (%.1f%% duplication, %d groups)\n",
+		fmt.Fprintf(cmd.ErrOrStderr(), "  Duplication:    %3d/100 %s  (%.1f%% fragments cloned, %d groups)\n",
 			response.Summary.DuplicationScore, icon,
 			response.Summary.CodeDuplication, response.Summary.CloneGroups)
 	}

--- a/cmd/pyscn/check.go
+++ b/cmd/pyscn/check.go
@@ -146,19 +146,6 @@ func (c *CheckCommand) runCheck(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.ErrOrStderr(), "🔍 Running quality check (%s)...\n", strings.Join(c.getEnabledAnalyses(skipComplexity, skipDeadCode, skipClones, skipDeps, skipMockdata, skipDI), ", "))
 	}
 
-	// No Python files to check is not a failure: report success and exit 0,
-	// consistent with clone detection's empty-input handling.
-	if files, err := service.NewFileReader().CollectPythonFiles(
-		args, true,
-		domain.DefaultAnalysisIncludePatterns(),
-		domain.DefaultAnalysisExcludePatterns(),
-	); err == nil && len(files) == 0 {
-		if !c.quiet {
-			fmt.Fprintf(cmd.ErrOrStderr(), "✅ No Python files found to check\n")
-		}
-		return nil
-	}
-
 	// Run complexity check if enabled
 	if !skipComplexity {
 		complexityIssues, err := c.checkComplexity(cmd, args)

--- a/cmd/pyscn/check.go
+++ b/cmd/pyscn/check.go
@@ -146,6 +146,19 @@ func (c *CheckCommand) runCheck(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.ErrOrStderr(), "🔍 Running quality check (%s)...\n", strings.Join(c.getEnabledAnalyses(skipComplexity, skipDeadCode, skipClones, skipDeps, skipMockdata, skipDI), ", "))
 	}
 
+	// No Python files to check is not a failure: report success and exit 0,
+	// consistent with clone detection's empty-input handling.
+	if files, err := service.NewFileReader().CollectPythonFiles(
+		args, true,
+		domain.DefaultAnalysisIncludePatterns(),
+		domain.DefaultAnalysisExcludePatterns(),
+	); err == nil && len(files) == 0 {
+		if !c.quiet {
+			fmt.Fprintf(cmd.ErrOrStderr(), "✅ No Python files found to check\n")
+		}
+		return nil
+	}
+
 	// Run complexity check if enabled
 	if !skipComplexity {
 		complexityIssues, err := c.checkComplexity(cmd, args)

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -56,20 +56,13 @@ const (
 	ComplexityPenaltyLow      = 6
 
 	// Code duplication thresholds and penalties
-	// 0% = perfect, 10% = max penalty
-	DuplicationThresholdHigh   = 10.0
-	DuplicationThresholdMedium = 5.0
+	// 0% = perfect, 30% = max penalty (using fragment ratio: clonedFragments/totalFragments)
+	DuplicationThresholdHigh   = 30.0
+	DuplicationThresholdMedium = 15.0
 	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12
 	DuplicationPenaltyLow      = 6
-
-	// K-Core group density calculation constants
-	// Group density = groups / (lines / GroupDensityLinesUnit)
-	// CodeDuplication% = min(DuplicationThresholdHigh, density * GroupDensityCoefficient)
-	GroupDensityLinesUnit   = 1000.0 // Calculate density per 1000 lines
-	GroupDensityMinLines    = 1.0    // Minimum lines in thousands (for small projects)
-	GroupDensityCoefficient = 20.0   // Multiplier to convert density to percentage
 
 	// CBO coupling scoring curve (used by calculateCouplingPenalty)
 	// Penalty grows linearly with the weighted ratio of problematic classes

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -334,13 +334,13 @@ func (s *AnalyzeSummary) calculateDeadCodePenalty(normalizationFactor float64) i
 // calculateDuplicationPenalty calculates the penalty for code duplication (max 20)
 // Uses continuous linear function based on defined thresholds
 func (s *AnalyzeSummary) calculateDuplicationPenalty() int {
-	// Linear penalty: 0% = 0 penalty, 5% = max penalty (20)
+	// Linear penalty: 0% = 0 penalty, 30% = max penalty (20)
 	if s.CodeDuplication <= DuplicationThresholdLow {
 		return 0
 	}
 
 	// Formula: penalty = (duplication - low) / (high - low) * 20
-	penaltyRange := DuplicationThresholdHigh - DuplicationThresholdLow // 5%
+	penaltyRange := DuplicationThresholdHigh - DuplicationThresholdLow // 30%
 	penalty := (s.CodeDuplication - DuplicationThresholdLow) / penaltyRange * 20.0
 	if penalty > 20.0 {
 		penalty = 20.0

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -303,10 +303,10 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				ArchEnabled:         true,
 				ArchCompliance:      0.9, // (1-0.9)*12 = 1.2 → 1
 			},
-			expectedScore:             90,  // Updated: 100-3-1-5-0-1 = 90
-			expectedGrade:             "A", // 90 ≤ 100 = A
-			expectError:               false,
-			expectedDuplicationScore:  95, // penalty=1, 100-(1/20)*100=95
+			expectedScore:            90,  // Updated: 100-3-1-5-0-1 = 90
+			expectedGrade:            "A", // 90 ≤ 100 = A
+			expectError:              false,
+			expectedDuplicationScore: 95, // penalty=1, 100-(1/20)*100=95
 		},
 		{
 			name: "grade C threshold",
@@ -319,9 +319,9 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				CriticalDeadCode:    0, // No critical issues, so no dead code penalty
 				TotalFiles:          1,
 			},
-			expectedScore: 58,  // Updated: 100-20-17-5 = 58
-			expectedGrade: "D", // 45 ≤ 58 < 60 = D
-			expectError:   false,
+			expectedScore:            58,  // Updated: 100-20-17-5 = 58
+			expectedGrade:            "D", // 45 ≤ 58 < 60 = D
+			expectError:              false,
 			expectedDuplicationScore: 15, // 100 - (17/20)*100 = 15
 		},
 		{

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -191,7 +191,7 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			name: "typical 74 score case",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity:         7.0,  // Continuous: (7-2)/13*20 = 7.69 → 8
-				CodeDuplication:           15.0, // Continuous: 15/10*20 = 30 → 20 (capped, 0-10% scale)
+				CodeDuplication:           15.0, // 15/30*20 = 10 penalty (0-30% scale)
 				CBOClasses:                10,
 				HighCouplingClasses:       2, // 20% ratio: 0.20/0.40*20 = 10
 				DepsEnabled:               true,
@@ -199,12 +199,12 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				ArchEnabled:               true,
 				ArchCompliance:            0.125, // (1-0.125)*12 = 10.5 → 11 (new max arch)
 			},
-			expectedScore:             48,  // Updated: 100-8-20-10-3-11 = 48 (CBO saturation 0.40)
-			expectedGrade:             "D", // 48 >= 45 = D
+			expectedScore:             58,  // Updated: 100-8-10-10-3-11 = 58
+			expectedGrade:             "D", // 58 >= 45 = D
 			expectError:               false,
 			expectedComplexityScore:   60,  // 100 - (8/20)*100 = 60
 			expectedDeadCodeScore:     100, // No dead code
-			expectedDuplicationScore:  0,   // 100 - (20/20)*100 = 0 (0-10% scale: 20 penalty capped)
+			expectedDuplicationScore:  50,  // 100 - (10/20)*100 = 50 (0-30% scale: 10 penalty)
 			expectedCouplingScore:     50,  // 100 - (10/20)*100 = 50 (CBO saturation 0.40)
 			expectedDependencyScore:   80,  // Normalized: (3/16)*20 = 3.75 → 4, Score: 100 - (4/20)*100 = 80
 			expectedArchitectureScore: 13,  // Compliance 0.125 * 100 = 12.5 → 13
@@ -225,10 +225,10 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			name: "high complexity",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity: 25.0, // Continuous: (25-2)/13*20 = 35.38 → 20 (capped)
-				CodeDuplication:   5.0,  // 5/10*20 = 10 penalty (0-10% scale)
+				CodeDuplication:   5.0,  // 5/30*20 = 3 penalty (0-30% scale)
 			},
-			expectedScore: 70,  // Updated: 100-20-10 = 70 (0-10% duplication scale)
-			expectedGrade: "C", // 60 ≤ 70 < 75 = C
+			expectedScore: 77,  // Updated: 100-20-3 = 77
+			expectedGrade: "B", // 75 ≤ 77 < 90 = B
 			expectError:   false,
 		},
 		{
@@ -294,7 +294,7 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 			name: "grade A threshold",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity:   4.0, // Continuous: (4-2)/13*20 = 3.08 → 3
-				CodeDuplication:     2.0, // 2/10*20 = 4 penalty (0-10% scale)
+				CodeDuplication:     2.0, // 2/30*20 = 1 penalty (0-30% scale)
 				CBOClasses:          20,
 				HighCouplingClasses: 2, // 10% ratio: 0.10/0.40*20 = 5 (CBO saturation 0.40)
 				DepsEnabled:         true,
@@ -303,24 +303,26 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 				ArchEnabled:         true,
 				ArchCompliance:      0.9, // (1-0.9)*12 = 1.2 → 1
 			},
-			expectedScore: 87,  // Updated: 100-3-4-5-0-1 = 87 (CBO saturation 0.40)
-			expectedGrade: "B", // 75 ≤ 87 < 90 = B
-			expectError:   false,
+			expectedScore:             90,  // Updated: 100-3-1-5-0-1 = 90
+			expectedGrade:             "A", // 90 ≤ 100 = A
+			expectError:               false,
+			expectedDuplicationScore:  95, // penalty=1, 100-(1/20)*100=95
 		},
 		{
 			name: "grade C threshold",
 			summary: domain.AnalyzeSummary{
 				AverageComplexity:   15.0, // Continuous: (15-2)/13*20 = 20 (capped)
-				CodeDuplication:     25.0, // 25/20*20 = 25 → capped at 20 penalty (0-20% scale)
+				CodeDuplication:     25.0, // 25/30*20 = 16.67 → 17 penalty (0-30% scale)
 				CBOClasses:          20,
 				HighCouplingClasses: 2, // 10% ratio: 0.10/0.40*20 = 5 (CBO saturation 0.40)
 				DeadCodeCount:       5,
 				CriticalDeadCode:    0, // No critical issues, so no dead code penalty
 				TotalFiles:          1,
 			},
-			expectedScore: 55,  // Updated: 100-20-20-5 = 55 (CBO saturation 0.40)
-			expectedGrade: "D", // 45 ≤ 55 < 60 = D
+			expectedScore: 58,  // Updated: 100-20-17-5 = 58
+			expectedGrade: "D", // 45 ≤ 58 < 60 = D
 			expectError:   false,
+			expectedDuplicationScore: 15, // 100 - (17/20)*100 = 15
 		},
 		{
 			// Softened cohesion curve (#529): a repo with a healthy average LCOM
@@ -362,12 +364,12 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 		{
 			name: "edge case - duplication at 1.0%",
 			summary: domain.AnalyzeSummary{
-				CodeDuplication: 1.0, // 1% duplication = 2 penalty (0-10% scale: 1/10*20=2)
+				CodeDuplication: 1.0, // 1% duplication = 1 penalty (0-30% scale: 1/30*20=0.67→1)
 			},
-			expectedScore:            98,
+			expectedScore:            99,
 			expectedGrade:            "A",
 			expectError:              false,
-			expectedDuplicationScore: 90, // penalty=2, score=100-(2/20)*100=90
+			expectedDuplicationScore: 95, // penalty=1, score=100-(1/20)*100=95
 		},
 		{
 			name: "edge case - small weighted dead code",

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -85,7 +85,7 @@ func (f *AnalyzeFormatter) writeText(response *domain.AnalyzeResponse, writer io
 		fmt.Fprint(writer, utils.FormatSectionHeader("CLONE DETECTION"))
 		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Unique Fragments", response.Summary.TotalClones))
 		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Clone Groups", response.Summary.CloneGroups))
-		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Code Duplication", utils.FormatPercentage(response.Summary.CodeDuplication)))
+		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Fragments Cloned", utils.FormatPercentage(response.Summary.CodeDuplication)))
 		fmt.Fprint(writer, utils.FormatSectionSeparator())
 	}
 
@@ -497,7 +497,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                         <div class="score-bar-container">
                             <div class="score-bar-fill score-{{scoreQuality .Summary.DuplicationScore}}" style="width: {{.Summary.DuplicationScore}}%"></div>
                         </div>
-                        <div class="score-detail">{{printf "%.1f%%" .Summary.CodeDuplication}} duplication, {{.Summary.CloneGroups}} groups</div>
+                        <div class="score-detail">{{printf "%.1f%%" .Summary.CodeDuplication}} of fragments cloned, {{.Summary.CloneGroups}} groups</div>
                     </div>
                     {{end}}
 

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -578,7 +578,7 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                     </div>
                     <div class="metric-card">
                         <div class="metric-value">{{printf "%.1f%%" .Summary.CodeDuplication}}</div>
-                        <div class="metric-label">Code Duplication</div>
+                        <div class="metric-label">Fragments Cloned</div>
                     </div>
                     {{if .Summary.CBOEnabled}}
                     <div class="metric-card">

--- a/website/docs/fr/output/health-score.md
+++ b/website/docs/fr/output/health-score.md
@@ -116,7 +116,7 @@ Source : `domain/analyze.go:283-296`. Facteur de normalisation dérivé dans `Ca
 
 ### Duplication
 
-**Entrées.** `CodeDuplication` (float64). Ce champ est un pourcentage de duplication pré-calculé, plafonné à 10 par le calcul en amont.
+**Entrées.** `CodeDuplication` (float64). Ce champ est le ratio de fragments : le pourcentage de tous les fragments de code extraits qui participent à une paire ou un groupe de clones, plafonné à 30 par le calcul en amont.
 
 **Formule.**
 
@@ -124,32 +124,30 @@ Source : `domain/analyze.go:283-296`. Facteur de normalisation dérivé dans `Ca
 if CodeDuplication <= 0:
     penalty = 0
 else:
-    penalty = min(20, round(CodeDuplication / 10.0 * 20.0))
+    penalty = min(20, round(CodeDuplication / 30.0 * 20.0))
 ```
 
 **Constantes.**
 
-| Nom                          | Valeur | Signification                  |
-| ---------------------------- | ------ | ------------------------------ |
-| `DuplicationThresholdLow`    | 0.0    | 0 % de duplication = pénalité 0 |
-| `DuplicationThresholdHigh`   | 10.0   | 10 % de duplication = pénalité max |
-| max                          | 20.0   | Plafond de pénalité            |
+| Nom                          | Valeur | Signification                       |
+| ---------------------------- | ------ | ----------------------------------- |
+| `DuplicationThresholdLow`    | 0.0    | 0 % de fragments clonés = pénalité 0 |
+| `DuplicationThresholdHigh`   | 30.0   | 30 % de fragments clonés = pénalité max |
+| max                          | 20.0   | Plafond de pénalité                 |
 
-**Calcul en amont.** `CodeDuplication` est calculé dans `app/analyze_usecase.go:570-583` :
+**Calcul en amont.** `CodeDuplication` est calculé dans `app/analyze_usecase.go` :
 
 ```
-lines_in_thousands = max(GroupDensityMinLines, total_lines / GroupDensityLinesUnit)
-group_density      = clone_groups / lines_in_thousands
-CodeDuplication    = min(DuplicationThresholdHigh, group_density * GroupDensityCoefficient)
+CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
 ```
 
-Où `GroupDensityLinesUnit = 1000.0`, `GroupDensityMinLines = 1.0`, `GroupDensityCoefficient = 20.0`, `DuplicationThresholdHigh = 10.0` (`domain/analyze.go:52, 62-64`).
+Où `TotalClones` est le nombre de fragments uniques participant à au moins une paire ou un groupe de clones, et `TotalFragments` est le nombre total de fragments de code extraits (`domain/clone.go:128-131`).
 
-**Saturation.** Atteint 20 lorsque `CodeDuplication >= 10.0`. Comme la valeur en amont est plafonnée à 10, la saturation est atteinte à exactement 0,5 groupe de clones pour 1000 lignes analysées.
+**Saturation.** Atteint 20 lorsque `CodeDuplication >= 30.0`.
 
-**Cas limites.** Aucun groupe de clones ou aucune ligne analysée → `CodeDuplication = 0` → pénalité 0. `Validate()` rejette les valeurs hors de `[0, 100]`.
+**Cas limites.** Aucun fragment cloné ou aucun fragment analysé → `CodeDuplication = 0` → pénalité 0. `Validate()` rejette les valeurs hors de `[0, 100]`.
 
-Source : `domain/analyze.go:300-314`.
+Source : `domain/analyze.go:336-350`.
 
 ### Couplage (CBO)
 

--- a/website/docs/ja/output/health-score.md
+++ b/website/docs/ja/output/health-score.md
@@ -116,7 +116,7 @@ else:
 
 ### 重複
 
-**入力.** `CodeDuplication` (float64)。このフィールドは事前計算された重複率で、上流の計算で 10 に上限が設定されています。
+**入力.** `CodeDuplication` (float64)。このフィールドはフラグメント比率で、抽出されたコードフラグメントのうちクローンペアまたはグループに含まれるユニークなフラグメントの割合を表します。上流の計算で 30 に上限が設定されています。
 
 **計算式.**
 
@@ -124,32 +124,30 @@ else:
 if CodeDuplication <= 0:
     penalty = 0
 else:
-    penalty = min(20, round(CodeDuplication / 10.0 * 20.0))
+    penalty = min(20, round(CodeDuplication / 30.0 * 20.0))
 ```
 
 **定数.**
 
-| 名前                         | 値 | 意味                     |
-| ---------------------------- | ----- | --------------------------- |
-| `DuplicationThresholdLow`    | 0.0   | 重複 0% = ペナルティ 0  |
-| `DuplicationThresholdHigh`   | 10.0  | 重複 10% = 最大ペナルティ |
-| max                          | 20.0  | ペナルティ上限                 |
+| 名前                         | 値    | 意味                          |
+| ---------------------------- | ----- | ----------------------------- |
+| `DuplicationThresholdLow`    | 0.0   | クローン対象 0% = ペナルティ 0 |
+| `DuplicationThresholdHigh`   | 30.0  | クローン対象 30% = 最大ペナルティ |
+| max                          | 20.0  | ペナルティ上限                |
 
-**上流の計算.** `CodeDuplication` 自体は `app/analyze_usecase.go:570-583` で計算されます:
+**上流の計算.** `CodeDuplication` 自体は `app/analyze_usecase.go` で計算されます:
 
 ```
-lines_in_thousands = max(GroupDensityMinLines, total_lines / GroupDensityLinesUnit)
-group_density      = clone_groups / lines_in_thousands
-CodeDuplication    = min(DuplicationThresholdHigh, group_density * GroupDensityCoefficient)
+CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
 ```
 
-ここで `GroupDensityLinesUnit = 1000.0`, `GroupDensityMinLines = 1.0`, `GroupDensityCoefficient = 20.0`, `DuplicationThresholdHigh = 10.0`（`domain/analyze.go:52, 62-64`）です。
+ここで `TotalClones` はクローンペアまたはグループに含まれるユニークなフラグメント数、`TotalFragments` は抽出されたコードフラグメントの総数です（`domain/clone.go:128-131`）。
 
-**飽和.** `CodeDuplication >= 10.0` で 20 に到達します。上流が 10 で上限を設定するため、分析対象 1000 行あたり 0.5 クローングループで飽和に達します。
+**飽和.** `CodeDuplication >= 30.0` で 20 に到達します。
 
-**エッジケース.** クローングループなしまたは分析対象行なしの場合 → `CodeDuplication = 0` → ペナルティ 0。`Validate()` は `[0, 100]` の範囲外の値を拒否します。
+**エッジケース.** クローン対象フラグメントなし、または分析対象フラグメントなしの場合 → `CodeDuplication = 0` → ペナルティ 0。`Validate()` は `[0, 100]` の範囲外の値を拒否します。
 
-ソース: `domain/analyze.go:300-314`。
+ソース: `domain/analyze.go:336-350`。
 
 ### 結合度（CBO）
 

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -116,7 +116,7 @@ Source: `domain/analyze.go:283-296`. Normalization factor derived in `CalculateH
 
 ### Duplication
 
-**Inputs.** `CodeDuplication` (float64). This field is a pre-computed duplication percentage, capped at 10 by the upstream calculation.
+**Inputs.** `CodeDuplication` (float64). This field is the fragment ratio: the percentage of all extracted code fragments that participate in clone pairs or groups, capped at 30 by the upstream calculation.
 
 **Formula.**
 
@@ -124,32 +124,30 @@ Source: `domain/analyze.go:283-296`. Normalization factor derived in `CalculateH
 if CodeDuplication <= 0:
     penalty = 0
 else:
-    penalty = min(20, round(CodeDuplication / 10.0 * 20.0))
+    penalty = min(20, round(CodeDuplication / 30.0 * 20.0))
 ```
 
 **Constants.**
 
-| Name                         | Value | Meaning                     |
-| ---------------------------- | ----- | --------------------------- |
-| `DuplicationThresholdLow`    | 0.0   | 0% duplication = 0 penalty  |
-| `DuplicationThresholdHigh`   | 10.0  | 10% duplication = max penalty |
-| max                          | 20.0  | Penalty cap                 |
+| Name                         | Value | Meaning                          |
+| ---------------------------- | ----- | -------------------------------- |
+| `DuplicationThresholdLow`    | 0.0   | 0% fragments cloned = 0 penalty  |
+| `DuplicationThresholdHigh`   | 30.0  | 30% fragments cloned = max penalty |
+| max                          | 20.0  | Penalty cap                      |
 
-**Upstream computation.** `CodeDuplication` itself is computed in `app/analyze_usecase.go:570-583`:
+**Upstream computation.** `CodeDuplication` itself is computed in `app/analyze_usecase.go`:
 
 ```
-lines_in_thousands = max(GroupDensityMinLines, total_lines / GroupDensityLinesUnit)
-group_density      = clone_groups / lines_in_thousands
-CodeDuplication    = min(DuplicationThresholdHigh, group_density * GroupDensityCoefficient)
+CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
 ```
 
-Where `GroupDensityLinesUnit = 1000.0`, `GroupDensityMinLines = 1.0`, `GroupDensityCoefficient = 20.0`, `DuplicationThresholdHigh = 10.0` (`domain/analyze.go:52, 62-64`).
+Where `TotalClones` is the number of unique fragments that participate in at least one clone pair or group, and `TotalFragments` is the total number of extracted code fragments (`domain/clone.go:128-131`).
 
-**Saturation.** Reaches 20 when `CodeDuplication >= 10.0`. Since the upstream caps at 10, saturation is reached at exactly 0.5 clone groups per 1000 analyzed lines.
+**Saturation.** Reaches 20 when `CodeDuplication >= 30.0`.
 
-**Edge cases.** No clone groups or no analyzed lines → `CodeDuplication = 0` → penalty 0. `Validate()` rejects values outside `[0, 100]`.
+**Edge cases.** No clone fragments or no fragments analyzed → `CodeDuplication = 0` → penalty 0. `Validate()` rejects values outside `[0, 100]`.
 
-Source: `domain/analyze.go:300-314`.
+Source: `domain/analyze.go:336-350`.
 
 ### Coupling (CBO)
 

--- a/website/docs/zh/output/health-score.md
+++ b/website/docs/zh/output/health-score.md
@@ -116,7 +116,7 @@ else:
 
 ### 代码重复
 
-**输入。** `CodeDuplication`（float64）。此字段是预先计算的重复百分比，上游计算限制为 10。
+**输入。** `CodeDuplication`（float64）。此字段是片段比率：所有提取出的代码片段中，参与克隆对或克隆组的唯一片段所占百分比，上游计算限制为 30。
 
 **公式。**
 
@@ -124,32 +124,30 @@ else:
 if CodeDuplication <= 0:
     penalty = 0
 else:
-    penalty = min(20, round(CodeDuplication / 10.0 * 20.0))
+    penalty = min(20, round(CodeDuplication / 30.0 * 20.0))
 ```
 
 **常量。**
 
 | 名称                         | 值    | 含义                        |
 | ---------------------------- | ----- | --------------------------- |
-| `DuplicationThresholdLow`    | 0.0   | 0% 重复 = 0 惩罚           |
-| `DuplicationThresholdHigh`   | 10.0  | 10% 重复 = 最大惩罚        |
+| `DuplicationThresholdLow`    | 0.0   | 0% 片段被克隆 = 0 惩罚     |
+| `DuplicationThresholdHigh`   | 30.0  | 30% 片段被克隆 = 最大惩罚  |
 | max                          | 20.0  | 惩罚上限                    |
 
-**上游计算。** `CodeDuplication` 本身在 `app/analyze_usecase.go:570-583` 中计算：
+**上游计算。** `CodeDuplication` 本身在 `app/analyze_usecase.go` 中计算：
 
 ```
-lines_in_thousands = max(GroupDensityMinLines, total_lines / GroupDensityLinesUnit)
-group_density      = clone_groups / lines_in_thousands
-CodeDuplication    = min(DuplicationThresholdHigh, group_density * GroupDensityCoefficient)
+CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
 ```
 
-其中 `GroupDensityLinesUnit = 1000.0`、`GroupDensityMinLines = 1.0`、`GroupDensityCoefficient = 20.0`、`DuplicationThresholdHigh = 10.0`（`domain/analyze.go:52, 62-64`）。
+其中 `TotalClones` 是至少参与一个克隆对或克隆组的唯一片段数量，`TotalFragments` 是提取出的代码片段总数（`domain/clone.go:128-131`）。
 
-**饱和。** 当 `CodeDuplication >= 10.0` 时达到 20。由于上游限制为 10，饱和恰好在每 1000 行分析代码有 0.5 个克隆组时达到。
+**饱和。** 当 `CodeDuplication >= 30.0` 时达到 20。
 
-**边界情况。** 无克隆组或无分析行 → `CodeDuplication = 0` → 惩罚 0。`Validate()` 拒绝 `[0, 100]` 范围外的值。
+**边界情况。** 无克隆片段或无分析片段 → `CodeDuplication = 0` → 惩罚 0。`Validate()` 拒绝 `[0, 100]` 范围外的值。
 
-来源：`domain/analyze.go:300-314`。
+来源：`domain/analyze.go:336-350`。
 
 ### 耦合度（CBO）
 


### PR DESCRIPTION
## Summary

Changes the duplication scoring metric from **group density** (clone groups per KLOC) to **fragment ratio** (unique cloned fragments / total fragments). This gives a more intuitive and fair measure of what proportion of the codebase is actually duplicated.

## Changes

- `app/analyze_usecase.go`: Replace group-density calculation with `TotalClones / TotalFragments * 100`
- `domain/analyze.go`: Raise `DuplicationThresholdHigh` from 10% → 30% to match the fragment-ratio scale; remove unused density constants
- `domain/analyze_test.go`: Update test expectations for the new penalty curve
- `cmd/pyscn/analyze.go`: CLI output "X% duplication" → "X% fragments cloned"
- `service/analyze_formatter.go`: Update text/HTML labels

## Impact on typical scores

| Metric | Before (density) | After (fragment ratio) |
|---|---|---|
| FastAPI Duplication | 0/100 (10.0% density) | **65/100** (10.4% fragments cloned) |
| FastAPI Health Score | 53/100 (D) | **66/100 (C)** |

The old density formula hit max penalty at just 0.5 clone groups/KLOC, which penalized even moderate duplication in larger codebases too severely. Fragment ratio measures "what fraction of your functions/classes are cloned" — a more intuitive and actionable metric.