### PR TITLE
fix(analyzer): prefer highest-similarity clone type for group classification (fixes #525)

### DIFF
--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -1037,3 +1037,120 @@ func TestCloneDetector_EdgeCases(t *testing.T) {
 	assert.Empty(t, pairs, "Should handle fragments without tree nodes gracefully")
 	assert.Empty(t, groups, "Should handle fragments without tree nodes gracefully")
 }
+
+// TestCloneDetector_PairsPromotedToGroups is a regression test for issue #525.
+// Every detected clone pair whose similarity is at or above the configured
+// grouping threshold must have both of its fragments present in at least one
+// emitted clone group. Otherwise the pair is silently lost from the
+// refactoring-facing group output.
+func TestCloneDetector_PairsPromotedToGroups(t *testing.T) {
+	src := `class Agg:
+    async def sum(self, field, session=None, ignore_cache=False):
+        pipeline = [
+            {"$match": self._build_match(session, ignore_cache)},
+            {"$group": {"_id": None, "v": {"$sum": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+
+    async def avg(self, field, session=None, ignore_cache=False):
+        pipeline = [
+            {"$match": self._build_match(session, ignore_cache)},
+            {"$group": {"_id": None, "v": {"$avg": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+
+    async def max(self, field, session=None, ignore_cache=False):
+        pipeline = [
+            {"$match": self._build_match(session, ignore_cache)},
+            {"$group": {"_id": None, "v": {"$max": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+
+    async def min(self, field, session=None, ignore_cache=False):
+        pipeline = [
+            {"$match": self._build_match(session, ignore_cache)},
+            {"$group": {"_id": None, "v": {"$min": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+`
+
+	pyParser := parser.New()
+	parseResult, err := pyParser.Parse(t.Context(), []byte(src))
+	require.NoError(t, err)
+	require.NotNil(t, parseResult)
+	require.NotNil(t, parseResult.AST)
+
+	cfg := DefaultCloneDetectorConfig()
+	cfg.GroupingThreshold = domain.DefaultType4CloneThreshold
+	detector := NewCloneDetector(cfg)
+	fragments := detector.ExtractFragmentsWithSource([]*parser.Node{parseResult.AST}, "/test/aggregation.py", []byte(src))
+	require.GreaterOrEqual(t, len(fragments), 4, "expected at least the four aggregation methods as fragments")
+
+	pairs, groups := detector.DetectClones(fragments)
+	require.NotEmpty(t, pairs, "expected clone pairs to be detected")
+	require.NotEmpty(t, groups, "expected clone groups to be emitted")
+
+	// Build a location-keyed set of group members.
+	groupMemberKeys := make(map[string]struct{})
+	for _, g := range groups {
+		for _, f := range g.Fragments {
+			groupMemberKeys[fragmentLocationKey(f)] = struct{}{}
+		}
+	}
+
+	missing := 0
+	for _, p := range pairs {
+		if p == nil || p.Fragment1 == nil || p.Fragment2 == nil {
+			continue
+		}
+		if p.Similarity < cfg.GroupingThreshold {
+			continue
+		}
+		pairInGroup := false
+		for _, g := range groups {
+			if groupContainsFragment(g, p.Fragment1) && groupContainsFragment(g, p.Fragment2) {
+				pairInGroup = true
+				break
+			}
+		}
+		if !pairInGroup {
+			missing++
+			t.Logf("pair not in any group: %s <-> %s (sim=%.3f type=%v)",
+				fragmentLocationKey(p.Fragment1), fragmentLocationKey(p.Fragment2), p.Similarity, p.CloneType)
+		}
+	}
+	require.Zero(t, missing, "%d clone pair(s) above the grouping threshold are absent from all groups", missing)
+}
+
+func fragmentLocationKey(f *CodeFragment) string {
+	if f == nil || f.Location == nil {
+		return ""
+	}
+	loc := f.Location
+	return fmt.Sprintf("%s|%d|%d", loc.FilePath, loc.StartLine, loc.EndLine)
+}
+
+func groupContainsFragment(g *CloneGroup, f *CodeFragment) bool {
+	if g == nil || f == nil {
+		return false
+	}
+	key := fragmentLocationKey(f)
+	for _, member := range g.Fragments {
+		if fragmentLocationKey(member) == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/analyzer/complete_linkage_grouping.go
+++ b/internal/analyzer/complete_linkage_grouping.go
@@ -137,7 +137,7 @@ func (c *CompleteLinkageGrouping) buildGroups(activeClusters []*completeLinkageC
 			group.AddFragment(fragment)
 		}
 		group.Similarity = averageGroupSimilarity(similarities, sortedMembers)
-		group.CloneType = majorityCloneType(types, sortedMembers)
+		group.CloneType = majorityCloneType(types, similarities, sortedMembers)
 		groups = append(groups, group)
 	}
 

--- a/internal/analyzer/complete_linkage_grouping_test.go
+++ b/internal/analyzer/complete_linkage_grouping_test.go
@@ -406,7 +406,7 @@ func referenceCompleteLinkageGroups(threshold float64, pairs []*ClonePair) []*Cl
 			group.AddFragment(fragment)
 		}
 		group.Similarity = averageGroupSimilarity(sims, cluster)
-		group.CloneType = majorityCloneType(types, cluster)
+		group.CloneType = majorityCloneType(types, sims, cluster)
 		groups = append(groups, group)
 	}
 

--- a/internal/analyzer/connected_grouping.go
+++ b/internal/analyzer/connected_grouping.go
@@ -117,7 +117,7 @@ func (c *ConnectedGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
 		// Compute average similarity using cached pairs among members
 		g.Similarity = averageGroupSimilarity(simMap, members)
 		// Determine predominant clone type from within-group available pairs
-		g.CloneType = majorityCloneType(typeMap, members)
+		g.CloneType = majorityCloneType(typeMap, simMap, members)
 		groups = append(groups, g)
 	}
 
@@ -138,29 +138,31 @@ func (c *ConnectedGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
 	return groups
 }
 
-// majorityCloneType chooses the most frequent CloneType among all pair edges in members.
-func majorityCloneType(typeMap map[string]CloneType, members []*CodeFragment) CloneType {
-	counts := make(map[CloneType]int)
+// majorityCloneType chooses the CloneType of the highest-similarity pair edge in
+// members. When several pairs share the maximum similarity, the most strict
+// (lowest enum) type wins. This prevents a high-similarity Type-2/Type-4 pair
+// from being hidden when lower-similarity Type-3 transitive edges outnumber it
+// in the same connected component (issue #525).
+func majorityCloneType(typeMap map[string]CloneType, simMap map[string]float64, members []*CodeFragment) CloneType {
+	maxSim := -1.0
+	var best CloneType
+	found := false
 	for i := 0; i < len(members); i++ {
 		for j := i + 1; j < len(members); j++ {
 			key := pairKey(members[i], members[j])
-			if t, ok := typeMap[key]; ok {
-				if t == 0 {
-					continue
-				}
-				counts[t]++
+			t, tok := typeMap[key]
+			s, sok := simMap[key]
+			if !tok || !sok || t == 0 {
+				continue
+			}
+			found = true
+			if s > maxSim || (almostEqual(s, maxSim) && t < best) {
+				maxSim = s
+				best = t
 			}
 		}
 	}
-	var best CloneType
-	maxC := -1
-	for t, c := range counts {
-		if c > maxC || (c == maxC && t < best) {
-			maxC = c
-			best = t
-		}
-	}
-	if maxC < 0 {
+	if !found {
 		return Type4Clone // conservative fallback: never report unknown as Type-1
 	}
 	return best

--- a/internal/analyzer/group_dedup.go
+++ b/internal/analyzer/group_dedup.go
@@ -290,7 +290,7 @@ func clonePairMetadata(pairs []*ClonePair) (map[string]float64, map[string]Clone
 
 func refreshGroupMetadata(group *CloneGroup, similarities map[string]float64, cloneTypes map[string]CloneType) {
 	group.Similarity = averageGroupSimilarity(similarities, group.Fragments)
-	group.CloneType = majorityCloneType(cloneTypes, group.Fragments)
+	group.CloneType = majorityCloneType(cloneTypes, similarities, group.Fragments)
 }
 
 func filterClonePairsWithSuppressedMembers(pairs []*ClonePair, suppressed map[*CodeFragment]struct{}) []*ClonePair {

--- a/internal/analyzer/grouping_strategies_test.go
+++ b/internal/analyzer/grouping_strategies_test.go
@@ -114,10 +114,52 @@ func TestMajorityCloneType_TieBreaksDeterministically(t *testing.T) {
 		pairKey(a, d): Type3Clone,
 		pairKey(b, c): Type1Clone,
 	}
+	simMap := map[string]float64{
+		pairKey(a, b): 0.9,
+		pairKey(a, c): 0.9,
+		pairKey(a, d): 0.9,
+		pairKey(b, c): 0.9,
+	}
 
-	got := majorityCloneType(typeMap, members)
+	got := majorityCloneType(typeMap, simMap, members)
 	if got != Type1Clone {
 		t.Fatalf("expected deterministic lower clone-type tie break, got %v", got)
+	}
+}
+
+// TestMajorityCloneType_PrefersHighSimilarityPair ensures a connected component
+// whose strongest edge is a high-similarity Type-2 pair is reported as Type-2
+// even when weaker Type-3 transitive edges outnumber it. This is the core
+// classification fix for issue #525 (clone pairs lost as Type-3 groups).
+func TestMajorityCloneType_PrefersHighSimilarityPair(t *testing.T) {
+	a := gf("a.py", 1, 3)
+	b := gf("b.py", 1, 3)
+	c := gf("c.py", 1, 3)
+	d := gf("d.py", 1, 3)
+
+	members := []*CodeFragment{a, b, c, d}
+	// One strong Type-2 edge (the real clone pair) and many weaker Type-3 edges
+	// that happen to transitively connect the same component.
+	typeMap := map[string]CloneType{
+		pairKey(a, b): Type2Clone,
+		pairKey(a, c): Type3Clone,
+		pairKey(a, d): Type3Clone,
+		pairKey(b, c): Type3Clone,
+		pairKey(b, d): Type3Clone,
+		pairKey(c, d): Type3Clone,
+	}
+	simMap := map[string]float64{
+		pairKey(a, b): 0.96, // high-sim Type-2 clone pair
+		pairKey(a, c): 0.85,
+		pairKey(a, d): 0.85,
+		pairKey(b, c): 0.85,
+		pairKey(b, d): 0.85,
+		pairKey(c, d): 0.85,
+	}
+
+	got := majorityCloneType(typeMap, simMap, members)
+	if got != Type2Clone {
+		t.Fatalf("expected Type-2 from the highest-similarity edge, got %v", got)
 	}
 }
 

--- a/internal/analyzer/k_core_grouping.go
+++ b/internal/analyzer/k_core_grouping.go
@@ -142,7 +142,7 @@ func (k *KCoreGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
 			g.AddFragment(f)
 		}
 		g.Similarity = averageGroupSimilarity(simMap, component)
-		g.CloneType = majorityCloneType(typeMap, component)
+		g.CloneType = majorityCloneType(typeMap, simMap, component)
 		groups = append(groups, g)
 	}
 

--- a/internal/analyzer/star_medoid_grouping.go
+++ b/internal/analyzer/star_medoid_grouping.go
@@ -166,7 +166,7 @@ func (s *StarMedoidGrouping) GroupClones(pairs []*ClonePair) []*CloneGroup {
 		}
 		// Compute average similarity from cache among group members
 		group.Similarity = averageGroupSimilarity(simMap, filtered)
-		group.CloneType = majorityCloneType(typeMap, filtered)
+		group.CloneType = majorityCloneType(typeMap, simMap, filtered)
 		result = append(result, group)
 	}
 

--- a/testdata/python/issue525/aggregation.py
+++ b/testdata/python/issue525/aggregation.py
@@ -1,0 +1,44 @@
+class Agg:
+    async def sum(self, field, session=None, ignore_cache=False):
+        match_stage = self._build_match(session, ignore_cache)
+        pipeline = [
+            {"$match": match_stage},
+            {"$group": {"_id": None, "v": {"$sum": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+
+    async def avg(self, field, session=None, ignore_cache=False):
+        match_stage = self._build_match(session, ignore_cache)
+        pipeline = [
+            {"$match": match_stage},
+            {"$group": {"_id": None, "v": {"$avg": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+
+    async def max(self, field, session=None, ignore_cache=False):
+        match_stage = self._build_match(session, ignore_cache)
+        pipeline = [
+            {"$match": match_stage},
+            {"$group": {"_id": None, "v": {"$max": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None
+
+    async def min(self, field, session=None, ignore_cache=False):
+        match_stage = self._build_match(session, ignore_cache)
+        pipeline = [
+            {"$match": match_stage},
+            {"$group": {"_id": None, "v": {"$min": f"${field}"}}},
+        ]
+        result = await self.aggregate(pipeline, session=session)
+        if result and len(result) > 0:
+            return result[0]["v"]
+        return None


### PR DESCRIPTION
## Problem

Issue #525 reported that high-similarity clone pairs were not promoted to clone groups. The pair-level detector found the clone, but the group-level output did not contain either fragment of the pair.

## Root Cause

`majorityCloneType` classified a connected component by the most frequent clone type among all pair edges. When a strong Type-2/Type-4 pair was linked through a component that also contained many weaker Type-3 transitive edges, the group was labeled Type-3 and then dropped by the default enabled clone types.

## Fix

Change `majorityCloneType` to use the clone type of the highest-similarity pair in the component, breaking ties toward the strictest (lowest) type. This keeps the high-similarity pair visible in the emitted group.

All grouping strategies (connected, k-core, star/medoid, complete-linkage) and the post-dedup metadata refresh are updated to pass the similarity map to `majorityCloneType`.

## Tests

- `TestMajorityCloneType_PrefersHighSimilarityPair` verifies the classification logic directly.
- `TestCloneDetector_PairsPromotedToGroups` is an end-to-end regression test that asserts every clone pair above the grouping threshold has both fragments present in at least one emitted group.
- A fixture `testdata/python/issue525/aggregation.py` reproduces the aggregation pattern from the issue.

## Verification

- `make test` passes.
- `make fmt lint` passes.
- `make coverage` reports `internal/analyzer` at 79.9%. The overall coverage command fails on `cmd/pyscn-mcp` with `go: no such tool "covdata"`, which appears to be an environment issue unrelated to this change.
- Manual verification on `BeanieODM/beanie@00c0f74`: after the fix, 0 of 68 pairs above threshold were missing from groups.

## Related

- Fixes #525
