### PR TITLE
fix(config): honor explicit threshold overrides matching defaults

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -33,6 +33,12 @@ type AnalyzeUseCaseConfig struct {
 	CloneSimilarity float64
 	MinCBO          int
 
+	// Complexity thresholds (0 = unset, use config file or default)
+	LowThreshold                 int
+	MediumThreshold              int
+	CognitiveComplexityThreshold int
+	NestingDepthThreshold        int
+
 	// Clone detection options
 	EnableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
@@ -511,6 +517,25 @@ func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig
 		minComplexity = executionCfg.ComplexityMinComplexity
 	}
 
+	// CLI flag values take precedence over config file when explicitly set (> 0).
+	// Otherwise fall back to execution config (from config file or defaults).
+	lowThreshold := executionCfg.ComplexityLowThreshold
+	if config.LowThreshold > 0 {
+		lowThreshold = config.LowThreshold
+	}
+	mediumThreshold := executionCfg.ComplexityMediumThreshold
+	if config.MediumThreshold > 0 {
+		mediumThreshold = config.MediumThreshold
+	}
+	cognitiveThreshold := executionCfg.CognitiveComplexityThreshold
+	if config.CognitiveComplexityThreshold > 0 {
+		cognitiveThreshold = config.CognitiveComplexityThreshold
+	}
+	nestingThreshold := executionCfg.NestingDepthThreshold
+	if config.NestingDepthThreshold > 0 {
+		nestingThreshold = config.NestingDepthThreshold
+	}
+
 	return domain.ComplexityRequest{
 		Paths:                        files,
 		Recursive:                    false,
@@ -521,10 +546,10 @@ func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig
 		MinComplexity:                minComplexity,
 		MaxComplexity:                executionCfg.ComplexityMaxComplexity,
 		SortBy:                       domain.SortByComplexity,
-		LowThreshold:                 executionCfg.ComplexityLowThreshold,
-		MediumThreshold:              executionCfg.ComplexityMediumThreshold,
-		CognitiveComplexityThreshold: executionCfg.CognitiveComplexityThreshold,
-		NestingDepthThreshold:        executionCfg.NestingDepthThreshold,
+		LowThreshold:                 lowThreshold,
+		MediumThreshold:              mediumThreshold,
+		CognitiveComplexityThreshold: cognitiveThreshold,
+		NestingDepthThreshold:        nestingThreshold,
 		Enabled:                      domain.BoolPtr(executionCfg.ComplexityEnabled),
 		ReportUnchanged:              domain.BoolPtr(executionCfg.ComplexityReportUnchanged),
 		ConfigPath:                   config.ConfigFile,

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -498,3 +498,76 @@ show_content = true
 		t.Fatal("expected show_content from config to be preserved")
 	}
 }
+
+// TestBuildComplexityTaskRequest_ThresholdOverrides verifies that CLI flag
+// values (> 0) in AnalyzeUseCaseConfig take precedence over execution config
+// values, and that zero (unset) falls back to execution config. This is the
+// runtime counterpart to the MergeConfig fix for issue #553.
+func TestBuildComplexityTaskRequest_ThresholdOverrides(t *testing.T) {
+	uc := &AnalyzeUseCase{}
+
+	executionCfg := domain.AnalyzeExecutionConfig{
+		ComplexityLowThreshold:       10,
+		ComplexityMediumThreshold:    20,
+		CognitiveComplexityThreshold: 30,
+		NestingDepthThreshold:        11,
+	}
+
+	t.Run("CLI flags override execution config", func(t *testing.T) {
+		config := AnalyzeUseCaseConfig{
+			LowThreshold:                 9,
+			MediumThreshold:              19,
+			CognitiveComplexityThreshold: 25,
+			NestingDepthThreshold:        7,
+		}
+		req := uc.buildComplexityTaskRequest(config, []string{"test.py"}, executionCfg)
+
+		if req.LowThreshold != 9 {
+			t.Errorf("LowThreshold: expected 9 (CLI), got %d", req.LowThreshold)
+		}
+		if req.MediumThreshold != 19 {
+			t.Errorf("MediumThreshold: expected 19 (CLI), got %d", req.MediumThreshold)
+		}
+		if req.CognitiveComplexityThreshold != 25 {
+			t.Errorf("CognitiveComplexityThreshold: expected 25 (CLI), got %d", req.CognitiveComplexityThreshold)
+		}
+		if req.NestingDepthThreshold != 7 {
+			t.Errorf("NestingDepthThreshold: expected 7 (CLI), got %d", req.NestingDepthThreshold)
+		}
+	})
+
+	t.Run("zero flags fall back to execution config", func(t *testing.T) {
+		config := AnalyzeUseCaseConfig{}
+		req := uc.buildComplexityTaskRequest(config, []string{"test.py"}, executionCfg)
+
+		if req.LowThreshold != 10 {
+			t.Errorf("LowThreshold: expected 10 (exec), got %d", req.LowThreshold)
+		}
+		if req.MediumThreshold != 20 {
+			t.Errorf("MediumThreshold: expected 20 (exec), got %d", req.MediumThreshold)
+		}
+		if req.CognitiveComplexityThreshold != 30 {
+			t.Errorf("CognitiveComplexityThreshold: expected 30 (exec), got %d", req.CognitiveComplexityThreshold)
+		}
+		if req.NestingDepthThreshold != 11 {
+			t.Errorf("NestingDepthThreshold: expected 11 (exec), got %d", req.NestingDepthThreshold)
+		}
+	})
+
+	t.Run("partial override only affects set flags", func(t *testing.T) {
+		config := AnalyzeUseCaseConfig{
+			CognitiveComplexityThreshold: 25,
+		}
+		req := uc.buildComplexityTaskRequest(config, []string{"test.py"}, executionCfg)
+
+		if req.LowThreshold != 10 {
+			t.Errorf("LowThreshold: expected 10 (exec), got %d", req.LowThreshold)
+		}
+		if req.CognitiveComplexityThreshold != 25 {
+			t.Errorf("CognitiveComplexityThreshold: expected 25 (CLI), got %d", req.CognitiveComplexityThreshold)
+		}
+		if req.NestingDepthThreshold != 11 {
+			t.Errorf("NestingDepthThreshold: expected 11 (exec), got %d", req.NestingDepthThreshold)
+		}
+	})
+}

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -46,6 +46,12 @@ type AnalyzeCommand struct {
 	cloneSimilarity float64
 	minCBO          int
 
+	// Complexity thresholds (0 = unset, use config/default)
+	lowThreshold                 int
+	mediumThreshold              int
+	cognitiveComplexityThreshold int
+	nestingDepthThreshold        int
+
 	// Clone detection options
 	enableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
@@ -141,6 +147,12 @@ Examples:
 	cmd.Flags().Float64Var(&c.cloneSimilarity, "clone-threshold", 0.65, "Minimum similarity for clone detection (0.0-1.0)")
 	cmd.Flags().IntVar(&c.minCBO, "min-cbo", 0, "Minimum CBO to report")
 
+	// Complexity threshold flags (0 = unset, use config file or default)
+	cmd.Flags().IntVar(&c.lowThreshold, "low-threshold", 0, "Upper bound for low-risk complexity (default: 9)")
+	cmd.Flags().IntVar(&c.mediumThreshold, "medium-threshold", 0, "Upper bound for medium-risk complexity (default: 19)")
+	cmd.Flags().IntVar(&c.cognitiveComplexityThreshold, "cognitive-complexity-threshold", 0, "High-risk threshold for cognitive complexity (default: 25)")
+	cmd.Flags().IntVar(&c.nestingDepthThreshold, "nesting-depth-threshold", 0, "High-risk threshold for maximum nesting depth (default: 7)")
+
 	return cmd
 }
 
@@ -207,6 +219,11 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 		EnableDFA:               c.enableDFA,
 		SkipCommunities:         false,
 		SkipCommunitiesExplicit: c.skipCommunities,
+
+		LowThreshold:                 c.lowThreshold,
+		MediumThreshold:              c.mediumThreshold,
+		CognitiveComplexityThreshold: c.cognitiveComplexityThreshold,
+		NestingDepthThreshold:        c.nestingDepthThreshold,
 	}
 	config = app.ApplyAnalyzeSelection(config, c.selectAnalyses)
 

--- a/cmd/pyscn/new_commands_test.go
+++ b/cmd/pyscn/new_commands_test.go
@@ -761,3 +761,66 @@ func TestCountDIAntipatternIssuesFailsOnAnalysisErrors(t *testing.T) {
 		t.Fatalf("expected parse error to be preserved, got: %v", err)
 	}
 }
+
+// TestAnalyzeCommandThresholdFlags verifies that complexity threshold flags
+// on the analyze command are mapped into AnalyzeUseCaseConfig. This is the CLI
+// counterpart to the MergeConfig fix for issue #553.
+func TestAnalyzeCommandThresholdFlags(t *testing.T) {
+	t.Run("default values are zero (unset)", func(t *testing.T) {
+		analyzeCmd := NewAnalyzeCommand()
+		config := analyzeCmd.createUseCaseConfig()
+
+		if config.LowThreshold != 0 {
+			t.Errorf("expected LowThreshold 0, got %d", config.LowThreshold)
+		}
+		if config.MediumThreshold != 0 {
+			t.Errorf("expected MediumThreshold 0, got %d", config.MediumThreshold)
+		}
+		if config.CognitiveComplexityThreshold != 0 {
+			t.Errorf("expected CognitiveComplexityThreshold 0, got %d", config.CognitiveComplexityThreshold)
+		}
+		if config.NestingDepthThreshold != 0 {
+			t.Errorf("expected NestingDepthThreshold 0, got %d", config.NestingDepthThreshold)
+		}
+	})
+
+	t.Run("explicit flag values are mapped", func(t *testing.T) {
+		analyzeCmd := NewAnalyzeCommand()
+		analyzeCmd.lowThreshold = 9
+		analyzeCmd.mediumThreshold = 19
+		analyzeCmd.cognitiveComplexityThreshold = 25
+		analyzeCmd.nestingDepthThreshold = 7
+
+		config := analyzeCmd.createUseCaseConfig()
+
+		if config.LowThreshold != 9 {
+			t.Errorf("expected LowThreshold 9, got %d", config.LowThreshold)
+		}
+		if config.MediumThreshold != 19 {
+			t.Errorf("expected MediumThreshold 19, got %d", config.MediumThreshold)
+		}
+		if config.CognitiveComplexityThreshold != 25 {
+			t.Errorf("expected CognitiveComplexityThreshold 25, got %d", config.CognitiveComplexityThreshold)
+		}
+		if config.NestingDepthThreshold != 7 {
+			t.Errorf("expected NestingDepthThreshold 7, got %d", config.NestingDepthThreshold)
+		}
+	})
+
+	t.Run("flags are registered on cobra command", func(t *testing.T) {
+		analyzeCmd := NewAnalyzeCommand()
+		cobraCmd := analyzeCmd.CreateCobraCommand()
+
+		expectedFlags := []string{
+			"low-threshold",
+			"medium-threshold",
+			"cognitive-complexity-threshold",
+			"nesting-depth-threshold",
+		}
+		for _, name := range expectedFlags {
+			if cobraCmd.Flags().Lookup(name) == nil {
+				t.Errorf("expected flag --%s to be registered", name)
+			}
+		}
+	})
+}

--- a/service/config_loader.go
+++ b/service/config_loader.go
@@ -83,20 +83,23 @@ func (c *ConfigurationLoaderImpl) MergeConfig(base *domain.ComplexityRequest, ov
 		merged.SortBy = override.SortBy
 	}
 
-	// Complexity thresholds - override if non-default
-	if override.LowThreshold != domain.DefaultComplexityLowThreshold && override.LowThreshold > 0 {
+	// Complexity thresholds - override whenever a positive value is supplied.
+	// A zero value means the caller did not set the field, so the base wins.
+	// Do NOT compare against domain defaults: an explicit override that happens
+	// to equal the default must still take precedence (issue #553).
+	if override.LowThreshold > 0 {
 		merged.LowThreshold = override.LowThreshold
 	}
 
-	if override.MediumThreshold != domain.DefaultComplexityMediumThreshold && override.MediumThreshold > 0 {
+	if override.MediumThreshold > 0 {
 		merged.MediumThreshold = override.MediumThreshold
 	}
 
-	if override.CognitiveComplexityThreshold != domain.DefaultCognitiveComplexityThreshold && override.CognitiveComplexityThreshold > 0 {
+	if override.CognitiveComplexityThreshold > 0 {
 		merged.CognitiveComplexityThreshold = override.CognitiveComplexityThreshold
 	}
 
-	if override.NestingDepthThreshold != domain.DefaultNestingDepthThreshold && override.NestingDepthThreshold > 0 {
+	if override.NestingDepthThreshold > 0 {
 		merged.NestingDepthThreshold = override.NestingDepthThreshold
 	}
 

--- a/service/config_loader_test.go
+++ b/service/config_loader_test.go
@@ -109,6 +109,58 @@ func TestConfigurationLoader_MergeConfig_Thresholds(t *testing.T) {
 	assert.Equal(t, 25, merged.MediumThreshold)
 }
 
+// TestConfigurationLoader_MergeConfig_ThresholdOverrideMatchesDefault is a
+// regression test for issue #553: an explicit override that happens to equal
+// the domain default must still win over the base value.
+func TestConfigurationLoader_MergeConfig_ThresholdOverrideMatchesDefault(t *testing.T) {
+	loader := NewConfigurationLoader()
+
+	base := &domain.ComplexityRequest{
+		LowThreshold:                 10,
+		MediumThreshold:              20,
+		CognitiveComplexityThreshold: 30,
+		NestingDepthThreshold:        11,
+	}
+
+	override := &domain.ComplexityRequest{
+		LowThreshold:                 domain.DefaultComplexityLowThreshold,       // 9
+		MediumThreshold:              domain.DefaultComplexityMediumThreshold,    // 19
+		CognitiveComplexityThreshold: domain.DefaultCognitiveComplexityThreshold, // 25
+		NestingDepthThreshold:        domain.DefaultNestingDepthThreshold,        // 7
+	}
+
+	merged := loader.MergeConfig(base, override)
+	assert.Equal(t, domain.DefaultComplexityLowThreshold, merged.LowThreshold,
+		"explicit override matching default should win over base")
+	assert.Equal(t, domain.DefaultComplexityMediumThreshold, merged.MediumThreshold,
+		"explicit override matching default should win over base")
+	assert.Equal(t, domain.DefaultCognitiveComplexityThreshold, merged.CognitiveComplexityThreshold,
+		"explicit override matching default should win over base")
+	assert.Equal(t, domain.DefaultNestingDepthThreshold, merged.NestingDepthThreshold,
+		"explicit override matching default should win over base")
+}
+
+// TestConfigurationLoader_MergeConfig_ThresholdZeroPreservesBase verifies that
+// a zero (unset) override leaves the base value intact.
+func TestConfigurationLoader_MergeConfig_ThresholdZeroPreservesBase(t *testing.T) {
+	loader := NewConfigurationLoader()
+
+	base := &domain.ComplexityRequest{
+		LowThreshold:                 10,
+		MediumThreshold:              20,
+		CognitiveComplexityThreshold: 30,
+		NestingDepthThreshold:        11,
+	}
+
+	override := &domain.ComplexityRequest{}
+
+	merged := loader.MergeConfig(base, override)
+	assert.Equal(t, 10, merged.LowThreshold)
+	assert.Equal(t, 20, merged.MediumThreshold)
+	assert.Equal(t, 30, merged.CognitiveComplexityThreshold)
+	assert.Equal(t, 11, merged.NestingDepthThreshold)
+}
+
 func TestConfigurationLoader_MergeConfig_Patterns(t *testing.T) {
 	loader := NewConfigurationLoader()
 

--- a/service/config_loader_with_flags.go
+++ b/service/config_loader_with_flags.go
@@ -86,6 +86,8 @@ func (c *ConfigurationLoaderWithFlags) MergeConfig(base *domain.ComplexityReques
 	// Complexity thresholds
 	merged.LowThreshold = c.flagTracker.MergeInt(merged.LowThreshold, override.LowThreshold, "low-threshold")
 	merged.MediumThreshold = c.flagTracker.MergeInt(merged.MediumThreshold, override.MediumThreshold, "medium-threshold")
+	merged.CognitiveComplexityThreshold = c.flagTracker.MergeInt(merged.CognitiveComplexityThreshold, override.CognitiveComplexityThreshold, "cognitive-complexity-threshold")
+	merged.NestingDepthThreshold = c.flagTracker.MergeInt(merged.NestingDepthThreshold, override.NestingDepthThreshold, "nesting-depth-threshold")
 
 	// Config path is always from override if provided
 	if override.ConfigPath != "" {

--- a/service/config_loader_with_flags_test.go
+++ b/service/config_loader_with_flags_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigurationLoaderWithFlags_MergeConfig_CognitiveAndNestingThresholds(t *testing.T) {
+	tests := []struct {
+		name          string
+		explicitFlags map[string]bool
+		base          *domain.ComplexityRequest
+		override      *domain.ComplexityRequest
+		wantCognitive int
+		wantNesting   int
+	}{
+		{
+			name:          "explicit cognitive flag wins even when equal to default",
+			explicitFlags: map[string]bool{"cognitive-complexity-threshold": true, "nesting-depth-threshold": true},
+			base: &domain.ComplexityRequest{
+				CognitiveComplexityThreshold: 30,
+				NestingDepthThreshold:        11,
+			},
+			override: &domain.ComplexityRequest{
+				CognitiveComplexityThreshold: domain.DefaultCognitiveComplexityThreshold, // 25
+				NestingDepthThreshold:        domain.DefaultNestingDepthThreshold,        // 7
+			},
+			wantCognitive: domain.DefaultCognitiveComplexityThreshold,
+			wantNesting:   domain.DefaultNestingDepthThreshold,
+		},
+		{
+			name:          "no explicit flags preserves base",
+			explicitFlags: map[string]bool{},
+			base: &domain.ComplexityRequest{
+				CognitiveComplexityThreshold: 30,
+				NestingDepthThreshold:        11,
+			},
+			override: &domain.ComplexityRequest{
+				CognitiveComplexityThreshold: 25,
+				NestingDepthThreshold:        7,
+			},
+			wantCognitive: 30,
+			wantNesting:   11,
+		},
+		{
+			name:          "only cognitive flag set, nesting preserves base",
+			explicitFlags: map[string]bool{"cognitive-complexity-threshold": true},
+			base: &domain.ComplexityRequest{
+				CognitiveComplexityThreshold: 30,
+				NestingDepthThreshold:        11,
+			},
+			override: &domain.ComplexityRequest{
+				CognitiveComplexityThreshold: 40,
+				NestingDepthThreshold:        7,
+			},
+			wantCognitive: 40,
+			wantNesting:   11,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := NewConfigurationLoaderWithFlags(tt.explicitFlags)
+			merged := loader.MergeConfig(tt.base, tt.override)
+			assert.Equal(t, tt.wantCognitive, merged.CognitiveComplexityThreshold)
+			assert.Equal(t, tt.wantNesting, merged.NestingDepthThreshold)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `ConfigurationLoaderImpl.MergeConfig` silently discarding explicit threshold overrides when the value happened to equal the domain default.
- Fix `ConfigurationLoaderWithFlags.MergeConfig` dropping `CognitiveComplexityThreshold` and `NestingDepthThreshold` entirely (only `LowThreshold`/`MediumThreshold` were wired up via `FlagTracker`).
- Add regression tests for both code paths.

## Rationale

Closes #553.

The merge guard used `override.X != domain.DefaultX && override.X > 0`. When a user explicitly passed `--cognitive-complexity-threshold 25` (the default), the `!= DefaultX` clause was false and the override was discarded, so the base/config-file value silently won. An explicit CLI flag must always take precedence.

The affected fields and their defaults:

| Field | Default | Origin |
|---|---|---|
| `LowThreshold` | 9 | Pre-existing |
| `MediumThreshold` | 19 | Pre-existing |
| `CognitiveComplexityThreshold` | 25 | PR #552 |
| `NestingDepthThreshold` | 7 | PR #552 |

The fix removes the `!= Default...` guards and relies solely on `> 0` to detect an unset field (0 = unset for int thresholds). This matches the pattern already used by the boolean fields (`*bool` + `!= nil`).

For `ConfigurationLoaderWithFlags`, the cognitive/nesting fields were not routed through `FlagTracker.MergeInt` at all — added them with flag names `cognitive-complexity-threshold` and `nesting-depth-threshold`.

## Validation

- `make fmt`
- `make lint` → 0 issues (visitor.go warning is stale from PR #552)
- `go test ./...` → all packages pass

## Breaking changes

None. Callers that leave thresholds unset (0) still get the base/default behavior; only explicit overrides now behave correctly.