### PR TITLE
fix(lcom): count self.<property> reads as method-call edges

### DIFF
--- a/internal/analyzer/lcom.go
+++ b/internal/analyzer/lcom.go
@@ -224,6 +224,11 @@ func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node, declaredFields map
 	calls := make(map[string]map[string]bool)
 	excluded := 0
 
+	// A bare `self.<name>` read of a @property is a method invocation via the
+	// descriptor protocol, not a field access. Collect property names first so
+	// such reads can be recorded as call edges instead of instance variables.
+	propertyNames := a.collectPropertyNames(classNode)
+
 	for _, node := range classNode.Body {
 		if node == nil {
 			continue
@@ -252,6 +257,18 @@ func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node, declaredFields map
 		// Extract self.xxx() method calls
 		methodCalls := make(map[string]bool)
 		a.extractMethodCalls(node, methodCalls)
+
+		// Reclassify bare `self.<prop>` reads: a property access invokes the
+		// getter via the descriptor protocol, so it is a call edge to that
+		// property, not an instance-variable access. Leaving it as a variable
+		// isolates the consuming method and overcounts LCOM4.
+		for name := range propertyNames {
+			if name != node.Name && vars[name] {
+				methodCalls[name] = true
+				delete(vars, name)
+			}
+		}
+
 		calls[node.Name] = methodCalls
 	}
 
@@ -266,6 +283,43 @@ func (a *LCOMAnalyzer) isClassOrStaticMethod(funcNode *parser.Node) bool {
 		}
 		name := a.getDecoratorName(decorator)
 		if name == "classmethod" || name == "staticmethod" {
+			return true
+		}
+	}
+	return false
+}
+
+// collectPropertyNames returns the set of method names decorated with @property
+// in the class body. Reads of these via `self.<name>` are descriptor-protocol
+// method invocations rather than instance-variable accesses.
+func (a *LCOMAnalyzer) collectPropertyNames(classNode *parser.Node) map[string]bool {
+	names := make(map[string]bool)
+	for _, node := range classNode.Body {
+		if node == nil {
+			continue
+		}
+		if node.Type != parser.NodeFunctionDef && node.Type != parser.NodeAsyncFunctionDef {
+			continue
+		}
+		if a.isProperty(node) {
+			names[node.Name] = true
+		}
+	}
+	return names
+}
+
+// isProperty reports whether a method is a @property getter. Like
+// isClassOrStaticMethod, this matches the bare decorator name "property" only;
+// other property-like descriptors (cached_property, or dotted forms like
+// @functools.cached_property) are out of scope, matching how the rest of the
+// analyzer resolves decorators.
+func (a *LCOMAnalyzer) isProperty(funcNode *parser.Node) bool {
+	for _, decorator := range funcNode.Decorator {
+		if decorator == nil {
+			continue
+		}
+		name := a.getDecoratorName(decorator)
+		if name == "property" {
 			return true
 		}
 	}

--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -152,6 +152,24 @@ class ClassWithProperty:
 			expectedRisk:  map[string]string{"ClassWithProperty": "low"},
 		},
 		{
+			name: "method consuming a property is connected via property-call edge",
+			pythonCode: `
+class PropertyConsumer:
+    def __init__(self):
+        self._x = 1
+
+    @property
+    def value(self):
+        return self._x
+
+    def use(self):
+        return self.value + 1
+`,
+			expectedCount: 1,
+			expectedLCOM:  map[string]int{"PropertyConsumer": 1},
+			expectedRisk:  map[string]string{"PropertyConsumer": "low"},
+		},
+		{
 			name: "single method class is trivially cohesive",
 			pythonCode: `
 class SingleMethodClass:


### PR DESCRIPTION
## what

a bare `self.<prop>` read of a `@property` now creates an LCOM4 method-call edge to that property, instead of being counted as an instance-variable access.

Fixes #545.

## why

LCOM4 treats `self.xxx()` calls as intra-class edges, but a bare `self.xxx` read that resolves to a `@property` created no edge. so a method that only consumes a property got split into its own connected component and LCOM4 was overcounted.

```python
class Config:
    def __init__(self):
        self._x = 1

    @property
    def value(self):
        return self._x

    def use(self):
        return self.value + 1
```

- before: `LCOM4 = 2`  (`[["__init__", "value"], ["use"]]`)
- after: `LCOM4 = 1`  (`use` connects to `value` via the property call; `value` shares `self._x` with `__init__`)

at runtime that read invokes the getter through the descriptor protocol, so the consumer really is connected.

## fix

in `collectMethods` (`internal/analyzer/lcom.go`): collect the class's `@property` names, then reclassify a bare `self.<prop>` read from an instance-variable access into a call edge, so the existing union pass connects the consumer. the new `collectPropertyNames`/`isProperty` helpers mirror the existing `isClassOrStaticMethod` + `getDecoratorName` handling.

## scope

matches `@property` (the bare decorator name) only, consistent with how the analyzer already resolves decorators. other property-like descriptors (`cached_property`, or dotted forms like `@functools.cached_property`) are out of scope, the same limitation the existing classmethod/staticmethod detection has.

## tests

`internal/analyzer/lcom_test.go`: a class where `use` consumes a property without sharing the underlying field, so LCOM4 must be 1. the existing "class with property included" case stays green - it connects via the shared field, a different path.
