### PR TITLE
[communities] Text/HTML/YAML/CSV/DOT summary output

### DIFF
--- a/app/community_usecase.go
+++ b/app/community_usecase.go
@@ -121,7 +121,7 @@ func (uc *CommunityUseCase) validateRequest(req domain.CommunityAnalysisRequest)
 		return fmt.Errorf("resolution cannot be negative")
 	}
 	switch req.OutputFormat {
-	case domain.OutputFormatText, domain.OutputFormatJSON, domain.OutputFormatYAML, domain.OutputFormatCSV, domain.OutputFormatHTML:
+	case domain.OutputFormatText, domain.OutputFormatJSON, domain.OutputFormatYAML, domain.OutputFormatCSV, domain.OutputFormatHTML, domain.OutputFormatDOT:
 	default:
 		return fmt.Errorf("unsupported output format: %s", req.OutputFormat)
 	}

--- a/app/community_usecase_test.go
+++ b/app/community_usecase_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -96,4 +97,42 @@ func TestCommunityUseCase_ValidateRequest(t *testing.T) {
 		MinCommunitySize: -1,
 	})
 	require.Error(t, err)
+
+	err = uc.validateRequest(domain.CommunityAnalysisRequest{
+		Paths:        []string{"."},
+		OutputWriter: io.Discard,
+		OutputFormat: domain.OutputFormatDOT,
+	})
+	require.NoError(t, err)
+}
+
+func TestCommunityUseCase_Execute_DOT(t *testing.T) {
+	fixtureRoot := filepath.Join("..", "testdata", "python", "community_bridge")
+	absRoot, err := filepath.Abs(fixtureRoot)
+	require.NoError(t, err)
+
+	uc, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewCommunityFormatter()).
+		Build()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	req := domain.CommunityAnalysisRequest{
+		Paths:            []string{absRoot},
+		SourcePaths:      []string{absRoot},
+		OutputFormat:     domain.OutputFormatDOT,
+		OutputWriter:     &buf,
+		Recursive:        domain.BoolPtr(true),
+		MinCommunitySize: 2,
+	}
+
+	err = uc.Execute(context.Background(), req)
+	require.NoError(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "digraph ModuleCommunities")
+	assert.Contains(t, output, "bridge")
+	assert.Contains(t, output, "->")
 }

--- a/domain/community.go
+++ b/domain/community.go
@@ -53,6 +53,12 @@ type CommunityMetrics struct {
 	Size                        int      `json:"size" yaml:"size"`
 }
 
+// CommunityModuleDependency is a directed module dependency edge used for graph export.
+type CommunityModuleDependency struct {
+	From string
+	To   string
+}
+
 // BridgeModule describes a module that couples multiple communities.
 type BridgeModule struct {
 	Module              string   `json:"module" yaml:"module"`
@@ -69,6 +75,9 @@ type CommunityAnalysisResult struct {
 	Modularity       float64            `json:"modularity" yaml:"modularity"`
 	Communities      []CommunityMetrics `json:"communities" yaml:"communities"`
 	BridgeModules    []BridgeModule     `json:"bridge_modules" yaml:"bridge_modules"`
+
+	// ModuleDependencies holds directed edges for DOT export and is omitted from JSON/YAML.
+	ModuleDependencies []CommunityModuleDependency `json:"-" yaml:"-"`
 
 	Warnings []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
 	Errors   []string `json:"errors,omitempty" yaml:"errors,omitempty"`

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -97,6 +97,10 @@ func (f *AnalyzeFormatter) writeText(response *domain.AnalyzeResponse, writer io
 		fmt.Fprint(writer, utils.FormatSectionSeparator())
 	}
 
+	if response.Summary.CommunitiesEnabled && response.Communities != nil {
+		WriteCommunityTextSummary(writer, response.Communities)
+	}
+
 	return nil
 }
 
@@ -121,6 +125,14 @@ func (f *AnalyzeFormatter) writeCSV(response *domain.AnalyzeResponse, writer io.
 	fmt.Fprintf(writer, "Total Classes Analyzed,%d\n", response.Summary.CBOClasses)
 	fmt.Fprintf(writer, "High Coupling (CBO) Classes,%d\n", response.Summary.HighCouplingClasses)
 	fmt.Fprintf(writer, "Average CBO,%.2f\n", response.Summary.AverageCoupling)
+
+	if response.Summary.CommunitiesEnabled && response.Communities != nil {
+		communities := response.Communities
+		fmt.Fprintf(writer, "Communities Enabled,true\n")
+		fmt.Fprintf(writer, "Total Communities,%d\n", communities.TotalCommunities)
+		fmt.Fprintf(writer, "Community Modularity,%.4f\n", communities.Modularity)
+		fmt.Fprintf(writer, "Bridge Modules,%d\n", len(communities.BridgeModules))
+	}
 
 	return nil
 }
@@ -166,6 +178,14 @@ func (f *AnalyzeFormatter) writeHTML(response *domain.AnalyzeResponse, writer io
 			default:
 				return "poor"
 			}
+		},
+		"communitySummaryHTML": func(result *domain.CommunityAnalysisResult) template.HTML {
+			if result == nil {
+				return ""
+			}
+			var builder strings.Builder
+			WriteCommunityHTMLSummary(&builder, result)
+			return template.HTML(builder.String())
 		},
 	}
 	tmpl := template.Must(template.New("analyze").Funcs(funcMap).Parse(analyzeHTMLTemplate))
@@ -455,6 +475,9 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 <button class="tab-button" onclick="showTab('sys-arch', this)">Architecture</button>
                 {{end}}
                 {{end}}
+                {{if and .Summary.CommunitiesEnabled .Communities}}
+                <button class="tab-button" onclick="showTab('communities', this)">Communities</button>
+                {{end}}
             </div>
 
             <div id="summary" class="tab-content active">
@@ -550,6 +573,19 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                             <div class="score-bar-fill score-{{scoreQuality .Summary.ArchitectureScore}}" style="width: {{.Summary.ArchitectureScore}}%"></div>
                         </div>
                         <div class="score-detail">{{printf "%.0f%%" (mul100 .Summary.ArchCompliance)}} compliant</div>
+                    </div>
+                    {{end}}
+
+                    {{if and .Summary.CommunitiesEnabled .Communities}}
+                    <div class="score-bar-item">
+                        <div class="score-bar-header">
+                            <span class="score-label">Communities</span>
+                            <span class="score-value">{{.Communities.TotalCommunities}}</span>
+                        </div>
+                        <div class="score-bar-container">
+                            <div class="score-bar-fill score-good" style="width: 100%"></div>
+                        </div>
+                        <div class="score-detail">Q={{printf "%.3f" .Communities.Modularity}}, {{len .Communities.BridgeModules}} bridge modules</div>
                     </div>
                     {{end}}
                 </div>
@@ -657,6 +693,28 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                     </div>
                 </div>
                 {{end}}
+                {{end}}
+
+                {{if and .Summary.CommunitiesEnabled .Communities}}
+                <h3 style="margin-top: 8px; color: var(--color-text);">Communities</h3>
+                <div class="metric-grid">
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Communities.TotalCommunities}}</div>
+                        <div class="metric-label">Communities</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{printf "%.3f" .Communities.Modularity}}</div>
+                        <div class="metric-label">Modularity (Q)</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{len .Communities.BridgeModules}}</div>
+                        <div class="metric-label">Bridge Modules</div>
+                    </div>
+                    <div class="metric-card">
+                        <div class="metric-value">{{.Communities.Algorithm}}</div>
+                        <div class="metric-label">Algorithm</div>
+                    </div>
+                </div>
                 {{end}}
             </div>
 
@@ -1300,6 +1358,14 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                 {{end}}
             </div>
             {{end}}
+            {{end}}
+
+            {{if and .Summary.CommunitiesEnabled .Communities}}
+            <div id="communities" class="tab-content">
+                <h2>Module Communities</h2>
+                <p style="margin-bottom: 20px; color: #666;">Detected module communities and bridge modules coupling them</p>
+                {{communitySummaryHTML .Communities}}
+            </div>
             {{end}}
         </div>
     </div>

--- a/service/analyze_formatter_test.go
+++ b/service/analyze_formatter_test.go
@@ -401,6 +401,51 @@ func TestAnalyzeFormatter_Write_UnsupportedFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid")
 }
 
+func TestAnalyzeFormatter_Write_IncludesCommunitySummary(t *testing.T) {
+	response := createMinimalAnalyzeResponse()
+	response.Summary.CommunitiesEnabled = true
+	response.Communities = &domain.CommunityAnalysisResult{
+		Algorithm:        "leiden",
+		Scope:            "module",
+		TotalCommunities: 2,
+		Modularity:       0.42,
+		Communities: []domain.CommunityMetrics{
+			{ID: "community_1", Size: 3, InternalEdges: 2, ExternalEdges: 1},
+			{ID: "community_2", Size: 2, InternalEdges: 1, ExternalEdges: 1},
+		},
+		BridgeModules: []domain.BridgeModule{
+			{
+				Module:              "bridge",
+				Community:           "community_1",
+				CrossCommunityEdges: 1,
+				TargetCommunities:   []string{"community_2"},
+			},
+		},
+	}
+
+	formatter := NewAnalyzeFormatter()
+
+	var textBuf bytes.Buffer
+	require.NoError(t, formatter.Write(response, domain.OutputFormatText, &textBuf))
+	text := textBuf.String()
+	assert.Contains(t, text, "COMMUNITY DETECTION")
+	assert.Contains(t, text, "BRIDGE MODULES")
+	assert.Contains(t, text, "bridge")
+
+	var csvBuf bytes.Buffer
+	require.NoError(t, formatter.Write(response, domain.OutputFormatCSV, &csvBuf))
+	csv := csvBuf.String()
+	assert.Contains(t, csv, "Communities Enabled,true")
+	assert.Contains(t, csv, "Total Communities,2")
+
+	var htmlBuf bytes.Buffer
+	require.NoError(t, formatter.Write(response, domain.OutputFormatHTML, &htmlBuf))
+	html := htmlBuf.String()
+	assert.Contains(t, html, "Communities")
+	assert.Contains(t, html, "Module Communities")
+	assert.Contains(t, html, "bridge")
+}
+
 func TestAnalyzeFormatter_WriteHTML_ScoreQuality(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -64,6 +64,8 @@ func (s *CommunityAnalysisServiceImpl) Analyze(ctx context.Context, req domain.C
 		result.BridgeModules = s.convertBridgeModules(metrics.BridgeModules)
 	}
 
+	result.ModuleDependencies = s.convertModuleDependencies(graph)
+
 	if graph.TotalModules == 0 {
 		result.Warnings = append(result.Warnings, "No modules found to analyze")
 	}
@@ -141,6 +143,37 @@ func (s *CommunityAnalysisServiceImpl) convertCommunities(partitions []analyzer.
 
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func (s *CommunityAnalysisServiceImpl) convertModuleDependencies(graph *analyzer.DependencyGraph) []domain.CommunityModuleDependency {
+	if graph == nil || len(graph.Edges) == 0 {
+		return nil
+	}
+
+	out := make([]domain.CommunityModuleDependency, 0, len(graph.Edges))
+	seen := make(map[string]struct{}, len(graph.Edges))
+	for _, edge := range graph.Edges {
+		if edge == nil || edge.From == "" || edge.To == "" {
+			continue
+		}
+		key := edge.From + "->" + edge.To
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, domain.CommunityModuleDependency{
+			From: edge.From,
+			To:   edge.To,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].From == out[j].From {
+			return out[i].To < out[j].To
+		}
+		return out[i].From < out[j].From
 	})
 	return out
 }

--- a/service/community_formatter.go
+++ b/service/community_formatter.go
@@ -1,13 +1,32 @@
 package service
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"math"
 	"sort"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/ludo-technologies/pyscn/domain"
 )
+
+const (
+	communitySummaryLimit = 5
+)
+
+var communityDOTColors = []string{
+	"lightblue",
+	"lightgreen",
+	"lightyellow",
+	"lightpink",
+	"lavender",
+	"peachpuff",
+	"lightgray",
+	"honeydew",
+}
 
 // CommunityFormatter formats community analysis results for output.
 type CommunityFormatter struct{}
@@ -28,6 +47,14 @@ func (f *CommunityFormatter) Format(response *domain.CommunityAnalysisResult, fo
 		return f.formatText(response), nil
 	case domain.OutputFormatJSON:
 		return f.formatJSON(response)
+	case domain.OutputFormatYAML:
+		return f.formatYAML(response)
+	case domain.OutputFormatCSV:
+		return f.formatCSV(response)
+	case domain.OutputFormatHTML:
+		return f.formatHTML(response)
+	case domain.OutputFormatDOT:
+		return f.formatDOT(response)
 	default:
 		return "", fmt.Errorf("community formatter does not support format %s", format)
 	}
@@ -42,6 +69,8 @@ func (f *CommunityFormatter) Write(response *domain.CommunityAnalysisResult, for
 	switch format {
 	case domain.OutputFormatJSON:
 		return WriteJSON(writer, normalizeCommunityResult(response))
+	case domain.OutputFormatYAML:
+		return WriteYAML(writer, normalizeCommunityResult(response))
 	default:
 		content, err := f.Format(response, format)
 		if err != nil {
@@ -53,12 +82,97 @@ func (f *CommunityFormatter) Write(response *domain.CommunityAnalysisResult, for
 }
 
 func (f *CommunityFormatter) formatText(response *domain.CommunityAnalysisResult) string {
-	return fmt.Sprintf(
-		"Community analysis: %d communities (modularity %.3f, algorithm %s)\n",
-		response.TotalCommunities,
-		response.Modularity,
-		response.Algorithm,
-	)
+	var builder strings.Builder
+	utils := NewFormatUtils()
+	builder.WriteString(utils.FormatMainHeader("Module Community Analysis"))
+	f.writeTextSummary(&builder, response, utils)
+	return builder.String()
+}
+
+// WriteCommunityTextSummary writes a concise community section for unified analyze text output.
+func WriteCommunityTextSummary(writer io.Writer, response *domain.CommunityAnalysisResult) {
+	if response == nil {
+		return
+	}
+
+	var builder strings.Builder
+	utils := NewFormatUtils()
+	builder.WriteString(utils.FormatSectionHeader("COMMUNITY DETECTION"))
+	f := &CommunityFormatter{}
+	f.writeTextSummary(&builder, response, utils)
+	_, _ = io.WriteString(writer, builder.String())
+}
+
+func (f *CommunityFormatter) writeTextSummary(builder *strings.Builder, response *domain.CommunityAnalysisResult, utils *FormatUtils) {
+	stats := map[string]interface{}{
+		"Total Communities": response.TotalCommunities,
+		"Modularity (Q)":    fmt.Sprintf("%.3f", response.Modularity),
+		"Algorithm":         response.Algorithm,
+		"Scope":             response.Scope,
+	}
+	builder.WriteString(utils.FormatSummaryStats(stats))
+
+	communities := communitiesBySize(response.Communities)
+	if len(communities) > 0 {
+		builder.WriteString(utils.FormatSectionHeader("LARGEST COMMUNITIES"))
+		limit := min(len(communities), communitySummaryLimit)
+		for i := 0; i < limit; i++ {
+			community := communities[i]
+			builder.WriteString(utils.FormatLabelWithIndent(
+				SectionPadding,
+				community.ID,
+				fmt.Sprintf(
+					"%d modules (internal: %d, external: %d, cross-in: %d, cross-out: %d)",
+					community.Size,
+					community.InternalEdges,
+					community.ExternalEdges,
+					community.IncomingCrossCommunityEdges,
+					community.OutgoingCrossCommunityEdges,
+				),
+			))
+		}
+		if len(communities) > limit {
+			builder.WriteString(utils.FormatLabelWithIndent(
+				SectionPadding,
+				"...",
+				fmt.Sprintf("and %d more communities", len(communities)-limit),
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	bridges := bridgesByCoupling(response.BridgeModules)
+	if len(bridges) > 0 {
+		builder.WriteString(utils.FormatSectionHeader("BRIDGE MODULES"))
+		limit := min(len(bridges), communitySummaryLimit)
+		for i := 0; i < limit; i++ {
+			bridge := bridges[i]
+			builder.WriteString(utils.FormatLabelWithIndent(
+				SectionPadding,
+				bridge.Module,
+				fmt.Sprintf(
+					"%d cross-community edges in %s -> %s",
+					bridge.CrossCommunityEdges,
+					bridge.Community,
+					strings.Join(bridge.TargetCommunities, ", "),
+				),
+			))
+		}
+		if len(bridges) > limit {
+			builder.WriteString(utils.FormatLabelWithIndent(
+				SectionPadding,
+				"...",
+				fmt.Sprintf("and %d more bridge modules", len(bridges)-limit),
+			))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(response.Warnings) > 0 {
+		builder.WriteString(utils.FormatWarningsSection(response.Warnings))
+	}
+
+	builder.WriteString(utils.FormatSectionSeparator())
 }
 
 func (f *CommunityFormatter) formatJSON(response *domain.CommunityAnalysisResult) (string, error) {
@@ -68,6 +182,327 @@ func (f *CommunityFormatter) formatJSON(response *domain.CommunityAnalysisResult
 		return "", err
 	}
 	return data + "\n", nil
+}
+
+func (f *CommunityFormatter) formatYAML(response *domain.CommunityAnalysisResult) (string, error) {
+	return EncodeYAML(normalizeCommunityResult(response))
+}
+
+func (f *CommunityFormatter) formatCSV(response *domain.CommunityAnalysisResult) (string, error) {
+	var builder strings.Builder
+	writer := csv.NewWriter(&builder)
+
+	if err := writer.Write([]string{"Section", "Metric", "Value"}); err != nil {
+		return "", fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	summaryRows := [][]string{
+		{"Summary", "Algorithm", response.Algorithm},
+		{"Summary", "Scope", response.Scope},
+		{"Summary", "Total Communities", strconv.Itoa(response.TotalCommunities)},
+		{"Summary", "Modularity", fmt.Sprintf("%.4f", response.Modularity)},
+		{"Summary", "Bridge Modules", strconv.Itoa(len(response.BridgeModules))},
+	}
+	for _, row := range summaryRows {
+		if err := writer.Write(row); err != nil {
+			return "", fmt.Errorf("failed to write CSV summary row: %w", err)
+		}
+	}
+
+	for _, community := range sortedCommunitiesByID(response.Communities) {
+		rows := [][]string{
+			{"Community", community.ID + " Size", strconv.Itoa(community.Size)},
+			{"Community", community.ID + " Internal Edges", strconv.Itoa(community.InternalEdges)},
+			{"Community", community.ID + " External Edges", strconv.Itoa(community.ExternalEdges)},
+			{"Community", community.ID + " External Ratio", fmt.Sprintf("%.4f", community.ExternalDependencyRatio)},
+			{"Community", community.ID + " Cross-In", strconv.Itoa(community.IncomingCrossCommunityEdges)},
+			{"Community", community.ID + " Cross-Out", strconv.Itoa(community.OutgoingCrossCommunityEdges)},
+			{"Community", community.ID + " Module Count", strconv.Itoa(len(community.Modules))},
+		}
+		for _, row := range rows {
+			if err := writer.Write(row); err != nil {
+				return "", fmt.Errorf("failed to write CSV community row: %w", err)
+			}
+		}
+	}
+
+	for _, bridge := range sortedBridgeModules(response.BridgeModules) {
+		rows := [][]string{
+			{"Bridge", bridge.Module + " Community", bridge.Community},
+			{"Bridge", bridge.Module + " Cross Edges", strconv.Itoa(bridge.CrossCommunityEdges)},
+			{"Bridge", bridge.Module + " Targets", strings.Join(bridge.TargetCommunities, ";")},
+		}
+		for _, row := range rows {
+			if err := writer.Write(row); err != nil {
+				return "", fmt.Errorf("failed to write CSV bridge row: %w", err)
+			}
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", fmt.Errorf("CSV writer error: %w", err)
+	}
+	return builder.String(), nil
+}
+
+func (f *CommunityFormatter) formatHTML(response *domain.CommunityAnalysisResult) (string, error) {
+	var builder strings.Builder
+
+	generatedAt, _ := time.Parse(time.RFC3339, response.GeneratedAt)
+	if generatedAt.IsZero() {
+		generatedAt = time.Now()
+	}
+
+	template := HTMLTemplate{
+		Title:       "Community Analysis Report",
+		Subtitle:    "Module Community Detection Summary",
+		GeneratedAt: generatedAt,
+		Version:     response.Version,
+		ShowScore:   false,
+	}
+
+	builder.WriteString(template.GenerateHTMLHeader())
+
+	var content strings.Builder
+	f.writeHTMLSummary(&content, response)
+	builder.WriteString(GenerateSinglePageContent(content.String()))
+	builder.WriteString(GenerateHTMLFooter())
+
+	return builder.String(), nil
+}
+
+// WriteCommunityHTMLSummary writes a concise community section for unified analyze HTML output.
+func WriteCommunityHTMLSummary(builder *strings.Builder, response *domain.CommunityAnalysisResult) {
+	if response == nil {
+		return
+	}
+	formatter := &CommunityFormatter{}
+	formatter.writeHTMLSummary(builder, response)
+}
+
+func (f *CommunityFormatter) writeHTMLSummary(builder *strings.Builder, response *domain.CommunityAnalysisResult) {
+	builder.WriteString(GenerateSectionHeader("Module Communities"))
+	builder.WriteString(`<div class="metric-grid">`)
+	builder.WriteString(GenerateMetricCard(strconv.Itoa(response.TotalCommunities), "Communities"))
+	builder.WriteString(GenerateMetricCard(fmt.Sprintf("%.3f", response.Modularity), "Modularity (Q)"))
+	builder.WriteString(GenerateMetricCard(response.Algorithm, "Algorithm"))
+	builder.WriteString(GenerateMetricCard(strconv.Itoa(len(response.BridgeModules)), "Bridge Modules"))
+	builder.WriteString(`</div>`)
+
+	communities := communitiesBySize(response.Communities)
+	if len(communities) > 0 {
+		builder.WriteString(GenerateSectionHeader("Largest Communities"))
+		builder.WriteString(`
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Community</th>
+                        <th>Modules</th>
+                        <th>Internal</th>
+                        <th>External</th>
+                        <th>Cross-In</th>
+                        <th>Cross-Out</th>
+                    </tr>
+                </thead>
+                <tbody>`)
+		limit := min(len(communities), communitySummaryLimit)
+		for i := 0; i < limit; i++ {
+			community := communities[i]
+			builder.WriteString(fmt.Sprintf(`
+                    <tr>
+                        <td><strong>%s</strong></td>
+                        <td>%d</td>
+                        <td>%d</td>
+                        <td>%d</td>
+                        <td>%d</td>
+                        <td>%d</td>
+                    </tr>`,
+				EscapeHTML(community.ID),
+				community.Size,
+				community.InternalEdges,
+				community.ExternalEdges,
+				community.IncomingCrossCommunityEdges,
+				community.OutgoingCrossCommunityEdges,
+			))
+		}
+		if len(communities) > limit {
+			builder.WriteString(fmt.Sprintf(`
+                    <tr>
+                        <td colspan="6"><em>... and %d more communities</em></td>
+                    </tr>`, len(communities)-limit))
+		}
+		builder.WriteString(`
+                </tbody>
+            </table>`)
+	}
+
+	bridges := bridgesByCoupling(response.BridgeModules)
+	if len(bridges) > 0 {
+		builder.WriteString(GenerateSectionHeader("Bridge Modules"))
+		builder.WriteString(`
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Module</th>
+                        <th>Community</th>
+                        <th>Cross Edges</th>
+                        <th>Target Communities</th>
+                    </tr>
+                </thead>
+                <tbody>`)
+		limit := min(len(bridges), communitySummaryLimit)
+		for i := 0; i < limit; i++ {
+			bridge := bridges[i]
+			builder.WriteString(fmt.Sprintf(`
+                    <tr>
+                        <td><code>%s</code></td>
+                        <td>%s</td>
+                        <td>%d</td>
+                        <td>%s</td>
+                    </tr>`,
+				EscapeHTML(bridge.Module),
+				EscapeHTML(bridge.Community),
+				bridge.CrossCommunityEdges,
+				JoinEscapedHTML(bridge.TargetCommunities, ", "),
+			))
+		}
+		if len(bridges) > limit {
+			builder.WriteString(fmt.Sprintf(`
+                    <tr>
+                        <td colspan="4"><em>... and %d more bridge modules</em></td>
+                    </tr>`, len(bridges)-limit))
+		}
+		builder.WriteString(`
+                </tbody>
+            </table>`)
+	}
+}
+
+func (f *CommunityFormatter) formatDOT(response *domain.CommunityAnalysisResult) (string, error) {
+	if response == nil {
+		return "", fmt.Errorf("community analysis result is nil")
+	}
+
+	moduleCommunity := make(map[string]string)
+	bridgeModules := make(map[string]bool)
+	for _, bridge := range response.BridgeModules {
+		bridgeModules[bridge.Module] = true
+	}
+
+	communityColors := make(map[string]string)
+	for i, community := range sortedCommunitiesByID(response.Communities) {
+		color := communityDOTColors[i%len(communityDOTColors)]
+		communityColors[community.ID] = color
+		for _, module := range community.Modules {
+			moduleCommunity[module] = community.ID
+		}
+	}
+
+	var builder strings.Builder
+	builder.WriteString("digraph ModuleCommunities {\n")
+	builder.WriteString("  rankdir=LR;\n")
+	builder.WriteString("  node [shape=box, style=filled];\n")
+	builder.WriteString("  edge [color=gray];\n\n")
+
+	for _, community := range sortedCommunitiesByID(response.Communities) {
+		clusterID := communityDOTClusterID(community.ID)
+		color := communityColors[community.ID]
+		builder.WriteString(fmt.Sprintf("  subgraph %s {\n", clusterID))
+		builder.WriteString(fmt.Sprintf("    label=\"%s\";\n", community.ID))
+		builder.WriteString("    style=filled;\n")
+		builder.WriteString(fmt.Sprintf("    color=%s;\n", color))
+		for _, module := range sortedStringCopy(community.Modules) {
+			nodeColor := color
+			if bridgeModules[module] {
+				nodeColor = "lightcoral"
+			}
+			builder.WriteString(fmt.Sprintf(
+				"    %s [label=\"%s\", fillcolor=%s];\n",
+				communityDOTNodeID(module),
+				module,
+				nodeColor,
+			))
+		}
+		builder.WriteString("  }\n\n")
+	}
+
+	for _, dep := range response.ModuleDependencies {
+		fromCommunity := moduleCommunity[dep.From]
+		toCommunity := moduleCommunity[dep.To]
+		edgeColor := "gray"
+		if fromCommunity != "" && toCommunity != "" && fromCommunity != toCommunity {
+			edgeColor = "red"
+		}
+		builder.WriteString(fmt.Sprintf(
+			"  %s -> %s [color=%s];\n",
+			communityDOTNodeID(dep.From),
+			communityDOTNodeID(dep.To),
+			edgeColor,
+		))
+	}
+
+	builder.WriteString("\n  subgraph cluster_legend {\n")
+	builder.WriteString("    label=\"Legend\";\n")
+	builder.WriteString("    style=filled;\n")
+	builder.WriteString("    fillcolor=white;\n")
+	builder.WriteString("    legend_bridge [label=\"Bridge Module\", fillcolor=lightcoral, shape=box];\n")
+	builder.WriteString("    legend_cross [label=\"Cross-Community Edge\", color=red, shape=plaintext];\n")
+	builder.WriteString("  }\n")
+	builder.WriteString("}\n")
+
+	return builder.String(), nil
+}
+
+func communitiesBySize(communities []domain.CommunityMetrics) []domain.CommunityMetrics {
+	out := append([]domain.CommunityMetrics(nil), communities...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Size == out[j].Size {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Size > out[j].Size
+	})
+	return out
+}
+
+func sortedCommunitiesByID(communities []domain.CommunityMetrics) []domain.CommunityMetrics {
+	out := append([]domain.CommunityMetrics(nil), communities...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+func bridgesByCoupling(bridges []domain.BridgeModule) []domain.BridgeModule {
+	out := append([]domain.BridgeModule(nil), bridges...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CrossCommunityEdges == out[j].CrossCommunityEdges {
+			return out[i].Module < out[j].Module
+		}
+		return out[i].CrossCommunityEdges > out[j].CrossCommunityEdges
+	})
+	return out
+}
+
+func sortedBridgeModules(bridges []domain.BridgeModule) []domain.BridgeModule {
+	out := append([]domain.BridgeModule(nil), bridges...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Module == out[j].Module {
+			return out[i].Community < out[j].Community
+		}
+		return out[i].Module < out[j].Module
+	})
+	return out
+}
+
+func communityDOTNodeID(module string) string {
+	clean := strings.ReplaceAll(module, ".", "_")
+	clean = strings.ReplaceAll(clean, "-", "_")
+	return clean
+}
+
+func communityDOTClusterID(communityID string) string {
+	return "cluster_" + communityDOTNodeID(communityID)
 }
 
 // normalizeCommunityResult returns a schema-stable copy with sorted lists and rounded ratios.
@@ -104,6 +539,7 @@ func normalizeCommunityResult(response *domain.CommunityAnalysisResult) *domain.
 		bridges[i].TargetCommunities = sortedStringCopy(bridges[i].TargetCommunities)
 	}
 	out.BridgeModules = bridges
+	out.ModuleDependencies = nil
 
 	return &out
 }

--- a/service/community_formatter_test.go
+++ b/service/community_formatter_test.go
@@ -142,14 +142,68 @@ func TestCommunityFormatter_Format_Text(t *testing.T) {
 	formatter := NewCommunityFormatter()
 	result := &domain.CommunityAnalysisResult{
 		Algorithm:        "leiden",
+		Scope:            "module",
 		TotalCommunities: 2,
 		Modularity:       0.42,
+		Communities: []domain.CommunityMetrics{
+			{ID: "community_1", Size: 3, InternalEdges: 2, ExternalEdges: 1},
+			{ID: "community_2", Size: 2, InternalEdges: 1, ExternalEdges: 1},
+		},
+		BridgeModules: []domain.BridgeModule{
+			{
+				Module:              "bridge",
+				Community:           "community_1",
+				CrossCommunityEdges: 2,
+				TargetCommunities:   []string{"community_2"},
+			},
+		},
 	}
 
 	output, err := formatter.Format(result, domain.OutputFormatText)
 	require.NoError(t, err)
-	assert.Contains(t, output, "2 communities")
+	assert.Contains(t, output, "Module Community Analysis")
+	assert.Contains(t, output, "Total Communities")
 	assert.Contains(t, output, "0.420")
+	assert.Contains(t, output, "LARGEST COMMUNITIES")
+	assert.Contains(t, output, "BRIDGE MODULES")
+	assert.Contains(t, output, "bridge")
+}
+
+func TestCommunityFormatter_Format_AllFormats_BridgeFixture(t *testing.T) {
+	result := analyzeCommunityBridgeFixture(t)
+	result.GeneratedAt = "2026-01-15T12:00:00Z"
+	result.Version = "0.0.0-test"
+
+	formatter := NewCommunityFormatter()
+
+	text, err := formatter.Format(result, domain.OutputFormatText)
+	require.NoError(t, err)
+	assert.Contains(t, text, "2")
+	assert.Contains(t, text, "BRIDGE MODULES")
+	assert.NotContains(t, text, "mod.a")
+
+	yamlOutput, err := formatter.Format(result, domain.OutputFormatYAML)
+	require.NoError(t, err)
+	assert.Contains(t, yamlOutput, "total_communities: 2")
+	assert.Contains(t, yamlOutput, "bridge_modules:")
+
+	csvOutput, err := formatter.Format(result, domain.OutputFormatCSV)
+	require.NoError(t, err)
+	assert.Contains(t, csvOutput, "Summary,Total Communities,2")
+	assert.Contains(t, csvOutput, "Bridge,bridge")
+
+	htmlOutput, err := formatter.Format(result, domain.OutputFormatHTML)
+	require.NoError(t, err)
+	assert.Contains(t, htmlOutput, "Community Analysis Report")
+	assert.Contains(t, htmlOutput, "Bridge Modules")
+	assert.Contains(t, htmlOutput, "bridge")
+	assert.NotContains(t, htmlOutput, "<nil>")
+
+	dotOutput, err := formatter.Format(result, domain.OutputFormatDOT)
+	require.NoError(t, err)
+	assert.Contains(t, dotOutput, "digraph ModuleCommunities")
+	assert.Contains(t, dotOutput, "bridge")
+	assert.Contains(t, dotOutput, "->")
 }
 
 func analyzeCommunityBridgeFixture(t *testing.T) *domain.CommunityAnalysisResult {


### PR DESCRIPTION
## Summary

Closes #585.

Adds the remaining `CommunityFormatter` output formats for community detection: concise **Text**, **HTML**, **YAML**, **CSV**, and **DOT** summaries. Wires community summaries into the unified `analyze` text, HTML, and CSV reports.

## Changes

- **Text**: Total communities, modularity (Q), largest communities, and top bridge modules (no full node dump).
- **YAML / CSV**: Mirror existing formatter patterns; CSV uses summary + per-community/bridge rows.
- **HTML**: Standalone community report with metric cards and concise tables.
- **DOT**: Module graph grouped by community clusters; bridge modules highlighted; cross-community edges in red.
- **Analyze integration**: Community section in text output, summary glance + tab in HTML, extra CSV rows when enabled.
- **DOT support**: `ModuleDependencies` on `CommunityAnalysisResult` (`json:"-"`) populated from the dependency graph so JSON schema/golden files stay unchanged.

## Testing

- `make fmt`
- `make lint`
- `make test`
- Formatter tests on `testdata/python/community_bridge` (2 communities + bridge fixture)

## Notes

Builds on the JSON formatter from #584. Full macro-architecture visualization remains a #564 follow-up.