### PR TITLE
refactor(clone): integrate statistics into detector result types

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -140,6 +140,28 @@ func (cg *CloneGroup) AddFragment(fragment *CodeFragment) {
 	cg.Size = len(cg.Fragments)
 }
 
+// CloneDetectionStatistics provides statistics computed during clone detection.
+// It tracks only the data the detector itself can derive from the fragment and
+// pair/group collections. Callers (e.g. service/clone_service.go) augment it
+// with file/line/node counts gathered while reading sources.
+type CloneDetectionStatistics struct {
+	TotalFragments    int
+	TotalClones       int
+	TotalClonePairs   int
+	TotalCloneGroups  int
+	ClonesByType      map[string]int
+	AverageSimilarity float64
+}
+
+// CloneDetectionResult bundles the detected clone pairs and groups with the
+// statistics derived from them. Wrapping the output prevents accidental use of
+// raw fragment counts where detected clone counts are required.
+type CloneDetectionResult struct {
+	Pairs      []*ClonePair
+	Groups     []*CloneGroup
+	Statistics *CloneDetectionStatistics
+}
+
 // CloneDetectorConfig holds configuration for clone detection
 type CloneDetectorConfig struct {
 	// Minimum number of lines for a code fragment to be considered
@@ -586,19 +608,19 @@ func isCancelled(ctx context.Context) bool {
 }
 
 // DetectClones detects clones in the given code fragments
-func (cd *CloneDetector) DetectClones(fragments []*CodeFragment) ([]*ClonePair, []*CloneGroup) {
+func (cd *CloneDetector) DetectClones(fragments []*CodeFragment) *CloneDetectionResult {
 	return cd.DetectClonesWithContext(context.Background(), fragments)
 }
 
 // DetectClonesWithContext detects clones with context support for cancellation
-func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments []*CodeFragment) ([]*ClonePair, []*CloneGroup) {
+func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments []*CodeFragment) *CloneDetectionResult {
 	cd.fragments = fragments
 	cd.clonePairs = []*ClonePair{}
 	cd.cloneGroups = []*CloneGroup{}
 
 	// Check for cancellation before starting
 	if isCancelled(ctx) {
-		return cd.clonePairs, cd.cloneGroups
+		return cd.buildCloneDetectionResult()
 	}
 
 	// Convert AST fragments to tree nodes
@@ -606,7 +628,7 @@ func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments 
 
 	// Check for cancellation after preparation
 	if isCancelled(ctx) {
-		return cd.clonePairs, cd.cloneGroups
+		return cd.buildCloneDetectionResult()
 	}
 
 	// Detect clone pairs with context
@@ -614,7 +636,7 @@ func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments 
 
 	// Check for cancellation before grouping
 	if isCancelled(ctx) {
-		return cd.clonePairs, cd.cloneGroups
+		return cd.buildCloneDetectionResult()
 	}
 
 	// Group related clones using configured strategy
@@ -641,12 +663,12 @@ func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments 
 	strategy := CreateGroupingStrategy(groupingConfig)
 	cd.groupClonesWithStrategy(strategy)
 
-	return cd.clonePairs, cd.cloneGroups
+	return cd.buildCloneDetectionResult()
 }
 
 // DetectClonesWithLSH runs a two-stage pipeline using LSH for candidate generation,
 // followed by APTED verification on candidates only. Falls back to exhaustive if misconfigured.
-func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*CodeFragment) ([]*ClonePair, []*CloneGroup) {
+func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*CodeFragment) *CloneDetectionResult {
 	// If not enabled, delegate to standard path
 	if cd == nil || !cd.cloneDetectorConfig.UseLSH {
 		return cd.DetectClonesWithContext(ctx, fragments)
@@ -657,14 +679,14 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 	cd.cloneGroups = []*CloneGroup{}
 
 	if isCancelled(ctx) {
-		return cd.clonePairs, cd.cloneGroups
+		return cd.buildCloneDetectionResult()
 	}
 
 	// Prepare TreeNodes for APTED and feature extraction
 	cd.prepareFragments()
 
 	if isCancelled(ctx) {
-		return cd.clonePairs, cd.cloneGroups
+		return cd.buildCloneDetectionResult()
 	}
 
 	// Stage 1: MinHash signatures from prepared clone features
@@ -810,7 +832,54 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 	strategy := CreateGroupingStrategy(groupingConfig)
 	cd.groupClonesWithStrategy(strategy)
 
-	return cd.clonePairs, cd.cloneGroups
+	return cd.buildCloneDetectionResult()
+}
+
+// buildCloneDetectionResult builds a CloneDetectionResult from the detector's
+// current state. It derives all statistics directly from the detected pairs and
+// groups so callers cannot accidentally pass a raw fragment count in their place.
+func (cd *CloneDetector) buildCloneDetectionResult() *CloneDetectionResult {
+	stats := &CloneDetectionStatistics{
+		TotalFragments:   len(cd.fragments),
+		TotalClonePairs:  len(cd.clonePairs),
+		TotalCloneGroups: len(cd.cloneGroups),
+		ClonesByType:     make(map[string]int),
+	}
+
+	seenFragments := make(map[*CodeFragment]struct{})
+	countFragment := func(f *CodeFragment) {
+		if f != nil {
+			seenFragments[f] = struct{}{}
+		}
+	}
+	for _, pair := range cd.clonePairs {
+		countFragment(pair.Fragment1)
+		countFragment(pair.Fragment2)
+		stats.ClonesByType[pair.CloneType.String()]++
+	}
+	for _, group := range cd.cloneGroups {
+		if group == nil {
+			continue
+		}
+		for _, f := range group.Fragments {
+			countFragment(f)
+		}
+	}
+	stats.TotalClones = len(seenFragments)
+
+	if len(cd.clonePairs) > 0 {
+		totalSim := 0.0
+		for _, pair := range cd.clonePairs {
+			totalSim += pair.Similarity
+		}
+		stats.AverageSimilarity = totalSim / float64(len(cd.clonePairs))
+	}
+
+	return &CloneDetectionResult{
+		Pairs:      cd.clonePairs,
+		Groups:     cd.cloneGroups,
+		Statistics: stats,
+	}
 }
 
 // prepareFragments converts AST fragments to tree nodes and populates clone features.
@@ -1149,31 +1218,21 @@ func (cd *CloneDetector) isOverlappingLocation(loc1, loc2 *CodeLocation) bool {
 	return !(loc1.EndLine < loc2.StartLine || loc2.EndLine < loc1.StartLine)
 }
 
-// GetStatistics returns clone detection statistics
+// GetStatistics returns clone detection statistics as a map for backward
+// compatibility with existing callers and tests. New code should prefer the
+// structured CloneDetectionResult returned by DetectClones* methods.
 func (cd *CloneDetector) GetStatistics() map[string]interface{} {
-	stats := make(map[string]interface{})
+	result := cd.buildCloneDetectionResult()
+	stats := result.Statistics
 
-	stats["total_fragments"] = len(cd.fragments)
-	stats["total_clone_pairs"] = len(cd.clonePairs)
-	stats["total_clone_groups"] = len(cd.cloneGroups)
+	m := make(map[string]interface{})
+	m["total_fragments"] = stats.TotalFragments
+	m["total_clone_pairs"] = stats.TotalClonePairs
+	m["total_clone_groups"] = stats.TotalCloneGroups
+	m["clone_types"] = stats.ClonesByType
+	m["average_similarity"] = stats.AverageSimilarity
 
-	// Count by clone type
-	typeCounts := make(map[string]int)
-	for _, pair := range cd.clonePairs {
-		typeCounts[pair.CloneType.String()]++
-	}
-	stats["clone_types"] = typeCounts
-
-	// Average similarity
-	if len(cd.clonePairs) > 0 {
-		totalSim := 0.0
-		for _, pair := range cd.clonePairs {
-			totalSim += pair.Similarity
-		}
-		stats["average_similarity"] = totalSim / float64(len(cd.clonePairs))
-	}
-
-	return stats
+	return m
 }
 
 // tryCreateClonePair attempts to create a clone pair if it meets similarity threshold

--- a/internal/analyzer/clone_detector_bench_test.go
+++ b/internal/analyzer/clone_detector_bench_test.go
@@ -39,9 +39,11 @@ func benchmarkCloneDetectionMode(b *testing.B, name string, config *CloneDetecto
 			var pairs []*ClonePair
 			var groups []*CloneGroup
 			if config.UseLSH {
-				pairs, groups = detector.DetectClonesWithLSH(ctx, fragments)
+				result := detector.DetectClonesWithLSH(ctx, fragments)
+				pairs, groups = result.Pairs, result.Groups
 			} else {
-				pairs, groups = detector.DetectClones(fragments)
+				result := detector.DetectClones(fragments)
+				pairs, groups = result.Pairs, result.Groups
 			}
 
 			if len(pairs) == 0 || len(groups) == 0 {
@@ -155,7 +157,7 @@ func BenchmarkCloneDetectionMemory(b *testing.B) {
 				detector := NewCloneDetector(cloneBenchmarkConfig(false))
 				detector.fragments = fragments
 				detector.clonePairs = nil
-				detector.DetectClones(detector.fragments)
+				_ = detector.DetectClones(detector.fragments)
 			}
 		})
 	}

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -831,7 +831,8 @@ func TestCloneDetector_DetectClones(t *testing.T) {
 			detector := NewCloneDetector(tt.config)
 
 			// Detect clones
-			pairs, groups := detector.DetectClones(tt.fragments)
+			result := detector.DetectClones(tt.fragments)
+			pairs, groups := result.Pairs, result.Groups
 
 			assert.Len(t, pairs, tt.expectedPairs, tt.description+" - pairs count")
 			assert.Len(t, groups, tt.expectedGroups, tt.description+" - groups count")
@@ -1011,7 +1012,8 @@ func TestCloneDetector_EdgeCases(t *testing.T) {
 
 	// Test with empty fragments
 	emptyFragments := []*CodeFragment{}
-	pairs, groups := detector.DetectClones(emptyFragments)
+	result := detector.DetectClones(emptyFragments)
+	pairs, groups := result.Pairs, result.Groups
 	assert.Empty(t, pairs, "Should return empty pairs for empty input")
 	assert.Empty(t, groups, "Should return empty groups for empty input")
 
@@ -1024,7 +1026,8 @@ func TestCloneDetector_EdgeCases(t *testing.T) {
 			LineCount: 5,
 		},
 	}
-	pairs, groups = detector.DetectClones(singleFragment)
+	result = detector.DetectClones(singleFragment)
+	pairs, groups = result.Pairs, result.Groups
 	assert.Empty(t, pairs, "Should return empty pairs for single fragment")
 	assert.Empty(t, groups, "Should return empty groups for single fragment")
 
@@ -1033,7 +1036,8 @@ func TestCloneDetector_EdgeCases(t *testing.T) {
 		{Location: &CodeLocation{FilePath: "/test1.py"}, TreeNode: nil},
 		{Location: &CodeLocation{FilePath: "/test2.py"}, TreeNode: nil},
 	}
-	pairs, groups = detector.DetectClones(fragmentsWithoutTrees)
+	result = detector.DetectClones(fragmentsWithoutTrees)
+	pairs, groups = result.Pairs, result.Groups
 	assert.Empty(t, pairs, "Should handle fragments without tree nodes gracefully")
 	assert.Empty(t, groups, "Should handle fragments without tree nodes gracefully")
 }
@@ -1098,7 +1102,8 @@ func TestCloneDetector_PairsPromotedToGroups(t *testing.T) {
 	fragments := detector.ExtractFragmentsWithSource([]*parser.Node{parseResult.AST}, "/test/aggregation.py", []byte(src))
 	require.GreaterOrEqual(t, len(fragments), 4, "expected at least the four aggregation methods as fragments")
 
-	pairs, groups := detector.DetectClones(fragments)
+	result := detector.DetectClones(fragments)
+	pairs, groups := result.Pairs, result.Groups
 	require.NotEmpty(t, pairs, "expected clone pairs to be detected")
 	require.NotEmpty(t, groups, "expected clone groups to be emitted")
 

--- a/internal/analyzer/clone_memory_test.go
+++ b/internal/analyzer/clone_memory_test.go
@@ -30,7 +30,7 @@ func TestCloneDetectorMemoryManagement(t *testing.T) {
 		runtime.ReadMemStats(&m1)
 
 		// Run detection
-		detector.DetectClones(detector.fragments)
+		_ = detector.DetectClones(detector.fragments)
 
 		// Measure memory after
 		runtime.ReadMemStats(&m2)
@@ -61,7 +61,7 @@ func TestCloneDetectorMemoryManagement(t *testing.T) {
 		startTime := time.Now()
 
 		// Run detection
-		detector.DetectClones(detector.fragments)
+		_ = detector.DetectClones(detector.fragments)
 		duration := time.Since(startTime)
 
 		// Measure memory after
@@ -104,7 +104,7 @@ func TestCloneDetectorMemoryManagement(t *testing.T) {
 			detector.cloneGroups = nil
 
 			// Run detection
-			detector.DetectClones(detector.fragments)
+			_ = detector.DetectClones(detector.fragments)
 
 			// Clear references to allow garbage collection
 			detector.fragments = nil
@@ -149,7 +149,7 @@ func TestCloneDetectorMemoryManagement(t *testing.T) {
 		detector.cloneGroups = nil
 
 		// Run detection
-		detector.DetectClones(detector.fragments)
+		_ = detector.DetectClones(detector.fragments)
 
 		// Should find pairs between similar-sized fragments
 		// and skip pairs between very different-sized fragments
@@ -190,14 +190,14 @@ func TestBatchingAlgorithmCorrectness(t *testing.T) {
 	// Test standard algorithm
 	detector1 := NewCloneDetector(config)
 	detector1.fragments = fragments
-	detector1.DetectClones(detector1.fragments)
+	_ = detector1.DetectClones(detector1.fragments)
 	standardPairs := detector1.clonePairs
 
 	// Test batching algorithm with small batch size
 	detector2 := NewCloneDetector(config)
 	detector2.fragments = fragments
 	detector2.SetBatchSizeLarge(30) // Small batch size for testing
-	detector2.DetectClones(detector2.fragments)
+	_ = detector2.DetectClones(detector2.fragments)
 	batchedPairs := detector2.clonePairs
 
 	// Both should find similar high-quality clone pairs

--- a/internal/analyzer/lsh_integration_test.go
+++ b/internal/analyzer/lsh_integration_test.go
@@ -66,7 +66,8 @@ func TestCloneDetector_DetectClonesWithLSH_Simple(t *testing.T) {
 	cfg.LSHMinHashCount = 128
 
 	det := NewCloneDetector(cfg)
-	pairs, _ := det.DetectClonesWithLSH(context.Background(), []*CodeFragment{f1, f2, f3})
+	result := det.DetectClonesWithLSH(context.Background(), []*CodeFragment{f1, f2, f3})
+	pairs := result.Pairs
 	if len(pairs) == 0 {
 		// As a sanity check, verify MinHash similarity and LSH candidate retrieval
 		ext := NewASTFeatureExtractor()
@@ -198,7 +199,8 @@ func TestCloneDetectorDetectClonesWithLSHRefreshesStaleFeatureCache(t *testing.T
 		t.Fatalf("test setup needs stale features below strict LSH threshold")
 	}
 
-	pairs, _ := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
+	result := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
+	pairs := result.Pairs
 	if len(pairs) != 1 {
 		t.Fatalf("expected LSH to refresh stale cached features before candidate generation, got %d pairs", len(pairs))
 	}
@@ -221,7 +223,8 @@ func TestCloneDetector_DetectClonesWithLSH_CandidateCapDoesNotDropExactFamily(t 
 	cfg.LSHSimilarityThreshold = 0.5
 	cfg.LSHMaxCandidates = 8
 
-	pairs, groups := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
+	result := NewCloneDetector(cfg).DetectClonesWithLSH(context.Background(), fragments)
+	pairs, groups := result.Pairs, result.Groups
 	if len(pairs) == 0 || len(groups) == 0 {
 		t.Fatalf("candidate cap dropped every exact clone candidate")
 	}
@@ -232,13 +235,15 @@ func TestCloneDetector_DetectClonesWithLSH_MatchesStandardOnBenchmarkFixture(t *
 	fragments := buildCloneBenchmarkFragments(4, 4, 8)
 
 	standardDetector := NewCloneDetector(cloneBenchmarkConfig(false))
-	standardPairs, standardGroups := standardDetector.DetectClones(fragments)
+	standardResult := standardDetector.DetectClones(fragments)
+	standardPairs, standardGroups := standardResult.Pairs, standardResult.Groups
 	if len(standardPairs) == 0 || len(standardGroups) == 0 {
 		t.Fatalf("expected standard benchmark fixture run to produce pairs and groups")
 	}
 
 	lshDetector := NewCloneDetector(cloneBenchmarkConfig(true))
-	lshPairs, lshGroups := lshDetector.DetectClonesWithLSH(context.Background(), fragments)
+	lshResult := lshDetector.DetectClonesWithLSH(context.Background(), fragments)
+	lshPairs, lshGroups := lshResult.Pairs, lshResult.Groups
 	if len(lshPairs) == 0 || len(lshGroups) == 0 {
 		t.Fatalf("expected LSH benchmark fixture run to produce pairs and groups")
 	}

--- a/internal/analyzer/type4_detector_test.go
+++ b/internal/analyzer/type4_detector_test.go
@@ -20,7 +20,8 @@ func TestType4CloneDetection(t *testing.T) {
 	detector := NewCloneDetector(config)
 	allFragments, functionFragments := loadType4FunctionFragments(t, detector)
 
-	pairs, groups := detector.DetectClones(allFragments)
+	result := detector.DetectClones(allFragments)
+	pairs, groups := result.Pairs, result.Groups
 	require.NotEmpty(t, pairs)
 	require.NotEmpty(t, groups)
 

--- a/service/basic_service_test.go
+++ b/service/basic_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/analyzer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -143,11 +144,16 @@ func TestCloneService_Basic(t *testing.T) {
 	})
 
 	// Test statistics creation
-	t.Run("createStatistics handles empty data", func(t *testing.T) {
+	t.Run("buildCloneStatistics handles empty data", func(t *testing.T) {
 		var pairs []*domain.ClonePair
 		var groups []*domain.CloneGroup
 
-		stats := service.createStatistics(pairs, groups, 0, 0, 0, 0)
+		result := &analyzer.CloneDetectionResult{
+			Pairs:      []*analyzer.ClonePair{},
+			Groups:     []*analyzer.CloneGroup{},
+			Statistics: &analyzer.CloneDetectionStatistics{TotalFragments: 0},
+		}
+		stats := service.buildCloneStatistics(result, pairs, groups, 0, 0, 0)
 
 		assert.Equal(t, 0, stats.TotalFragments)
 		assert.Equal(t, 0, stats.TotalClones)

--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -159,12 +159,12 @@ func (s *CloneService) buildCloneResponse(
 	detector.SetUseLSH(useLSH)
 
 	// Detect clones (detector will automatically use LSH or standard algorithm based on UseLSH setting)
-	clonePairs, cloneGroups := detector.DetectClonesWithLSH(ctx, allFragments)
+	detectionResult := detector.DetectClonesWithLSH(ctx, allFragments)
 
 	// Convert to domain objects
 	domainClones, fragmentIDs := s.convertFragmentsToDomainClones(allFragments)
-	domainClonePairs := s.convertClonePairsToDomain(clonePairs, req.ShowContent)
-	domainCloneGroups := s.convertCloneGroupsToDomain(cloneGroups, req.ShowContent, fragmentIDs)
+	domainClonePairs := s.convertClonePairsToDomain(detectionResult.Pairs, req.ShowContent)
+	domainCloneGroups := s.convertCloneGroupsToDomain(detectionResult.Groups, req.ShowContent, fragmentIDs)
 
 	// Filter results based on request criteria
 	domainClonePairs = s.filterClonePairs(domainClonePairs, req)
@@ -173,9 +173,11 @@ func (s *CloneService) buildCloneResponse(
 	// Sort results
 	s.sortResults(domainClones, domainClonePairs, domainCloneGroups, req)
 
-	// Create statistics
-	totalFragments := len(allFragments)
-	statistics := s.createStatistics(domainClonePairs, domainCloneGroups, totalFragments, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
+	// Build statistics from the filtered results so that counts always match the
+	// returned clone pairs and groups. The detector's result already separates
+	// raw candidates from detected items; we derive final numbers only from the
+	// detected items exposed in the response.
+	statistics := s.buildCloneStatistics(detectionResult, domainClonePairs, domainCloneGroups, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
 
 	duration := time.Since(startTime).Milliseconds()
 	// s.progress.Complete(fmt.Sprintf("Clone detection completed in %dms. Found %d clone pairs in %d groups.",
@@ -506,10 +508,17 @@ func (s *CloneService) sortResults(clones []*domain.Clone, pairs []*domain.Clone
 	// For now, we'll keep the default ordering from the detector
 }
 
-// createStatistics creates clone detection statistics
-func (s *CloneService) createStatistics(pairs []*domain.ClonePair, groups []*domain.CloneGroup, totalFragments, filesAnalyzed, linesAnalyzed, nodesAnalyzed int) *domain.CloneStatistics {
+// buildCloneStatistics converts analyzer-level detection statistics into the
+// domain statistics attached to the response. All counts are derived from the
+// filtered results so that reported numbers always match what is returned.
+func (s *CloneService) buildCloneStatistics(
+	result *analyzer.CloneDetectionResult,
+	pairs []*domain.ClonePair,
+	groups []*domain.CloneGroup,
+	filesAnalyzed, linesAnalyzed, nodesAnalyzed int,
+) *domain.CloneStatistics {
 	stats := domain.NewCloneStatistics()
-	stats.TotalFragments = totalFragments
+	stats.TotalFragments = result.Statistics.TotalFragments
 	stats.TotalClones = countUniqueCloneFragments(pairs, groups)
 	stats.TotalClonePairs = len(pairs)
 	stats.TotalCloneGroups = len(groups)
@@ -535,7 +544,9 @@ func (s *CloneService) createStatistics(pairs []*domain.ClonePair, groups []*dom
 	return stats
 }
 
-// countUniqueCloneFragments counts distinct fragments that participate in at least one clone pair or group.
+// countUniqueCloneFragments counts distinct domain clones that participate in
+// at least one clone pair or group. Counting detected items separately from the
+// raw fragment collection prevents accidentally reporting the candidate count.
 func countUniqueCloneFragments(pairs []*domain.ClonePair, groups []*domain.CloneGroup) int {
 	type locKey struct {
 		file      string

--- a/service/clone_service_test.go
+++ b/service/clone_service_test.go
@@ -636,7 +636,7 @@ func TestCloneService_FilterCloneGroups(t *testing.T) {
 	})
 }
 
-func TestCloneService_CreateStatistics(t *testing.T) {
+func TestCloneService_BuildCloneStatistics(t *testing.T) {
 	service := NewCloneService()
 
 	cloneA := &domain.Clone{ID: 1, Location: &domain.CloneLocation{FilePath: "a.py", StartLine: 1, EndLine: 10}}
@@ -654,12 +654,28 @@ func TestCloneService_CreateStatistics(t *testing.T) {
 		{ID: 2, Clones: []*domain.Clone{cloneB, cloneC}},
 	}
 
-	totalFragments := 10
+	fragA := &analyzer.CodeFragment{Location: &analyzer.CodeLocation{FilePath: "a.py", StartLine: 1, EndLine: 10}}
+	fragB := &analyzer.CodeFragment{Location: &analyzer.CodeLocation{FilePath: "b.py", StartLine: 1, EndLine: 10}}
+	fragC := &analyzer.CodeFragment{Location: &analyzer.CodeLocation{FilePath: "c.py", StartLine: 1, EndLine: 10}}
+
+	result := &analyzer.CloneDetectionResult{
+		Pairs: []*analyzer.ClonePair{
+			{Fragment1: fragA, Fragment2: fragB, Similarity: 0.8, CloneType: analyzer.Type1Clone},
+			{Fragment1: fragB, Fragment2: fragC, Similarity: 0.9, CloneType: analyzer.Type2Clone},
+			{Fragment1: fragA, Fragment2: fragC, Similarity: 0.7, CloneType: analyzer.Type1Clone},
+		},
+		Groups: []*analyzer.CloneGroup{
+			{Fragments: []*analyzer.CodeFragment{fragA, fragB}},
+			{Fragments: []*analyzer.CodeFragment{fragB, fragC}},
+		},
+		Statistics: &analyzer.CloneDetectionStatistics{TotalFragments: 10},
+	}
+
 	filesAnalyzed := 5
 	linesAnalyzed := 1000
 	nodesAnalyzed := 500
 
-	stats := service.createStatistics(pairs, groups, totalFragments, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
+	stats := service.buildCloneStatistics(result, pairs, groups, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
 
 	assert.NotNil(t, stats)
 	assert.Equal(t, 10, stats.TotalFragments)
@@ -676,7 +692,7 @@ func TestCloneService_CreateStatistics(t *testing.T) {
 	assert.Equal(t, 1, stats.ClonesByType["Type-2"])
 
 	// When groups are pruned but pairs exist, TotalClones should still count pair endpoints
-	statsNilGroups := service.createStatistics(pairs, nil, totalFragments, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
+	statsNilGroups := service.buildCloneStatistics(result, pairs, nil, filesAnalyzed, linesAnalyzed, nodesAnalyzed)
 	assert.Equal(t, 3, statsNilGroups.TotalClones)
 }
 


### PR DESCRIPTION
## Summary

Closes #486 (pilot for clone detection).

This PR integrates clone detection statistics directly into the detector result type so that raw fragment counts and detected clone counts are structurally separated, preventing the class of count-mismatch bugs described in #486 and #418.

## Changes

- Added "CloneDetectionResult" and "CloneDetectionStatistics" types in "internal/analyzer".
- Changed "DetectClones", "DetectClonesWithContext", and "DetectClonesWithLSH" to return "*CloneDetectionResult".
- Updated all callers (tests, benchmarks, and service layer) to use "result.Pairs" / "result.Groups".
- Removed the "createStatistics" helper from "service/clone_service.go"; statistics are now derived from the detector result.
- Kept "GetStatistics()" backward-compatible by delegating to the new structured result internally.

## Verification

- make fmt ✅
- make test ✅ (all packages pass)
- make lint ✅ (0 issues)
- make build ✅

## Scope note

This implements the clone-detection pilot proposed in #486. Extending the same pattern to complexity, cohesion, CBO, and other detectors is left for follow-up work.