### PR TITLE
fix: collapse enum member CBO dependencies

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -590,6 +590,17 @@ func (a *CBOAnalyzer) callDependencyName(className string, allClasses map[string
 	}
 	imported := a.isImportedDependency(className)
 	parts := strings.Split(className, ".")
+
+	// Enum members and other class constants are attribute reads on the imported
+	// class, not distinct classes. Prefer the imported class binding before the
+	// generic dotted-name heuristic has a chance to treat ALL_CAPS members as
+	// CapWords-style class references.
+	if imported && len(parts) > 1 {
+		if binding := parts[0]; a.isImportedDependency(binding) && a.looksLikeClassReference(binding) {
+			return binding
+		}
+	}
+
 	for end := len(parts); end > 0; end-- {
 		prefix := strings.Join(parts[:end], ".")
 		if _, isClass := allClasses[prefix]; isClass {

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -1115,6 +1115,49 @@ class Worker:
 	assert.Equal(t, 2, worker.CouplingCount)
 }
 
+func TestCBOAnalyzer_ImportedEnumMembersCollapseToEnumClass(t *testing.T) {
+	pythonCode := `
+from rules import RuleGranularity, RuleMode, RuleRisk
+from parameters import Parameter
+
+class Rule:
+    DEFAULT_MODE = RuleMode.BLOCKING
+    FALLBACK_MODE = RuleMode.ALLOWED
+    GRANULARITY = RuleGranularity.STACK
+    RISK = RuleRisk.MEDIUM
+
+class HardcodedRDSPasswordRule:
+    CHECKS = (
+        Parameter.NO_ECHO_NO_DEFAULT,
+        Parameter.NO_ECHO_WITH_DEFAULT,
+        Parameter.NO_ECHO_WITH_VALUE,
+    )
+    GRANULARITY = RuleGranularity.RESOURCE
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "rules.py")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	resultMap := make(map[string]*CBOResult)
+	for _, result := range results {
+		resultMap[result.ClassName] = result
+	}
+
+	rule := resultMap["Rule"]
+	require.NotNil(t, rule)
+	assert.Equal(t, []string{"RuleGranularity", "RuleMode", "RuleRisk"}, rule.DependentClasses)
+	assert.Equal(t, 3, rule.CouplingCount)
+
+	hardcoded := resultMap["HardcodedRDSPasswordRule"]
+	require.NotNil(t, hardcoded)
+	assert.Equal(t, []string{"Parameter", "RuleGranularity"}, hardcoded.DependentClasses)
+	assert.Equal(t, 2, hardcoded.CouplingCount)
+}
+
 func TestCBOAnalyzer_LocalClassMethodCallsCountClassCoupling(t *testing.T) {
 	pythonCode := `
 class Widget:


### PR DESCRIPTION
## Summary

Fixes CBO inflation from enum-member / class-constant attribute reads.

When imported class-like dependencies are referenced as `Class.MEMBER`, the analyzer now records the class binding (`Class`) instead of treating each member (`Class.MEMBER`) as a separate dependency. This prevents ALL_CAPS enum members such as `RuleMode.BLOCKING` and `Parameter.NO_ECHO_WITH_VALUE` from inflating `CouplingCount` and risk tiers.

Closes #593.

## Changes

- Prefer the imported class binding before applying the generic dotted-name heuristic in `callDependencyName`.
- Preserve existing behavior for module/class-method calls such as `datetime.datetime.now()` and namespace alias grouping such as `cst.Arg`.
- Add a regression test covering the issue examples:
  - `RuleMode.BLOCKING` / `RuleMode.ALLOWED` collapse to `RuleMode`.
  - `RuleGranularity.STACK` / `RuleGranularity.RESOURCE` collapse to `RuleGranularity`.
  - `RuleRisk.MEDIUM` collapses to `RuleRisk`.
  - Multiple `Parameter.NO_ECHO_*` values collapse to `Parameter`.

## Verification

- [x] `gofmt -w internal/analyzer/cbo.go internal/analyzer/cbo_test.go`
- [x] `go test ./internal/analyzer -run 'TestCBOAnalyzer_(ImportedEnumMembersCollapseToEnumClass|ImportedClassMethodCallsCountClassCoupling|NamespaceImportMembersAreGrouped|NamespaceImportCallsAreGrouped|NonAliasedModuleMembersAreNotGrouped)' -v`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/pyscn`
- [x] `git diff --check`
