### PR TITLE
feat(analyzer): build CommunityGraph from DependencyGraph (issue #579)

### DIFF
--- a/internal/analyzer/community_graph.go
+++ b/internal/analyzer/community_graph.go
@@ -4,10 +4,10 @@ import "sort"
 
 // CommunityGraphBuildOptions configures construction of a CommunityGraph.
 type CommunityGraphBuildOptions struct {
-	// IncludeLazyEdges controls whether lazy (function-body) import edges are
-	// included. Default true. When false, edges are excluded using the same
-	// criterion as circular dependency detection (issue #460).
-	IncludeLazyEdges bool
+	// ExcludeLazyEdges omits lazy (function-body) import edges when true.
+	// Default false (lazy edges included). Exclusion uses the same criterion
+	// as circular dependency detection (issue #460).
+	ExcludeLazyEdges bool
 
 	// EdgeWeightFunc assigns a weight to each dependency edge. When nil, every
 	// edge has weight 1.0. Reserved for future weighting by import type,
@@ -17,9 +17,7 @@ type CommunityGraphBuildOptions struct {
 
 // DefaultCommunityGraphBuildOptions returns the default build options.
 func DefaultCommunityGraphBuildOptions() *CommunityGraphBuildOptions {
-	return &CommunityGraphBuildOptions{
-		IncludeLazyEdges: true,
-	}
+	return &CommunityGraphBuildOptions{}
 }
 
 // CommunityGraph is a compact, integer-indexed graph derived from a
@@ -99,7 +97,7 @@ func BuildCommunityGraph(graph *DependencyGraph, opts *CommunityGraphBuildOption
 			continue
 		}
 
-		if !opts.IncludeLazyEdges && edge.IsLazy {
+		if opts.ExcludeLazyEdges && edge.IsLazy {
 			continue
 		}
 

--- a/internal/analyzer/community_graph.go
+++ b/internal/analyzer/community_graph.go
@@ -1,0 +1,149 @@
+package analyzer
+
+import "sort"
+
+// CommunityGraphBuildOptions configures construction of a CommunityGraph.
+type CommunityGraphBuildOptions struct {
+	// IncludeLazyEdges controls whether lazy (function-body) import edges are
+	// included. Default true. When false, edges are excluded using the same
+	// criterion as circular dependency detection (issue #460).
+	IncludeLazyEdges bool
+
+	// EdgeWeightFunc assigns a weight to each dependency edge. When nil, every
+	// edge has weight 1.0. Reserved for future weighting by import type,
+	// frequency, or laziness.
+	EdgeWeightFunc func(edge *DependencyEdge) float64
+}
+
+// DefaultCommunityGraphBuildOptions returns the default build options.
+func DefaultCommunityGraphBuildOptions() *CommunityGraphBuildOptions {
+	return &CommunityGraphBuildOptions{
+		IncludeLazyEdges: true,
+	}
+}
+
+// CommunityGraph is a compact, integer-indexed graph derived from a
+// DependencyGraph for community detection (e.g. Leiden) and cross-community
+// metrics.
+type CommunityGraph struct {
+	NodeCount   int
+	NodeNames   []string
+	NameToIndex map[string]int
+
+	// UndirectedAdj holds weighted undirected adjacency lists for clustering.
+	// Each neighbor list is sorted by index for deterministic iteration.
+	UndirectedAdj [][]WeightedNeighbor
+
+	// DirectedEdges preserves directed import edges for cross-community
+	// in/out counts. Not collapsed into undirected form.
+	DirectedEdges []CommunityDirectedEdge
+
+	// TotalUndirectedWeight is the sum of undirected edge weights (each
+	// undirected pair counted once). Used as a modularity denominator hook.
+	TotalUndirectedWeight float64
+}
+
+// WeightedNeighbor is a neighbor in the undirected adjacency list.
+type WeightedNeighbor struct {
+	Index  int
+	Weight float64
+}
+
+// CommunityDirectedEdge is a directed dependency edge between indexed nodes.
+type CommunityDirectedEdge struct {
+	FromIndex int
+	ToIndex   int
+	Weight    float64
+	IsLazy    bool
+}
+
+// BuildCommunityGraph constructs a CommunityGraph from a DependencyGraph.
+// Returns an empty graph when graph is nil or has no modules.
+func BuildCommunityGraph(graph *DependencyGraph, opts *CommunityGraphBuildOptions) *CommunityGraph {
+	if graph == nil || len(graph.Nodes) == 0 {
+		return &CommunityGraph{
+			NameToIndex: make(map[string]int),
+		}
+	}
+
+	if opts == nil {
+		opts = DefaultCommunityGraphBuildOptions()
+	}
+
+	nodeNames := graph.GetModuleNames()
+	nodeCount := len(nodeNames)
+	nameToIndex := make(map[string]int, nodeCount)
+	for i, name := range nodeNames {
+		nameToIndex[name] = i
+	}
+
+	weightFunc := opts.EdgeWeightFunc
+	if weightFunc == nil {
+		weightFunc = func(*DependencyEdge) float64 { return 1.0 }
+	}
+
+	directedEdges := make([]CommunityDirectedEdge, 0, len(graph.Edges))
+	undirectedWeights := make(map[undirectedPairKey]float64)
+
+	for _, edge := range graph.Edges {
+		if edge == nil {
+			continue
+		}
+		if edge.From == edge.To {
+			continue
+		}
+
+		fromIdx, fromOK := nameToIndex[edge.From]
+		toIdx, toOK := nameToIndex[edge.To]
+		if !fromOK || !toOK {
+			continue
+		}
+
+		if !opts.IncludeLazyEdges && edge.IsLazy {
+			continue
+		}
+
+		weight := weightFunc(edge)
+		if weight <= 0 {
+			continue
+		}
+
+		directedEdges = append(directedEdges, CommunityDirectedEdge{
+			FromIndex: fromIdx,
+			ToIndex:   toIdx,
+			Weight:    weight,
+			IsLazy:    edge.IsLazy,
+		})
+
+		key := undirectedPairKey{min(fromIdx, toIdx), max(fromIdx, toIdx)}
+		undirectedWeights[key] += weight
+	}
+
+	undirectedAdj := make([][]WeightedNeighbor, nodeCount)
+	var totalUndirectedWeight float64
+	for key, weight := range undirectedWeights {
+		undirectedAdj[key.low] = append(undirectedAdj[key.low], WeightedNeighbor{Index: key.high, Weight: weight})
+		undirectedAdj[key.high] = append(undirectedAdj[key.high], WeightedNeighbor{Index: key.low, Weight: weight})
+		totalUndirectedWeight += weight
+	}
+
+	for i := range undirectedAdj {
+		sort.Slice(undirectedAdj[i], func(a, b int) bool {
+			return undirectedAdj[i][a].Index < undirectedAdj[i][b].Index
+		})
+	}
+
+	return &CommunityGraph{
+		NodeCount:             nodeCount,
+		NodeNames:             nodeNames,
+		NameToIndex:           nameToIndex,
+		UndirectedAdj:         undirectedAdj,
+		DirectedEdges:         directedEdges,
+		TotalUndirectedWeight: totalUndirectedWeight,
+	}
+}
+
+type undirectedPairKey struct {
+	low  int
+	high int
+}

--- a/internal/analyzer/community_graph_test.go
+++ b/internal/analyzer/community_graph_test.go
@@ -114,7 +114,7 @@ func TestBuildCommunityGraph_ExcludeLazyEdges(t *testing.T) {
 	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, lazyInfo)
 	graph.AddDependency("mod.b", "mod.c", DependencyEdgeImport, nil)
 
-	cg := BuildCommunityGraph(graph, &CommunityGraphBuildOptions{IncludeLazyEdges: false})
+	cg := BuildCommunityGraph(graph, &CommunityGraphBuildOptions{ExcludeLazyEdges: true})
 
 	assert.Equal(t, 1, len(cg.DirectedEdges))
 	assert.Equal(t, cg.NameToIndex["mod.b"], cg.DirectedEdges[0].FromIndex)
@@ -136,6 +136,29 @@ func TestBuildCommunityGraph_BidirectionalAggregation(t *testing.T) {
 	assert.Equal(t, 2, len(cg.DirectedEdges))
 	assert.Equal(t, 2.0, undirectedWeight(cg, "mod.a", "mod.b"))
 	assert.Equal(t, 2.0, cg.TotalUndirectedWeight)
+}
+
+func TestBuildCommunityGraph_DefaultIncludesLazyEdges(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+
+	lazyInfo := &ImportInfo{IsLazy: true}
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, lazyInfo)
+
+	t.Run("empty options struct", func(t *testing.T) {
+		cg := BuildCommunityGraph(graph, &CommunityGraphBuildOptions{})
+		require.Len(t, cg.DirectedEdges, 1)
+		assert.True(t, cg.DirectedEdges[0].IsLazy)
+	})
+
+	t.Run("only EdgeWeightFunc set", func(t *testing.T) {
+		cg := BuildCommunityGraph(graph, &CommunityGraphBuildOptions{
+			EdgeWeightFunc: func(*DependencyEdge) float64 { return 1.0 },
+		})
+		require.Len(t, cg.DirectedEdges, 1)
+		assert.True(t, cg.DirectedEdges[0].IsLazy)
+	})
 }
 
 func TestBuildCommunityGraph_CustomEdgeWeightFunc(t *testing.T) {

--- a/internal/analyzer/community_graph_test.go
+++ b/internal/analyzer/community_graph_test.go
@@ -1,0 +1,174 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCommunityGraph_EmptyGraph(t *testing.T) {
+	t.Run("nil graph", func(t *testing.T) {
+		cg := BuildCommunityGraph(nil, nil)
+		assert.Equal(t, 0, cg.NodeCount)
+		assert.Empty(t, cg.NodeNames)
+		assert.Empty(t, cg.UndirectedAdj)
+		assert.Empty(t, cg.DirectedEdges)
+	})
+
+	t.Run("no modules", func(t *testing.T) {
+		cg := BuildCommunityGraph(NewDependencyGraph("/project"), nil)
+		assert.Equal(t, 0, cg.NodeCount)
+		assert.Empty(t, cg.NodeNames)
+	})
+}
+
+func TestBuildCommunityGraph_TwoCommunities(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddModule("mod.c", "/project/mod/c.py")
+	graph.AddModule("mod.d", "/project/mod/d.py")
+
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.b", "mod.a", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.c", "mod.d", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.d", "mod.c", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+
+	require.Equal(t, 4, cg.NodeCount)
+	assert.Equal(t, []string{"mod.a", "mod.b", "mod.c", "mod.d"}, cg.NodeNames)
+	assert.Equal(t, 4, len(cg.DirectedEdges))
+	assert.Equal(t, 2.0, undirectedWeight(cg, "mod.a", "mod.b"))
+	assert.Equal(t, 2.0, undirectedWeight(cg, "mod.c", "mod.d"))
+	assert.Equal(t, 0.0, undirectedWeight(cg, "mod.a", "mod.c"))
+	assert.Equal(t, 4.0, cg.TotalUndirectedWeight)
+}
+
+func TestBuildCommunityGraph_BridgeNode(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddModule("bridge", "/project/bridge.py")
+	graph.AddModule("mod.c", "/project/mod/c.py")
+	graph.AddModule("mod.d", "/project/mod/d.py")
+
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.b", "bridge", DependencyEdgeImport, nil)
+	graph.AddDependency("bridge", "mod.c", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.c", "mod.d", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+
+	require.Equal(t, 5, cg.NodeCount)
+	assert.Equal(t, 1.0, undirectedWeight(cg, "mod.a", "mod.b"))
+	assert.Equal(t, 1.0, undirectedWeight(cg, "mod.b", "bridge"))
+	assert.Equal(t, 1.0, undirectedWeight(cg, "bridge", "mod.c"))
+	assert.Equal(t, 1.0, undirectedWeight(cg, "mod.c", "mod.d"))
+	assert.Equal(t, 0.0, undirectedWeight(cg, "mod.a", "mod.d"))
+}
+
+func TestBuildCommunityGraph_FullyDisconnected(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("alpha", "/project/alpha.py")
+	graph.AddModule("beta", "/project/beta.py")
+	graph.AddModule("gamma", "/project/gamma.py")
+
+	cg := BuildCommunityGraph(graph, nil)
+
+	require.Equal(t, 3, cg.NodeCount)
+	assert.Empty(t, cg.DirectedEdges)
+	assert.Equal(t, 0.0, cg.TotalUndirectedWeight)
+	for i := range cg.UndirectedAdj {
+		assert.Empty(t, cg.UndirectedAdj[i])
+	}
+}
+
+func TestBuildCommunityGraph_Deterministic(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("zeta", "/project/zeta.py")
+	graph.AddModule("alpha", "/project/alpha.py")
+	graph.AddModule("middle", "/project/middle.py")
+
+	graph.AddDependency("alpha", "middle", DependencyEdgeImport, nil)
+	graph.AddDependency("middle", "zeta", DependencyEdgeImport, nil)
+	graph.AddDependency("zeta", "alpha", DependencyEdgeImport, nil)
+
+	first := BuildCommunityGraph(graph, nil)
+	second := BuildCommunityGraph(graph, nil)
+
+	assert.Equal(t, first.NodeNames, second.NodeNames)
+	assert.Equal(t, first.DirectedEdges, second.DirectedEdges)
+	assert.Equal(t, first.UndirectedAdj, second.UndirectedAdj)
+	assert.Equal(t, first.TotalUndirectedWeight, second.TotalUndirectedWeight)
+}
+
+func TestBuildCommunityGraph_ExcludeLazyEdges(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddModule("mod.c", "/project/mod/c.py")
+
+	lazyInfo := &ImportInfo{IsLazy: true}
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, lazyInfo)
+	graph.AddDependency("mod.b", "mod.c", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, &CommunityGraphBuildOptions{IncludeLazyEdges: false})
+
+	assert.Equal(t, 1, len(cg.DirectedEdges))
+	assert.Equal(t, cg.NameToIndex["mod.b"], cg.DirectedEdges[0].FromIndex)
+	assert.Equal(t, cg.NameToIndex["mod.c"], cg.DirectedEdges[0].ToIndex)
+	assert.Equal(t, 1.0, undirectedWeight(cg, "mod.b", "mod.c"))
+	assert.Equal(t, 0.0, undirectedWeight(cg, "mod.a", "mod.b"))
+}
+
+func TestBuildCommunityGraph_BidirectionalAggregation(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.b", "mod.a", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+
+	assert.Equal(t, 2, len(cg.DirectedEdges))
+	assert.Equal(t, 2.0, undirectedWeight(cg, "mod.a", "mod.b"))
+	assert.Equal(t, 2.0, cg.TotalUndirectedWeight)
+}
+
+func TestBuildCommunityGraph_CustomEdgeWeightFunc(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeFromImport, nil)
+
+	cg := BuildCommunityGraph(graph, &CommunityGraphBuildOptions{
+		EdgeWeightFunc: func(edge *DependencyEdge) float64 {
+			if edge.EdgeType == DependencyEdgeFromImport {
+				return 2.5
+			}
+			return 1.0
+		},
+	})
+
+	assert.Equal(t, 2.5, cg.DirectedEdges[0].Weight)
+	assert.Equal(t, 2.5, undirectedWeight(cg, "mod.a", "mod.b"))
+	assert.Equal(t, 2.5, cg.TotalUndirectedWeight)
+}
+
+func undirectedWeight(cg *CommunityGraph, from, to string) float64 {
+	fromIdx, fromOK := cg.NameToIndex[from]
+	toIdx, toOK := cg.NameToIndex[to]
+	if !fromOK || !toOK {
+		return 0
+	}
+
+	for _, neighbor := range cg.UndirectedAdj[fromIdx] {
+		if neighbor.Index == toIdx {
+			return neighbor.Weight
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
## Summary

Implements the Phase 1 foundation for community detection (#564): a compact, integer-indexed `CommunityGraph` built from the existing `DependencyGraph`.

Closes #579

## Changes

- Add `CommunityGraph`, `CommunityGraphBuildOptions`, and `BuildCommunityGraph()` in `internal/analyzer/community_graph.go`
- Undirected weighted projection for Leiden clustering (#580)
- Preserve directed edges for future cross-community metrics (#581)
- Configurable lazy-edge inclusion (`IncludeLazyEdges`, default `true`)
- `EdgeWeightFunc` hook for future edge weighting
- Deterministic node ordering via sorted module names

## Tests

- Empty graph
- Two disconnected communities
- Bridge-node graph
- Fully disconnected nodes
- Deterministic repeat builds
- Lazy-edge exclusion
- Bidirectional edge aggregation
- Custom edge weight function

## Verification

```bash
go test ./internal/analyzer/ -run TestBuildCommunityGraph -v
make fmt
make lint
```

All passed locally.