### PR TITLE
[communities] CLI --select communities + [communities] config (opt-in)

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -23,6 +23,11 @@ type AnalyzeUseCaseConfig struct {
 	SkipSystem      bool
 	SkipCommunities bool
 
+	// SelectAnalysesUsed is true when --select was provided on the CLI.
+	SelectAnalysesUsed bool
+	// SkipCommunitiesExplicit is true when --skip-communities was provided.
+	SkipCommunitiesExplicit bool
+
 	MinComplexity   int
 	MinSeverity     domain.DeadCodeSeverity
 	CloneSimilarity float64
@@ -230,6 +235,13 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 	}
 	if !executionCfg.SystemEnabled {
 		useCaseCfg.SkipSystem = true
+	}
+
+	if !useCaseCfg.SelectAnalysesUsed && executionCfg.CommunitiesEnabled {
+		useCaseCfg.SkipCommunities = false
+	}
+	if useCaseCfg.SkipCommunitiesExplicit {
+		useCaseCfg.SkipCommunities = true
 	}
 
 	// Validate and collect files using configured patterns

--- a/app/analyze_usecase_community_test.go
+++ b/app/analyze_usecase_community_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -48,6 +49,98 @@ func TestAnalyzeUseCase_CommunityTask(t *testing.T) {
 	require.NotNil(t, response.Communities)
 	assert.Greater(t, response.Communities.TotalCommunities, 0)
 	assert.NotEmpty(t, response.Communities.Communities)
+}
+
+func TestAnalyzeUseCase_CommunityEnabledFromConfig(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
+	require.NoError(t, err)
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, ".pyscn.toml")
+	configContent := `[communities]
+enabled = true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+	communityUC, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		WithConfigLoader(service.NewCommunityConfigurationLoader()).
+		Build()
+	require.NoError(t, err)
+
+	useCase, err := NewAnalyzeUseCaseBuilder().
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithConfigLoader(service.NewAnalyzeConfigurationLoader()).
+		WithCommunityUseCase(communityUC).
+		Build()
+	require.NoError(t, err)
+
+	config := AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: true,
+		ConfigFile:      configPath,
+	}
+
+	response, err := useCase.Execute(context.Background(), config, []string{fixtureRoot})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	assert.True(t, response.Summary.CommunitiesEnabled)
+	require.NotNil(t, response.Communities)
+}
+
+func TestAnalyzeUseCase_CommunityConfigSkippedWhenSelectOmitsCommunities(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
+	require.NoError(t, err)
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, ".pyscn.toml")
+	configContent := `[communities]
+enabled = true
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+	communityUC, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		Build()
+	require.NoError(t, err)
+
+	useCase, err := NewAnalyzeUseCaseBuilder().
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithConfigLoader(service.NewAnalyzeConfigurationLoader()).
+		WithCommunityUseCase(communityUC).
+		Build()
+	require.NoError(t, err)
+
+	config := AnalyzeUseCaseConfig{
+		SkipComplexity:     true,
+		SkipDeadCode:       true,
+		SkipClones:         true,
+		SkipCBO:            true,
+		SkipLCOM:           true,
+		SkipSystem:         true,
+		SkipCommunities:    true,
+		SelectAnalysesUsed: true,
+		ConfigFile:         configPath,
+	}
+
+	response, err := useCase.Execute(context.Background(), config, []string{fixtureRoot})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	assert.False(t, response.Summary.CommunitiesEnabled)
+	assert.Nil(t, response.Communities)
 }
 
 func TestAnalyzeUseCase_CommunityTaskSkippedByDefault(t *testing.T) {

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -31,13 +31,14 @@ type AnalyzeCommand struct {
 	verbose    bool
 
 	// Analysis selection
-	skipComplexity bool
-	skipDeadCode   bool
-	skipClones     bool
-	skipCBO        bool
-	skipLCOM       bool
-	skipSystem     bool
-	selectAnalyses []string // Only run specified analyses
+	skipComplexity  bool
+	skipDeadCode    bool
+	skipClones      bool
+	skipCBO         bool
+	skipLCOM        bool
+	skipSystem      bool
+	skipCommunities bool
+	selectAnalyses  []string // Only run specified analyses
 
 	// Quick filters
 	minComplexity   int
@@ -131,6 +132,7 @@ Examples:
 	cmd.Flags().BoolVar(&c.skipCBO, "skip-cbo", false, "Skip class coupling (CBO) analysis")
 	cmd.Flags().BoolVar(&c.skipLCOM, "skip-lcom", false, "Skip class cohesion (LCOM4) analysis")
 	cmd.Flags().BoolVar(&c.skipSystem, "skip-deps", false, "Skip module dependencies and architecture analysis")
+	cmd.Flags().BoolVar(&c.skipCommunities, "skip-communities", false, "Skip module community detection (overrides config-enabled communities)")
 	cmd.Flags().StringSliceVar(&c.selectAnalyses, "select", []string{}, "Only run specified analyses (complexity,deadcode,clones,cbo,lcom,deps,communities)")
 
 	// Quick filter flags
@@ -197,13 +199,15 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 // createUseCaseConfig creates the use case configuration from command flags
 func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 	config := app.AnalyzeUseCaseConfig{
-		ConfigFile:      c.configFile,
-		Verbose:         c.verbose,
-		MinComplexity:   c.minComplexity,
-		CloneSimilarity: c.cloneSimilarity,
-		MinCBO:          c.minCBO,
-		EnableDFA:       c.enableDFA,
-		SkipCommunities: true, // opt-in until --select/config wiring (#583)
+		ConfigFile:              c.configFile,
+		Verbose:                 c.verbose,
+		MinComplexity:           c.minComplexity,
+		CloneSimilarity:         c.cloneSimilarity,
+		MinCBO:                  c.minCBO,
+		EnableDFA:               c.enableDFA,
+		SkipCommunities:         true, // opt-in: enable via --select communities or [communities] enabled=true
+		SelectAnalysesUsed:      len(c.selectAnalyses) > 0,
+		SkipCommunitiesExplicit: c.skipCommunities,
 	}
 
 	// Handle analysis selection
@@ -231,6 +235,9 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 	config.SkipCBO = config.SkipCBO || c.skipCBO
 	config.SkipLCOM = config.SkipLCOM || c.skipLCOM
 	config.SkipSystem = config.SkipSystem || c.skipSystem
+	if c.skipCommunities {
+		config.SkipCommunities = true
+	}
 
 	// Parse severity
 	switch c.minSeverity {
@@ -376,10 +383,12 @@ func (c *AnalyzeCommand) buildIndividualUseCases(builder *app.AnalyzeUseCaseBuil
 	// Community analysis use case
 	communityService := service.NewCommunityAnalysisService()
 	communityFormatter := service.NewCommunityFormatter()
+	communityConfigLoader := service.NewCommunityConfigurationLoader()
 	communityUseCase, err := app.NewCommunityUseCaseBuilder().
 		WithService(communityService).
 		WithFileReader(service.NewFileReader()).
 		WithFormatter(communityFormatter).
+		WithConfigLoader(communityConfigLoader).
 		Build()
 	if err != nil {
 		return fmt.Errorf("failed to build community analysis use case: %w", err)

--- a/cmd/pyscn/new_commands_test.go
+++ b/cmd/pyscn/new_commands_test.go
@@ -353,6 +353,33 @@ func TestAnalyzeCommandSelectCommunitiesEnablesAnalysis(t *testing.T) {
 	}
 }
 
+func TestAnalyzeCommandSelectDepsCommunities(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+	analyzeCmd.selectAnalyses = []string{"deps", "communities"}
+
+	config := analyzeCmd.createUseCaseConfig()
+	if config.SkipSystem {
+		t.Fatal("expected --select deps to enable system analysis")
+	}
+	if config.SkipCommunities {
+		t.Fatal("expected --select communities to enable community analysis")
+	}
+}
+
+func TestAnalyzeCommandSkipCommunitiesOverridesSelect(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+	analyzeCmd.selectAnalyses = []string{"communities"}
+	analyzeCmd.skipCommunities = true
+
+	config := analyzeCmd.createUseCaseConfig()
+	if !config.SkipCommunities {
+		t.Fatal("expected --skip-communities to disable community analysis")
+	}
+	if !config.SkipCommunitiesExplicit {
+		t.Fatal("expected skip-communities explicit flag to be set")
+	}
+}
+
 func TestAnalyzeCommandSelectComposesWithSkipFlags(t *testing.T) {
 	analyzeCmd := NewAnalyzeCommand()
 	analyzeCmd.selectAnalyses = []string{"complexity", "clones"}

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -38,6 +38,8 @@ type AnalyzeExecutionConfig struct {
 	SystemEnabled             bool
 	SystemAnalyzeDependencies bool
 	SystemAnalyzeArchitecture bool
+
+	CommunitiesEnabled bool
 }
 
 // AnalyzeConfigurationLoader resolves and loads configuration for AnalyzeUseCase.

--- a/internal/config/communities_config_test.go
+++ b/internal/config/communities_config_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+)
+
+func TestLoadCommunitiesFromPyscnToml(t *testing.T) {
+	tempDir := t.TempDir()
+
+	configContent := `[communities]
+enabled = true
+algorithm = "leiden"
+scope = "module"
+min_community_size = 3
+include_lazy_edges = false
+report_bridge_modules = false
+resolution = 0.75
+`
+	configPath := filepath.Join(tempDir, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	loader := NewTomlConfigLoader()
+	cfg, err := loader.LoadConfig(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if !domain.BoolValue(cfg.CommunitiesEnabled, false) {
+		t.Errorf("Expected enabled true, got %v", cfg.CommunitiesEnabled)
+	}
+	if cfg.CommunitiesAlgorithm != "leiden" {
+		t.Errorf("Expected algorithm leiden, got %q", cfg.CommunitiesAlgorithm)
+	}
+	if cfg.CommunitiesScope != "module" {
+		t.Errorf("Expected scope module, got %q", cfg.CommunitiesScope)
+	}
+	if cfg.CommunitiesMinCommunitySize != 3 {
+		t.Errorf("Expected min_community_size 3, got %d", cfg.CommunitiesMinCommunitySize)
+	}
+	if domain.BoolValue(cfg.CommunitiesIncludeLazyEdges, true) {
+		t.Errorf("Expected include_lazy_edges false, got %v", cfg.CommunitiesIncludeLazyEdges)
+	}
+	if domain.BoolValue(cfg.CommunitiesReportBridgeModules, true) {
+		t.Errorf("Expected report_bridge_modules false, got %v", cfg.CommunitiesReportBridgeModules)
+	}
+	if cfg.CommunitiesResolution != 0.75 {
+		t.Errorf("Expected resolution 0.75, got %f", cfg.CommunitiesResolution)
+	}
+}
+
+func TestLoadCommunitiesFromPyscnTomlPartial(t *testing.T) {
+	tempDir := t.TempDir()
+
+	configContent := `[communities]
+enabled = true
+min_community_size = 4
+`
+	configPath := filepath.Join(tempDir, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	loader := NewTomlConfigLoader()
+	cfg, err := loader.LoadConfig(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if !domain.BoolValue(cfg.CommunitiesEnabled, false) {
+		t.Errorf("Expected enabled true, got %v", cfg.CommunitiesEnabled)
+	}
+	if cfg.CommunitiesMinCommunitySize != 4 {
+		t.Errorf("Expected min_community_size 4, got %d", cfg.CommunitiesMinCommunitySize)
+	}
+	if cfg.CommunitiesAlgorithm != domain.DefaultCommunityAlgorithm {
+		t.Errorf("Expected default algorithm %q, got %q", domain.DefaultCommunityAlgorithm, cfg.CommunitiesAlgorithm)
+	}
+	if cfg.CommunitiesScope != domain.DefaultCommunityScope {
+		t.Errorf("Expected default scope %q, got %q", domain.DefaultCommunityScope, cfg.CommunitiesScope)
+	}
+	if !domain.BoolValue(cfg.CommunitiesIncludeLazyEdges, false) {
+		t.Errorf("Expected default include_lazy_edges true, got %v", cfg.CommunitiesIncludeLazyEdges)
+	}
+	if !domain.BoolValue(cfg.CommunitiesReportBridgeModules, false) {
+		t.Errorf("Expected default report_bridge_modules true, got %v", cfg.CommunitiesReportBridgeModules)
+	}
+	if cfg.CommunitiesResolution != domain.DefaultCommunityResolution {
+		t.Errorf("Expected default resolution %f, got %f", domain.DefaultCommunityResolution, cfg.CommunitiesResolution)
+	}
+}
+
+func TestMergeCommunitiesSection(t *testing.T) {
+	cfg := DefaultPyscnConfig()
+
+	communities := CommunitiesTomlConfig{
+		Enabled:             boolPtr(true),
+		Algorithm:           "leiden",
+		Scope:               "module",
+		MinCommunitySize:    intPtr(5),
+		IncludeLazyEdges:    boolPtr(false),
+		ReportBridgeModules: boolPtr(false),
+		Resolution:          float64Ptr(1.5),
+	}
+
+	mergeCommunitiesSection(cfg, &communities)
+
+	if !domain.BoolValue(cfg.CommunitiesEnabled, false) {
+		t.Errorf("Expected enabled true, got %v", cfg.CommunitiesEnabled)
+	}
+	if cfg.CommunitiesAlgorithm != "leiden" {
+		t.Errorf("Expected algorithm leiden, got %q", cfg.CommunitiesAlgorithm)
+	}
+	if cfg.CommunitiesScope != "module" {
+		t.Errorf("Expected scope module, got %q", cfg.CommunitiesScope)
+	}
+	if cfg.CommunitiesMinCommunitySize != 5 {
+		t.Errorf("Expected min_community_size 5, got %d", cfg.CommunitiesMinCommunitySize)
+	}
+	if domain.BoolValue(cfg.CommunitiesIncludeLazyEdges, true) {
+		t.Errorf("Expected include_lazy_edges false, got %v", cfg.CommunitiesIncludeLazyEdges)
+	}
+	if domain.BoolValue(cfg.CommunitiesReportBridgeModules, true) {
+		t.Errorf("Expected report_bridge_modules false, got %v", cfg.CommunitiesReportBridgeModules)
+	}
+	if cfg.CommunitiesResolution != 1.5 {
+		t.Errorf("Expected resolution 1.5, got %f", cfg.CommunitiesResolution)
+	}
+}
+
+func TestMergeCommunitiesSectionNilValues(t *testing.T) {
+	cfg := DefaultPyscnConfig()
+	originalAlgorithm := cfg.CommunitiesAlgorithm
+
+	communities := CommunitiesTomlConfig{}
+	mergeCommunitiesSection(cfg, &communities)
+
+	if cfg.CommunitiesAlgorithm != originalAlgorithm {
+		t.Errorf("Expected defaults to remain, got algorithm %q", cfg.CommunitiesAlgorithm)
+	}
+	if domain.BoolValue(cfg.CommunitiesEnabled, true) {
+		t.Error("Expected communities to remain disabled by default")
+	}
+}
+
+func TestDefaultPyscnConfigCommunitiesDefaults(t *testing.T) {
+	cfg := DefaultPyscnConfig()
+
+	if domain.BoolValue(cfg.CommunitiesEnabled, true) {
+		t.Error("Expected communities disabled by default")
+	}
+	if cfg.CommunitiesAlgorithm != domain.DefaultCommunityAlgorithm {
+		t.Errorf("Expected algorithm %q, got %q", domain.DefaultCommunityAlgorithm, cfg.CommunitiesAlgorithm)
+	}
+	if cfg.CommunitiesScope != domain.DefaultCommunityScope {
+		t.Errorf("Expected scope %q, got %q", domain.DefaultCommunityScope, cfg.CommunitiesScope)
+	}
+	if cfg.CommunitiesMinCommunitySize != 2 {
+		t.Errorf("Expected min_community_size 2, got %d", cfg.CommunitiesMinCommunitySize)
+	}
+	if !domain.BoolValue(cfg.CommunitiesIncludeLazyEdges, false) {
+		t.Error("Expected include_lazy_edges true by default")
+	}
+	if !domain.BoolValue(cfg.CommunitiesReportBridgeModules, false) {
+		t.Error("Expected report_bridge_modules true by default")
+	}
+	if cfg.CommunitiesResolution != domain.DefaultCommunityResolution {
+		t.Errorf("Expected resolution %f, got %f", domain.DefaultCommunityResolution, cfg.CommunitiesResolution)
+	}
+}
+
+func float64Ptr(val float64) *float64 {
+	return &val
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,9 @@ type Config struct {
 	// Dependencies holds dependency analysis configuration
 	Dependencies DependencyAnalysisConfig `mapstructure:"dependencies" yaml:"dependencies"`
 
+	// Communities holds module community detection configuration
+	Communities CommunitiesConfig `mapstructure:"communities" yaml:"communities"`
+
 	// Architecture holds architecture validation configuration
 	Architecture ArchitectureConfig `mapstructure:"architecture" yaml:"architecture"`
 
@@ -194,6 +197,17 @@ func DefaultConfig() *Config {
 			UseClonesData:         true,
 			UseDeadCodeData:       true,
 			GenerateUnifiedReport: true,
+		},
+
+		// Community detection configuration
+		Communities: CommunitiesConfig{
+			Enabled:             false,
+			Algorithm:           domain.DefaultCommunityAlgorithm,
+			Scope:               domain.DefaultCommunityScope,
+			MinCommunitySize:    2,
+			IncludeLazyEdges:    true,
+			ReportBridgeModules: true,
+			Resolution:          domain.DefaultCommunityResolution,
 		},
 
 		// Dependency analysis configuration
@@ -415,6 +429,29 @@ func PyscnConfigToConfig(pyscn *PyscnConfig) *Config {
 	}
 	if pyscn.SystemAnalysisGenerateUnifiedReport != nil {
 		cfg.SystemAnalysis.GenerateUnifiedReport = *pyscn.SystemAnalysisGenerateUnifiedReport
+	}
+
+	// Communities settings
+	if pyscn.CommunitiesEnabled != nil {
+		cfg.Communities.Enabled = *pyscn.CommunitiesEnabled
+	}
+	if pyscn.CommunitiesAlgorithm != "" {
+		cfg.Communities.Algorithm = pyscn.CommunitiesAlgorithm
+	}
+	if pyscn.CommunitiesScope != "" {
+		cfg.Communities.Scope = pyscn.CommunitiesScope
+	}
+	if pyscn.CommunitiesMinCommunitySize > 0 {
+		cfg.Communities.MinCommunitySize = pyscn.CommunitiesMinCommunitySize
+	}
+	if pyscn.CommunitiesIncludeLazyEdges != nil {
+		cfg.Communities.IncludeLazyEdges = *pyscn.CommunitiesIncludeLazyEdges
+	}
+	if pyscn.CommunitiesReportBridgeModules != nil {
+		cfg.Communities.ReportBridgeModules = *pyscn.CommunitiesReportBridgeModules
+	}
+	if pyscn.CommunitiesResolution > 0 {
+		cfg.Communities.Resolution = pyscn.CommunitiesResolution
 	}
 
 	// Dependencies settings
@@ -805,6 +842,17 @@ type SystemAnalysisConfig struct {
 
 	// Output options
 	GenerateUnifiedReport bool `mapstructure:"generate_unified_report" yaml:"generate_unified_report"`
+}
+
+// CommunitiesConfig holds configuration for module community detection
+type CommunitiesConfig struct {
+	Enabled             bool    `mapstructure:"enabled" yaml:"enabled"`
+	Algorithm           string  `mapstructure:"algorithm" yaml:"algorithm"`
+	Scope               string  `mapstructure:"scope" yaml:"scope"`
+	MinCommunitySize    int     `mapstructure:"min_community_size" yaml:"min_community_size"`
+	IncludeLazyEdges    bool    `mapstructure:"include_lazy_edges" yaml:"include_lazy_edges"`
+	ReportBridgeModules bool    `mapstructure:"report_bridge_modules" yaml:"report_bridge_modules"`
+	Resolution          float64 `mapstructure:"resolution" yaml:"resolution"`
 }
 
 // DependencyAnalysisConfig holds configuration for dependency analysis

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -28,6 +28,7 @@ type PyprojectPyscnSection struct {
 	Architecture   ArchitectureTomlConfig   `toml:"architecture"`
 	SystemAnalysis SystemAnalysisTomlConfig `toml:"system_analysis"`
 	Dependencies   DependenciesTomlConfig   `toml:"dependencies"`
+	Communities    CommunitiesTomlConfig    `toml:"communities"`
 	Clones         ClonesConfig             `toml:"clones"`
 	DI             DITomlConfig             `toml:"di"`
 }
@@ -78,6 +79,7 @@ func loadPyprojectConfigData(data []byte) (*PyscnConfig, error) {
 	mergeArchitectureSection(config, &pyproject.Tool.Pyscn.Architecture)
 	mergeSystemAnalysisSection(config, &pyproject.Tool.Pyscn.SystemAnalysis)
 	mergeDependenciesSection(config, &pyproject.Tool.Pyscn.Dependencies)
+	mergeCommunitiesSection(config, &pyproject.Tool.Pyscn.Communities)
 	mergeClonesSection(config, &pyproject.Tool.Pyscn.Clones)
 	mergeDISection(config, &pyproject.Tool.Pyscn.DI)
 
@@ -474,6 +476,31 @@ func mergeSystemAnalysisSection(defaults *PyscnConfig, sa *SystemAnalysisTomlCon
 	}
 	if sa.GenerateUnifiedReport != nil {
 		defaults.SystemAnalysisGenerateUnifiedReport = sa.GenerateUnifiedReport
+	}
+}
+
+// mergeCommunitiesSection merges settings from the [communities] section
+func mergeCommunitiesSection(defaults *PyscnConfig, communities *CommunitiesTomlConfig) {
+	if communities.Enabled != nil {
+		defaults.CommunitiesEnabled = communities.Enabled
+	}
+	if communities.Algorithm != "" {
+		defaults.CommunitiesAlgorithm = communities.Algorithm
+	}
+	if communities.Scope != "" {
+		defaults.CommunitiesScope = communities.Scope
+	}
+	if communities.MinCommunitySize != nil {
+		defaults.CommunitiesMinCommunitySize = *communities.MinCommunitySize
+	}
+	if communities.IncludeLazyEdges != nil {
+		defaults.CommunitiesIncludeLazyEdges = communities.IncludeLazyEdges
+	}
+	if communities.ReportBridgeModules != nil {
+		defaults.CommunitiesReportBridgeModules = communities.ReportBridgeModules
+	}
+	if communities.Resolution != nil {
+		defaults.CommunitiesResolution = *communities.Resolution
 	}
 }
 

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -119,6 +119,15 @@ type PyscnConfig struct {
 	SystemAnalysisUseDeadCodeData       *bool `mapstructure:"system_analysis_use_dead_code_data" yaml:"system_analysis_use_dead_code_data" json:"system_analysis_use_dead_code_data"`
 	SystemAnalysisGenerateUnifiedReport *bool `mapstructure:"system_analysis_generate_unified_report" yaml:"system_analysis_generate_unified_report" json:"system_analysis_generate_unified_report"`
 
+	// Communities Configuration (from [communities] section in TOML)
+	CommunitiesEnabled             *bool   `mapstructure:"communities_enabled" yaml:"communities_enabled" json:"communities_enabled"`
+	CommunitiesAlgorithm           string  `mapstructure:"communities_algorithm" yaml:"communities_algorithm" json:"communities_algorithm"`
+	CommunitiesScope               string  `mapstructure:"communities_scope" yaml:"communities_scope" json:"communities_scope"`
+	CommunitiesMinCommunitySize    int     `mapstructure:"communities_min_community_size" yaml:"communities_min_community_size" json:"communities_min_community_size"`
+	CommunitiesIncludeLazyEdges    *bool   `mapstructure:"communities_include_lazy_edges" yaml:"communities_include_lazy_edges" json:"communities_include_lazy_edges"`
+	CommunitiesReportBridgeModules *bool   `mapstructure:"communities_report_bridge_modules" yaml:"communities_report_bridge_modules" json:"communities_report_bridge_modules"`
+	CommunitiesResolution          float64 `mapstructure:"communities_resolution" yaml:"communities_resolution" json:"communities_resolution"`
+
 	// Dependencies Configuration (from [dependencies] section in TOML)
 	DependenciesEnabled           *bool   `mapstructure:"dependencies_enabled" yaml:"dependencies_enabled" json:"dependencies_enabled"`
 	DependenciesIncludeStdLib     *bool   `mapstructure:"dependencies_include_stdlib" yaml:"dependencies_include_stdlib" json:"dependencies_include_stdlib"`
@@ -418,6 +427,15 @@ func DefaultPyscnConfig() *PyscnConfig {
 		SystemAnalysisUseClonesData:         domain.BoolPtr(true),
 		SystemAnalysisUseDeadCodeData:       domain.BoolPtr(true),
 		SystemAnalysisGenerateUnifiedReport: domain.BoolPtr(true),
+
+		// Communities defaults (from [communities] section)
+		CommunitiesEnabled:             domain.BoolPtr(false), // Disabled by default - opt-in
+		CommunitiesAlgorithm:           domain.DefaultCommunityAlgorithm,
+		CommunitiesScope:               domain.DefaultCommunityScope,
+		CommunitiesMinCommunitySize:    2,
+		CommunitiesIncludeLazyEdges:    domain.BoolPtr(true),
+		CommunitiesReportBridgeModules: domain.BoolPtr(true),
+		CommunitiesResolution:          domain.DefaultCommunityResolution,
 
 		// Dependencies defaults (from [dependencies] section)
 		DependenciesEnabled:           domain.BoolPtr(false), // Disabled by default - opt-in

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -20,6 +20,7 @@ type PyscnTomlConfig struct {
 	Architecture   ArchitectureTomlConfig   `toml:"architecture"`    // [architecture] section
 	SystemAnalysis SystemAnalysisTomlConfig `toml:"system_analysis"` // [system_analysis] section
 	Dependencies   DependenciesTomlConfig   `toml:"dependencies"`    // [dependencies] section
+	Communities    CommunitiesTomlConfig    `toml:"communities"`     // [communities] section
 	Clones         ClonesConfig             `toml:"clones"`          // [clones] section - unified flat structure
 	MockData       MockDataTomlConfig       `toml:"mock_data"`       // [mock_data] section
 	DI             DITomlConfig             `toml:"di"`              // [di] section
@@ -146,6 +147,17 @@ type SystemAnalysisTomlConfig struct {
 	UseClonesData         *bool `toml:"use_clones_data"`
 	UseDeadCodeData       *bool `toml:"use_dead_code_data"`
 	GenerateUnifiedReport *bool `toml:"generate_unified_report"`
+}
+
+// CommunitiesTomlConfig represents the [communities] section
+type CommunitiesTomlConfig struct {
+	Enabled             *bool    `toml:"enabled"`
+	Algorithm           string   `toml:"algorithm"`
+	Scope               string   `toml:"scope"`
+	MinCommunitySize    *int     `toml:"min_community_size"`
+	IncludeLazyEdges    *bool    `toml:"include_lazy_edges"`
+	ReportBridgeModules *bool    `toml:"report_bridge_modules"`
+	Resolution          *float64 `toml:"resolution"`
 }
 
 // DependenciesTomlConfig represents the [dependencies] section
@@ -507,6 +519,9 @@ func (l *TomlConfigLoader) mergePyscnTomlConfigs(defaults *PyscnConfig, pyscnTom
 
 	// Merge from [dependencies] section
 	mergeDependenciesSection(defaults, &pyscnToml.Dependencies)
+
+	// Merge from [communities] section
+	mergeCommunitiesSection(defaults, &pyscnToml.Communities)
 
 	// Merge from [clones] section (unified flat structure)
 	mergeClonesSection(defaults, &pyscnToml.Clones)

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -53,6 +53,7 @@ type analyzeEnabledOverrides struct {
 	SystemAnalyzeArchitecture *bool
 	DependenciesEnabled       *bool
 	ArchitectureEnabled       *bool
+	CommunitiesEnabled        *bool
 }
 
 func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
@@ -78,6 +79,7 @@ func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
 		SystemEnabled:                true,
 		SystemAnalyzeDependencies:    true,
 		SystemAnalyzeArchitecture:    true,
+		CommunitiesEnabled:           false,
 	}
 }
 
@@ -115,8 +117,19 @@ func analyzeExecutionConfigFromConfig(cfg *config.Config, overrides analyzeEnabl
 	}
 
 	applySystemEnabledOverrides(&executionCfg, overrides)
+	applyCommunitiesEnabledOverrides(&executionCfg, overrides, cfg)
 
 	return executionCfg
+}
+
+func applyCommunitiesEnabledOverrides(executionCfg *domain.AnalyzeExecutionConfig, overrides analyzeEnabledOverrides, cfg *config.Config) {
+	if overrides.CommunitiesEnabled != nil {
+		executionCfg.CommunitiesEnabled = *overrides.CommunitiesEnabled
+		return
+	}
+	if cfg != nil {
+		executionCfg.CommunitiesEnabled = cfg.Communities.Enabled
+	}
 }
 
 func applySystemEnabledOverrides(executionCfg *domain.AnalyzeExecutionConfig, overrides analyzeEnabledOverrides) {
@@ -174,6 +187,7 @@ func loadAnalyzeEnabledOverrides(configPath string) (analyzeEnabledOverrides, er
 			parsed.Tool.Pyscn.SystemAnalysis,
 			parsed.Tool.Pyscn.Dependencies,
 			parsed.Tool.Pyscn.Architecture,
+			parsed.Tool.Pyscn.Communities,
 		), nil
 	}
 
@@ -181,15 +195,16 @@ func loadAnalyzeEnabledOverrides(configPath string) (analyzeEnabledOverrides, er
 	if err := toml.Unmarshal(data, &parsed); err != nil {
 		return analyzeEnabledOverrides{}, err
 	}
-	return enabledOverridesFromSections(parsed.SystemAnalysis, parsed.Dependencies, parsed.Architecture), nil
+	return enabledOverridesFromSections(parsed.SystemAnalysis, parsed.Dependencies, parsed.Architecture, parsed.Communities), nil
 }
 
-func enabledOverridesFromSections(system config.SystemAnalysisTomlConfig, dependencies config.DependenciesTomlConfig, architecture config.ArchitectureTomlConfig) analyzeEnabledOverrides {
+func enabledOverridesFromSections(system config.SystemAnalysisTomlConfig, dependencies config.DependenciesTomlConfig, architecture config.ArchitectureTomlConfig, communities config.CommunitiesTomlConfig) analyzeEnabledOverrides {
 	return analyzeEnabledOverrides{
 		SystemEnabled:             system.Enabled,
 		SystemAnalyzeDependencies: system.EnableDependencies,
 		SystemAnalyzeArchitecture: system.EnableArchitecture,
 		DependenciesEnabled:       dependencies.Enabled,
 		ArchitectureEnabled:       architecture.Enabled,
+		CommunitiesEnabled:        communities.Enabled,
 	}
 }

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -41,6 +41,9 @@ func TestAnalyzeConfigurationLoader_LoadAnalyzeExecutionConfig(t *testing.T) {
 		if !cfg.SystemAnalyzeArchitecture {
 			t.Error("expected architecture analysis enabled by default")
 		}
+		if cfg.CommunitiesEnabled {
+			t.Error("expected communities disabled by default")
+		}
 		defaultCloneReq := domain.DefaultCloneRequest()
 		if cfg.CloneLSHEnabled != defaultCloneReq.LSHEnabled {
 			t.Errorf("expected default LSH enabled %q, got %q", defaultCloneReq.LSHEnabled, cfg.CloneLSHEnabled)
@@ -144,6 +147,25 @@ lsh_auto_threshold = 123
 		}
 		if cfg.CloneLSHAutoThreshold != 123 {
 			t.Errorf("expected LSH threshold 123, got %d", cfg.CloneLSHAutoThreshold)
+		}
+	})
+
+	t.Run("loads communities enabled setting from config", func(t *testing.T) {
+		projectDir := t.TempDir()
+		configPath := filepath.Join(projectDir, ".pyscn.toml")
+		configContent := `[communities]
+enabled = true
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		cfg, err := loader.LoadAnalyzeExecutionConfig("", projectDir)
+		if err != nil {
+			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
+		}
+		if !cfg.CommunitiesEnabled {
+			t.Error("expected communities enabled from config")
 		}
 	})
 

--- a/service/community_config_loader.go
+++ b/service/community_config_loader.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/config"
+)
+
+// CommunityConfigurationLoaderImpl implements domain.CommunityConfigurationLoader.
+type CommunityConfigurationLoaderImpl struct{}
+
+// NewCommunityConfigurationLoader creates a new community configuration loader.
+func NewCommunityConfigurationLoader() *CommunityConfigurationLoaderImpl {
+	return &CommunityConfigurationLoaderImpl{}
+}
+
+// LoadConfig loads community configuration from the specified path.
+func (cl *CommunityConfigurationLoaderImpl) LoadConfig(path string) (*domain.CommunityAnalysisRequest, error) {
+	tomlLoader := config.NewTomlConfigLoader()
+	pyscnCfg, err := tomlLoader.LoadConfig(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config from %s: %w", path, err)
+	}
+
+	return cl.configToRequest(pyscnCfg), nil
+}
+
+// LoadDefaultConfig loads the default community configuration, checking for project config first.
+func (cl *CommunityConfigurationLoaderImpl) LoadDefaultConfig() *domain.CommunityAnalysisRequest {
+	configFile := cl.FindDefaultConfigFile()
+	if configFile != "" {
+		if configReq, err := cl.LoadConfig(configFile); err == nil {
+			return configReq
+		}
+	}
+
+	return cl.configToRequest(config.DefaultPyscnConfig())
+}
+
+// MergeConfig merges configuration file values with request overrides.
+func (cl *CommunityConfigurationLoaderImpl) MergeConfig(base *domain.CommunityAnalysisRequest, override *domain.CommunityAnalysisRequest) *domain.CommunityAnalysisRequest {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+
+	merged := *base
+
+	if len(override.Paths) > 0 {
+		merged.Paths = override.Paths
+	}
+	if len(override.SourcePaths) > 0 {
+		merged.SourcePaths = override.SourcePaths
+	}
+	if override.OutputFormat != "" {
+		merged.OutputFormat = override.OutputFormat
+	}
+	if override.OutputWriter != nil {
+		merged.OutputWriter = override.OutputWriter
+	}
+	if override.OutputPath != "" {
+		merged.OutputPath = override.OutputPath
+	}
+	merged.NoOpen = override.NoOpen
+
+	if override.ConfigPath != "" {
+		merged.ConfigPath = override.ConfigPath
+	}
+	if override.Recursive != nil {
+		merged.Recursive = override.Recursive
+	}
+	if len(override.IncludePatterns) > 0 {
+		merged.IncludePatterns = override.IncludePatterns
+	}
+	if len(override.ExcludePatterns) > 0 {
+		merged.ExcludePatterns = override.ExcludePatterns
+	}
+
+	if override.Algorithm != "" {
+		merged.Algorithm = override.Algorithm
+	}
+	if override.Scope != "" {
+		merged.Scope = override.Scope
+	}
+	if override.MinCommunitySize > 0 {
+		merged.MinCommunitySize = override.MinCommunitySize
+	}
+	if override.IncludeLazyEdges != nil {
+		merged.IncludeLazyEdges = override.IncludeLazyEdges
+	}
+	if override.ReportBridgeModules != nil {
+		merged.ReportBridgeModules = override.ReportBridgeModules
+	}
+	if override.Resolution > 0 {
+		merged.Resolution = override.Resolution
+	}
+
+	if override.IncludeStdLib != nil {
+		merged.IncludeStdLib = override.IncludeStdLib
+	}
+	if override.IncludeThirdParty != nil {
+		merged.IncludeThirdParty = override.IncludeThirdParty
+	}
+	if override.FollowRelative != nil {
+		merged.FollowRelative = override.FollowRelative
+	}
+
+	return &merged
+}
+
+func (cl *CommunityConfigurationLoaderImpl) configToRequest(pyscnCfg *config.PyscnConfig) *domain.CommunityAnalysisRequest {
+	if pyscnCfg == nil {
+		return domain.DefaultCommunityAnalysisRequest()
+	}
+
+	req := domain.DefaultCommunityAnalysisRequest()
+	req.Algorithm = pyscnCfg.CommunitiesAlgorithm
+	req.Scope = pyscnCfg.CommunitiesScope
+	req.MinCommunitySize = pyscnCfg.CommunitiesMinCommunitySize
+	req.IncludeLazyEdges = pyscnCfg.CommunitiesIncludeLazyEdges
+	req.ReportBridgeModules = pyscnCfg.CommunitiesReportBridgeModules
+	req.Resolution = pyscnCfg.CommunitiesResolution
+	req.Recursive = pyscnCfg.AnalysisRecursive
+	req.IncludePatterns = pyscnCfg.AnalysisIncludePatterns
+	req.ExcludePatterns = pyscnCfg.AnalysisExcludePatterns
+
+	if req.Algorithm == "" {
+		req.Algorithm = domain.DefaultCommunityAlgorithm
+	}
+	if req.Scope == "" {
+		req.Scope = domain.DefaultCommunityScope
+	}
+	if req.MinCommunitySize <= 0 {
+		req.MinCommunitySize = 2
+	}
+	if req.Resolution <= 0 {
+		req.Resolution = domain.DefaultCommunityResolution
+	}
+
+	return req
+}
+
+// FindDefaultConfigFile looks for TOML config files from the current directory upward.
+func (cl *CommunityConfigurationLoaderImpl) FindDefaultConfigFile() string {
+	tomlLoader := config.NewTomlConfigLoader()
+	return tomlLoader.FindConfigFileFromPath("")
+}

--- a/service/community_config_loader_test.go
+++ b/service/community_config_loader_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+)
+
+func TestCommunityConfigurationLoader_LoadConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	configContent := `[communities]
+enabled = true
+algorithm = "leiden"
+scope = "module"
+min_community_size = 3
+include_lazy_edges = false
+report_bridge_modules = true
+resolution = 1.25
+`
+	configPath := filepath.Join(tempDir, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	loader := NewCommunityConfigurationLoader()
+	req, err := loader.LoadConfig(tempDir)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+
+	if req.Algorithm != "leiden" {
+		t.Errorf("expected algorithm leiden, got %q", req.Algorithm)
+	}
+	if req.Scope != "module" {
+		t.Errorf("expected scope module, got %q", req.Scope)
+	}
+	if req.MinCommunitySize != 3 {
+		t.Errorf("expected min_community_size 3, got %d", req.MinCommunitySize)
+	}
+	if domain.BoolValue(req.IncludeLazyEdges, true) {
+		t.Errorf("expected include_lazy_edges false, got %v", req.IncludeLazyEdges)
+	}
+	if !domain.BoolValue(req.ReportBridgeModules, false) {
+		t.Errorf("expected report_bridge_modules true, got %v", req.ReportBridgeModules)
+	}
+	if req.Resolution != 1.25 {
+		t.Errorf("expected resolution 1.25, got %f", req.Resolution)
+	}
+}
+
+func TestCommunityConfigurationLoader_LoadDefaultConfigUsesDefaults(t *testing.T) {
+	loader := NewCommunityConfigurationLoader()
+	req := loader.LoadDefaultConfig()
+
+	if req.Algorithm != domain.DefaultCommunityAlgorithm {
+		t.Errorf("expected algorithm %q, got %q", domain.DefaultCommunityAlgorithm, req.Algorithm)
+	}
+	if req.Scope != domain.DefaultCommunityScope {
+		t.Errorf("expected scope %q, got %q", domain.DefaultCommunityScope, req.Scope)
+	}
+	if req.MinCommunitySize != 2 {
+		t.Errorf("expected min_community_size 2, got %d", req.MinCommunitySize)
+	}
+	if !domain.BoolValue(req.IncludeLazyEdges, false) {
+		t.Error("expected include_lazy_edges true by default")
+	}
+	if !domain.BoolValue(req.ReportBridgeModules, false) {
+		t.Error("expected report_bridge_modules true by default")
+	}
+	if req.Resolution != domain.DefaultCommunityResolution {
+		t.Errorf("expected resolution %f, got %f", domain.DefaultCommunityResolution, req.Resolution)
+	}
+}


### PR DESCRIPTION
Closes #583

Part of #564. Wires community detection as an opt-in analysis surface via CLI flags and TOML config.

## Changes

### CLI
- `communities` is a valid `--select` token
- `--skip-communities` overrides config-enabled communities
- Merge order: flags > config > defaults
  - Default: disabled
  - `--select communities` or `--select deps,communities` enables it
  - When `--select` is used without `communities`, config `enabled=true` does **not** silently enable it
  - `[communities] enabled=true` enables it when `--select` is not used
  - `--skip-communities` always wins

### Config
- New `[communities]` section in `.pyscn.toml` and `pyproject.toml` `[tool.pyscn]`
- Defaults: `enabled=false`, `algorithm=leiden`, `scope=module`, `min_community_size=2`, `include_lazy_edges=true`, `report_bridge_modules=true`, `resolution=1.0`
- Config round-trip / merge tests mirror `cbo_config_test.go`

### Wiring
- `CommunityConfigurationLoader` for community use case
- `AnalyzeExecutionConfig.CommunitiesEnabled` drives analyze-time activation
- Community use case config loader wired in `analyze` command builder

## Testing

- `make fmt`
- `go test ./internal/config/... ./service/... ./app/... ./cmd/pyscn/...`