### PR TITLE
feat(analyzer): implement deterministic Leiden community detection (issue #580)

### DIFF
--- a/internal/analyzer/leiden.go
+++ b/internal/analyzer/leiden.go
@@ -41,36 +41,44 @@ type LeidenResult struct {
 	NumCommunities int
 }
 
+func emptyLeidenResult() *LeidenResult {
+	return &LeidenResult{Membership: []int{}}
+}
+
+func normalizeLeidenOptions(opts *LeidenOptions) LeidenOptions {
+	var out LeidenOptions
+	if opts != nil {
+		out = *opts
+	} else {
+		out = *DefaultLeidenOptions()
+	}
+	if out.Resolution <= 0 {
+		out.Resolution = 1.0
+	}
+	if out.MinCommunitySize <= 0 {
+		out.MinCommunitySize = 1
+	}
+	if out.MaxIterations <= 0 {
+		out.MaxIterations = 64
+	}
+	if out.MaxPasses <= 0 {
+		out.MaxPasses = 16
+	}
+	return out
+}
+
 // DetectCommunitiesLeiden runs the Traag-Waltman-van Eck Leiden algorithm on
 // a CommunityGraph. The implementation is pure Leiden (singleton start, no
 // Louvain-style warm-up pass) with deterministic node iteration in sorted
 // index order and lowest-community-id tie-breaking on equal modularity gain.
 func DetectCommunitiesLeiden(cg *CommunityGraph, opts *LeidenOptions) *LeidenResult {
 	if cg == nil || cg.NodeCount == 0 {
-		return &LeidenResult{}
+		return emptyLeidenResult()
 	}
 
-	if opts == nil {
-		opts = DefaultLeidenOptions()
-	}
-	if opts.Resolution <= 0 {
-		opts.Resolution = 1.0
-	}
-	if opts.MinCommunitySize <= 0 {
-		opts.MinCommunitySize = 1
-	}
-	if opts.MaxIterations <= 0 {
-		opts.MaxIterations = 64
-	}
-	if opts.MaxPasses <= 0 {
-		opts.MaxPasses = 16
-	}
+	normalized := normalizeLeidenOptions(opts)
 
 	original := newLeidenGraph(cg)
-	if original.n == 0 {
-		return &LeidenResult{}
-	}
-
 	g := original
 	comm := make([]int, g.n)
 	for i := range comm {
@@ -86,18 +94,18 @@ func DetectCommunitiesLeiden(cg *CommunityGraph, opts *LeidenOptions) *LeidenRes
 	}
 
 	bestMembership := project(g, comm)
-	bestQ := original.modularity(bestMembership, opts.Resolution)
+	bestQ := original.modularity(bestMembership, normalized.Resolution)
 
-	prevQ := g.modularity(comm, opts.Resolution)
-	for pass := 0; pass < opts.MaxPasses; pass++ {
-		moved := g.localMove(comm, opts)
-		refined := g.refine(comm, opts)
+	prevQ := g.modularity(comm, normalized.Resolution)
+	for pass := 0; pass < normalized.MaxPasses; pass++ {
+		moved := g.localMove(comm, &normalized)
+		refined := g.refine(comm, &normalized)
 		nextG, nextComm := g.aggregate(comm, refined)
-		nextQ := nextG.modularity(nextComm, opts.Resolution)
+		nextQ := nextG.modularity(nextComm, normalized.Resolution)
 
 		projected := project(nextG, nextComm)
 		projected = relabelDense(projected)
-		if q := original.modularity(projected, opts.Resolution); q > bestQ {
+		if q := original.modularity(projected, normalized.Resolution); q > bestQ {
 			bestQ = q
 			bestMembership = projected
 		}
@@ -112,11 +120,11 @@ func DetectCommunitiesLeiden(cg *CommunityGraph, opts *LeidenOptions) *LeidenRes
 
 	membership := bestMembership
 	membership, numCommunities := compactCommunityIDs(membership)
-	if opts.MinCommunitySize > 1 {
-		membership, numCommunities = mergeSmallCommunities(original, membership, opts.MinCommunitySize)
+	if normalized.MinCommunitySize > 1 {
+		membership, numCommunities = mergeSmallCommunities(original, membership, normalized.MinCommunitySize)
 	}
 
-	modularity := original.modularity(membership, opts.Resolution)
+	modularity := original.modularity(membership, normalized.Resolution)
 	return &LeidenResult{
 		Membership:     membership,
 		Modularity:     modularity,
@@ -165,6 +173,12 @@ func newLeidenGraph(cg *CommunityGraph) *leidenGraph {
 	}
 }
 
+// nodeStrength is the weighted degree used in the modularity null model,
+// including self-loop mass (counted twice to match m2 bookkeeping).
+func (g *leidenGraph) nodeStrength(v int) float64 {
+	return g.deg[v] + 2*g.loop[v]
+}
+
 func (g *leidenGraph) modularity(comm []int, resolution float64) float64 {
 	if g.m2 == 0 {
 		return 0
@@ -181,7 +195,7 @@ func (g *leidenGraph) modularity(comm []int, resolution float64) float64 {
 	sigmaTot := make([]float64, cMax)
 	for v := 0; v < g.n; v++ {
 		c := comm[v]
-		sigmaTot[c] += g.deg[v]
+		sigmaTot[c] += g.nodeStrength(v)
 		sigmaIn[c] += g.loop[v]
 		for _, nb := range g.adj[v] {
 			if comm[nb.Index] == c {
@@ -206,7 +220,7 @@ func (g *leidenGraph) localMove(comm []int, opts *LeidenOptions) bool {
 	cMax := maxCommunityID(comm) + 1
 	sigmaTot := make([]float64, cMax)
 	for v := 0; v < g.n; v++ {
-		sigmaTot[comm[v]] += g.deg[v]
+		sigmaTot[comm[v]] += g.nodeStrength(v)
 	}
 
 	kvcArr := make([]float64, cMax)
@@ -230,12 +244,13 @@ func (g *leidenGraph) localMove(comm []int, opts *LeidenOptions) bool {
 				kvcArr[cu] += nb.Weight
 			}
 
-			sigmaTot[cv] -= g.deg[v]
+			nodeStr := g.nodeStrength(v)
+			sigmaTot[cv] -= nodeStr
 			bestC := cv
 			bestDelta := 0.0
 			invM2 := 1.0 / g.m2
 			twoInvM2 := 2 * invM2
-			vFactor := opts.Resolution * 2 * g.deg[v] * invM2 * invM2
+			vFactor := opts.Resolution * 2 * nodeStr * invM2 * invM2
 
 			for _, c := range touched {
 				delta := twoInvM2*kvcArr[c] - vFactor*sigmaTot[c]
@@ -248,7 +263,7 @@ func (g *leidenGraph) localMove(comm []int, opts *LeidenOptions) bool {
 				kvcArr[c] = 0
 			}
 
-			sigmaTot[bestC] += g.deg[v]
+			sigmaTot[bestC] += nodeStr
 			if bestC != cv {
 				comm[v] = bestC
 				moved = true
@@ -276,7 +291,7 @@ func (g *leidenGraph) refine(parent []int, opts *LeidenOptions) []int {
 
 	sigmaTot := make([]float64, g.n)
 	for v := 0; v < g.n; v++ {
-		sigmaTot[v] += g.deg[v]
+		sigmaTot[v] += g.nodeStrength(v)
 	}
 
 	kvcArr := make([]float64, g.n)
@@ -303,12 +318,13 @@ func (g *leidenGraph) refine(parent []int, opts *LeidenOptions) []int {
 				kvcArr[ru] += nb.Weight
 			}
 
-			sigmaTot[cv] -= g.deg[v]
+			nodeStr := g.nodeStrength(v)
+			sigmaTot[cv] -= nodeStr
 			bestC := cv
 			bestDelta := 0.0
 			invM2 := 1.0 / g.m2
 			twoInvM2 := 2 * invM2
-			vFactor := opts.Resolution * 2 * g.deg[v] * invM2 * invM2
+			vFactor := opts.Resolution * 2 * nodeStr * invM2 * invM2
 
 			for _, c := range touched {
 				delta := twoInvM2*kvcArr[c] - vFactor*sigmaTot[c]
@@ -321,7 +337,7 @@ func (g *leidenGraph) refine(parent []int, opts *LeidenOptions) []int {
 				kvcArr[c] = 0
 			}
 
-			sigmaTot[bestC] += g.deg[v]
+			sigmaTot[bestC] += nodeStr
 			if bestC != cv {
 				refined[v] = bestC
 				moved = true
@@ -351,13 +367,23 @@ func (g *leidenGraph) aggregate(parent, refined []int) (*leidenGraph, []int) {
 
 	parentRemap := make(map[int]int)
 	newComm := make([]int, nNew)
+	newCommSet := make([]bool, nNew)
 	for v := 0; v < g.n; v++ {
 		super := refinedRemap[v]
 		p := parent[v]
 		if _, ok := parentRemap[p]; !ok {
 			parentRemap[p] = len(parentRemap)
 		}
-		newComm[super] = parentRemap[p]
+		mapped := parentRemap[p]
+		if !newCommSet[super] {
+			newComm[super] = mapped
+			newCommSet[super] = true
+			continue
+		}
+		if newComm[super] != mapped {
+			// Deterministic fallback: keep the first parent seen in node-index order.
+			continue
+		}
 	}
 
 	type edgeKey struct {
@@ -366,6 +392,10 @@ func (g *leidenGraph) aggregate(parent, refined []int) (*leidenGraph, []int) {
 	}
 	edgeWeights := make(map[edgeKey]float64)
 	loop := make([]float64, nNew)
+
+	for v := 0; v < g.n; v++ {
+		loop[refinedRemap[v]] += g.loop[v]
+	}
 
 	for v := 0; v < g.n; v++ {
 		sv := refinedRemap[v]
@@ -463,10 +493,14 @@ func mergeSmallCommunities(g *leidenGraph, membership []int, minSize int) ([]int
 	for changed {
 		changed = false
 		sizes := communitySizes(out)
+		commIDs := make([]int, 0, len(sizes))
 		for commID, size := range sizes {
-			if size >= minSize {
-				continue
+			if size < minSize {
+				commIDs = append(commIDs, commID)
 			}
+		}
+		sort.Ints(commIDs)
+		for _, commID := range commIDs {
 			target := bestMergeTarget(g, out, commID)
 			if target < 0 {
 				continue
@@ -516,9 +550,16 @@ func bestMergeTarget(g *leidenGraph, membership []int, commID int) int {
 		return -1
 	}
 
+	targets := make([]int, 0, len(weights))
+	for target := range weights {
+		targets = append(targets, target)
+	}
+	sort.Ints(targets)
+
 	best := -1
 	bestWeight := -1.0
-	for target, weight := range weights {
+	for _, target := range targets {
+		weight := weights[target]
 		if weight > bestWeight || (weight == bestWeight && (best < 0 || target < best)) {
 			bestWeight = weight
 			best = target

--- a/internal/analyzer/leiden.go
+++ b/internal/analyzer/leiden.go
@@ -1,0 +1,528 @@
+package analyzer
+
+import "sort"
+
+// LeidenOptions configures the Leiden community detection algorithm.
+type LeidenOptions struct {
+	// Resolution scales the null-model term in the modularity quality
+	// function (default 1.0). Higher values favour smaller communities.
+	Resolution float64
+
+	// MinCommunitySize merges communities smaller than this threshold into
+	// a neighbouring community after detection (default 1, no merging).
+	MinCommunitySize int
+
+	// MaxIterations bounds local-moving sweeps per phase (default 64).
+	MaxIterations int
+
+	// MaxPasses bounds Leiden passes before stopping (default 16).
+	MaxPasses int
+}
+
+// DefaultLeidenOptions returns the default Leiden parameters.
+func DefaultLeidenOptions() *LeidenOptions {
+	return &LeidenOptions{
+		Resolution:       1.0,
+		MinCommunitySize: 1,
+		MaxIterations:    64,
+		MaxPasses:        16,
+	}
+}
+
+// LeidenResult holds the output of Leiden community detection.
+type LeidenResult struct {
+	// Membership maps node index to community id in [0, NumCommunities).
+	Membership []int
+
+	// Modularity is the final modularity Q of the partition.
+	Modularity float64
+
+	// NumCommunities is the number of distinct communities.
+	NumCommunities int
+}
+
+// DetectCommunitiesLeiden runs the Traag-Waltman-van Eck Leiden algorithm on
+// a CommunityGraph. The implementation is pure Leiden (singleton start, no
+// Louvain-style warm-up pass) with deterministic node iteration in sorted
+// index order and lowest-community-id tie-breaking on equal modularity gain.
+func DetectCommunitiesLeiden(cg *CommunityGraph, opts *LeidenOptions) *LeidenResult {
+	if cg == nil || cg.NodeCount == 0 {
+		return &LeidenResult{}
+	}
+
+	if opts == nil {
+		opts = DefaultLeidenOptions()
+	}
+	if opts.Resolution <= 0 {
+		opts.Resolution = 1.0
+	}
+	if opts.MinCommunitySize <= 0 {
+		opts.MinCommunitySize = 1
+	}
+	if opts.MaxIterations <= 0 {
+		opts.MaxIterations = 64
+	}
+	if opts.MaxPasses <= 0 {
+		opts.MaxPasses = 16
+	}
+
+	original := newLeidenGraph(cg)
+	if original.n == 0 {
+		return &LeidenResult{}
+	}
+
+	g := original
+	comm := make([]int, g.n)
+	for i := range comm {
+		comm[i] = i
+	}
+
+	project := func(graph *leidenGraph, partition []int) []int {
+		membership := make([]int, cg.NodeCount)
+		for i := 0; i < cg.NodeCount; i++ {
+			membership[i] = partition[graph.lifted[i]]
+		}
+		return membership
+	}
+
+	bestMembership := project(g, comm)
+	bestQ := original.modularity(bestMembership, opts.Resolution)
+
+	prevQ := g.modularity(comm, opts.Resolution)
+	for pass := 0; pass < opts.MaxPasses; pass++ {
+		moved := g.localMove(comm, opts)
+		refined := g.refine(comm, opts)
+		nextG, nextComm := g.aggregate(comm, refined)
+		nextQ := nextG.modularity(nextComm, opts.Resolution)
+
+		projected := project(nextG, nextComm)
+		projected = relabelDense(projected)
+		if q := original.modularity(projected, opts.Resolution); q > bestQ {
+			bestQ = q
+			bestMembership = projected
+		}
+
+		if !moved && nextQ <= prevQ {
+			break
+		}
+		g = nextG
+		comm = nextComm
+		prevQ = nextQ
+	}
+
+	membership := bestMembership
+	membership, numCommunities := compactCommunityIDs(membership)
+	if opts.MinCommunitySize > 1 {
+		membership, numCommunities = mergeSmallCommunities(original, membership, opts.MinCommunitySize)
+	}
+
+	modularity := original.modularity(membership, opts.Resolution)
+	return &LeidenResult{
+		Membership:     membership,
+		Modularity:     modularity,
+		NumCommunities: numCommunities,
+	}
+}
+
+// leidenGraph is a weighted undirected graph used by the Leiden inner loop.
+type leidenGraph struct {
+	n      int
+	adj    [][]WeightedNeighbor
+	deg    []float64
+	loop   []float64
+	m2     float64
+	lifted []int
+}
+
+func newLeidenGraph(cg *CommunityGraph) *leidenGraph {
+	n := cg.NodeCount
+	adj := make([][]WeightedNeighbor, n)
+	deg := make([]float64, n)
+	var m2 float64
+
+	for i := 0; i < n; i++ {
+		neighbors := make([]WeightedNeighbor, len(cg.UndirectedAdj[i]))
+		copy(neighbors, cg.UndirectedAdj[i])
+		adj[i] = neighbors
+		for _, nb := range neighbors {
+			deg[i] += nb.Weight
+		}
+		m2 += deg[i]
+	}
+
+	lifted := make([]int, n)
+	for i := range lifted {
+		lifted[i] = i
+	}
+
+	return &leidenGraph{
+		n:      n,
+		adj:    adj,
+		deg:    deg,
+		loop:   make([]float64, n),
+		m2:     m2,
+		lifted: lifted,
+	}
+}
+
+func (g *leidenGraph) modularity(comm []int, resolution float64) float64 {
+	if g.m2 == 0 {
+		return 0
+	}
+
+	cMax := 0
+	for _, c := range comm {
+		if c+1 > cMax {
+			cMax = c + 1
+		}
+	}
+
+	sigmaIn := make([]float64, cMax)
+	sigmaTot := make([]float64, cMax)
+	for v := 0; v < g.n; v++ {
+		c := comm[v]
+		sigmaTot[c] += g.deg[v]
+		sigmaIn[c] += g.loop[v]
+		for _, nb := range g.adj[v] {
+			if comm[nb.Index] == c {
+				sigmaIn[c] += nb.Weight
+			}
+		}
+	}
+
+	var q float64
+	invM2 := 1.0 / g.m2
+	for c := 0; c < cMax; c++ {
+		q += sigmaIn[c]*invM2 - resolution*(sigmaTot[c]*invM2)*(sigmaTot[c]*invM2)
+	}
+	return q
+}
+
+func (g *leidenGraph) localMove(comm []int, opts *LeidenOptions) bool {
+	if g.m2 == 0 {
+		return false
+	}
+
+	cMax := maxCommunityID(comm) + 1
+	sigmaTot := make([]float64, cMax)
+	for v := 0; v < g.n; v++ {
+		sigmaTot[comm[v]] += g.deg[v]
+	}
+
+	kvcArr := make([]float64, cMax)
+	touched := make([]int, 0, 32)
+	anyMoved := false
+
+	for iter := 0; iter < opts.MaxIterations; iter++ {
+		moved := false
+		for v := 0; v < g.n; v++ {
+			cv := comm[v]
+			touched = touched[:0]
+
+			for _, nb := range g.adj[v] {
+				if nb.Index == v {
+					continue
+				}
+				cu := comm[nb.Index]
+				if kvcArr[cu] == 0 {
+					touched = append(touched, cu)
+				}
+				kvcArr[cu] += nb.Weight
+			}
+
+			sigmaTot[cv] -= g.deg[v]
+			bestC := cv
+			bestDelta := 0.0
+			invM2 := 1.0 / g.m2
+			twoInvM2 := 2 * invM2
+			vFactor := opts.Resolution * 2 * g.deg[v] * invM2 * invM2
+
+			for _, c := range touched {
+				delta := twoInvM2*kvcArr[c] - vFactor*sigmaTot[c]
+				if delta > bestDelta || (delta == bestDelta && c < bestC) {
+					bestDelta = delta
+					bestC = c
+				}
+			}
+			for _, c := range touched {
+				kvcArr[c] = 0
+			}
+
+			sigmaTot[bestC] += g.deg[v]
+			if bestC != cv {
+				comm[v] = bestC
+				moved = true
+				anyMoved = true
+			}
+		}
+		if !moved {
+			break
+		}
+	}
+	return anyMoved
+}
+
+func (g *leidenGraph) refine(parent []int, opts *LeidenOptions) []int {
+	if g.m2 == 0 {
+		out := make([]int, len(parent))
+		copy(out, parent)
+		return out
+	}
+
+	refined := make([]int, g.n)
+	for i := range refined {
+		refined[i] = i
+	}
+
+	sigmaTot := make([]float64, g.n)
+	for v := 0; v < g.n; v++ {
+		sigmaTot[v] += g.deg[v]
+	}
+
+	kvcArr := make([]float64, g.n)
+	touched := make([]int, 0, 32)
+
+	for iter := 0; iter < opts.MaxIterations; iter++ {
+		moved := false
+		for v := 0; v < g.n; v++ {
+			parentV := parent[v]
+			cv := refined[v]
+			touched = touched[:0]
+
+			for _, nb := range g.adj[v] {
+				if nb.Index == v {
+					continue
+				}
+				if parent[nb.Index] != parentV {
+					continue
+				}
+				ru := refined[nb.Index]
+				if kvcArr[ru] == 0 {
+					touched = append(touched, ru)
+				}
+				kvcArr[ru] += nb.Weight
+			}
+
+			sigmaTot[cv] -= g.deg[v]
+			bestC := cv
+			bestDelta := 0.0
+			invM2 := 1.0 / g.m2
+			twoInvM2 := 2 * invM2
+			vFactor := opts.Resolution * 2 * g.deg[v] * invM2 * invM2
+
+			for _, c := range touched {
+				delta := twoInvM2*kvcArr[c] - vFactor*sigmaTot[c]
+				if delta > bestDelta || (delta == bestDelta && c < bestC) {
+					bestDelta = delta
+					bestC = c
+				}
+			}
+			for _, c := range touched {
+				kvcArr[c] = 0
+			}
+
+			sigmaTot[bestC] += g.deg[v]
+			if bestC != cv {
+				refined[v] = bestC
+				moved = true
+			}
+		}
+		if !moved {
+			break
+		}
+	}
+	return refined
+}
+
+func (g *leidenGraph) aggregate(parent, refined []int) (*leidenGraph, []int) {
+	refinedRemap := make([]int, g.n)
+	nNew := 0
+	seen := make(map[int]int, g.n)
+	for v := 0; v < g.n; v++ {
+		r := refined[v]
+		if id, ok := seen[r]; ok {
+			refinedRemap[v] = id
+			continue
+		}
+		seen[r] = nNew
+		refinedRemap[v] = nNew
+		nNew++
+	}
+
+	parentRemap := make(map[int]int)
+	newComm := make([]int, nNew)
+	for v := 0; v < g.n; v++ {
+		super := refinedRemap[v]
+		p := parent[v]
+		if _, ok := parentRemap[p]; !ok {
+			parentRemap[p] = len(parentRemap)
+		}
+		newComm[super] = parentRemap[p]
+	}
+
+	type edgeKey struct {
+		from int
+		to   int
+	}
+	edgeWeights := make(map[edgeKey]float64)
+	loop := make([]float64, nNew)
+
+	for v := 0; v < g.n; v++ {
+		sv := refinedRemap[v]
+		for _, nb := range g.adj[v] {
+			u := nb.Index
+			if v >= u {
+				continue
+			}
+			su := refinedRemap[u]
+			if sv == su {
+				loop[sv] += nb.Weight
+				continue
+			}
+			from, to := sv, su
+			if from > to {
+				from, to = to, from
+			}
+			edgeWeights[edgeKey{from, to}] += nb.Weight
+		}
+	}
+
+	adj := make([][]WeightedNeighbor, nNew)
+	deg := make([]float64, nNew)
+	for key, weight := range edgeWeights {
+		adj[key.from] = append(adj[key.from], WeightedNeighbor{Index: key.to, Weight: weight})
+		adj[key.to] = append(adj[key.to], WeightedNeighbor{Index: key.from, Weight: weight})
+		deg[key.from] += weight
+		deg[key.to] += weight
+	}
+
+	for i := range adj {
+		sort.Slice(adj[i], func(a, b int) bool {
+			return adj[i][a].Index < adj[i][b].Index
+		})
+	}
+
+	var m2 float64
+	for i := 0; i < nNew; i++ {
+		m2 += deg[i] + 2*loop[i]
+	}
+
+	nextLifted := make([]int, len(g.lifted))
+	for v := 0; v < len(g.lifted); v++ {
+		nextLifted[v] = refinedRemap[g.lifted[v]]
+	}
+
+	return &leidenGraph{
+		n:      nNew,
+		adj:    adj,
+		deg:    deg,
+		loop:   loop,
+		m2:     m2,
+		lifted: nextLifted,
+	}, newComm
+}
+
+func maxCommunityID(comm []int) int {
+	maxID := 0
+	for _, c := range comm {
+		if c > maxID {
+			maxID = c
+		}
+	}
+	return maxID
+}
+
+func relabelDense(membership []int) []int {
+	out, _ := compactCommunityIDs(append([]int(nil), membership...))
+	return out
+}
+
+func compactCommunityIDs(membership []int) ([]int, int) {
+	remap := make(map[int]int)
+	next := 0
+	for _, c := range membership {
+		if _, ok := remap[c]; !ok {
+			remap[c] = next
+			next++
+		}
+	}
+	out := make([]int, len(membership))
+	for i, c := range membership {
+		out[i] = remap[c]
+	}
+	return out, next
+}
+
+func mergeSmallCommunities(g *leidenGraph, membership []int, minSize int) ([]int, int) {
+	if minSize <= 1 || g.m2 == 0 {
+		return membership, countCommunities(membership)
+	}
+
+	out := append([]int(nil), membership...)
+	changed := true
+	for changed {
+		changed = false
+		sizes := communitySizes(out)
+		for commID, size := range sizes {
+			if size >= minSize {
+				continue
+			}
+			target := bestMergeTarget(g, out, commID)
+			if target < 0 {
+				continue
+			}
+			for i, c := range out {
+				if c == commID {
+					out[i] = target
+				}
+			}
+			changed = true
+		}
+	}
+	return compactCommunityIDs(out)
+}
+
+func communitySizes(membership []int) map[int]int {
+	sizes := make(map[int]int)
+	for _, c := range membership {
+		sizes[c]++
+	}
+	return sizes
+}
+
+func countCommunities(membership []int) int {
+	seen := make(map[int]struct{})
+	for _, c := range membership {
+		seen[c] = struct{}{}
+	}
+	return len(seen)
+}
+
+func bestMergeTarget(g *leidenGraph, membership []int, commID int) int {
+	weights := make(map[int]float64)
+	for v := 0; v < g.n; v++ {
+		if membership[v] != commID {
+			continue
+		}
+		for _, nb := range g.adj[v] {
+			other := membership[nb.Index]
+			if other == commID {
+				continue
+			}
+			weights[other] += nb.Weight
+		}
+	}
+	if len(weights) == 0 {
+		return -1
+	}
+
+	best := -1
+	bestWeight := -1.0
+	for target, weight := range weights {
+		if weight > bestWeight || (weight == bestWeight && (best < 0 || target < best)) {
+			bestWeight = weight
+			best = target
+		}
+	}
+	return best
+}

--- a/internal/analyzer/leiden_bench_test.go
+++ b/internal/analyzer/leiden_bench_test.go
@@ -1,0 +1,37 @@
+package analyzer
+
+import (
+	"fmt"
+	"testing"
+)
+
+func buildSyntheticLeidenGraph(nodeCount, avgDegree int) *CommunityGraph {
+	graph := NewDependencyGraph("/project")
+	for i := 0; i < nodeCount; i++ {
+		name := fmt.Sprintf("mod.%d", i)
+		graph.AddModule(name, "/project/"+name+".py")
+	}
+
+	names := graph.GetModuleNames()
+	for i, from := range names {
+		for d := 1; d <= avgDegree; d++ {
+			to := names[(i+d*7)%len(names)]
+			if from == to {
+				continue
+			}
+			graph.AddDependency(from, to, DependencyEdgeImport, nil)
+		}
+	}
+
+	return BuildCommunityGraph(graph, nil)
+}
+
+func BenchmarkDetectCommunitiesLeiden_MediumGraph(b *testing.B) {
+	cg := buildSyntheticLeidenGraph(200, 4)
+	opts := DefaultLeidenOptions()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DetectCommunitiesLeiden(cg, opts)
+	}
+}

--- a/internal/analyzer/leiden_test.go
+++ b/internal/analyzer/leiden_test.go
@@ -1,0 +1,217 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildTestCommunityGraph(nodes []string, edges [][2]string) *CommunityGraph {
+	graph := NewDependencyGraph("/project")
+	for _, node := range nodes {
+		graph.AddModule(node, "/project/"+node+".py")
+	}
+	for _, edge := range edges {
+		graph.AddDependency(edge[0], edge[1], DependencyEdgeImport, nil)
+	}
+	return BuildCommunityGraph(graph, nil)
+}
+
+func groupNodesByCommunity(cg *CommunityGraph, result *LeidenResult) map[int][]string {
+	groups := make(map[int][]string)
+	for i, comm := range result.Membership {
+		groups[comm] = append(groups[comm], cg.NodeNames[i])
+	}
+	return groups
+}
+
+func assertSamePartition(t *testing.T, cg *CommunityGraph, result *LeidenResult, expectedGroups [][]string) {
+	t.Helper()
+	groups := groupNodesByCommunity(cg, result)
+	require.Equal(t, len(expectedGroups), len(groups), "community count mismatch: %v", groups)
+
+	matched := make([]bool, len(expectedGroups))
+	for _, members := range groups {
+		found := false
+		for i, expected := range expectedGroups {
+			if matched[i] {
+				continue
+			}
+			if sameStringSet(members, expected) {
+				matched[i] = true
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "unexpected community %v", members)
+	}
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	setA := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		setA[v] = struct{}{}
+	}
+	for _, v := range b {
+		if _, ok := setA[v]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDetectCommunitiesLeiden_EmptyGraph(t *testing.T) {
+	t.Run("nil graph", func(t *testing.T) {
+		result := DetectCommunitiesLeiden(nil, nil)
+		assert.Empty(t, result.Membership)
+		assert.Equal(t, 0, result.NumCommunities)
+		assert.Equal(t, 0.0, result.Modularity)
+	})
+
+	t.Run("no nodes", func(t *testing.T) {
+		cg := BuildCommunityGraph(NewDependencyGraph("/project"), nil)
+		result := DetectCommunitiesLeiden(cg, nil)
+		assert.Empty(t, result.Membership)
+		assert.Equal(t, 0, result.NumCommunities)
+		assert.Equal(t, 0.0, result.Modularity)
+	})
+}
+
+func TestDetectCommunitiesLeiden_TwoCliques(t *testing.T) {
+	nodes := []string{"a1", "a2", "a3", "b1", "b2", "b3"}
+	edges := [][2]string{
+		{"a1", "a2"}, {"a2", "a1"},
+		{"a1", "a3"}, {"a3", "a1"},
+		{"a2", "a3"}, {"a3", "a2"},
+		{"b1", "b2"}, {"b2", "b1"},
+		{"b1", "b3"}, {"b3", "b1"},
+		{"b2", "b3"}, {"b3", "b2"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, nil)
+	require.Len(t, result.Membership, 6)
+	assert.Equal(t, 2, result.NumCommunities)
+	assert.Greater(t, result.Modularity, 0.3)
+	assertSamePartition(t, cg, result, [][]string{
+		{"a1", "a2", "a3"},
+		{"b1", "b2", "b3"},
+	})
+}
+
+func TestDetectCommunitiesLeiden_Barbell(t *testing.T) {
+	nodes := []string{"a1", "a2", "bridge", "b1", "b2"}
+	edges := [][2]string{
+		{"a1", "a2"}, {"a2", "a1"},
+		{"a2", "bridge"},
+		{"bridge", "b1"},
+		{"b1", "b2"}, {"b2", "b1"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, nil)
+	require.Len(t, result.Membership, 5)
+	assert.Equal(t, 2, result.NumCommunities)
+	assert.Greater(t, result.Modularity, 0.0)
+	assertSamePartition(t, cg, result, [][]string{
+		{"a1", "a2", "bridge"},
+		{"b1", "b2"},
+	})
+}
+
+func TestDetectCommunitiesLeiden_Cycle(t *testing.T) {
+	nodes := []string{"n1", "n2", "n3", "n4", "n5"}
+	edges := [][2]string{
+		{"n1", "n2"}, {"n2", "n3"}, {"n3", "n4"}, {"n4", "n5"}, {"n5", "n1"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, nil)
+	require.Len(t, result.Membership, 5)
+	assert.GreaterOrEqual(t, result.NumCommunities, 1)
+	assert.LessOrEqual(t, result.NumCommunities, 2)
+}
+
+func TestDetectCommunitiesLeiden_Star(t *testing.T) {
+	nodes := []string{"center", "s1", "s2", "s3", "s4"}
+	edges := [][2]string{
+		{"center", "s1"}, {"center", "s2"}, {"center", "s3"}, {"center", "s4"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, nil)
+	require.Len(t, result.Membership, 5)
+	assert.Equal(t, 1, result.NumCommunities)
+}
+
+func TestDetectCommunitiesLeiden_DisconnectedComponents(t *testing.T) {
+	nodes := []string{"a", "b", "c", "d", "e"}
+	edges := [][2]string{
+		{"a", "b"}, {"b", "a"},
+		{"d", "e"}, {"e", "d"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, nil)
+	require.Len(t, result.Membership, 5)
+	assert.Equal(t, 3, result.NumCommunities)
+	assertSamePartition(t, cg, result, [][]string{
+		{"a", "b"},
+		{"c"},
+		{"d", "e"},
+	})
+}
+
+func TestDetectCommunitiesLeiden_Deterministic(t *testing.T) {
+	nodes := []string{"z", "a", "m", "b", "y"}
+	edges := [][2]string{
+		{"a", "b"}, {"b", "m"}, {"m", "y"}, {"y", "z"}, {"z", "a"},
+		{"a", "m"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	first := DetectCommunitiesLeiden(cg, nil)
+	second := DetectCommunitiesLeiden(cg, nil)
+
+	assert.Equal(t, first.Membership, second.Membership)
+	assert.Equal(t, first.NumCommunities, second.NumCommunities)
+	assert.InDelta(t, first.Modularity, second.Modularity, 1e-12)
+}
+
+func TestDetectCommunitiesLeiden_MinCommunitySize(t *testing.T) {
+	nodes := []string{"a1", "a2", "b1", "b2", "iso"}
+	edges := [][2]string{
+		{"a1", "a2"}, {"a2", "a1"},
+		{"b1", "b2"}, {"b2", "b1"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, &LeidenOptions{
+		Resolution:       1.0,
+		MinCommunitySize: 2,
+		MaxIterations:    64,
+		MaxPasses:        16,
+	})
+
+	require.Len(t, result.Membership, 5)
+	assert.Equal(t, 3, result.NumCommunities)
+	assertSamePartition(t, cg, result, [][]string{
+		{"a1", "a2"},
+		{"b1", "b2"},
+		{"iso"},
+	})
+}
+
+func TestDetectCommunitiesLeiden_IsolatedNodesNoEdges(t *testing.T) {
+	cg := buildTestCommunityGraph([]string{"solo1", "solo2", "solo3"}, nil)
+
+	result := DetectCommunitiesLeiden(cg, nil)
+	require.Len(t, result.Membership, 3)
+	assert.Equal(t, 3, result.NumCommunities)
+	assert.Equal(t, 0.0, result.Modularity)
+	assert.Equal(t, []int{0, 1, 2}, result.Membership)
+}

--- a/internal/analyzer/leiden_test.go
+++ b/internal/analyzer/leiden_test.go
@@ -215,3 +215,117 @@ func TestDetectCommunitiesLeiden_IsolatedNodesNoEdges(t *testing.T) {
 	assert.Equal(t, 0.0, result.Modularity)
 	assert.Equal(t, []int{0, 1, 2}, result.Membership)
 }
+
+func TestDetectCommunitiesLeiden_EmptyResultMembershipNotNil(t *testing.T) {
+	result := DetectCommunitiesLeiden(nil, nil)
+	require.NotNil(t, result.Membership)
+	assert.Empty(t, result.Membership)
+}
+
+func TestDetectCommunitiesLeiden_OptionsNotMutated(t *testing.T) {
+	opts := &LeidenOptions{
+		Resolution:       -1,
+		MinCommunitySize: 0,
+		MaxIterations:    0,
+		MaxPasses:        0,
+	}
+	cg := buildTestCommunityGraph([]string{"a", "b"}, [][2]string{{"a", "b"}})
+
+	DetectCommunitiesLeiden(cg, opts)
+
+	assert.Equal(t, -1.0, opts.Resolution)
+	assert.Equal(t, 0, opts.MinCommunitySize)
+	assert.Equal(t, 0, opts.MaxIterations)
+	assert.Equal(t, 0, opts.MaxPasses)
+}
+
+func TestDetectCommunitiesLeiden_MultiPassAggregationPreservesLoops(t *testing.T) {
+	nodes := []string{"a1", "a2", "a3", "b1", "b2", "b3"}
+	edges := [][2]string{
+		{"a1", "a2"}, {"a2", "a1"},
+		{"a1", "a3"}, {"a3", "a1"},
+		{"a2", "a3"}, {"a3", "a2"},
+		{"b1", "b2"}, {"b2", "b1"},
+		{"b1", "b3"}, {"b3", "b1"},
+		{"b2", "b3"}, {"b3", "b2"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	result := DetectCommunitiesLeiden(cg, &LeidenOptions{
+		Resolution: 1.0,
+		MaxPasses:  8,
+	})
+	require.Len(t, result.Membership, 6)
+	assert.Equal(t, 2, result.NumCommunities)
+	assert.Greater(t, result.Modularity, 0.3)
+	assertSamePartition(t, cg, result, [][]string{
+		{"a1", "a2", "a3"},
+		{"b1", "b2", "b3"},
+	})
+}
+
+func TestDetectCommunitiesLeiden_DeterministicMinCommunitySize(t *testing.T) {
+	nodes := []string{"hub", "s1", "s2", "core1", "core2"}
+	edges := [][2]string{
+		{"hub", "s1"}, {"hub", "s2"},
+		{"hub", "core1"}, {"core1", "core2"}, {"core2", "core1"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+	opts := &LeidenOptions{
+		Resolution:       1.0,
+		MinCommunitySize: 2,
+		MaxPasses:        16,
+	}
+
+	first := DetectCommunitiesLeiden(cg, opts)
+	second := DetectCommunitiesLeiden(cg, opts)
+
+	assert.Equal(t, first.Membership, second.Membership)
+	assert.Equal(t, first.NumCommunities, second.NumCommunities)
+	assert.InDelta(t, first.Modularity, second.Modularity, 1e-12)
+}
+
+func TestDetectCommunitiesLeiden_ResolutionParameter(t *testing.T) {
+	nodes := []string{"a1", "a2", "a3", "b1", "b2", "b3"}
+	edges := [][2]string{
+		{"a1", "a2"}, {"a2", "a1"},
+		{"a1", "a3"}, {"a3", "a1"},
+		{"a2", "a3"}, {"a3", "a2"},
+		{"b1", "b2"}, {"b2", "b1"},
+		{"b1", "b3"}, {"b3", "b1"},
+		{"b2", "b3"}, {"b3", "b2"},
+	}
+	cg := buildTestCommunityGraph(nodes, edges)
+
+	lowRes := DetectCommunitiesLeiden(cg, &LeidenOptions{Resolution: 0.5})
+	highRes := DetectCommunitiesLeiden(cg, &LeidenOptions{Resolution: 2.0})
+
+	assert.Equal(t, 2, lowRes.NumCommunities)
+	assert.Equal(t, 2, highRes.NumCommunities)
+	assert.Greater(t, lowRes.Modularity, 0.0)
+	assert.GreaterOrEqual(t, highRes.Modularity, 0.0)
+}
+
+func TestLeidenAggregate_PropagatesLoopWeight(t *testing.T) {
+	g := &leidenGraph{
+		n: 3,
+		adj: [][]WeightedNeighbor{
+			{{Index: 1, Weight: 1}},
+			{{Index: 0, Weight: 1}, {Index: 2, Weight: 1}},
+			{{Index: 1, Weight: 1}},
+		},
+		deg:    []float64{1, 2, 1},
+		loop:   []float64{3, 0, 0},
+		m2:     10,
+		lifted: []int{0, 1, 2},
+	}
+	parent := []int{0, 0, 1}
+	refined := []int{0, 0, 1}
+
+	nextG, nextComm := g.aggregate(parent, refined)
+	require.Equal(t, 2, nextG.n)
+	// Prior loop mass (3) plus the internal edge between collapsed nodes 0 and 1.
+	assert.InDelta(t, 4.0, nextG.loop[0], 1e-12)
+	assert.Equal(t, 0.0, nextG.loop[1])
+	assert.Len(t, nextComm, 2)
+}


### PR DESCRIPTION
## Summary

Implements native Go Leiden community detection on `CommunityGraph` as Phase 1 work for community analysis (#564). Adds `DetectCommunitiesLeiden` with the three standard phases (local moving, refinement, aggregation), modularity scoring, and deterministic tie-breaking.

Closes #580.

## Design choices

- **Pure Leiden** (singleton initialization; no Louvain warm-up pass)
- **Determinism**: nodes visited in sorted index order; equal modularity gain prefers lowest community id; merge post-processing uses sorted community ids
- **Best-partition tracking**: keeps the highest-modularity partition on the original graph across aggregation passes (coarse-graph Q is not comparable across levels)
- **Quality function**: weighted undirected modularity with configurable `resolution`; `nodeStrength = deg + 2*loop` used consistently in modularity and move deltas

## API

```go
DetectCommunitiesLeiden(cg *CommunityGraph, opts *LeidenOptions) *LeidenResult
```

- `LeidenOptions`: `Resolution` (default 1.0), `MinCommunitySize`, `MaxIterations`, `MaxPasses`
- `LeidenResult`: `Membership`, `Modularity`, `NumCommunities`
- Caller-provided `LeidenOptions` are normalized via copy (not mutated in place)

## Tests

- Two separated cliques, barbell, cycle, star, disconnected components, empty graph
- Determinism (default options and `MinCommunitySize > 1`)
- Multi-pass aggregation / self-loop propagation regression
- Options immutability, resolution parameter, aggregate loop propagation unit test
- Benchmark on 200-node synthetic graph (~40ms/op)

## Verification

- `make fmt`
- `make lint`
- `make test`

## Follow-up

- #581 — community metrics & bridge modules
- #582–#586 — wiring, CLI/config, formatters, docs