### PR TITLE
[communities] Domain types, service & use-case wiring for community analysis

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -15,12 +15,13 @@ import (
 
 // AnalyzeUseCaseConfig holds configuration for the analyze use case
 type AnalyzeUseCaseConfig struct {
-	SkipComplexity bool
-	SkipDeadCode   bool
-	SkipClones     bool
-	SkipCBO        bool
-	SkipLCOM       bool
-	SkipSystem     bool
+	SkipComplexity  bool
+	SkipDeadCode    bool
+	SkipClones      bool
+	SkipCBO         bool
+	SkipLCOM        bool
+	SkipSystem      bool
+	SkipCommunities bool
 
 	MinComplexity   int
 	MinSeverity     domain.DeadCodeSeverity
@@ -42,6 +43,7 @@ type AnalyzeUseCase struct {
 	cboUseCase        *CBOUseCase
 	lcomUseCase       *LCOMUseCase
 	systemUseCase     *SystemAnalysisUseCase
+	communityUseCase  *CommunityUseCase
 
 	fileReader       domain.FileReader
 	configLoader     domain.AnalyzeConfigurationLoader
@@ -59,6 +61,7 @@ type AnalyzeUseCaseBuilder struct {
 	cboUseCase        *CBOUseCase
 	lcomUseCase       *LCOMUseCase
 	systemUseCase     *SystemAnalysisUseCase
+	communityUseCase  *CommunityUseCase
 
 	fileReader       domain.FileReader
 	configLoader     domain.AnalyzeConfigurationLoader
@@ -106,6 +109,12 @@ func (b *AnalyzeUseCaseBuilder) WithLCOMUseCase(uc *LCOMUseCase) *AnalyzeUseCase
 // WithSystemUseCase sets the system analysis use case
 func (b *AnalyzeUseCaseBuilder) WithSystemUseCase(uc *SystemAnalysisUseCase) *AnalyzeUseCaseBuilder {
 	b.systemUseCase = uc
+	return b
+}
+
+// WithCommunityUseCase sets the community analysis use case
+func (b *AnalyzeUseCaseBuilder) WithCommunityUseCase(uc *CommunityUseCase) *AnalyzeUseCaseBuilder {
+	b.communityUseCase = uc
 	return b
 }
 
@@ -173,6 +182,7 @@ func (b *AnalyzeUseCaseBuilder) Build() (*AnalyzeUseCase, error) {
 		cboUseCase:        b.cboUseCase,
 		lcomUseCase:       b.lcomUseCase,
 		systemUseCase:     b.systemUseCase,
+		communityUseCase:  b.communityUseCase,
 		fileReader:        b.fileReader,
 		configLoader:      b.configLoader,
 		formatter:         b.formatter,
@@ -184,12 +194,13 @@ func (b *AnalyzeUseCaseBuilder) Build() (*AnalyzeUseCase, error) {
 
 // Task names used both for display and as keys for progress estimation
 const (
-	taskNameComplexity = "Complexity Analysis"
-	taskNameDeadCode   = "Dead Code Detection"
-	taskNameClones     = "Clone Detection"
-	taskNameCBO        = "Class Coupling (CBO)"
-	taskNameLCOM       = "Class Cohesion (LCOM)"
-	taskNameSystem     = "System Analysis"
+	taskNameComplexity  = "Complexity Analysis"
+	taskNameDeadCode    = "Dead Code Detection"
+	taskNameClones      = "Clone Detection"
+	taskNameCBO         = "Class Coupling (CBO)"
+	taskNameLCOM        = "Class Cohesion (LCOM)"
+	taskNameSystem      = "System Analysis"
+	taskNameCommunities = "Community Detection"
 )
 
 // AnalysisTask represents a single analysis task
@@ -458,6 +469,26 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 		})
 	}
 
+	// Community detection task (opt-in via SkipCommunities until CLI/config #583)
+	if uc.communityUseCase != nil {
+		tasks = append(tasks, &AnalysisTask{
+			Name:    taskNameCommunities,
+			Enabled: !config.SkipCommunities,
+			Execute: func(ctx context.Context) (interface{}, error) {
+				request := domain.CommunityAnalysisRequest{
+					Paths:           files,
+					Recursive:       nil,
+					IncludePatterns: []string{},
+					ExcludePatterns: []string{},
+					OutputFormat:    domain.OutputFormatJSON,
+					OutputWriter:    io.Discard,
+					ConfigPath:      config.ConfigFile,
+				}
+				return uc.communityUseCase.AnalyzeAndReturn(ctx, request)
+			},
+		})
+	}
+
 	return tasks
 }
 
@@ -545,6 +576,11 @@ func (uc *AnalyzeUseCase) buildResponse(tasks []*AnalysisTask, startTime time.Ti
 					response.Summary.ArchEnabled = true
 				}
 			}
+		case *domain.CommunityAnalysisResult:
+			response.Summary.CommunitiesEnabled = true
+			if result != nil {
+				response.Communities = result
+			}
 		case nil:
 			uc.markSummaryForTask(&response.Summary, task.Name)
 		default:
@@ -576,6 +612,8 @@ func (uc *AnalyzeUseCase) markSummaryForTask(summary *domain.AnalyzeSummary, tas
 		summary.LCOMEnabled = true
 	case "System Analysis":
 		summary.DepsEnabled = true
+	case taskNameCommunities:
+		summary.CommunitiesEnabled = true
 	}
 }
 
@@ -694,6 +732,9 @@ func (uc *AnalyzeUseCase) estimateTaskSeconds(fileCount int, config AnalyzeUseCa
 	}
 	if uc.systemUseCase != nil && !config.SkipSystem {
 		estimates[taskNameSystem] = 0.02 * n // System: ~0.02s per file (slightly heavier)
+	}
+	if uc.communityUseCase != nil && !config.SkipCommunities {
+		estimates[taskNameCommunities] = 0.02 * n
 	}
 
 	// Clone detection - account for LSH configuration

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -269,7 +269,7 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 
 	// Create analysis tasks
-	tasks := uc.createAnalysisTasks(useCaseCfg, files, snapshot, executionCfg)
+	tasks := uc.createAnalysisTasks(useCaseCfg, paths, files, snapshot, executionCfg)
 
 	// Execute tasks in parallel
 	var wg sync.WaitGroup
@@ -332,7 +332,7 @@ func (uc *AnalyzeUseCase) needsProjectSnapshot(config AnalyzeUseCaseConfig) bool
 }
 
 // createAnalysisTasks creates the analysis tasks based on configuration
-func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files []string, snapshot *service.ProjectSnapshot, executionCfg domain.AnalyzeExecutionConfig) []*AnalysisTask {
+func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourcePaths []string, files []string, snapshot *service.ProjectSnapshot, executionCfg domain.AnalyzeExecutionConfig) []*AnalysisTask {
 	tasks := []*AnalysisTask{}
 
 	// Complexity analysis task
@@ -477,6 +477,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, files
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.CommunityAnalysisRequest{
 					Paths:           files,
+					SourcePaths:     append([]string(nil), sourcePaths...),
 					Recursive:       nil,
 					IncludePatterns: []string{},
 					ExcludePatterns: []string{},

--- a/app/analyze_usecase_community_test.go
+++ b/app/analyze_usecase_community_test.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeUseCase_CommunityTask(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
+	require.NoError(t, err)
+
+	communityUC, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		Build()
+	require.NoError(t, err)
+
+	useCase, err := NewAnalyzeUseCaseBuilder().
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithCommunityUseCase(communityUC).
+		Build()
+	require.NoError(t, err)
+
+	config := AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: false,
+	}
+
+	response, err := useCase.Execute(context.Background(), config, []string{fixtureRoot})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	assert.True(t, response.Summary.CommunitiesEnabled)
+	require.NotNil(t, response.Communities)
+	assert.Greater(t, response.Communities.TotalCommunities, 0)
+	assert.NotEmpty(t, response.Communities.Communities)
+}
+
+func TestAnalyzeUseCase_CommunityTaskSkippedByDefault(t *testing.T) {
+	communityUC, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		Build()
+	require.NoError(t, err)
+
+	useCase, err := NewAnalyzeUseCaseBuilder().
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithCommunityUseCase(communityUC).
+		Build()
+	require.NoError(t, err)
+
+	tasks := useCase.createAnalysisTasks(AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: true,
+	}, []string{"."}, nil, domain.AnalyzeExecutionConfig{})
+
+	var communityTask *AnalysisTask
+	for _, task := range tasks {
+		if task.Name == taskNameCommunities {
+			communityTask = task
+			break
+		}
+	}
+	require.NotNil(t, communityTask)
+	assert.False(t, communityTask.Enabled)
+}
+
+func TestAnalyzeUseCase_CommunityTaskRequestUsesDiscardWriter(t *testing.T) {
+	communityUC, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		Build()
+	require.NoError(t, err)
+
+	useCase, err := NewAnalyzeUseCaseBuilder().
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithCommunityUseCase(communityUC).
+		Build()
+	require.NoError(t, err)
+
+	tasks := useCase.createAnalysisTasks(AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: false,
+	}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, nil, domain.AnalyzeExecutionConfig{})
+
+	var communityTask *AnalysisTask
+	for _, task := range tasks {
+		if task.Name == taskNameCommunities {
+			communityTask = task
+			break
+		}
+	}
+	require.NotNil(t, communityTask)
+	require.True(t, communityTask.Enabled)
+
+	_, err = communityTask.Execute(context.Background())
+	require.NoError(t, err)
+	_ = io.Discard
+}

--- a/app/analyze_usecase_community_test.go
+++ b/app/analyze_usecase_community_test.go
@@ -73,7 +73,7 @@ func TestAnalyzeUseCase_CommunityTaskSkippedByDefault(t *testing.T) {
 		SkipLCOM:        true,
 		SkipSystem:      true,
 		SkipCommunities: true,
-	}, []string{"."}, nil, domain.AnalyzeExecutionConfig{})
+	}, []string{"."}, []string{"."}, nil, domain.AnalyzeExecutionConfig{})
 
 	var communityTask *AnalysisTask
 	for _, task := range tasks {
@@ -109,7 +109,7 @@ func TestAnalyzeUseCase_CommunityTaskRequestUsesDiscardWriter(t *testing.T) {
 		SkipLCOM:        true,
 		SkipSystem:      true,
 		SkipCommunities: false,
-	}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, nil, domain.AnalyzeExecutionConfig{})
+	}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, nil, domain.AnalyzeExecutionConfig{})
 
 	var communityTask *AnalysisTask
 	for _, task := range tasks {

--- a/app/community_usecase.go
+++ b/app/community_usecase.go
@@ -1,0 +1,213 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	svc "github.com/ludo-technologies/pyscn/service"
+)
+
+// CommunityUseCase orchestrates the community analysis workflow.
+type CommunityUseCase struct {
+	service      domain.CommunityAnalysisService
+	fileReader   domain.FileReader
+	formatter    domain.CommunityAnalysisOutputFormatter
+	configLoader domain.CommunityConfigurationLoader
+	output       domain.ReportWriter
+}
+
+// NewCommunityUseCase creates a new community use case.
+func NewCommunityUseCase(
+	service domain.CommunityAnalysisService,
+	fileReader domain.FileReader,
+	formatter domain.CommunityAnalysisOutputFormatter,
+	configLoader domain.CommunityConfigurationLoader,
+) *CommunityUseCase {
+	return &CommunityUseCase{
+		service:      service,
+		fileReader:   fileReader,
+		formatter:    formatter,
+		configLoader: configLoader,
+		output:       svc.NewFileOutputWriter(nil),
+	}
+}
+
+func (uc *CommunityUseCase) prepareAnalysis(ctx context.Context, req domain.CommunityAnalysisRequest) (domain.CommunityAnalysisRequest, error) {
+	finalReq, err := uc.loadAndMergeConfig(req)
+	if err != nil {
+		return req, domain.NewConfigError("failed to load configuration", err)
+	}
+
+	if err := uc.validateRequest(finalReq); err != nil {
+		return req, domain.NewInvalidInputError("invalid request", err)
+	}
+
+	files, err := ResolveFilePaths(
+		uc.fileReader,
+		finalReq.Paths,
+		domain.BoolValue(finalReq.Recursive, true),
+		finalReq.IncludePatterns,
+		finalReq.ExcludePatterns,
+		false,
+	)
+	if err != nil {
+		return req, domain.NewFileNotFoundError("failed to collect files", err)
+	}
+
+	if len(files) == 0 {
+		return req, domain.NewInvalidInputError("no Python files found in the specified paths", nil)
+	}
+
+	finalReq.Paths = files
+	return finalReq, nil
+}
+
+// Execute performs the complete community analysis workflow.
+func (uc *CommunityUseCase) Execute(ctx context.Context, req domain.CommunityAnalysisRequest) error {
+	finalReq, err := uc.prepareAnalysis(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	response, err := uc.service.Analyze(ctx, finalReq)
+	if err != nil {
+		return domain.NewAnalysisError("community analysis failed", err)
+	}
+
+	var out io.Writer
+	if finalReq.OutputPath == "" {
+		out = finalReq.OutputWriter
+	}
+	if err := uc.output.Write(out, finalReq.OutputPath, finalReq.OutputFormat, finalReq.NoOpen, func(w io.Writer) error {
+		return uc.formatter.Write(response, finalReq.OutputFormat, w)
+	}); err != nil {
+		return domain.NewOutputError("failed to write output", err)
+	}
+
+	return nil
+}
+
+// AnalyzeAndReturn performs community analysis and returns the response without formatting.
+func (uc *CommunityUseCase) AnalyzeAndReturn(ctx context.Context, req domain.CommunityAnalysisRequest) (*domain.CommunityAnalysisResult, error) {
+	finalReq, err := uc.prepareAnalysis(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := uc.service.Analyze(ctx, finalReq)
+	if err != nil {
+		return nil, domain.NewAnalysisError("community analysis failed", err)
+	}
+
+	return response, nil
+}
+
+func (uc *CommunityUseCase) validateRequest(req domain.CommunityAnalysisRequest) error {
+	if len(req.Paths) == 0 {
+		return fmt.Errorf("no input paths specified")
+	}
+	if req.OutputWriter == nil && req.OutputPath == "" {
+		return fmt.Errorf("output writer or output path is required")
+	}
+	if req.MinCommunitySize < 0 {
+		return fmt.Errorf("minimum community size cannot be negative")
+	}
+	if req.Resolution < 0 {
+		return fmt.Errorf("resolution cannot be negative")
+	}
+	switch req.OutputFormat {
+	case domain.OutputFormatText, domain.OutputFormatJSON, domain.OutputFormatYAML, domain.OutputFormatCSV, domain.OutputFormatHTML:
+	default:
+		return fmt.Errorf("unsupported output format: %s", req.OutputFormat)
+	}
+	return nil
+}
+
+func (uc *CommunityUseCase) loadAndMergeConfig(req domain.CommunityAnalysisRequest) (domain.CommunityAnalysisRequest, error) {
+	if uc.configLoader == nil {
+		return req, nil
+	}
+
+	var configReq *domain.CommunityAnalysisRequest
+	var err error
+
+	if req.ConfigPath != "" {
+		configReq, err = uc.configLoader.LoadConfig(req.ConfigPath)
+		if err != nil {
+			return req, fmt.Errorf("failed to load config from %s: %w", req.ConfigPath, err)
+		}
+	} else {
+		configReq = uc.configLoader.LoadDefaultConfig()
+	}
+
+	if configReq != nil {
+		merged := uc.configLoader.MergeConfig(configReq, &req)
+		return *merged, nil
+	}
+
+	return req, nil
+}
+
+// CommunityUseCaseBuilder provides a builder pattern for creating CommunityUseCase.
+type CommunityUseCaseBuilder struct {
+	service      domain.CommunityAnalysisService
+	fileReader   domain.FileReader
+	formatter    domain.CommunityAnalysisOutputFormatter
+	configLoader domain.CommunityConfigurationLoader
+	output       domain.ReportWriter
+}
+
+// NewCommunityUseCaseBuilder creates a new builder.
+func NewCommunityUseCaseBuilder() *CommunityUseCaseBuilder {
+	return &CommunityUseCaseBuilder{}
+}
+
+func (b *CommunityUseCaseBuilder) WithService(service domain.CommunityAnalysisService) *CommunityUseCaseBuilder {
+	b.service = service
+	return b
+}
+
+func (b *CommunityUseCaseBuilder) WithFileReader(fileReader domain.FileReader) *CommunityUseCaseBuilder {
+	b.fileReader = fileReader
+	return b
+}
+
+func (b *CommunityUseCaseBuilder) WithFormatter(formatter domain.CommunityAnalysisOutputFormatter) *CommunityUseCaseBuilder {
+	b.formatter = formatter
+	return b
+}
+
+func (b *CommunityUseCaseBuilder) WithConfigLoader(configLoader domain.CommunityConfigurationLoader) *CommunityUseCaseBuilder {
+	b.configLoader = configLoader
+	return b
+}
+
+func (b *CommunityUseCaseBuilder) WithOutputWriter(output domain.ReportWriter) *CommunityUseCaseBuilder {
+	b.output = output
+	return b
+}
+
+func (b *CommunityUseCaseBuilder) Build() (*CommunityUseCase, error) {
+	if b.service == nil {
+		return nil, fmt.Errorf("community analysis service is required")
+	}
+	if b.fileReader == nil {
+		return nil, fmt.Errorf("file reader is required")
+	}
+	if b.formatter == nil {
+		return nil, fmt.Errorf("output formatter is required")
+	}
+
+	uc := NewCommunityUseCase(
+		b.service,
+		b.fileReader,
+		b.formatter,
+		b.configLoader,
+	)
+	if b.output != nil {
+		uc.output = b.output
+	}
+	return uc, nil
+}

--- a/app/community_usecase.go
+++ b/app/community_usecase.go
@@ -60,6 +60,9 @@ func (uc *CommunityUseCase) prepareAnalysis(ctx context.Context, req domain.Comm
 		return req, domain.NewInvalidInputError("no Python files found in the specified paths", nil)
 	}
 
+	if len(finalReq.SourcePaths) == 0 {
+		finalReq.SourcePaths = append([]string(nil), finalReq.Paths...)
+	}
 	finalReq.Paths = files
 	return finalReq, nil
 }

--- a/app/community_usecase_test.go
+++ b/app/community_usecase_test.go
@@ -1,0 +1,99 @@
+package app
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type noopCommunityFormatter struct{}
+
+func (noopCommunityFormatter) Format(*domain.CommunityAnalysisResult, domain.OutputFormat) (string, error) {
+	return "", nil
+}
+
+func (noopCommunityFormatter) Write(*domain.CommunityAnalysisResult, domain.OutputFormat, io.Writer) error {
+	return nil
+}
+
+func TestCommunityUseCase_AnalyzeAndReturn_FixtureProject(t *testing.T) {
+	fixtureRoot := filepath.Join("..", "testdata", "python", "mvc_app")
+	absRoot, err := filepath.Abs(fixtureRoot)
+	require.NoError(t, err)
+
+	uc, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		Build()
+	require.NoError(t, err)
+
+	req := domain.CommunityAnalysisRequest{
+		Paths:        []string{absRoot},
+		OutputFormat: domain.OutputFormatJSON,
+		OutputWriter: io.Discard,
+		Recursive:    domain.BoolPtr(true),
+	}
+
+	result, err := uc.AnalyzeAndReturn(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "leiden", result.Algorithm)
+	assert.Equal(t, "module", result.Scope)
+	assert.Greater(t, result.TotalCommunities, 0)
+	assert.NotEmpty(t, result.Communities)
+	assert.NotEmpty(t, result.GeneratedAt)
+	assert.NotEmpty(t, result.Version)
+
+	totalModules := 0
+	for _, community := range result.Communities {
+		assert.NotEmpty(t, community.ID)
+		assert.Greater(t, community.Size, 0)
+		assert.NotEmpty(t, community.Modules)
+		totalModules += community.Size
+	}
+	assert.Greater(t, totalModules, 0)
+}
+
+func TestCommunityUseCaseBuilder_RequiresDependencies(t *testing.T) {
+	_, err := NewCommunityUseCaseBuilder().Build()
+	require.Error(t, err)
+
+	_, err = NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		Build()
+	require.Error(t, err)
+
+	_, err = NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		Build()
+	require.Error(t, err)
+}
+
+func TestCommunityUseCase_ValidateRequest(t *testing.T) {
+	uc := NewCommunityUseCase(
+		service.NewCommunityAnalysisService(),
+		service.NewFileReader(),
+		noopCommunityFormatter{},
+		nil,
+	)
+
+	err := uc.validateRequest(domain.CommunityAnalysisRequest{})
+	require.Error(t, err)
+
+	err = uc.validateRequest(domain.CommunityAnalysisRequest{
+		Paths:            []string{"."},
+		OutputWriter:     os.Stdout,
+		MinCommunitySize: -1,
+	})
+	require.Error(t, err)
+}

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -203,6 +203,7 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 		CloneSimilarity: c.cloneSimilarity,
 		MinCBO:          c.minCBO,
 		EnableDFA:       c.enableDFA,
+		SkipCommunities: true, // opt-in until --select/config wiring (#583)
 	}
 
 	// Handle analysis selection
@@ -214,6 +215,7 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 		config.SkipCBO = !c.containsAnalysis("cbo")
 		config.SkipLCOM = !c.containsAnalysis("lcom")
 		config.SkipSystem = !c.containsAnalysis("deps")
+		config.SkipCommunities = !c.containsAnalysis("communities")
 	} else {
 		// Otherwise use skip flags
 		config.SkipComplexity = c.skipComplexity
@@ -370,6 +372,19 @@ func (c *AnalyzeCommand) buildIndividualUseCases(builder *app.AnalyzeUseCaseBuil
 		return fmt.Errorf("failed to build system analysis use case: %w", err)
 	}
 	builder.WithSystemUseCase(systemUseCase)
+
+	// Community analysis use case
+	communityService := service.NewCommunityAnalysisService()
+	communityFormatter := service.NewCommunityFormatter()
+	communityUseCase, err := app.NewCommunityUseCaseBuilder().
+		WithService(communityService).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(communityFormatter).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to build community analysis use case: %w", err)
+	}
+	builder.WithCommunityUseCase(communityUseCase)
 
 	return nil
 }

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -131,7 +131,7 @@ Examples:
 	cmd.Flags().BoolVar(&c.skipCBO, "skip-cbo", false, "Skip class coupling (CBO) analysis")
 	cmd.Flags().BoolVar(&c.skipLCOM, "skip-lcom", false, "Skip class cohesion (LCOM4) analysis")
 	cmd.Flags().BoolVar(&c.skipSystem, "skip-deps", false, "Skip module dependencies and architecture analysis")
-	cmd.Flags().StringSliceVar(&c.selectAnalyses, "select", []string{}, "Only run specified analyses (complexity,deadcode,clones,cbo,lcom,deps)")
+	cmd.Flags().StringSliceVar(&c.selectAnalyses, "select", []string{}, "Only run specified analyses (complexity,deadcode,clones,cbo,lcom,deps,communities)")
 
 	// Quick filter flags
 	cmd.Flags().IntVar(&c.minComplexity, "min-complexity", 5, "Minimum complexity to report")
@@ -631,16 +631,17 @@ func (c *AnalyzeCommand) containsAnalysis(analysis string) bool {
 
 func (c *AnalyzeCommand) validateSelectedAnalyses() error {
 	validAnalyses := map[string]bool{
-		"complexity": true,
-		"deadcode":   true,
-		"clones":     true,
-		"cbo":        true,
-		"lcom":       true,
-		"deps":       true,
+		"complexity":   true,
+		"deadcode":     true,
+		"clones":       true,
+		"cbo":          true,
+		"lcom":         true,
+		"deps":         true,
+		"communities":  true,
 	}
 	for _, analysis := range c.selectAnalyses {
 		if !validAnalyses[strings.ToLower(analysis)] {
-			return fmt.Errorf("invalid analysis type: %s. Valid options: complexity, deadcode, clones, cbo, lcom, deps", analysis)
+			return fmt.Errorf("invalid analysis type: %s. Valid options: complexity, deadcode, clones, cbo, lcom, deps, communities", analysis)
 		}
 	}
 	return nil

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -631,13 +631,13 @@ func (c *AnalyzeCommand) containsAnalysis(analysis string) bool {
 
 func (c *AnalyzeCommand) validateSelectedAnalyses() error {
 	validAnalyses := map[string]bool{
-		"complexity":   true,
-		"deadcode":     true,
-		"clones":       true,
-		"cbo":          true,
-		"lcom":         true,
-		"deps":         true,
-		"communities":  true,
+		"complexity":  true,
+		"deadcode":    true,
+		"clones":      true,
+		"cbo":         true,
+		"lcom":        true,
+		"deps":        true,
+		"communities": true,
 	}
 	for _, analysis := range c.selectAnalyses {
 		if !validAnalyses[strings.ToLower(analysis)] {

--- a/cmd/pyscn/analyze_wiring_test.go
+++ b/cmd/pyscn/analyze_wiring_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/app"
+	"github.com/ludo-technologies/pyscn/service"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeCommand_BuildAnalyzeUseCase_WiresCommunityAnalysis(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "..", "testdata", "python", "mvc_app"))
+	require.NoError(t, err)
+
+	cmd := &AnalyzeCommand{}
+	cobraCmd := &cobra.Command{}
+	builder := app.NewAnalyzeUseCaseBuilder()
+	require.NoError(t, cmd.buildIndividualUseCases(builder, cobraCmd))
+
+	progressManager := service.NewProgressManager()
+	progressManager.SetWriter(io.Discard)
+
+	useCase, err := builder.
+		WithFileReader(service.NewFileReader()).
+		WithConfigLoader(service.NewAnalyzeConfigurationLoader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithProgressManager(progressManager).
+		WithParallelExecutor(service.NewParallelExecutor()).
+		WithErrorCategorizer(service.NewErrorCategorizer()).
+		Build()
+	require.NoError(t, err)
+
+	response, err := useCase.Execute(context.Background(), app.AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: false,
+	}, []string{fixtureRoot})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.NotNil(t, response.Communities)
+	assert.Greater(t, response.Communities.TotalCommunities, 0)
+}

--- a/cmd/pyscn/new_commands_test.go
+++ b/cmd/pyscn/new_commands_test.go
@@ -332,7 +332,7 @@ func TestAnalyzeCommandValidation(t *testing.T) {
 
 func TestAnalyzeCommandSelectValidation(t *testing.T) {
 	analyzeCmd := NewAnalyzeCommand()
-	analyzeCmd.selectAnalyses = []string{"complexity", "deps"}
+	analyzeCmd.selectAnalyses = []string{"complexity", "deps", "communities"}
 	if err := analyzeCmd.validateSelectedAnalyses(); err != nil {
 		t.Fatalf("expected valid selected analyses, got %v", err)
 	}
@@ -340,6 +340,16 @@ func TestAnalyzeCommandSelectValidation(t *testing.T) {
 	analyzeCmd.selectAnalyses = []string{"complexity", "nope"}
 	if err := analyzeCmd.validateSelectedAnalyses(); err == nil {
 		t.Fatal("expected invalid selected analysis to fail")
+	}
+}
+
+func TestAnalyzeCommandSelectCommunitiesEnablesAnalysis(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+	analyzeCmd.selectAnalyses = []string{"communities"}
+
+	config := analyzeCmd.createUseCaseConfig()
+	if config.SkipCommunities {
+		t.Fatal("expected --select communities to enable community analysis")
 	}
 }
 

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -113,13 +113,14 @@ const (
 // AnalyzeResponse represents the combined results of all analyses
 type AnalyzeResponse struct {
 	// Analysis results
-	Complexity *ComplexityResponse     `json:"complexity,omitempty" yaml:"complexity,omitempty"`
-	DeadCode   *DeadCodeResponse       `json:"dead_code,omitempty" yaml:"dead_code,omitempty"`
-	Clone      *CloneResponse          `json:"clone,omitempty" yaml:"clone,omitempty"`
-	CBO        *CBOResponse            `json:"cbo,omitempty" yaml:"cbo,omitempty"`
-	LCOM       *LCOMResponse           `json:"lcom,omitempty" yaml:"lcom,omitempty"`
-	System     *SystemAnalysisResponse `json:"system,omitempty" yaml:"system,omitempty"`
-	MockData   *MockDataResponse       `json:"mock_data,omitempty" yaml:"mock_data,omitempty"`
+	Complexity  *ComplexityResponse      `json:"complexity,omitempty" yaml:"complexity,omitempty"`
+	DeadCode    *DeadCodeResponse        `json:"dead_code,omitempty" yaml:"dead_code,omitempty"`
+	Clone       *CloneResponse           `json:"clone,omitempty" yaml:"clone,omitempty"`
+	CBO         *CBOResponse             `json:"cbo,omitempty" yaml:"cbo,omitempty"`
+	LCOM        *LCOMResponse            `json:"lcom,omitempty" yaml:"lcom,omitempty"`
+	System      *SystemAnalysisResponse  `json:"system,omitempty" yaml:"system,omitempty"`
+	Communities *CommunityAnalysisResult `json:"community_analysis,omitempty" yaml:"community_analysis,omitempty"`
+	MockData    *MockDataResponse        `json:"mock_data,omitempty" yaml:"mock_data,omitempty"`
 
 	// Actionable suggestions derived from analysis results
 	Suggestions []Suggestion `json:"suggestions,omitempty" yaml:"suggestions,omitempty"`
@@ -150,6 +151,7 @@ type AnalyzeSummary struct {
 	// System-level (module dependencies & architecture) summary used for scoring
 	DepsEnabled               bool    `json:"deps_enabled" yaml:"deps_enabled"`
 	ArchEnabled               bool    `json:"arch_enabled" yaml:"arch_enabled"`
+	CommunitiesEnabled        bool    `json:"communities_enabled" yaml:"communities_enabled"`
 	DepsTotalModules          int     `json:"deps_total_modules" yaml:"deps_total_modules"`
 	DepsModulesInCycles       int     `json:"deps_modules_in_cycles" yaml:"deps_modules_in_cycles"`
 	DepsMaxDepth              int     `json:"deps_max_depth" yaml:"deps_max_depth"`

--- a/domain/community.go
+++ b/domain/community.go
@@ -1,0 +1,112 @@
+package domain
+
+import (
+	"context"
+	"io"
+)
+
+// CommunityAnalysisRequest represents a request for module community detection.
+type CommunityAnalysisRequest struct {
+	// Input files or directories to analyze
+	Paths []string
+
+	// Output configuration
+	OutputFormat OutputFormat
+	OutputWriter io.Writer
+	OutputPath   string
+	NoOpen       bool
+
+	// Configuration
+	ConfigPath      string
+	Recursive       *bool
+	IncludePatterns []string
+	ExcludePatterns []string
+
+	// Community detection options
+	Algorithm           string
+	Scope               string
+	MinCommunitySize    int
+	IncludeLazyEdges    *bool
+	ReportBridgeModules *bool
+	Resolution          float64
+
+	// Module graph options
+	IncludeStdLib     *bool
+	IncludeThirdParty *bool
+	FollowRelative    *bool
+}
+
+// CommunityMetrics describes one detected module community.
+type CommunityMetrics struct {
+	ID                          string   `json:"id" yaml:"id"`
+	Modules                     []string `json:"modules" yaml:"modules"`
+	Packages                    []string `json:"packages" yaml:"packages"`
+	InternalEdges               int      `json:"internal_edges" yaml:"internal_edges"`
+	ExternalEdges               int      `json:"external_edges" yaml:"external_edges"`
+	ExternalDependencyRatio     float64  `json:"external_dependency_ratio" yaml:"external_dependency_ratio"`
+	IncomingCrossCommunityEdges int      `json:"incoming_cross_community_edges" yaml:"incoming_cross_community_edges"`
+	OutgoingCrossCommunityEdges int      `json:"outgoing_cross_community_edges" yaml:"outgoing_cross_community_edges"`
+	Size                        int      `json:"size" yaml:"size"`
+}
+
+// BridgeModule describes a module that couples multiple communities.
+type BridgeModule struct {
+	Module              string   `json:"module" yaml:"module"`
+	Community           string   `json:"community" yaml:"community"`
+	CrossCommunityEdges int      `json:"cross_community_edges" yaml:"cross_community_edges"`
+	TargetCommunities   []string `json:"target_communities" yaml:"target_communities"`
+}
+
+// CommunityAnalysisResult represents the complete community analysis output.
+type CommunityAnalysisResult struct {
+	Algorithm        string             `json:"algorithm" yaml:"algorithm"`
+	Scope            string             `json:"scope" yaml:"scope"`
+	TotalCommunities int                `json:"total_communities" yaml:"total_communities"`
+	Modularity       float64            `json:"modularity" yaml:"modularity"`
+	Communities      []CommunityMetrics `json:"communities" yaml:"communities"`
+	BridgeModules    []BridgeModule     `json:"bridge_modules" yaml:"bridge_modules"`
+
+	Warnings []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+	Errors   []string `json:"errors,omitempty" yaml:"errors,omitempty"`
+
+	GeneratedAt string      `json:"generated_at" yaml:"generated_at"`
+	Version     string      `json:"version" yaml:"version"`
+	Config      interface{} `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+// CommunityAnalysisService defines the core business logic for community analysis.
+type CommunityAnalysisService interface {
+	Analyze(ctx context.Context, req CommunityAnalysisRequest) (*CommunityAnalysisResult, error)
+}
+
+// CommunityConfigurationLoader defines the interface for loading community configuration.
+type CommunityConfigurationLoader interface {
+	LoadConfig(path string) (*CommunityAnalysisRequest, error)
+	LoadDefaultConfig() *CommunityAnalysisRequest
+	MergeConfig(base *CommunityAnalysisRequest, override *CommunityAnalysisRequest) *CommunityAnalysisRequest
+}
+
+// CommunityAnalysisOutputFormatter defines the interface for formatting community results.
+type CommunityAnalysisOutputFormatter interface {
+	Format(response *CommunityAnalysisResult, format OutputFormat) (string, error)
+	Write(response *CommunityAnalysisResult, format OutputFormat, writer io.Writer) error
+}
+
+// DefaultCommunityAnalysisRequest returns a CommunityAnalysisRequest with default values.
+func DefaultCommunityAnalysisRequest() *CommunityAnalysisRequest {
+	return &CommunityAnalysisRequest{
+		OutputFormat:        OutputFormatText,
+		Algorithm:           DefaultCommunityAlgorithm,
+		Scope:               DefaultCommunityScope,
+		MinCommunitySize:    DefaultCommunityMinSize,
+		IncludeLazyEdges:    BoolPtr(true),
+		ReportBridgeModules: BoolPtr(true),
+		Resolution:          DefaultCommunityResolution,
+		Recursive:           BoolPtr(true),
+		IncludePatterns:     DefaultPythonModuleIncludePatterns(),
+		ExcludePatterns:     DefaultAnalysisExcludePatterns(),
+		IncludeStdLib:       BoolPtr(false),
+		IncludeThirdParty:   BoolPtr(true),
+		FollowRelative:      BoolPtr(true),
+	}
+}

--- a/domain/community.go
+++ b/domain/community.go
@@ -10,6 +10,10 @@ type CommunityAnalysisRequest struct {
 	// Input files or directories to analyze
 	Paths []string
 
+	// SourcePaths preserves the original user-provided paths before file expansion.
+	// Used for project-root detection when Paths contains only resolved files.
+	SourcePaths []string
+
 	// Output configuration
 	OutputFormat OutputFormat
 	OutputWriter io.Writer

--- a/domain/defaults.go
+++ b/domain/defaults.go
@@ -170,6 +170,18 @@ const (
 	// DefaultLCOMMediumThreshold is the upper bound for medium-risk LCOM.
 	// Classes with LCOM4 3-5 have acceptable cohesion.
 	DefaultLCOMMediumThreshold = 5
+
+	// DefaultCommunityAlgorithm is the community detection algorithm identifier.
+	DefaultCommunityAlgorithm = "leiden"
+
+	// DefaultCommunityScope is the graph scope for community detection.
+	DefaultCommunityScope = "module"
+
+	// DefaultCommunityMinSize is the minimum community size after detection.
+	DefaultCommunityMinSize = 1
+
+	// DefaultCommunityResolution is the Leiden resolution parameter.
+	DefaultCommunityResolution = 1.0
 )
 
 // ============================================================================

--- a/internal/analyzer/community_metrics.go
+++ b/internal/analyzer/community_metrics.go
@@ -1,0 +1,235 @@
+package analyzer
+
+import (
+	"fmt"
+	"sort"
+)
+
+// CommunityPartitionMetrics holds community-level metrics derived from a Leiden
+// partition over a module dependency graph.
+type CommunityPartitionMetrics struct {
+	Communities      []CommunityPartition
+	BridgeModules    []BridgeModuleMetrics
+	TotalCommunities int
+	Modularity       float64
+}
+
+// CommunityPartition describes one detected community.
+type CommunityPartition struct {
+	ID                          string
+	Modules                     []string
+	Packages                    []string
+	InternalEdges               int
+	ExternalEdges               int
+	ExternalDependencyRatio     float64
+	IncomingCrossCommunityEdges int
+	OutgoingCrossCommunityEdges int
+	Size                        int
+}
+
+// BridgeModuleMetrics describes a module that couples multiple communities.
+type BridgeModuleMetrics struct {
+	Module              string
+	CommunityID         string
+	CrossCommunityEdges int
+	TargetCommunities   []string
+}
+
+// ComputeCommunityMetrics derives per-community and bridge-module metrics from
+// a Leiden partition. graph supplies package metadata; cg supplies directed edges.
+func ComputeCommunityMetrics(graph *DependencyGraph, cg *CommunityGraph, leiden *LeidenResult) *CommunityPartitionMetrics {
+	if cg == nil || leiden == nil || cg.NodeCount == 0 || len(leiden.Membership) == 0 {
+		return &CommunityPartitionMetrics{}
+	}
+
+	communityIDs := buildStableCommunityIDs(leiden.Membership)
+	nodeCommunity := make([]string, cg.NodeCount)
+	for i, commIdx := range leiden.Membership {
+		if i < len(nodeCommunity) && commIdx >= 0 && commIdx < len(communityIDs) {
+			nodeCommunity[i] = communityIDs[commIdx]
+		}
+	}
+
+	commIndex := make(map[string]int, len(communityIDs))
+	partitions := make([]CommunityPartition, len(communityIDs))
+	for i, id := range communityIDs {
+		commIndex[id] = i
+		partitions[i].ID = id
+	}
+
+	for i, name := range cg.NodeNames {
+		if i >= len(nodeCommunity) || nodeCommunity[i] == "" {
+			continue
+		}
+		idx := commIndex[nodeCommunity[i]]
+		partitions[idx].Modules = append(partitions[idx].Modules, name)
+		if graph != nil {
+			if node, ok := graph.Nodes[name]; ok && node.Package != "" {
+				partitions[idx].Packages = appendUniqueString(partitions[idx].Packages, node.Package)
+			}
+		}
+	}
+
+	for i := range partitions {
+		sort.Strings(partitions[i].Modules)
+		sort.Strings(partitions[i].Packages)
+		partitions[i].Size = len(partitions[i].Modules)
+	}
+
+	for _, edge := range cg.DirectedEdges {
+		if edge.FromIndex >= len(nodeCommunity) || edge.ToIndex >= len(nodeCommunity) {
+			continue
+		}
+		fromComm := nodeCommunity[edge.FromIndex]
+		toComm := nodeCommunity[edge.ToIndex]
+		if fromComm == "" || toComm == "" {
+			continue
+		}
+
+		if fromComm == toComm {
+			fromIdx := commIndex[fromComm]
+			partitions[fromIdx].InternalEdges++
+			continue
+		}
+
+		fromIdx := commIndex[fromComm]
+		toIdx := commIndex[toComm]
+		partitions[fromIdx].ExternalEdges++
+		partitions[fromIdx].OutgoingCrossCommunityEdges++
+		partitions[toIdx].ExternalEdges++
+		partitions[toIdx].IncomingCrossCommunityEdges++
+	}
+
+	for i := range partitions {
+		total := partitions[i].InternalEdges + partitions[i].ExternalEdges
+		if total > 0 {
+			partitions[i].ExternalDependencyRatio = float64(partitions[i].ExternalEdges) / float64(total)
+		}
+	}
+
+	bridgeModules := computeBridgeModules(cg, nodeCommunity)
+
+	return &CommunityPartitionMetrics{
+		Communities:      partitions,
+		BridgeModules:    bridgeModules,
+		TotalCommunities: leiden.NumCommunities,
+		Modularity:       leiden.Modularity,
+	}
+}
+
+func buildStableCommunityIDs(membership []int) []string {
+	if len(membership) == 0 {
+		return nil
+	}
+
+	seen := make(map[int]struct{})
+	ids := make([]int, 0)
+	for _, comm := range membership {
+		if comm < 0 {
+			continue
+		}
+		if _, ok := seen[comm]; ok {
+			continue
+		}
+		seen[comm] = struct{}{}
+		ids = append(ids, comm)
+	}
+	sort.Ints(ids)
+
+	maxID := -1
+	for _, id := range ids {
+		if id > maxID {
+			maxID = id
+		}
+	}
+	if maxID < 0 {
+		return nil
+	}
+
+	// Index by raw community id so membership lookups stay O(1).
+	byID := make([]string, maxID+1)
+	for rank, id := range ids {
+		byID[id] = fmt.Sprintf("community_%d", rank+1)
+	}
+	return byID
+}
+
+func computeBridgeModules(cg *CommunityGraph, nodeCommunity []string) []BridgeModuleMetrics {
+	type bridgeAccumulator struct {
+		homeCommunity     string
+		crossEdges        int
+		targetCommunities map[string]struct{}
+	}
+
+	bridges := make(map[int]*bridgeAccumulator)
+
+	for _, edge := range cg.DirectedEdges {
+		if edge.FromIndex >= len(nodeCommunity) || edge.ToIndex >= len(nodeCommunity) {
+			continue
+		}
+		fromComm := nodeCommunity[edge.FromIndex]
+		toComm := nodeCommunity[edge.ToIndex]
+		if fromComm == "" || toComm == "" || fromComm == toComm {
+			continue
+		}
+
+		updateBridge := func(nodeIdx int, homeComm, targetComm string) {
+			acc, ok := bridges[nodeIdx]
+			if !ok {
+				acc = &bridgeAccumulator{
+					homeCommunity:     homeComm,
+					targetCommunities: make(map[string]struct{}),
+				}
+				bridges[nodeIdx] = acc
+			}
+			acc.crossEdges++
+			acc.targetCommunities[targetComm] = struct{}{}
+		}
+
+		updateBridge(edge.FromIndex, fromComm, toComm)
+		updateBridge(edge.ToIndex, toComm, fromComm)
+	}
+
+	results := make([]BridgeModuleMetrics, 0, len(bridges))
+	for nodeIdx, acc := range bridges {
+		if len(acc.targetCommunities) == 0 {
+			continue
+		}
+
+		targets := make([]string, 0, len(acc.targetCommunities))
+		for target := range acc.targetCommunities {
+			targets = append(targets, target)
+		}
+		sort.Strings(targets)
+
+		moduleName := ""
+		if nodeIdx >= 0 && nodeIdx < len(cg.NodeNames) {
+			moduleName = cg.NodeNames[nodeIdx]
+		}
+
+		results = append(results, BridgeModuleMetrics{
+			Module:              moduleName,
+			CommunityID:         acc.homeCommunity,
+			CrossCommunityEdges: acc.crossEdges,
+			TargetCommunities:   targets,
+		})
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].CrossCommunityEdges != results[j].CrossCommunityEdges {
+			return results[i].CrossCommunityEdges > results[j].CrossCommunityEdges
+		}
+		return results[i].Module < results[j].Module
+	})
+
+	return results
+}
+
+func appendUniqueString(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/analyzer/community_metrics_test.go
+++ b/internal/analyzer/community_metrics_test.go
@@ -1,0 +1,130 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeCommunityMetrics_SeparatedCommunities(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddModule("mod.c", "/project/mod/c.py")
+	graph.AddModule("mod.d", "/project/mod/d.py")
+
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.b", "mod.a", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.c", "mod.d", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.d", "mod.c", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+	leiden := DetectCommunitiesLeiden(cg, nil)
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+
+	require.Equal(t, 2, metrics.TotalCommunities)
+	require.Len(t, metrics.Communities, 2)
+
+	for _, comm := range metrics.Communities {
+		assert.Equal(t, 0, comm.ExternalEdges)
+		assert.Equal(t, 0.0, comm.ExternalDependencyRatio)
+		assert.Equal(t, 0, comm.IncomingCrossCommunityEdges)
+		assert.Equal(t, 0, comm.OutgoingCrossCommunityEdges)
+		assert.Greater(t, comm.InternalEdges, 0)
+	}
+	assert.Empty(t, metrics.BridgeModules)
+}
+
+func TestComputeCommunityMetrics_BridgeModule(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddModule("bridge", "/project/bridge.py")
+	graph.AddModule("mod.c", "/project/mod/c.py")
+	graph.AddModule("mod.d", "/project/mod/d.py")
+
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.b", "bridge", DependencyEdgeImport, nil)
+	graph.AddDependency("bridge", "mod.c", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.c", "mod.d", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+	leiden := DetectCommunitiesLeiden(cg, nil)
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+
+	require.NotEmpty(t, metrics.BridgeModules)
+
+	var bridgeEntry *BridgeModuleMetrics
+	for i := range metrics.BridgeModules {
+		if metrics.BridgeModules[i].Module == "bridge" {
+			bridgeEntry = &metrics.BridgeModules[i]
+			break
+		}
+	}
+	require.NotNil(t, bridgeEntry)
+	assert.GreaterOrEqual(t, bridgeEntry.CrossCommunityEdges, 1)
+	assert.NotEmpty(t, bridgeEntry.TargetCommunities)
+	assert.NotEmpty(t, bridgeEntry.CommunityID)
+}
+
+func TestComputeCommunityMetrics_CrossCommunityEdgeCounts(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("left.a", "/project/left/a.py")
+	graph.AddModule("left.b", "/project/left/b.py")
+	graph.AddModule("hub", "/project/hub.py")
+	graph.AddModule("right.a", "/project/right/a.py")
+	graph.AddModule("right.b", "/project/right/b.py")
+
+	graph.AddDependency("left.a", "left.b", DependencyEdgeImport, nil)
+	graph.AddDependency("left.b", "hub", DependencyEdgeImport, nil)
+	graph.AddDependency("hub", "right.a", DependencyEdgeImport, nil)
+	graph.AddDependency("right.a", "right.b", DependencyEdgeImport, nil)
+	graph.AddDependency("hub", "right.b", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+
+	membership := make([]int, cg.NodeCount)
+	for i, name := range cg.NodeNames {
+		switch name {
+		case "left.a", "left.b":
+			membership[i] = 0
+		case "hub":
+			membership[i] = 1
+		default:
+			membership[i] = 2
+		}
+	}
+
+	leiden := &LeidenResult{
+		Membership:     membership,
+		NumCommunities: 3,
+		Modularity:     0.42,
+	}
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+
+	byID := make(map[string]CommunityPartition)
+	for _, comm := range metrics.Communities {
+		byID[comm.ID] = comm
+	}
+
+	hubComm := byID["community_2"]
+	assert.Equal(t, 2, hubComm.OutgoingCrossCommunityEdges)
+	assert.Equal(t, 1, hubComm.IncomingCrossCommunityEdges)
+	assert.Equal(t, 3, hubComm.ExternalEdges)
+
+	leftComm := byID["community_1"]
+	assert.Equal(t, 1, leftComm.OutgoingCrossCommunityEdges)
+	assert.Equal(t, 0, leftComm.IncomingCrossCommunityEdges)
+
+	rightComm := byID["community_3"]
+	assert.Equal(t, 0, rightComm.OutgoingCrossCommunityEdges)
+	assert.Equal(t, 2, rightComm.IncomingCrossCommunityEdges)
+}
+
+func TestComputeCommunityMetrics_EmptyInput(t *testing.T) {
+	metrics := ComputeCommunityMetrics(nil, nil, nil)
+	assert.Empty(t, metrics.Communities)
+	assert.Empty(t, metrics.BridgeModules)
+	assert.Equal(t, 0, metrics.TotalCommunities)
+}

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -62,6 +62,7 @@ func (h *HandlerSet) HandleAnalyzeCode(ctx context.Context, request mcp.CallTool
 		SkipCBO:         !contains(analyses, "cbo") && len(analyses) > 0,
 		SkipLCOM:        !contains(analyses, "lcom") && len(analyses) > 0,
 		SkipSystem:      !contains(analyses, "deps") && len(analyses) > 0,
+		SkipCommunities: !contains(analyses, "communities") && len(analyses) > 0,
 		MinComplexity:   1,
 		MinSeverity:     domain.DeadCodeSeverityWarning,
 		CloneSimilarity: 0.8,
@@ -1393,6 +1394,18 @@ func buildAnalyzeUseCase(fileReader domain.FileReader) (*app.AnalyzeUseCase, err
 	systemFormatter := service.NewSystemAnalysisFormatter()
 	systemUC := app.NewSystemAnalysisUseCase(systemService, fileReader, systemFormatter, systemConfigLoader)
 
+	// Build community analysis use case
+	communityService := service.NewCommunityAnalysisService()
+	communityFormatter := service.NewCommunityFormatter()
+	communityUC, err := app.NewCommunityUseCaseBuilder().
+		WithService(communityService).
+		WithFileReader(fileReader).
+		WithFormatter(communityFormatter).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
 	// Build analyze use case
 	return app.NewAnalyzeUseCaseBuilder().
 		WithComplexityUseCase(complexityUC).
@@ -1401,6 +1414,7 @@ func buildAnalyzeUseCase(fileReader domain.FileReader) (*app.AnalyzeUseCase, err
 		WithCBOUseCase(cboUC).
 		WithLCOMUseCase(lcomUC).
 		WithSystemUseCase(systemUC).
+		WithCommunityUseCase(communityUC).
 		WithFileReader(fileReader).
 		WithProgressManager(service.NewProgressManager()).
 		WithParallelExecutor(service.NewParallelExecutor()).

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -62,7 +62,7 @@ func (h *HandlerSet) HandleAnalyzeCode(ctx context.Context, request mcp.CallTool
 		SkipCBO:         !contains(analyses, "cbo") && len(analyses) > 0,
 		SkipLCOM:        !contains(analyses, "lcom") && len(analyses) > 0,
 		SkipSystem:      !contains(analyses, "deps") && len(analyses) > 0,
-		SkipCommunities: !contains(analyses, "communities") && len(analyses) > 0,
+		SkipCommunities: shouldSkipCommunitiesAnalysis(analyses),
 		MinComplexity:   1,
 		MinSeverity:     domain.DeadCodeSeverityWarning,
 		CloneSimilarity: 0.8,
@@ -780,6 +780,12 @@ func (h *HandlerSet) HandleGetHealthScore(ctx context.Context, request mcp.CallT
 }
 
 // Helper functions
+
+func shouldSkipCommunitiesAnalysis(analyses []string) bool {
+	// Communities remain opt-in: omitted analyses lists and explicit subsets
+	// without "communities" must not run community detection.
+	return len(analyses) == 0 || !contains(analyses, "communities")
+}
 
 func contains(slice []string, item string) bool {
 	for _, s := range slice {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -15,7 +15,7 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Description("Path to Python code (file or directory) to analyze")),
 		mcp.WithArray("analyses",
 			mcp.WithStringEnumItems([]string{"complexity", "dead_code", "clone", "cbo", "lcom", "deps", "communities"}),
-			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps, communities. Default: all analyses")),
+			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps, communities. Default: all analyses except communities (opt-in)")),
 		mcp.WithBoolean("recursive",
 			mcp.Description("Recursively analyze directories (default: true)")),
 	), handlers.HandleAnalyzeCode)

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -14,8 +14,8 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Required(),
 			mcp.Description("Path to Python code (file or directory) to analyze")),
 		mcp.WithArray("analyses",
-			mcp.WithStringEnumItems([]string{"complexity", "dead_code", "clone", "cbo", "lcom", "deps"}),
-			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps. Default: all analyses")),
+			mcp.WithStringEnumItems([]string{"complexity", "dead_code", "clone", "cbo", "lcom", "deps", "communities"}),
+			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps, communities. Default: all analyses")),
 		mcp.WithBoolean("recursive",
 			mcp.Description("Recursively analyze directories (default: true)")),
 	), handlers.HandleAnalyzeCode)

--- a/mcp/wiring_test.go
+++ b/mcp/wiring_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestShouldSkipCommunitiesAnalysis_OptInByDefault(t *testing.T) {
+	assert.True(t, shouldSkipCommunitiesAnalysis(nil))
+	assert.True(t, shouldSkipCommunitiesAnalysis([]string{}))
+	assert.True(t, shouldSkipCommunitiesAnalysis([]string{"complexity", "deps"}))
+	assert.False(t, shouldSkipCommunitiesAnalysis([]string{"communities"}))
+	assert.False(t, shouldSkipCommunitiesAnalysis([]string{"complexity", "communities"}))
+}
+
 func TestBuildAnalyzeUseCase_WiresCommunityAnalysis(t *testing.T) {
 	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
 	require.NoError(t, err)

--- a/mcp/wiring_test.go
+++ b/mcp/wiring_test.go
@@ -1,0 +1,34 @@
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/app"
+	"github.com/ludo-technologies/pyscn/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAnalyzeUseCase_WiresCommunityAnalysis(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
+	require.NoError(t, err)
+
+	uc, err := buildAnalyzeUseCase(service.NewFileReader())
+	require.NoError(t, err)
+
+	response, err := uc.Execute(context.Background(), app.AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: false,
+	}, []string{fixtureRoot})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.NotNil(t, response.Communities)
+	assert.Greater(t, response.Communities.TotalCommunities, 0)
+}

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -1,0 +1,233 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/analyzer"
+	"github.com/ludo-technologies/pyscn/internal/version"
+)
+
+// CommunityAnalysisServiceImpl implements domain.CommunityAnalysisService.
+type CommunityAnalysisServiceImpl struct{}
+
+// NewCommunityAnalysisService creates a new community analysis service.
+func NewCommunityAnalysisService() *CommunityAnalysisServiceImpl {
+	return &CommunityAnalysisServiceImpl{}
+}
+
+// Analyze performs community detection over the module dependency graph.
+func (s *CommunityAnalysisServiceImpl) Analyze(ctx context.Context, req domain.CommunityAnalysisRequest) (*domain.CommunityAnalysisResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("community analysis cancelled: %w", err)
+	}
+
+	graph, err := s.buildDependencyGraph(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	graphOpts := &analyzer.CommunityGraphBuildOptions{
+		ExcludeLazyEdges: !domain.BoolValue(req.IncludeLazyEdges, true),
+	}
+	cg := analyzer.BuildCommunityGraph(graph, graphOpts)
+
+	leidenOpts := &analyzer.LeidenOptions{
+		Resolution:       req.Resolution,
+		MinCommunitySize: req.MinCommunitySize,
+	}
+	if leidenOpts.Resolution <= 0 {
+		leidenOpts.Resolution = domain.DefaultCommunityResolution
+	}
+	if leidenOpts.MinCommunitySize <= 0 {
+		leidenOpts.MinCommunitySize = domain.DefaultCommunityMinSize
+	}
+
+	leiden := analyzer.DetectCommunitiesLeiden(cg, leidenOpts)
+	metrics := analyzer.ComputeCommunityMetrics(graph, cg, leiden)
+
+	result := &domain.CommunityAnalysisResult{
+		Algorithm:        s.resolveAlgorithm(req.Algorithm),
+		Scope:            s.resolveScope(req.Scope),
+		TotalCommunities: metrics.TotalCommunities,
+		Modularity:       metrics.Modularity,
+		Communities:      s.convertCommunities(metrics.Communities),
+		GeneratedAt:      time.Now().Format(time.RFC3339),
+		Version:          version.Version,
+		Config:           s.buildConfigForResponse(req),
+	}
+
+	if domain.BoolValue(req.ReportBridgeModules, true) {
+		result.BridgeModules = s.convertBridgeModules(metrics.BridgeModules)
+	}
+
+	if graph.TotalModules == 0 {
+		result.Warnings = append(result.Warnings, "No modules found to analyze")
+	}
+
+	return result, nil
+}
+
+func (s *CommunityAnalysisServiceImpl) buildDependencyGraph(ctx context.Context, req domain.CommunityAnalysisRequest) (*analyzer.DependencyGraph, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("module graph cancelled: %w", err)
+	}
+
+	projectRoot := s.findProjectRoot(req.Paths)
+	options := &analyzer.ModuleAnalysisOptions{
+		ProjectRoot:       projectRoot,
+		IncludeStdLib:     req.IncludeStdLib,
+		IncludeThirdParty: req.IncludeThirdParty,
+		FollowRelative:    req.FollowRelative,
+		IncludePatterns:   req.IncludePatterns,
+		ExcludePatterns:   req.ExcludePatterns,
+	}
+
+	ma, err := analyzer.NewModuleAnalyzer(options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create module analyzer: %w", err)
+	}
+
+	graph, err := ma.AnalyzeFiles(req.Paths)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build module graph: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("module graph cancelled: %w", err)
+	}
+	return graph, nil
+}
+
+func (s *CommunityAnalysisServiceImpl) findProjectRoot(paths []string) string {
+	if len(paths) == 0 {
+		cwd, _ := os.Getwd()
+		return cwd
+	}
+
+	absPaths := make([]string, 0, len(paths))
+	for _, p := range paths {
+		absPath, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(absPath)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			absPath = filepath.Dir(absPath)
+		}
+		absPaths = append(absPaths, absPath)
+	}
+
+	if len(absPaths) == 0 {
+		cwd, _ := os.Getwd()
+		return cwd
+	}
+
+	common := absPaths[0]
+	for _, p := range absPaths[1:] {
+		common = longestCommonDir(common, p)
+	}
+	return common
+}
+
+func longestCommonDir(a, b string) string {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+
+	i := 0
+	for i < minLen && a[i] == b[i] {
+		i++
+	}
+
+	common := a[:i]
+	if common == "" {
+		return string(filepath.Separator)
+	}
+	if info, err := os.Stat(common); err != nil || !info.IsDir() {
+		return filepath.Dir(common)
+	}
+	return common
+}
+
+func (s *CommunityAnalysisServiceImpl) resolveAlgorithm(algorithm string) string {
+	if algorithm == "" {
+		return domain.DefaultCommunityAlgorithm
+	}
+	return algorithm
+}
+
+func (s *CommunityAnalysisServiceImpl) resolveScope(scope string) string {
+	if scope == "" {
+		return domain.DefaultCommunityScope
+	}
+	return scope
+}
+
+func (s *CommunityAnalysisServiceImpl) convertCommunities(partitions []analyzer.CommunityPartition) []domain.CommunityMetrics {
+	if len(partitions) == 0 {
+		return []domain.CommunityMetrics{}
+	}
+
+	out := make([]domain.CommunityMetrics, 0, len(partitions))
+	for _, partition := range partitions {
+		out = append(out, domain.CommunityMetrics{
+			ID:                          partition.ID,
+			Modules:                     append([]string(nil), partition.Modules...),
+			Packages:                    append([]string(nil), partition.Packages...),
+			InternalEdges:               partition.InternalEdges,
+			ExternalEdges:               partition.ExternalEdges,
+			ExternalDependencyRatio:     partition.ExternalDependencyRatio,
+			IncomingCrossCommunityEdges: partition.IncomingCrossCommunityEdges,
+			OutgoingCrossCommunityEdges: partition.OutgoingCrossCommunityEdges,
+			Size:                        partition.Size,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func (s *CommunityAnalysisServiceImpl) convertBridgeModules(bridges []analyzer.BridgeModuleMetrics) []domain.BridgeModule {
+	if len(bridges) == 0 {
+		return []domain.BridgeModule{}
+	}
+
+	out := make([]domain.BridgeModule, 0, len(bridges))
+	for _, bridge := range bridges {
+		out = append(out, domain.BridgeModule{
+			Module:              bridge.Module,
+			Community:           bridge.CommunityID,
+			CrossCommunityEdges: bridge.CrossCommunityEdges,
+			TargetCommunities:   append([]string(nil), bridge.TargetCommunities...),
+		})
+	}
+	return out
+}
+
+func (s *CommunityAnalysisServiceImpl) buildConfigForResponse(req domain.CommunityAnalysisRequest) any {
+	return map[string]any{
+		"algorithm":           s.resolveAlgorithm(req.Algorithm),
+		"scope":               s.resolveScope(req.Scope),
+		"minCommunitySize":    req.MinCommunitySize,
+		"includeLazyEdges":    domain.BoolValue(req.IncludeLazyEdges, true),
+		"reportBridgeModules": domain.BoolValue(req.ReportBridgeModules, true),
+		"resolution":          req.Resolution,
+		"includeStdLib":       domain.BoolValue(req.IncludeStdLib, false),
+		"includeThirdParty":   domain.BoolValue(req.IncludeThirdParty, true),
+		"followRelative":      domain.BoolValue(req.FollowRelative, true),
+	}
+}

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
@@ -78,7 +76,11 @@ func (s *CommunityAnalysisServiceImpl) buildDependencyGraph(ctx context.Context,
 		return nil, fmt.Errorf("module graph cancelled: %w", err)
 	}
 
-	projectRoot := s.findProjectRoot(req.Paths)
+	rootPaths := req.SourcePaths
+	if len(rootPaths) == 0 {
+		rootPaths = req.Paths
+	}
+	projectRoot := FindProjectRoot(rootPaths)
 	options := &analyzer.ModuleAnalysisOptions{
 		ProjectRoot:       projectRoot,
 		IncludeStdLib:     req.IncludeStdLib,
@@ -101,64 +103,6 @@ func (s *CommunityAnalysisServiceImpl) buildDependencyGraph(ctx context.Context,
 		return nil, fmt.Errorf("module graph cancelled: %w", err)
 	}
 	return graph, nil
-}
-
-func (s *CommunityAnalysisServiceImpl) findProjectRoot(paths []string) string {
-	if len(paths) == 0 {
-		cwd, _ := os.Getwd()
-		return cwd
-	}
-
-	absPaths := make([]string, 0, len(paths))
-	for _, p := range paths {
-		absPath, err := filepath.Abs(p)
-		if err != nil {
-			continue
-		}
-		info, err := os.Stat(absPath)
-		if err != nil {
-			continue
-		}
-		if !info.IsDir() {
-			absPath = filepath.Dir(absPath)
-		}
-		absPaths = append(absPaths, absPath)
-	}
-
-	if len(absPaths) == 0 {
-		cwd, _ := os.Getwd()
-		return cwd
-	}
-
-	common := absPaths[0]
-	for _, p := range absPaths[1:] {
-		common = longestCommonDir(common, p)
-	}
-	return common
-}
-
-func longestCommonDir(a, b string) string {
-	a = filepath.Clean(a)
-	b = filepath.Clean(b)
-
-	minLen := len(a)
-	if len(b) < minLen {
-		minLen = len(b)
-	}
-
-	i := 0
-	for i < minLen && a[i] == b[i] {
-		i++
-	}
-
-	common := a[:i]
-	if common == "" {
-		return string(filepath.Separator)
-	}
-	if info, err := os.Stat(common); err != nil || !info.IsDir() {
-		return filepath.Dir(common)
-	}
-	return common
 }
 
 func (s *CommunityAnalysisServiceImpl) resolveAlgorithm(algorithm string) string {

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,4 +33,26 @@ func TestCommunityAnalysisService_Analyze_FixtureProject(t *testing.T) {
 	assert.Greater(t, result.TotalCommunities, 0)
 	assert.NotEmpty(t, result.Communities)
 	assert.GreaterOrEqual(t, result.Modularity, 0.0)
+}
+
+func TestCommunityAnalysisService_Analyze_UsesSourcePathsForProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "src", "myapp")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[project]\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "__init__.py"), []byte(""), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "service.py"), []byte("from myapp import repo\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "repo.py"), []byte("pass\n"), 0o644))
+
+	fileA := filepath.Join(srcDir, "service.py")
+	fileB := filepath.Join(srcDir, "repo.py")
+
+	service := NewCommunityAnalysisService()
+	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
+		Paths:       []string{fileA, fileB},
+		SourcePaths: []string{srcDir},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Greater(t, result.TotalCommunities, 0)
 }

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommunityAnalysisService_Analyze_FixtureProject(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "hexagonal_ports"))
+	require.NoError(t, err)
+
+	fileReader := NewFileReader()
+	files, err := fileReader.CollectPythonFiles([]string{fixtureRoot}, true, nil, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	service := NewCommunityAnalysisService()
+	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
+		Paths:        files,
+		OutputFormat: domain.OutputFormatJSON,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "leiden", result.Algorithm)
+	assert.Equal(t, "module", result.Scope)
+	assert.Greater(t, result.TotalCommunities, 0)
+	assert.NotEmpty(t, result.Communities)
+	assert.GreaterOrEqual(t, result.Modularity, 0.0)
+}

--- a/service/community_formatter.go
+++ b/service/community_formatter.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/ludo-technologies/pyscn/domain"
+)
+
+// CommunityFormatter is a placeholder formatter until dedicated output lands in #584.
+type CommunityFormatter struct{}
+
+// NewCommunityFormatter creates a community analysis formatter.
+func NewCommunityFormatter() *CommunityFormatter {
+	return &CommunityFormatter{}
+}
+
+// Format returns a minimal text summary of community analysis results.
+func (f *CommunityFormatter) Format(response *domain.CommunityAnalysisResult, format domain.OutputFormat) (string, error) {
+	if response == nil {
+		return "", fmt.Errorf("community analysis result is nil")
+	}
+
+	switch format {
+	case domain.OutputFormatText:
+		return fmt.Sprintf(
+			"Community analysis: %d communities (modularity %.3f, algorithm %s)\n",
+			response.TotalCommunities,
+			response.Modularity,
+			response.Algorithm,
+		), nil
+	default:
+		return "", fmt.Errorf("community formatter does not yet support format %s", format)
+	}
+}
+
+// Write formats and writes community analysis output.
+func (f *CommunityFormatter) Write(response *domain.CommunityAnalysisResult, format domain.OutputFormat, writer io.Writer) error {
+	content, err := f.Format(response, format)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(writer, content)
+	return err
+}

--- a/service/project_root.go
+++ b/service/project_root.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FindProjectRoot locates the project root from the given paths by finding their
+// common parent and walking upward for standard Python project markers.
+func FindProjectRoot(paths []string) string {
+	if len(paths) == 0 {
+		cwd, _ := os.Getwd()
+		return cwd
+	}
+
+	absPaths := make([]string, 0, len(paths))
+	for _, p := range paths {
+		absPath, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+
+		info, err := os.Stat(absPath)
+		if err == nil && !info.IsDir() {
+			absPath = filepath.Dir(absPath)
+		}
+
+		absPaths = append(absPaths, absPath)
+	}
+
+	if len(absPaths) == 0 {
+		cwd, _ := os.Getwd()
+		return cwd
+	}
+
+	commonParent := absPaths[0]
+	for _, path := range absPaths[1:] {
+		for !strings.HasPrefix(path, commonParent) {
+			commonParent = filepath.Dir(commonParent)
+			if commonParent == "/" || commonParent == "." {
+				break
+			}
+		}
+	}
+
+	for {
+		markers := []string{"setup.py", "pyproject.toml", "setup.cfg", ".git", "requirements.txt"}
+		for _, marker := range markers {
+			if _, err := os.Stat(filepath.Join(commonParent, marker)); err == nil {
+				return commonParent
+			}
+		}
+
+		parent := filepath.Dir(commonParent)
+		if parent == commonParent || parent == "/" || parent == "." {
+			break
+		}
+
+		if !strings.HasPrefix(absPaths[0], parent) {
+			break
+		}
+
+		commonParent = parent
+	}
+
+	return commonParent
+}

--- a/service/project_root_test.go
+++ b/service/project_root_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindProjectRoot_FromSubpackageFiles(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "src", "myapp")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[project]\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.py"), []byte("pass\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "b.py"), []byte("pass\n"), 0o644))
+
+	got := FindProjectRoot([]string{
+		filepath.Join(srcDir, "a.py"),
+		filepath.Join(srcDir, "b.py"),
+	})
+	assert.Equal(t, root, got)
+}
+
+func TestFindProjectRoot_FromSiblingPackages(t *testing.T) {
+	root := t.TempDir()
+	pkgA := filepath.Join(root, "src", "pkg_a")
+	pkgB := filepath.Join(root, "src", "pkg_b")
+	require.NoError(t, os.MkdirAll(pkgA, 0o755))
+	require.NoError(t, os.MkdirAll(pkgB, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[project]\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgA, "a.py"), []byte("pass\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgB, "b.py"), []byte("pass\n"), 0o644))
+
+	got := FindProjectRoot([]string{
+		filepath.Join(pkgA, "a.py"),
+		filepath.Join(pkgB, "b.py"),
+	})
+	assert.Equal(t, root, got)
+}

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -545,7 +543,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyGraph(ctx context.Context, re
 		return nil, fmt.Errorf("module graph cancelled: %w", err)
 	}
 
-	projectRoot := s.findProjectRoot(req.Paths)
+	projectRoot := FindProjectRoot(req.Paths)
 	options := &analyzer.ModuleAnalysisOptions{
 		ProjectRoot:       projectRoot,
 		IncludeStdLib:     req.IncludeStdLib,
@@ -1326,74 +1324,6 @@ func (s *SystemAnalysisServiceImpl) toLayerViolations(vs []domain.ArchitectureVi
 }
 
 // Helper methods
-
-// findProjectRoot finds the common parent directory of all given paths
-func (s *SystemAnalysisServiceImpl) findProjectRoot(paths []string) string {
-	if len(paths) == 0 {
-		cwd, _ := os.Getwd()
-		return cwd
-	}
-
-	// Get absolute paths
-	absPaths := make([]string, 0, len(paths))
-	for _, p := range paths {
-		absPath, err := filepath.Abs(p)
-		if err != nil {
-			continue
-		}
-
-		// If it's a file, get its directory
-		info, err := os.Stat(absPath)
-		if err == nil && !info.IsDir() {
-			absPath = filepath.Dir(absPath)
-		}
-
-		absPaths = append(absPaths, absPath)
-	}
-
-	if len(absPaths) == 0 {
-		cwd, _ := os.Getwd()
-		return cwd
-	}
-
-	// Find common parent
-	commonParent := absPaths[0]
-	for _, path := range absPaths[1:] {
-		for !strings.HasPrefix(path, commonParent) {
-			commonParent = filepath.Dir(commonParent)
-			if commonParent == "/" || commonParent == "." {
-				break
-			}
-		}
-	}
-
-	// If common parent has __init__.py, it's a Python package root
-	// Otherwise, look for common markers like setup.py, pyproject.toml, etc.
-	for {
-		// Check for Python project markers
-		markers := []string{"setup.py", "pyproject.toml", "setup.cfg", ".git", "requirements.txt"}
-		for _, marker := range markers {
-			if _, err := os.Stat(filepath.Join(commonParent, marker)); err == nil {
-				return commonParent
-			}
-		}
-
-		// Check if we've reached the root
-		parent := filepath.Dir(commonParent)
-		if parent == commonParent || parent == "/" || parent == "." {
-			break
-		}
-
-		// Don't go above the original common parent too much
-		if !strings.HasPrefix(absPaths[0], parent) {
-			break
-		}
-
-		commonParent = parent
-	}
-
-	return commonParent
-}
 
 func (s *SystemAnalysisServiceImpl) buildDependencyMatrix(graph *analyzer.DependencyGraph) map[string]map[string]bool {
 	matrix := make(map[string]map[string]bool)


### PR DESCRIPTION
Closes #582

## Summary

Wires community detection into the Clean Architecture layers, following the LCOM/system analysis patterns. This is Phase 1 wiring for the communities epic (#564).

## Changes

- **`domain/community.go`**: `CommunityAnalysisRequest`, `CommunityAnalysisResult`, metrics/bridge types, and service/config/formatter interfaces
- **`internal/analyzer/community_metrics.go`**: per-community and bridge-module metrics (implements #581 dependency required by the service)
- **`service/community_analysis_service.go`**: builds module dependency graph, runs Leiden, computes metrics
- **`app/community_usecase.go`**: `CommunityUseCase` + builder with `AnalyzeAndReturn()`
- **`app/analyze_usecase.go`**: `WithCommunityUseCase()`, `taskNameCommunities` gated on `SkipCommunities`
- **`domain/analyze.go`**: `AnalyzeResponse.Communities` and `Summary.CommunitiesEnabled`

## Acceptance

- [x] `CommunityUseCase` produces a populated `CommunityAnalysisResult` for fixture projects (`mvc_app`, `hexagonal_ports`)
- [x] Wiring compiles and the analyze pipeline runs the new task when `SkipCommunities=false`
- [x] `make fmt`, `make lint`, `make test` pass

## Out of scope (follow-up issues)

- CLI `--select communities` + config (#583)
- JSON/text/HTML formatters (#584, #585)