### PR TITLE
feat(communities): add package mismatch scoring

### DIFF
--- a/domain/community.go
+++ b/domain/community.go
@@ -51,6 +51,11 @@ type CommunityMetrics struct {
 	IncomingCrossCommunityEdges int      `json:"incoming_cross_community_edges" yaml:"incoming_cross_community_edges"`
 	OutgoingCrossCommunityEdges int      `json:"outgoing_cross_community_edges" yaml:"outgoing_cross_community_edges"`
 	Size                        int      `json:"size" yaml:"size"`
+
+	// Package mismatch metrics (omitted when package metadata is unavailable).
+	DominantPackage  string  `json:"dominant_package,omitempty" yaml:"dominant_package,omitempty"`
+	PackageCount     int     `json:"package_count,omitempty" yaml:"package_count,omitempty"`
+	PackageAlignment float64 `json:"package_alignment,omitempty" yaml:"package_alignment,omitempty"`
 }
 
 // CommunityModuleDependency is a directed module dependency edge used for graph export.
@@ -75,6 +80,11 @@ type CommunityAnalysisResult struct {
 	Modularity       float64            `json:"modularity" yaml:"modularity"`
 	Communities      []CommunityMetrics `json:"communities" yaml:"communities"`
 	BridgeModules    []BridgeModule     `json:"bridge_modules" yaml:"bridge_modules"`
+
+	// Package mismatch metrics compare inferred communities to declared package boundaries.
+	PackageAlignmentScore *float64 `json:"package_alignment_score,omitempty" yaml:"package_alignment_score,omitempty"`
+	SplitPackages         []string `json:"split_packages,omitempty" yaml:"split_packages,omitempty"`
+	MixedCommunities      []string `json:"mixed_communities,omitempty" yaml:"mixed_communities,omitempty"`
 
 	// ModuleDependencies holds directed edges for DOT export and is omitted from JSON/YAML.
 	ModuleDependencies []CommunityModuleDependency `json:"-" yaml:"-"`

--- a/integration/community_integration_test.go
+++ b/integration/community_integration_test.go
@@ -16,11 +16,12 @@ import (
 )
 
 const (
-	communityBridgeDir    = "../testdata/python/community_bridge"
-	communitySeparatedDir = "../testdata/python/community_separated"
-	communityCycleDir     = "../testdata/python/community_cycle"
-	communityMinimalDir   = "../testdata/python/community_minimal"
-	communityIsolatedDir  = "../testdata/python/community_isolated"
+	communityBridgeDir          = "../testdata/python/community_bridge"
+	communitySeparatedDir       = "../testdata/python/community_separated"
+	communityPackageMismatchDir = "../testdata/python/community_package_mismatch"
+	communityCycleDir           = "../testdata/python/community_cycle"
+	communityMinimalDir         = "../testdata/python/community_minimal"
+	communityIsolatedDir        = "../testdata/python/community_isolated"
 )
 
 func newCommunityUseCase() *app.CommunityUseCase {
@@ -94,6 +95,38 @@ func TestCommunity_BridgeModules(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 1, modC.CrossCommunityEdges)
 	assert.Contains(t, modC.TargetCommunities, "community_1")
+}
+
+func TestCommunity_PackageMismatchSplitPackage(t *testing.T) {
+	result := analyzeCommunityFixture(t, communityBridgeDir)
+
+	require.NotNil(t, result.PackageAlignmentScore)
+	assert.InDelta(t, 0.0, *result.PackageAlignmentScore, 1e-9)
+	assert.Equal(t, []string{"mod"}, result.SplitPackages)
+	assert.Empty(t, result.MixedCommunities)
+}
+
+func TestCommunity_PackageMismatchAlignedPackages(t *testing.T) {
+	result := analyzeCommunityFixture(t, communitySeparatedDir)
+
+	require.NotNil(t, result.PackageAlignmentScore)
+	assert.InDelta(t, 1.0, *result.PackageAlignmentScore, 1e-9)
+	assert.Empty(t, result.SplitPackages)
+	assert.Empty(t, result.MixedCommunities)
+}
+
+func TestCommunity_PackageMismatchMixedCommunities(t *testing.T) {
+	result := analyzeCommunityFixture(t, communityPackageMismatchDir)
+
+	require.Equal(t, 2, result.TotalCommunities)
+	require.NotNil(t, result.PackageAlignmentScore)
+	assert.InDelta(t, 0.0, *result.PackageAlignmentScore, 1e-9)
+	assert.Equal(t, []string{"pkg_alpha", "pkg_beta"}, result.SplitPackages)
+	assert.Equal(t, []string{"community_1", "community_2"}, result.MixedCommunities)
+
+	for _, community := range result.Communities {
+		assert.Equal(t, 2, community.PackageCount)
+	}
 }
 
 func TestCommunity_CycleGraph(t *testing.T) {

--- a/internal/analyzer/community_metrics.go
+++ b/internal/analyzer/community_metrics.go
@@ -25,6 +25,18 @@ type CommunityPartition struct {
 	IncomingCrossCommunityEdges int
 	OutgoingCrossCommunityEdges int
 	Size                        int
+
+	DominantPackage  string
+	PackageCount     int
+	PackageAlignment float64
+}
+
+// PackageMismatchMetrics summarizes how well detected communities align with
+// declared package boundaries.
+type PackageMismatchMetrics struct {
+	PackageAlignmentScore float64
+	SplitPackages         []string
+	MixedCommunities      []string
 }
 
 // BridgeModuleMetrics describes a module that couples multiple communities.
@@ -108,12 +120,169 @@ func ComputeCommunityMetrics(graph *DependencyGraph, cg *CommunityGraph, leiden 
 	}
 
 	bridgeModules := computeBridgeModules(cg, nodeCommunity)
+	applyPackageMismatchMetrics(graph, cg, nodeCommunity, partitions)
 
 	return &CommunityPartitionMetrics{
 		Communities:      partitions,
 		BridgeModules:    bridgeModules,
 		TotalCommunities: leiden.NumCommunities,
 		Modularity:       leiden.Modularity,
+	}
+}
+
+// ComputePackageMismatchMetrics derives system-level package alignment metrics
+// from per-community partitions that already include package mismatch fields.
+func ComputePackageMismatchMetrics(partitions []CommunityPartition) *PackageMismatchMetrics {
+	if len(partitions) == 0 {
+		return &PackageMismatchMetrics{}
+	}
+
+	packageCommunities := make(map[string]map[string]struct{})
+	mixedCommunities := make([]string, 0)
+	var alignedPackages int
+	var totalPackages int
+
+	for _, partition := range partitions {
+		if partition.PackageCount >= 2 {
+			mixedCommunities = append(mixedCommunities, partition.ID)
+		}
+
+		for _, pkg := range partition.Packages {
+			if pkg == "" {
+				continue
+			}
+			if packageCommunities[pkg] == nil {
+				packageCommunities[pkg] = make(map[string]struct{})
+			}
+			packageCommunities[pkg][partition.ID] = struct{}{}
+		}
+	}
+
+	splitPackages := make([]string, 0)
+	for pkg, communities := range packageCommunities {
+		totalPackages++
+		if len(communities) >= 2 {
+			splitPackages = append(splitPackages, pkg)
+			continue
+		}
+		alignedPackages++
+	}
+	sort.Strings(splitPackages)
+	sort.Strings(mixedCommunities)
+
+	score := 0.0
+	if totalPackages > 0 {
+		score = float64(alignedPackages) / float64(totalPackages)
+	}
+
+	return &PackageMismatchMetrics{
+		PackageAlignmentScore: score,
+		SplitPackages:         splitPackages,
+		MixedCommunities:      mixedCommunities,
+	}
+}
+
+func applyPackageMismatchMetrics(
+	graph *DependencyGraph,
+	cg *CommunityGraph,
+	nodeCommunity []string,
+	partitions []CommunityPartition,
+) {
+	if graph == nil || cg == nil || len(partitions) == 0 {
+		return
+	}
+
+	modulePackage := make(map[string]string, len(cg.NodeNames))
+	for i, name := range cg.NodeNames {
+		if i >= len(nodeCommunity) || nodeCommunity[i] == "" {
+			continue
+		}
+		if node, ok := graph.Nodes[name]; ok && node.Package != "" {
+			modulePackage[name] = node.Package
+		}
+	}
+	if len(modulePackage) == 0 {
+		return
+	}
+
+	commIndex := make(map[string]int, len(partitions))
+	for i := range partitions {
+		commIndex[partitions[i].ID] = i
+	}
+
+	type edgeCohesion struct {
+		samePackage int
+		total       int
+	}
+	cohesionByCommunity := make(map[string]*edgeCohesion, len(partitions))
+
+	for i := range partitions {
+		packageCounts := make(map[string]int)
+		modulesWithPackage := 0
+		for _, module := range partitions[i].Modules {
+			pkg, ok := modulePackage[module]
+			if !ok || pkg == "" {
+				continue
+			}
+			modulesWithPackage++
+			packageCounts[pkg]++
+		}
+		if modulesWithPackage == 0 {
+			continue
+		}
+
+		partitions[i].PackageCount = len(packageCounts)
+
+		dominantPackage := ""
+		dominantCount := 0
+		for pkg, count := range packageCounts {
+			if count > dominantCount || (count == dominantCount && (dominantPackage == "" || pkg < dominantPackage)) {
+				dominantPackage = pkg
+				dominantCount = count
+			}
+		}
+		partitions[i].DominantPackage = dominantPackage
+		partitions[i].PackageAlignment = float64(dominantCount) / float64(modulesWithPackage)
+	}
+
+	for _, edge := range cg.DirectedEdges {
+		if edge.FromIndex >= len(nodeCommunity) || edge.ToIndex >= len(nodeCommunity) {
+			continue
+		}
+		fromComm := nodeCommunity[edge.FromIndex]
+		toComm := nodeCommunity[edge.ToIndex]
+		if fromComm == "" || toComm == "" || fromComm != toComm {
+			continue
+		}
+
+		fromName := cg.NodeNames[edge.FromIndex]
+		toName := cg.NodeNames[edge.ToIndex]
+		fromPkg, fromOK := modulePackage[fromName]
+		toPkg, toOK := modulePackage[toName]
+		if !fromOK || !toOK {
+			continue
+		}
+
+		acc, ok := cohesionByCommunity[fromComm]
+		if !ok {
+			acc = &edgeCohesion{}
+			cohesionByCommunity[fromComm] = acc
+		}
+		acc.total++
+		if fromPkg == toPkg {
+			acc.samePackage++
+		}
+	}
+
+	for commID, acc := range cohesionByCommunity {
+		if acc.total == 0 {
+			continue
+		}
+		idx, ok := commIndex[commID]
+		if !ok {
+			continue
+		}
+		partitions[idx].PackageAlignment = float64(acc.samePackage) / float64(acc.total)
 	}
 }
 

--- a/internal/analyzer/community_package_mismatch_test.go
+++ b/internal/analyzer/community_package_mismatch_test.go
@@ -1,0 +1,128 @@
+package analyzer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputePackageMismatchMetrics_SplitPackage(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("mod.a", "/project/mod/a.py")
+	graph.AddModule("mod.b", "/project/mod/b.py")
+	graph.AddModule("bridge", "/project/bridge.py")
+	graph.AddModule("mod.c", "/project/mod/c.py")
+	graph.AddModule("mod.d", "/project/mod/d.py")
+
+	graph.AddDependency("mod.a", "mod.b", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.b", "bridge", DependencyEdgeImport, nil)
+	graph.AddDependency("bridge", "mod.c", DependencyEdgeImport, nil)
+	graph.AddDependency("mod.c", "mod.d", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+	leiden := DetectCommunitiesLeiden(cg, nil)
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+	mismatch := ComputePackageMismatchMetrics(metrics.Communities)
+
+	require.NotNil(t, mismatch)
+	assert.Equal(t, []string{"mod"}, mismatch.SplitPackages)
+	assert.Empty(t, mismatch.MixedCommunities)
+	assert.InDelta(t, 0.0, mismatch.PackageAlignmentScore, 1e-9)
+
+	byID := communityPartitionsByID(metrics.Communities)
+	for _, id := range []string{"community_1", "community_2"} {
+		comm, ok := byID[id]
+		require.True(t, ok)
+		assert.Equal(t, 1, comm.PackageCount)
+		assert.Equal(t, "mod", comm.DominantPackage)
+		assert.InDelta(t, 1.0, comm.PackageAlignment, 1e-9)
+	}
+}
+
+func TestComputePackageMismatchMetrics_AlignedPackages(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("billing.invoice", "/project/billing/invoice.py")
+	graph.AddModule("billing.tax", "/project/billing/tax.py")
+	graph.AddModule("inventory.stock", "/project/inventory/stock.py")
+	graph.AddModule("inventory.warehouse", "/project/inventory/warehouse.py")
+
+	graph.AddDependency("billing.invoice", "billing.tax", DependencyEdgeImport, nil)
+	graph.AddDependency("inventory.stock", "inventory.warehouse", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+	leiden := DetectCommunitiesLeiden(cg, nil)
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+	mismatch := ComputePackageMismatchMetrics(metrics.Communities)
+
+	require.NotNil(t, mismatch)
+	assert.Empty(t, mismatch.SplitPackages)
+	assert.Empty(t, mismatch.MixedCommunities)
+	assert.InDelta(t, 1.0, mismatch.PackageAlignmentScore, 1e-9)
+}
+
+func TestComputePackageMismatchMetrics_MixedCommunity(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.AddModule("pkg_alpha.one", "/project/pkg_alpha/one.py")
+	graph.AddModule("pkg_alpha.two", "/project/pkg_alpha/two.py")
+	graph.AddModule("pkg_beta.one", "/project/pkg_beta/one.py")
+	graph.AddModule("pkg_beta.two", "/project/pkg_beta/two.py")
+
+	graph.AddDependency("pkg_alpha.one", "pkg_alpha.two", DependencyEdgeImport, nil)
+	graph.AddDependency("pkg_alpha.one", "pkg_beta.one", DependencyEdgeImport, nil)
+	graph.AddDependency("pkg_alpha.two", "pkg_beta.two", DependencyEdgeImport, nil)
+	graph.AddDependency("pkg_beta.one", "pkg_alpha.one", DependencyEdgeImport, nil)
+	graph.AddDependency("pkg_beta.two", "pkg_beta.one", DependencyEdgeImport, nil)
+
+	cg := BuildCommunityGraph(graph, nil)
+	membership := make([]int, cg.NodeCount)
+	for i, name := range cg.NodeNames {
+		membership[i] = 0
+		_ = name
+	}
+	leiden := &LeidenResult{
+		Membership:     membership,
+		NumCommunities: 1,
+		Modularity:     0.1,
+	}
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+	mismatch := ComputePackageMismatchMetrics(metrics.Communities)
+
+	require.NotNil(t, mismatch)
+	require.Len(t, metrics.Communities, 1)
+	assert.Equal(t, []string{"pkg_alpha", "pkg_beta"}, metrics.Communities[0].Packages)
+	assert.Equal(t, 2, metrics.Communities[0].PackageCount)
+	assert.Equal(t, []string{"community_1"}, mismatch.MixedCommunities)
+	assert.Empty(t, mismatch.SplitPackages)
+	assert.InDelta(t, 1.0, mismatch.PackageAlignmentScore, 1e-9)
+}
+
+func TestComputePackageMismatchMetrics_NoPackageMetadata(t *testing.T) {
+	graph := NewDependencyGraph("/project")
+	graph.Nodes["solo"] = &ModuleNode{Name: "solo", FilePath: "/project/solo.py"}
+
+	cg := &CommunityGraph{
+		NodeNames: []string{"solo"},
+		NodeCount: 1,
+	}
+	leiden := &LeidenResult{
+		Membership:     []int{0},
+		NumCommunities: 1,
+	}
+	metrics := ComputeCommunityMetrics(graph, cg, leiden)
+	mismatch := ComputePackageMismatchMetrics(metrics.Communities)
+
+	require.NotNil(t, mismatch)
+	assert.Equal(t, 0.0, mismatch.PackageAlignmentScore)
+	assert.Empty(t, mismatch.SplitPackages)
+	assert.Empty(t, mismatch.MixedCommunities)
+	assert.Equal(t, 0, metrics.Communities[0].PackageCount)
+}
+
+func communityPartitionsByID(partitions []CommunityPartition) map[string]CommunityPartition {
+	out := make(map[string]CommunityPartition, len(partitions))
+	for _, partition := range partitions {
+		out[partition.ID] = partition
+	}
+	return out
+}

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -48,6 +48,7 @@ func (s *CommunityAnalysisServiceImpl) Analyze(ctx context.Context, req domain.C
 
 	leiden := analyzer.DetectCommunitiesLeiden(cg, leidenOpts)
 	metrics := analyzer.ComputeCommunityMetrics(graph, cg, leiden)
+	packageMismatch := analyzer.ComputePackageMismatchMetrics(metrics.Communities)
 
 	result := &domain.CommunityAnalysisResult{
 		Algorithm:        s.resolveAlgorithm(req.Algorithm),
@@ -58,6 +59,12 @@ func (s *CommunityAnalysisServiceImpl) Analyze(ctx context.Context, req domain.C
 		GeneratedAt:      time.Now().Format(time.RFC3339),
 		Version:          version.Version,
 		Config:           s.buildConfigForResponse(req),
+	}
+	if packageMismatch != nil && s.hasPackageMismatchData(metrics.Communities) {
+		score := packageMismatch.PackageAlignmentScore
+		result.PackageAlignmentScore = &score
+		result.SplitPackages = append([]string(nil), packageMismatch.SplitPackages...)
+		result.MixedCommunities = append([]string(nil), packageMismatch.MixedCommunities...)
 	}
 
 	if domain.BoolValue(req.ReportBridgeModules, true) {
@@ -128,7 +135,7 @@ func (s *CommunityAnalysisServiceImpl) convertCommunities(partitions []analyzer.
 
 	out := make([]domain.CommunityMetrics, 0, len(partitions))
 	for _, partition := range partitions {
-		out = append(out, domain.CommunityMetrics{
+		community := domain.CommunityMetrics{
 			ID:                          partition.ID,
 			Modules:                     append([]string(nil), partition.Modules...),
 			Packages:                    append([]string(nil), partition.Packages...),
@@ -138,7 +145,13 @@ func (s *CommunityAnalysisServiceImpl) convertCommunities(partitions []analyzer.
 			IncomingCrossCommunityEdges: partition.IncomingCrossCommunityEdges,
 			OutgoingCrossCommunityEdges: partition.OutgoingCrossCommunityEdges,
 			Size:                        partition.Size,
-		})
+		}
+		if partition.PackageCount > 0 {
+			community.DominantPackage = partition.DominantPackage
+			community.PackageCount = partition.PackageCount
+			community.PackageAlignment = partition.PackageAlignment
+		}
+		out = append(out, community)
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -193,6 +206,15 @@ func (s *CommunityAnalysisServiceImpl) convertBridgeModules(bridges []analyzer.B
 		})
 	}
 	return out
+}
+
+func (s *CommunityAnalysisServiceImpl) hasPackageMismatchData(partitions []analyzer.CommunityPartition) bool {
+	for _, partition := range partitions {
+		if partition.PackageCount > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *CommunityAnalysisServiceImpl) buildConfigForResponse(req domain.CommunityAnalysisRequest) any {

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -78,6 +78,83 @@ func TestCommunityAnalysisService_Analyze_IsolatedModulesNoEdges(t *testing.T) {
 	assert.Empty(t, result.BridgeModules)
 }
 
+func TestCommunityAnalysisService_Analyze_PackageMismatch_BridgeFixture(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_bridge"))
+	require.NoError(t, err)
+
+	fileReader := NewFileReader()
+	files, err := fileReader.CollectPythonFiles([]string{fixtureRoot}, true, nil, nil)
+	require.NoError(t, err)
+
+	service := NewCommunityAnalysisService()
+	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
+		Paths:            files,
+		SourcePaths:      []string{fixtureRoot},
+		MinCommunitySize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.PackageAlignmentScore)
+	assert.InDelta(t, 0.0, *result.PackageAlignmentScore, 1e-9)
+	assert.Equal(t, []string{"mod"}, result.SplitPackages)
+	assert.Empty(t, result.MixedCommunities)
+
+	for _, community := range result.Communities {
+		assert.Equal(t, 1, community.PackageCount)
+		assert.Equal(t, "mod", community.DominantPackage)
+		assert.InDelta(t, 1.0, community.PackageAlignment, 1e-9)
+	}
+}
+
+func TestCommunityAnalysisService_Analyze_PackageMismatch_SeparatedFixture(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_separated"))
+	require.NoError(t, err)
+
+	fileReader := NewFileReader()
+	files, err := fileReader.CollectPythonFiles([]string{fixtureRoot}, true, nil, nil)
+	require.NoError(t, err)
+
+	service := NewCommunityAnalysisService()
+	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
+		Paths:            files,
+		SourcePaths:      []string{fixtureRoot},
+		MinCommunitySize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.PackageAlignmentScore)
+	assert.InDelta(t, 1.0, *result.PackageAlignmentScore, 1e-9)
+	assert.Empty(t, result.SplitPackages)
+	assert.Empty(t, result.MixedCommunities)
+}
+
+func TestCommunityAnalysisService_Analyze_PackageMismatch_MixedFixture(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_package_mismatch"))
+	require.NoError(t, err)
+
+	fileReader := NewFileReader()
+	files, err := fileReader.CollectPythonFiles([]string{fixtureRoot}, true, nil, nil)
+	require.NoError(t, err)
+
+	service := NewCommunityAnalysisService()
+	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
+		Paths:            files,
+		SourcePaths:      []string{fixtureRoot},
+		MinCommunitySize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.PackageAlignmentScore)
+	assert.InDelta(t, 0.0, *result.PackageAlignmentScore, 1e-9)
+	assert.Equal(t, []string{"pkg_alpha", "pkg_beta"}, result.SplitPackages)
+	assert.Equal(t, []string{"community_1", "community_2"}, result.MixedCommunities)
+
+	for _, community := range result.Communities {
+		assert.Equal(t, 2, community.PackageCount)
+		assert.Contains(t, []string{"pkg_alpha", "pkg_beta"}, community.DominantPackage)
+	}
+}
+
 func TestCommunityAnalysisService_Analyze_Deterministic(t *testing.T) {
 	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_bridge"))
 	require.NoError(t, err)
@@ -102,6 +179,9 @@ func TestCommunityAnalysisService_Analyze_Deterministic(t *testing.T) {
 	assert.InDelta(t, first.Modularity, second.Modularity, 1e-12)
 	assert.Equal(t, first.Communities, second.Communities)
 	assert.Equal(t, first.BridgeModules, second.BridgeModules)
+	assert.Equal(t, first.PackageAlignmentScore, second.PackageAlignmentScore)
+	assert.Equal(t, first.SplitPackages, second.SplitPackages)
+	assert.Equal(t, first.MixedCommunities, second.MixedCommunities)
 }
 
 func TestCommunityAnalysisService_Analyze_UsesSourcePathsForProjectRoot(t *testing.T) {

--- a/service/community_formatter.go
+++ b/service/community_formatter.go
@@ -110,7 +110,29 @@ func (f *CommunityFormatter) writeTextSummary(builder *strings.Builder, response
 		"Algorithm":         response.Algorithm,
 		"Scope":             response.Scope,
 	}
+	if response.PackageAlignmentScore != nil {
+		stats["Package Alignment"] = fmt.Sprintf("%.3f", *response.PackageAlignmentScore)
+	}
 	builder.WriteString(utils.FormatSummaryStats(stats))
+
+	if len(response.SplitPackages) > 0 || len(response.MixedCommunities) > 0 {
+		builder.WriteString(utils.FormatSectionHeader("PACKAGE MISMATCH"))
+		if len(response.SplitPackages) > 0 {
+			builder.WriteString(utils.FormatLabelWithIndent(
+				SectionPadding,
+				"Split Packages",
+				strings.Join(response.SplitPackages, ", "),
+			))
+		}
+		if len(response.MixedCommunities) > 0 {
+			builder.WriteString(utils.FormatLabelWithIndent(
+				SectionPadding,
+				"Mixed Communities",
+				strings.Join(response.MixedCommunities, ", "),
+			))
+		}
+		builder.WriteString("\n")
+	}
 
 	communities := communitiesBySize(response.Communities)
 	if len(communities) > 0 {
@@ -118,17 +140,26 @@ func (f *CommunityFormatter) writeTextSummary(builder *strings.Builder, response
 		limit := min(len(communities), communitySummaryLimit)
 		for i := 0; i < limit; i++ {
 			community := communities[i]
+			detail := fmt.Sprintf(
+				"%d modules (internal: %d, external: %d, cross-in: %d, cross-out: %d)",
+				community.Size,
+				community.InternalEdges,
+				community.ExternalEdges,
+				community.IncomingCrossCommunityEdges,
+				community.OutgoingCrossCommunityEdges,
+			)
+			if community.PackageCount > 0 {
+				detail += fmt.Sprintf(
+					", pkg-align: %.3f (%s, %d pkgs)",
+					community.PackageAlignment,
+					community.DominantPackage,
+					community.PackageCount,
+				)
+			}
 			builder.WriteString(utils.FormatLabelWithIndent(
 				SectionPadding,
 				community.ID,
-				fmt.Sprintf(
-					"%d modules (internal: %d, external: %d, cross-in: %d, cross-out: %d)",
-					community.Size,
-					community.InternalEdges,
-					community.ExternalEdges,
-					community.IncomingCrossCommunityEdges,
-					community.OutgoingCrossCommunityEdges,
-				),
+				detail,
 			))
 		}
 		if len(communities) > limit {
@@ -288,7 +319,28 @@ func (f *CommunityFormatter) writeHTMLSummary(builder *strings.Builder, response
 	builder.WriteString(GenerateMetricCard(fmt.Sprintf("%.3f", response.Modularity), "Modularity (Q)"))
 	builder.WriteString(GenerateMetricCard(response.Algorithm, "Algorithm"))
 	builder.WriteString(GenerateMetricCard(strconv.Itoa(len(response.BridgeModules)), "Bridge Modules"))
+	if response.PackageAlignmentScore != nil {
+		builder.WriteString(GenerateMetricCard(fmt.Sprintf("%.3f", *response.PackageAlignmentScore), "Package Alignment"))
+	}
 	builder.WriteString(`</div>`)
+
+	if len(response.SplitPackages) > 0 || len(response.MixedCommunities) > 0 {
+		builder.WriteString(GenerateSectionHeader("Package Mismatch"))
+		builder.WriteString(`<ul>`)
+		if len(response.SplitPackages) > 0 {
+			builder.WriteString(fmt.Sprintf(
+				`<li><strong>Split packages:</strong> %s</li>`,
+				JoinEscapedHTML(response.SplitPackages, ", "),
+			))
+		}
+		if len(response.MixedCommunities) > 0 {
+			builder.WriteString(fmt.Sprintf(
+				`<li><strong>Mixed communities:</strong> %s</li>`,
+				JoinEscapedHTML(response.MixedCommunities, ", "),
+			))
+		}
+		builder.WriteString(`</ul>`)
+	}
 
 	communities := communitiesBySize(response.Communities)
 	if len(communities) > 0 {
@@ -513,6 +565,12 @@ func normalizeCommunityResult(response *domain.CommunityAnalysisResult) *domain.
 
 	out := *response
 	out.Modularity = roundCommunityFloat(response.Modularity)
+	if response.PackageAlignmentScore != nil {
+		score := roundCommunityFloat(*response.PackageAlignmentScore)
+		out.PackageAlignmentScore = &score
+	}
+	out.SplitPackages = sortedStringCopy(response.SplitPackages)
+	out.MixedCommunities = sortedStringCopy(response.MixedCommunities)
 
 	communities := make([]domain.CommunityMetrics, len(response.Communities))
 	copy(communities, response.Communities)
@@ -524,6 +582,9 @@ func normalizeCommunityResult(response *domain.CommunityAnalysisResult) *domain.
 		communities[i].Modules = sortedStringCopy(communities[i].Modules)
 		communities[i].Packages = sortedStringCopy(communities[i].Packages)
 		communities[i].ExternalDependencyRatio = roundCommunityFloat(communities[i].ExternalDependencyRatio)
+		if communities[i].PackageCount > 0 {
+			communities[i].PackageAlignment = roundCommunityFloat(communities[i].PackageAlignment)
+		}
 	}
 	out.Communities = communities
 

--- a/service/community_formatter.go
+++ b/service/community_formatter.go
@@ -355,6 +355,9 @@ func (f *CommunityFormatter) writeHTMLSummary(builder *strings.Builder, response
                         <th>External</th>
                         <th>Cross-In</th>
                         <th>Cross-Out</th>
+                        <th>Dominant Package</th>
+                        <th>Packages</th>
+                        <th>Package Alignment</th>
                     </tr>
                 </thead>
                 <tbody>`)
@@ -369,6 +372,9 @@ func (f *CommunityFormatter) writeHTMLSummary(builder *strings.Builder, response
                         <td>%d</td>
                         <td>%d</td>
                         <td>%d</td>
+                        <td>%s</td>
+                        <td>%s</td>
+                        <td>%s</td>
                     </tr>`,
 				EscapeHTML(community.ID),
 				community.Size,
@@ -376,12 +382,15 @@ func (f *CommunityFormatter) writeHTMLSummary(builder *strings.Builder, response
 				community.ExternalEdges,
 				community.IncomingCrossCommunityEdges,
 				community.OutgoingCrossCommunityEdges,
+				formatCommunityDominantPackageHTML(community),
+				formatCommunityPackageCountHTML(community),
+				formatCommunityPackageAlignmentHTML(community),
 			))
 		}
 		if len(communities) > limit {
 			builder.WriteString(fmt.Sprintf(`
                     <tr>
-                        <td colspan="6"><em>... and %d more communities</em></td>
+                        <td colspan="9"><em>... and %d more communities</em></td>
                     </tr>`, len(communities)-limit))
 		}
 		builder.WriteString(`
@@ -504,6 +513,27 @@ func (f *CommunityFormatter) formatDOT(response *domain.CommunityAnalysisResult)
 	builder.WriteString("}\n")
 
 	return builder.String(), nil
+}
+
+func formatCommunityDominantPackageHTML(community domain.CommunityMetrics) string {
+	if community.PackageCount == 0 {
+		return "—"
+	}
+	return EscapeHTML(community.DominantPackage)
+}
+
+func formatCommunityPackageCountHTML(community domain.CommunityMetrics) string {
+	if community.PackageCount == 0 {
+		return "—"
+	}
+	return strconv.Itoa(community.PackageCount)
+}
+
+func formatCommunityPackageAlignmentHTML(community domain.CommunityMetrics) string {
+	if community.PackageCount == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.3f", community.PackageAlignment)
 }
 
 func communitiesBySize(communities []domain.CommunityMetrics) []domain.CommunityMetrics {

--- a/service/community_formatter_test.go
+++ b/service/community_formatter_test.go
@@ -169,6 +169,35 @@ func TestCommunityFormatter_Format_Text(t *testing.T) {
 	assert.Contains(t, output, "bridge")
 }
 
+func TestCommunityFormatter_Format_Text_PackageMismatch(t *testing.T) {
+	score := 0.0
+	result := &domain.CommunityAnalysisResult{
+		Algorithm:             "leiden",
+		Scope:                 "module",
+		TotalCommunities:      2,
+		Modularity:            0.42,
+		PackageAlignmentScore: &score,
+		SplitPackages:         []string{"mod"},
+		Communities: []domain.CommunityMetrics{
+			{
+				ID:               "community_1",
+				Size:             3,
+				DominantPackage:  "mod",
+				PackageCount:     1,
+				PackageAlignment: 1.0,
+			},
+		},
+	}
+
+	formatter := NewCommunityFormatter()
+	output, err := formatter.Format(result, domain.OutputFormatText)
+	require.NoError(t, err)
+	assert.Contains(t, output, "Package Alignment")
+	assert.Contains(t, output, "PACKAGE MISMATCH")
+	assert.Contains(t, output, "Split Packages")
+	assert.Contains(t, output, "pkg-align")
+}
+
 func TestCommunityFormatter_Format_AllFormats_BridgeFixture(t *testing.T) {
 	result := analyzeCommunityBridgeFixture(t)
 	result.GeneratedAt = "2026-01-15T12:00:00Z"

--- a/service/community_formatter_test.go
+++ b/service/community_formatter_test.go
@@ -169,6 +169,58 @@ func TestCommunityFormatter_Format_Text(t *testing.T) {
 	assert.Contains(t, output, "bridge")
 }
 
+func TestCommunityFormatter_Format_HTML_PackageMismatch(t *testing.T) {
+	score := 0.0
+	result := &domain.CommunityAnalysisResult{
+		Algorithm:             "leiden",
+		Scope:                 "module",
+		TotalCommunities:      2,
+		Modularity:            0.42,
+		PackageAlignmentScore: &score,
+		SplitPackages:         []string{"mod"},
+		MixedCommunities:      []string{"community_2"},
+		Communities: []domain.CommunityMetrics{
+			{
+				ID:                          "community_1",
+				Size:                        3,
+				InternalEdges:               2,
+				ExternalEdges:               1,
+				IncomingCrossCommunityEdges: 0,
+				OutgoingCrossCommunityEdges: 1,
+				DominantPackage:             "mod",
+				PackageCount:                1,
+				PackageAlignment:            1.0,
+			},
+			{
+				ID:                          "community_2",
+				Size:                        2,
+				InternalEdges:               1,
+				ExternalEdges:               1,
+				IncomingCrossCommunityEdges: 1,
+				OutgoingCrossCommunityEdges: 0,
+				DominantPackage:             "billing",
+				PackageCount:                2,
+				PackageAlignment:            0.5,
+			},
+		},
+	}
+
+	formatter := NewCommunityFormatter()
+	output, err := formatter.Format(result, domain.OutputFormatHTML)
+	require.NoError(t, err)
+	assert.Contains(t, output, "Package Alignment")
+	assert.Contains(t, output, "Package Mismatch")
+	assert.Contains(t, output, "<th>Dominant Package</th>")
+	assert.Contains(t, output, "<th>Packages</th>")
+	assert.Contains(t, output, "<th>Package Alignment</th>")
+	assert.Contains(t, output, ">mod<")
+	assert.Contains(t, output, ">billing<")
+	assert.Contains(t, output, ">1.000<")
+	assert.Contains(t, output, ">0.500<")
+	assert.Contains(t, output, "Split packages:")
+	assert.Contains(t, output, "Mixed communities:")
+}
+
 func TestCommunityFormatter_Format_Text_PackageMismatch(t *testing.T) {
 	score := 0.0
 	result := &domain.CommunityAnalysisResult{
@@ -226,6 +278,10 @@ func TestCommunityFormatter_Format_AllFormats_BridgeFixture(t *testing.T) {
 	assert.Contains(t, htmlOutput, "Community Analysis Report")
 	assert.Contains(t, htmlOutput, "Bridge Modules")
 	assert.Contains(t, htmlOutput, "bridge")
+	assert.Contains(t, htmlOutput, "<th>Dominant Package</th>")
+	assert.Contains(t, htmlOutput, "<th>Package Alignment</th>")
+	assert.Contains(t, htmlOutput, ">mod<")
+	assert.Contains(t, htmlOutput, "Split packages:")
 	assert.NotContains(t, htmlOutput, "<nil>")
 
 	dotOutput, err := formatter.Format(result, domain.OutputFormatDOT)

--- a/service/testdata/golden/community_analysis.json
+++ b/service/testdata/golden/community_analysis.json
@@ -19,7 +19,10 @@
       "external_dependency_ratio": 0.3333,
       "incoming_cross_community_edges": 0,
       "outgoing_cross_community_edges": 1,
-      "size": 3
+      "size": 3,
+      "dominant_package": "mod",
+      "package_count": 1,
+      "package_alignment": 1
     },
     {
       "id": "community_2",
@@ -35,7 +38,10 @@
       "external_dependency_ratio": 0.5,
       "incoming_cross_community_edges": 1,
       "outgoing_cross_community_edges": 0,
-      "size": 2
+      "size": 2,
+      "dominant_package": "mod",
+      "package_count": 1,
+      "package_alignment": 1
     }
   ],
   "bridge_modules": [
@@ -55,6 +61,10 @@
         "community_1"
       ]
     }
+  ],
+  "package_alignment_score": 0,
+  "split_packages": [
+    "mod"
   ],
   "generated_at": "2026-01-15T12:00:00Z",
   "version": "0.0.0-test",

--- a/testdata/python/community_package_mismatch/pkg_alpha/one.py
+++ b/testdata/python/community_package_mismatch/pkg_alpha/one.py
@@ -1,0 +1,6 @@
+import pkg_alpha.two
+import pkg_beta.one
+
+
+def run() -> str:
+    return pkg_alpha.two.VALUE + pkg_beta.one.label()

--- a/testdata/python/community_package_mismatch/pkg_alpha/two.py
+++ b/testdata/python/community_package_mismatch/pkg_alpha/two.py
@@ -1,0 +1,3 @@
+import pkg_beta.two
+
+VALUE = "alpha"

--- a/testdata/python/community_package_mismatch/pkg_beta/one.py
+++ b/testdata/python/community_package_mismatch/pkg_beta/one.py
@@ -1,0 +1,5 @@
+import pkg_alpha.one
+
+
+def label() -> str:
+    return "beta"

--- a/testdata/python/community_package_mismatch/pkg_beta/two.py
+++ b/testdata/python/community_package_mismatch/pkg_beta/two.py
@@ -1,0 +1,5 @@
+import pkg_beta.one
+
+
+def status() -> str:
+    return pkg_beta.one.label()

--- a/testdata/python/community_package_mismatch/pyproject.toml
+++ b/testdata/python/community_package_mismatch/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "community-package-mismatch-fixture"
+version = "0.1.0"

--- a/website/docs/guides/module-community-detection.md
+++ b/website/docs/guides/module-community-detection.md
@@ -73,6 +73,21 @@ A bridge module belongs to one community but has import edges into other communi
 - **0.3 – 0.7** — typical for repositories with identifiable subsystems.
 - **Very high** — strong separation; verify the graph is not trivially disconnected.
 
+### Package mismatch
+
+Community detection groups modules by import topology. Package mismatch metrics compare that partition to declared package boundaries (from module paths and `ModuleNode.Package` metadata).
+
+| Field | What it suggests |
+| --- | --- |
+| `package_alignment_score` (0–1) | How well communities respect package boundaries. **1.0** means every package's modules live in exactly one community; **0.0** means every package is split. |
+| `split_packages` | Packages whose modules appear in two or more communities — refactor candidates when you expect package = subsystem. |
+| `mixed_communities` | Communities that contain modules from two or more packages — cross-cutting clusters that span declared boundaries. |
+| `dominant_package` / `package_count` / `package_alignment` | Per-community composition: which package dominates, how many packages are represented, and how cohesive internal edges are within that community. |
+
+**Example:** A bridge fixture where `mod.a`/`mod.b` cluster separately from `mod.c`/`mod.d` yields `package_alignment_score: 0` and `split_packages: ["mod"]` even though each community is internally cohesive. A billing/inventory fixture with no cross-package imports yields `package_alignment_score: 1`.
+
+This is distinct from `SystemMetrics.ModularityIndex` in dependency analysis (an intra-package edge ratio), which measures a different cohesion signal.
+
 ## Configuration
 
 All keys live under `[communities]` in `.pyscn.toml` or `[tool.pyscn.communities]` in `pyproject.toml`. Full reference: [Configuration Reference](../configuration/reference.md#communities).
@@ -135,6 +150,8 @@ Given a bridge fixture where `bridge.py` imports one cluster and is imported by 
 {
   "total_communities": 2,
   "modularity": 0.2188,
+  "package_alignment_score": 0,
+  "split_packages": ["mod"],
   "bridge_modules": [
     {
       "module": "bridge",
@@ -146,13 +163,13 @@ Given a bridge fixture where `bridge.py` imports one cluster and is imported by 
 }
 ```
 
-Read this as: two natural clusters exist, and `bridge` is the coupling point between them. Extracting shared logic from `bridge` or inverting dependencies may improve modularity.
+Read this as: two natural clusters exist, and `bridge` is the coupling point between them. The `mod` package is split across both communities (`package_alignment_score: 0`), so import topology disagrees with the declared package boundary. Extracting shared logic from `bridge` or regrouping `mod` modules may improve alignment.
 
 ## Follow-up work (Phase 2 and 3)
 
-Module-level community detection is Phase 1 of [GitHub issue #564](https://github.com/ludo-technologies/pyscn/issues/564). Planned extensions include:
+Module-level community detection is Phase 1 of [GitHub issue #564](https://github.com/ludo-technologies/pyscn/issues/564). Package mismatch scoring (Phase 2) is available via `package_alignment_score`, `split_packages`, and `mixed_communities`. Remaining planned extensions include:
 
-- Community vs package/layer mismatch scoring
+- Layer/community mismatch scoring
 - DOT export with community-colored subgraphs
 - HTML macro-architecture visualization
 - AI-agent context maps

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -727,6 +727,9 @@ Mirrors `domain.CommunityAnalysisResult`. Emitted as a top-level field in unifie
 | `modularity`        | number  | Partition modularity score.                                         |
 | `communities`       | array   | Per-community metrics. See [`community`](#community-object).      |
 | `bridge_modules`    | array   | Cross-community coupling modules. See [`bridge_module`](#bridge-module-object). |
+| `package_alignment_score` | number \| absent | Share of packages whose modules all reside in one community (0–1). Omitted when package metadata is unavailable. |
+| `split_packages`    | array \| absent | Packages whose modules appear in two or more communities (sorted). |
+| `mixed_communities` | array \| absent | Community ids containing modules from two or more packages (sorted). |
 | `warnings`          | array \| absent | Non-fatal analysis warnings.                              |
 | `errors`            | array \| absent | Fatal analysis errors.                                    |
 | `generated_at`      | string (RFC 3339) | Community analysis completion time.                 |
@@ -746,6 +749,9 @@ Mirrors `domain.CommunityAnalysisResult`. Emitted as a top-level field in unifie
 | `incoming_cross_community_edges`   | integer | Incoming edges from other communities.                   |
 | `outgoing_cross_community_edges`   | integer | Outgoing edges to other communities.                   |
 | `size`                             | integer | Number of modules in the community.                      |
+| `dominant_package`                 | string \| absent | Package with the most modules in this community.   |
+| `package_count`                    | integer \| absent | Distinct packages represented in this community.  |
+| `package_alignment`                | number \| absent | Cohesion within the community: share of internal edges whose endpoints share a package, or dominant-package module ratio when no qualifying internal edges exist. |
 
 ### `bridge_module` object { #bridge-module-object }
 


### PR DESCRIPTION
Closes #600

## Summary

Adds package mismatch metrics on top of community detection so teams can compare inferred import communities to declared package boundaries.

## Changes

- **System metrics:** `package_alignment_score`, `split_packages`, `mixed_communities`
- **Per-community metrics:** `dominant_package`, `package_count`, `package_alignment`
- Wired through analyzer → service → JSON/YAML/text/HTML formatters
- Graceful omission when package metadata is unavailable

## Interpretation

- `package_alignment_score` = share of packages whose modules all reside in one community (0–1)
- `split_packages` = packages spanning multiple communities
- `mixed_communities` = communities containing modules from 2+ packages
- Distinct from `SystemMetrics.ModularityIndex` in dependency analysis

## Tests

- Unit tests on `community_bridge`, aligned multi-package graph, forced mixed community, and missing metadata
- Service + integration tests on `community_bridge`, `community_separated`, and new `community_package_mismatch` fixture
- Golden JSON snapshot updated

## Docs

- `website/docs/output/schemas.md` — new fields documented
- `website/docs/guides/module-community-detection.md` — interpretation section added

## Verification

- [x] `make fmt`
- [x] `make lint`
- [x] `make test`