### PR TITLE
feat(communities): community risk score + Health Score integration

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -702,6 +702,23 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 		}
 	}
 
+	// Community detection statistics (feed the community risk score / health penalty)
+	if response.Communities != nil {
+		c := response.Communities
+		summary.CommunityCount = c.TotalCommunities
+		summary.CommunityModularity = c.Modularity
+		summary.CommunityBridgeModules = len(c.BridgeModules)
+		internalEdges, crossEdges := 0, 0
+		for i := range c.Communities {
+			internalEdges += c.Communities[i].InternalEdges
+			crossEdges += c.Communities[i].OutgoingCrossCommunityEdges
+		}
+		summary.CommunityInternalEdges = internalEdges
+		summary.CommunityCrossEdges = crossEdges
+		summary.CommunityPackageAlignment = c.PackageAlignmentScore
+		summary.CommunityLayerAlignment = c.LayerAlignmentScore
+	}
+
 	// Calculate health score with error handling
 	if err := summary.CalculateHealthScore(); err != nil {
 		// Log warning

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -707,7 +707,9 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 		c := response.Communities
 		summary.CommunityCount = c.TotalCommunities
 		summary.CommunityModularity = c.Modularity
-		summary.CommunityBridgeModules = len(c.BridgeModules)
+		// Use the analysis bridge count, not the emitted list, so the health
+		// penalty is independent of whether bridge modules are reported.
+		summary.CommunityBridgeModules = c.BridgeModuleCount
 		internalEdges, crossEdges := 0, 0
 		for i := range c.Communities {
 			internalEdges += c.Communities[i].InternalEdges

--- a/docs/ANALYZE_SCORING.md
+++ b/docs/ANALYZE_SCORING.md
@@ -22,8 +22,35 @@ Penalties are additive. Each category subtracts up to the maximum listed points 
 | Coupling (CBO)      | Weighted ratio of high-risk (`CBO > 7`) and medium-risk (`3 < CBO ≤ 7`) classes using weight 1.0 and 0.5 respectively, divided by total measured classes | Continuous linear: `min(20, ratio / 0.12 * 20)`<br/>Starts at 0%, reaches max at 12%                                  | 20          |
 | Dependencies        | Module dependency graph: proportion of modules in cycles, dependency depth above `log₂(N)+1`, Main Sequence Deviation                                    | Cycles: up to 10 pts (proportional)<br/>Depth: up to 3 pts (excess over expected)<br/>MSD: up to 3 pts (proportional) | 16          |
 | Architecture        | Architecture rules compliance ratio (0–1)                                                                                                                | `round((1 - compliance) * 12)`                                                                                         | 12          |
+| Communities         | Module community structure: low modularity Q, cross-community edge ratio, bridge-module count, and (when available) package/layer alignment              | `round(riskRatio * 10)` where `riskRatio` is the weighted risk blend below                                            | 10          |
 
 When a category is disabled (e.g., `--skip-clones`), its penalty is zero and the prior score (100) carries forward so the missing analysis does not hurt the overall grade.
+
+## Community Risk Score
+
+Community detection is opt-in. The community penalty only applies when communities ran **and** at least two communities were detected; otherwise the category scores 100 with a zero penalty, so enabling or disabling communities never changes existing grades (backward compatible).
+
+The system-level **community risk score** (`community_risk_score`, 0–100, higher = worse) is a weighted blend of normalised risk factors. The category quality score is its inverse: `CommunityScore = 100 - community_risk_score`. The health-score penalty is `round(riskRatio * 10)`.
+
+Each factor is normalised to `0..1` (1 = worst). The blend is a weighted average that is renormalised over whichever factors are available, so optional factors only count when their metadata exists:
+
+| Factor                      | Weight | Formula                                                                 | Availability                       |
+|-----------------------------|--------|------------------------------------------------------------------------|------------------------------------|
+| Low modularity Q            | 0.40   | `clamp01((0.30 - Q) / 0.30)` — risk rises as Q falls below 0.30        | Always (when ≥ 2 communities)      |
+| Cross-community edge ratio  | 0.30   | `clamp01(crossRatio / 0.50)`, `crossRatio = crossEdges / (internal + cross)` | When the graph has edges     |
+| Bridge-module count         | 0.30   | `clamp01(bridgeModules / communityCount)` — saturates at ~1 per community | When communities exist          |
+| Low package alignment       | 0.25   | `clamp01(1 - package_alignment_score)`                                 | When package metadata is present   |
+| Low layer alignment         | 0.25   | `clamp01(1 - layer_alignment_score)`                                   | When architecture layers configured |
+
+The cross-community edge ratio also captures the aggregate `external_dependency_ratio` at the system level, so that signal is not double-counted.
+
+### Per-community `risk_level`
+
+Each community is also classified `low` / `medium` / `high` from a local risk ratio blending its `external_dependency_ratio` (weight 0.5) with `1 - package_alignment` (0.25, when available) and `1 - layer_alignment` (0.25, when available):
+
+- `high`: ratio ≥ 0.60
+- `medium`: 0.30 ≤ ratio < 0.60
+- `low`: ratio < 0.30
 
 ## Overall Health Score and Grade
 

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -86,6 +86,24 @@ const (
 	MaxArchPenalty     = 12 // Increased from 8 for stricter scoring
 	MaxMSDPenalty      = 3  // Increased from 2 for stricter scoring
 
+	// Community detection scoring (opt-in; only applied when communities ran
+	// with at least two detected communities). The risk score is a weighted
+	// blend of the factors below; the health-score penalty is bounded at
+	// MaxCommunityPenalty so disabling communities cannot move existing grades.
+	MaxCommunityPenalty          = 10   // bounded contribution to the overall health score
+	CommunityModularityTarget    = 0.30 // Q at or above which modularity risk is zero
+	CommunityCrossEdgeSaturation = 0.50 // cross-community edge ratio at which that risk maxes out
+	// Risk-factor weights (core factors sum to 1.0; optional factors are added
+	// and the blend is renormalised over whatever factors are available).
+	CommunityModularityWeight = 0.40
+	CommunityCrossEdgeWeight  = 0.30
+	CommunityBridgeWeight     = 0.30
+	CommunityPackageWeight    = 0.25
+	CommunityLayerWeight      = 0.25
+	// Per-community risk_level thresholds, expressed as risk ratios (0..1).
+	CommunityRiskHighRatio   = 0.60 // >= high
+	CommunityRiskMediumRatio = 0.30 // >= medium, otherwise low
+
 	// Score display scale - all categories normalized to this base
 	MaxScoreBase = 20
 
@@ -160,6 +178,15 @@ type AnalyzeSummary struct {
 	DepsMainSequenceDeviation float64 `json:"deps_main_sequence_deviation" yaml:"deps_main_sequence_deviation"`
 	ArchCompliance            float64 `json:"arch_compliance" yaml:"arch_compliance"`
 
+	// Community detection metrics used for scoring (populated when CommunitiesEnabled).
+	CommunityCount            int      `json:"community_count" yaml:"community_count"`
+	CommunityModularity       float64  `json:"community_modularity" yaml:"community_modularity"`
+	CommunityBridgeModules    int      `json:"community_bridge_modules" yaml:"community_bridge_modules"`
+	CommunityInternalEdges    int      `json:"community_internal_edges" yaml:"community_internal_edges"`
+	CommunityCrossEdges       int      `json:"community_cross_edges" yaml:"community_cross_edges"`
+	CommunityPackageAlignment *float64 `json:"community_package_alignment,omitempty" yaml:"community_package_alignment,omitempty"`
+	CommunityLayerAlignment   *float64 `json:"community_layer_alignment,omitempty" yaml:"community_layer_alignment,omitempty"`
+
 	// Key metrics
 	TotalFunctions             int     `json:"total_functions" yaml:"total_functions"`
 	AverageComplexity          float64 `json:"average_complexity" yaml:"average_complexity"`
@@ -205,6 +232,11 @@ type AnalyzeSummary struct {
 	CohesionScore     int `json:"cohesion_score" yaml:"cohesion_score"`
 	DependencyScore   int `json:"dependency_score" yaml:"dependency_score"`
 	ArchitectureScore int `json:"architecture_score" yaml:"architecture_score"`
+	CommunityScore    int `json:"community_score" yaml:"community_score"`
+
+	// CommunityRiskScore is a system-level 0-100 risk signal (higher = worse).
+	// It is the inverse of CommunityScore and only meaningful when communities ran.
+	CommunityRiskScore int `json:"community_risk_score" yaml:"community_risk_score"`
 }
 
 // Validate checks if the summary contains valid values
@@ -242,6 +274,19 @@ func (s *AnalyzeSummary) Validate() error {
 		if s.DepsTotalModules > 0 && s.DepsModulesInCycles > s.DepsTotalModules {
 			return fmt.Errorf("DepsModulesInCycles (%d) cannot exceed DepsTotalModules (%d)",
 				s.DepsModulesInCycles, s.DepsTotalModules)
+		}
+	}
+
+	// Community metric checks (when enabled)
+	if s.CommunitiesEnabled {
+		if s.CommunityModularity < -1 || s.CommunityModularity > 1 {
+			return fmt.Errorf("CommunityModularity must be -1..1, got %f", s.CommunityModularity)
+		}
+		if s.CommunityPackageAlignment != nil && (*s.CommunityPackageAlignment < 0 || *s.CommunityPackageAlignment > 1) {
+			return fmt.Errorf("CommunityPackageAlignment must be 0-1, got %f", *s.CommunityPackageAlignment)
+		}
+		if s.CommunityLayerAlignment != nil && (*s.CommunityLayerAlignment < 0 || *s.CommunityLayerAlignment > 1) {
+			return fmt.Errorf("CommunityLayerAlignment must be 0-1, got %f", *s.CommunityLayerAlignment)
 		}
 	}
 
@@ -461,6 +506,97 @@ func (s *AnalyzeSummary) calculateArchitecturePenalty() int {
 	return int(math.Round(float64(MaxArchPenalty) * (1 - comp)))
 }
 
+// clamp01 bounds a value to the [0, 1] interval.
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// communityRiskInputs collects the raw signals used to derive the community
+// risk score. It is shared by the AnalyzeSummary path (health scoring) and the
+// CommunityAnalysisResult path (standalone community command) so both produce
+// identical numbers.
+type communityRiskInputs struct {
+	communityCount   int
+	modularity       float64
+	bridgeModules    int
+	internalEdges    int
+	crossEdges       int
+	packageAlignment *float64 // nil when package metadata is unavailable
+	layerAlignment   *float64 // nil when architecture layers are not configured
+}
+
+// computeCommunityRiskRatio blends the community risk factors into a single
+// 0..1 ratio (0 = healthy, 1 = worst). Optional factors (package/layer
+// alignment) are only included when available, and the weighted average is
+// renormalised over whichever factors contributed. See docs/ANALYZE_SCORING.md.
+func computeCommunityRiskRatio(in communityRiskInputs) float64 {
+	var weightedSum, totalWeight float64
+
+	// Low modularity Q: risk rises as Q falls below the "good separation" target.
+	modularityRisk := clamp01((CommunityModularityTarget - in.modularity) / CommunityModularityTarget)
+	weightedSum += CommunityModularityWeight * modularityRisk
+	totalWeight += CommunityModularityWeight
+
+	// Cross-community edge ratio: how tangled the partitions are. This also
+	// captures the aggregate external_dependency_ratio at the system level.
+	if denom := in.internalEdges + in.crossEdges; denom > 0 {
+		crossRatio := float64(in.crossEdges) / float64(denom)
+		crossRisk := clamp01(crossRatio / CommunityCrossEdgeSaturation)
+		weightedSum += CommunityCrossEdgeWeight * crossRisk
+		totalWeight += CommunityCrossEdgeWeight
+	}
+
+	// Bridge modules: count relative to the number of communities, saturating at
+	// roughly one bridge module per community.
+	if in.communityCount > 0 {
+		bridgeRisk := clamp01(float64(in.bridgeModules) / float64(in.communityCount))
+		weightedSum += CommunityBridgeWeight * bridgeRisk
+		totalWeight += CommunityBridgeWeight
+	}
+
+	// Low package alignment (when available).
+	if in.packageAlignment != nil {
+		weightedSum += CommunityPackageWeight * clamp01(1-*in.packageAlignment)
+		totalWeight += CommunityPackageWeight
+	}
+
+	// Low layer alignment (when available).
+	if in.layerAlignment != nil {
+		weightedSum += CommunityLayerWeight * clamp01(1-*in.layerAlignment)
+		totalWeight += CommunityLayerWeight
+	}
+
+	if totalWeight == 0 {
+		return 0
+	}
+	return weightedSum / totalWeight
+}
+
+// communityRiskRatio returns the system community risk ratio (0..1) for the
+// summary and whether community scoring applies. Scoring is skipped unless
+// communities ran and at least two communities were detected (a single
+// community has no meaningful modular structure to score).
+func (s *AnalyzeSummary) communityRiskRatio() (float64, bool) {
+	if !s.CommunitiesEnabled || s.CommunityCount < 2 {
+		return 0, false
+	}
+	return computeCommunityRiskRatio(communityRiskInputs{
+		communityCount:   s.CommunityCount,
+		modularity:       s.CommunityModularity,
+		bridgeModules:    s.CommunityBridgeModules,
+		internalEdges:    s.CommunityInternalEdges,
+		crossEdges:       s.CommunityCrossEdges,
+		packageAlignment: s.CommunityPackageAlignment,
+		layerAlignment:   s.CommunityLayerAlignment,
+	}), true
+}
+
 // normalizeToScoreBase normalizes a penalty value to the MaxScoreBase scale (0-20)
 // This ensures all category scores use a consistent display scale
 func normalizeToScoreBase(penalty int, maxPenalty int) int {
@@ -506,6 +642,8 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 		s.CohesionScore = 0
 		s.DependencyScore = 0
 		s.ArchitectureScore = 0
+		s.CommunityScore = 0
+		s.CommunityRiskScore = 0
 		return fmt.Errorf("invalid summary data: %w", err)
 	}
 	score := 100
@@ -549,6 +687,18 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 	// Use compliance directly as score (98% compliance = 98 points)
 	s.ArchitectureScore = int(math.Round(s.ArchCompliance * 100))
 	score -= architecturePenalty
+
+	// Community detection: only penalises when communities ran with >= 2
+	// communities. Disabled or trivial cases score 100 / risk 0 so existing
+	// grades are unaffected (backward compatible).
+	if communityRatio, scored := s.communityRiskRatio(); scored {
+		s.CommunityRiskScore = int(math.Round(communityRatio * 100))
+		s.CommunityScore = 100 - s.CommunityRiskScore
+		score -= int(math.Round(communityRatio * float64(MaxCommunityPenalty)))
+	} else {
+		s.CommunityScore = 100
+		s.CommunityRiskScore = 0
+	}
 
 	// Minimum score floor
 	if score < MinimumScore {

--- a/domain/analyze_test.go
+++ b/domain/analyze_test.go
@@ -480,6 +480,126 @@ func TestAnalyzeSummary_CalculateHealthScore(t *testing.T) {
 	}
 }
 
+func floatPtr(v float64) *float64 { return &v }
+
+func TestAnalyzeSummary_CommunityScoring(t *testing.T) {
+	tests := []struct {
+		name               string
+		summary            domain.AnalyzeSummary
+		expectedScore      int // CommunityScore (category quality)
+		expectedRiskScore  int // CommunityRiskScore (system risk)
+		expectHealthChange bool
+	}{
+		{
+			name: "communities disabled - no effect",
+			summary: domain.AnalyzeSummary{
+				AverageComplexity:   2.0,
+				CommunitiesEnabled:  false,
+				CommunityCount:      5,
+				CommunityModularity: 0.0,
+			},
+			expectedScore:      100,
+			expectedRiskScore:  0,
+			expectHealthChange: false,
+		},
+		{
+			name: "single community - not scored",
+			summary: domain.AnalyzeSummary{
+				AverageComplexity:   2.0,
+				CommunitiesEnabled:  true,
+				CommunityCount:      1,
+				CommunityModularity: 0.0,
+			},
+			expectedScore:      100,
+			expectedRiskScore:  0,
+			expectHealthChange: false,
+		},
+		{
+			name: "clean separation - high modularity, no bridges",
+			summary: domain.AnalyzeSummary{
+				AverageComplexity:      2.0,
+				CommunitiesEnabled:     true,
+				CommunityCount:         4,
+				CommunityModularity:    0.45, // >= target 0.30 -> 0 modularity risk
+				CommunityBridgeModules: 0,
+				CommunityInternalEdges: 40,
+				CommunityCrossEdges:    0,
+			},
+			expectedScore:      100,
+			expectedRiskScore:  0,
+			expectHealthChange: false,
+		},
+		{
+			name: "tangled - low Q, many bridges, high cross ratio",
+			summary: domain.AnalyzeSummary{
+				AverageComplexity:      2.0,
+				CommunitiesEnabled:     true,
+				CommunityCount:         4,
+				CommunityModularity:    0.0, // modularity risk = 1.0
+				CommunityBridgeModules: 4,   // bridge risk = 1.0
+				CommunityInternalEdges: 10,
+				CommunityCrossEdges:    10, // crossRatio 0.5 -> /0.5 = 1.0 risk
+			},
+			// All three core factors at 1.0 -> ratio 1.0 -> risk 100, score 0, penalty 10.
+			expectedScore:      0,
+			expectedRiskScore:  100,
+			expectHealthChange: true,
+		},
+		{
+			name: "low package and layer alignment increase risk",
+			summary: domain.AnalyzeSummary{
+				AverageComplexity:         2.0,
+				CommunitiesEnabled:        true,
+				CommunityCount:            3,
+				CommunityModularity:       0.30, // 0 modularity risk
+				CommunityBridgeModules:    0,
+				CommunityInternalEdges:    30,
+				CommunityCrossEdges:       0,
+				CommunityPackageAlignment: floatPtr(0.0), // risk 1.0
+				CommunityLayerAlignment:   floatPtr(0.0), // risk 1.0
+			},
+			// All factors count toward the weight denominator even at zero risk:
+			// modularity .4 (0), cross .3 (0), bridge .3 (0), package .25 (1), layer .25 (1)
+			// ratio = (0.25+0.25)/(0.4+0.3+0.3+0.25+0.25) = 0.5/1.5 = 0.3333 -> 33
+			expectedScore:      67,
+			expectedRiskScore:  33,
+			expectHealthChange: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.summary
+			baseline := s
+			baseline.CommunitiesEnabled = false
+			if err := baseline.CalculateHealthScore(); err != nil {
+				t.Fatalf("baseline CalculateHealthScore() error: %v", err)
+			}
+
+			if err := s.CalculateHealthScore(); err != nil {
+				t.Fatalf("CalculateHealthScore() error: %v", err)
+			}
+
+			if s.CommunityScore != tt.expectedScore {
+				t.Errorf("CommunityScore = %d, want %d", s.CommunityScore, tt.expectedScore)
+			}
+			if s.CommunityRiskScore != tt.expectedRiskScore {
+				t.Errorf("CommunityRiskScore = %d, want %d", s.CommunityRiskScore, tt.expectedRiskScore)
+			}
+			if s.CommunityScore+s.CommunityRiskScore != 100 {
+				t.Errorf("CommunityScore (%d) + CommunityRiskScore (%d) should equal 100",
+					s.CommunityScore, s.CommunityRiskScore)
+			}
+
+			healthChanged := s.HealthScore != baseline.HealthScore
+			if healthChanged != tt.expectHealthChange {
+				t.Errorf("health change = %v (community=%d, baseline=%d), want %v",
+					healthChanged, s.HealthScore, baseline.HealthScore, tt.expectHealthChange)
+			}
+		})
+	}
+}
+
 func TestAnalyzeSummary_IsHealthy(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/domain/community.go
+++ b/domain/community.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"io"
+	"math"
 )
 
 // CommunityAnalysisRequest represents a request for module community detection.
@@ -66,6 +67,10 @@ type CommunityMetrics struct {
 	LayerCount     int      `json:"layer_count,omitempty" yaml:"layer_count,omitempty"`
 	Layers         []string `json:"layers,omitempty" yaml:"layers,omitempty"`
 	LayerAlignment *float64 `json:"layer_alignment,omitempty" yaml:"layer_alignment,omitempty"`
+
+	// RiskLevel classifies the community as low/medium/high using documented
+	// thresholds (see docs/ANALYZE_SCORING.md). Populated by ScoreCommunityResult.
+	RiskLevel string `json:"risk_level,omitempty" yaml:"risk_level,omitempty"`
 }
 
 // CommunityModuleDependency is a directed module dependency edge used for graph export.
@@ -101,6 +106,11 @@ type CommunityAnalysisResult struct {
 	CrossLayerCommunities []string `json:"cross_layer_communities,omitempty" yaml:"cross_layer_communities,omitempty"`
 	LayerBridgeModules    []string `json:"layer_bridge_modules,omitempty" yaml:"layer_bridge_modules,omitempty"`
 
+	// RiskScore is a system-level community risk score (0-100, higher = worse),
+	// populated by ScoreCommunityResult. Nil when fewer than two communities were
+	// detected (no meaningful modular structure to score).
+	RiskScore *int `json:"community_risk_score,omitempty" yaml:"community_risk_score,omitempty"`
+
 	// ModuleDependencies holds directed edges for DOT export and is omitted from JSON/YAML.
 	ModuleDependencies []CommunityModuleDependency `json:"-" yaml:"-"`
 
@@ -110,6 +120,78 @@ type CommunityAnalysisResult struct {
 	GeneratedAt string      `json:"generated_at" yaml:"generated_at"`
 	Version     string      `json:"version" yaml:"version"`
 	Config      interface{} `json:"config,omitempty" yaml:"config,omitempty"`
+}
+
+// ScoreCommunityResult computes the system-level community risk score and the
+// per-community risk_level, mutating the result in place. It is the single entry
+// point used by both the standalone community command and the analyze health
+// score, so the numbers stay consistent. Safe to call with a nil result.
+func ScoreCommunityResult(result *CommunityAnalysisResult) {
+	if result == nil {
+		return
+	}
+
+	// Per-community risk levels are always classifiable from local metrics.
+	for i := range result.Communities {
+		result.Communities[i].RiskLevel = communityRiskLevel(&result.Communities[i])
+	}
+
+	// The system risk score needs at least two communities to be meaningful.
+	if result.TotalCommunities < 2 {
+		result.RiskScore = nil
+		return
+	}
+
+	internalEdges, crossEdges := 0, 0
+	for i := range result.Communities {
+		internalEdges += result.Communities[i].InternalEdges
+		crossEdges += result.Communities[i].OutgoingCrossCommunityEdges
+	}
+
+	ratio := computeCommunityRiskRatio(communityRiskInputs{
+		communityCount:   result.TotalCommunities,
+		modularity:       result.Modularity,
+		bridgeModules:    len(result.BridgeModules),
+		internalEdges:    internalEdges,
+		crossEdges:       crossEdges,
+		packageAlignment: result.PackageAlignmentScore,
+		layerAlignment:   result.LayerAlignmentScore,
+	})
+	score := int(math.Round(ratio * 100))
+	result.RiskScore = &score
+}
+
+// communityRiskLevel classifies a single community as low/medium/high. It blends
+// the community's external dependency ratio with its package and layer alignment
+// (each included only when the underlying metadata is available).
+func communityRiskLevel(c *CommunityMetrics) string {
+	var weightedSum, totalWeight float64
+
+	weightedSum += 0.5 * clamp01(c.ExternalDependencyRatio)
+	totalWeight += 0.5
+
+	if c.PackageCount > 0 {
+		weightedSum += 0.25 * clamp01(1-c.PackageAlignment)
+		totalWeight += 0.25
+	}
+	if c.LayerAlignment != nil {
+		weightedSum += 0.25 * clamp01(1-*c.LayerAlignment)
+		totalWeight += 0.25
+	}
+
+	ratio := 0.0
+	if totalWeight > 0 {
+		ratio = weightedSum / totalWeight
+	}
+
+	switch {
+	case ratio >= CommunityRiskHighRatio:
+		return "high"
+	case ratio >= CommunityRiskMediumRatio:
+		return "medium"
+	default:
+		return "low"
+	}
 }
 
 // CommunityAnalysisService defines the core business logic for community analysis.

--- a/domain/community.go
+++ b/domain/community.go
@@ -114,6 +114,12 @@ type CommunityAnalysisResult struct {
 	// ModuleDependencies holds directed edges for DOT export and is omitted from JSON/YAML.
 	ModuleDependencies []CommunityModuleDependency `json:"-" yaml:"-"`
 
+	// BridgeModuleCount is the number of detected bridge modules from the
+	// underlying analysis. It is tracked independently of BridgeModules (which is
+	// only populated when bridge reporting is enabled) so risk scoring does not
+	// depend on a presentation option. Omitted from JSON/YAML.
+	BridgeModuleCount int `json:"-" yaml:"-"`
+
 	Warnings []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
 	Errors   []string `json:"errors,omitempty" yaml:"errors,omitempty"`
 
@@ -151,7 +157,7 @@ func ScoreCommunityResult(result *CommunityAnalysisResult) {
 	ratio := computeCommunityRiskRatio(communityRiskInputs{
 		communityCount:   result.TotalCommunities,
 		modularity:       result.Modularity,
-		bridgeModules:    len(result.BridgeModules),
+		bridgeModules:    result.BridgeModuleCount,
 		internalEdges:    internalEdges,
 		crossEdges:       crossEdges,
 		packageAlignment: result.PackageAlignmentScore,

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -134,6 +134,14 @@ func (h *HandlerSet) HandleAnalyzeCode(ctx context.Context, request mcp.CallTool
 		}
 	}
 
+	// Surface community scores in summary mode only when communities ran.
+	if m, ok := responseData.(map[string]interface{}); ok && result.Summary.CommunitiesEnabled {
+		if sum, ok := m["summary"].(map[string]interface{}); ok {
+			sum["community_score"] = result.Summary.CommunityScore
+			sum["community_risk_score"] = result.Summary.CommunityRiskScore
+		}
+	}
+
 	// Convert result to JSON
 	jsonData, err := json.Marshal(responseData)
 	if err != nil {
@@ -768,6 +776,16 @@ func (h *HandlerSet) HandleGetHealthScore(ctx context.Context, request mcp.CallT
 			"high_coupling_classes": result.Summary.HighCouplingClasses,
 			"high_lcom_classes":     result.Summary.HighLCOMClasses,
 		},
+	}
+
+	// Include the community score only when community detection ran.
+	if result.Summary.CommunitiesEnabled {
+		if cs, ok := healthScoreResult["category_scores"].(map[string]int); ok {
+			cs["community_score"] = result.Summary.CommunityScore
+		}
+		if sum, ok := healthScoreResult["summary"].(map[string]interface{}); ok {
+			sum["community_risk_score"] = result.Summary.CommunityRiskScore
+		}
 	}
 
 	// Convert to JSON

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -132,6 +132,8 @@ func (f *AnalyzeFormatter) writeCSV(response *domain.AnalyzeResponse, writer io.
 		fmt.Fprintf(writer, "Total Communities,%d\n", communities.TotalCommunities)
 		fmt.Fprintf(writer, "Community Modularity,%.4f\n", communities.Modularity)
 		fmt.Fprintf(writer, "Bridge Modules,%d\n", len(communities.BridgeModules))
+		fmt.Fprintf(writer, "Community Score,%d\n", response.Summary.CommunityScore)
+		fmt.Fprintf(writer, "Community Risk Score,%d\n", response.Summary.CommunityRiskScore)
 	}
 
 	return nil
@@ -580,12 +582,12 @@ const analyzeHTMLTemplate = `<!DOCTYPE html>
                     <div class="score-bar-item">
                         <div class="score-bar-header">
                             <span class="score-label">Communities</span>
-                            <span class="score-value">{{.Communities.TotalCommunities}}</span>
+                            <span class="score-value">{{.Summary.CommunityScore}}/100</span>
                         </div>
                         <div class="score-bar-container">
-                            <div class="score-bar-fill score-good" style="width: 100%"></div>
+                            <div class="score-bar-fill score-{{scoreQuality .Summary.CommunityScore}}" style="width: {{.Summary.CommunityScore}}%"></div>
                         </div>
-                        <div class="score-detail">Q={{printf "%.3f" .Communities.Modularity}}, {{len .Communities.BridgeModules}} bridge modules</div>
+                        <div class="score-detail">{{.Communities.TotalCommunities}} communities, Q={{printf "%.3f" .Communities.Modularity}}, {{len .Communities.BridgeModules}} bridge modules</div>
                     </div>
                     {{end}}
                 </div>

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -76,6 +76,10 @@ func (s *CommunityAnalysisServiceImpl) Analyze(ctx context.Context, req domain.C
 		result.LayerBridgeModules = append([]string(nil), layerMismatch.LayerBridgeModules...)
 	}
 
+	// Track the bridge-module count from the analysis independently of whether
+	// bridge modules are emitted, so risk scoring is unaffected by the reporting
+	// option.
+	result.BridgeModuleCount = len(metrics.BridgeModules)
 	if domain.BoolValue(req.ReportBridgeModules, true) {
 		result.BridgeModules = s.convertBridgeModules(metrics.BridgeModules)
 	}

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -82,6 +82,9 @@ func (s *CommunityAnalysisServiceImpl) Analyze(ctx context.Context, req domain.C
 
 	result.ModuleDependencies = s.convertModuleDependencies(graph)
 
+	// Derive the community risk score and per-community risk levels.
+	domain.ScoreCommunityResult(result)
+
 	if graph.TotalModules == 0 {
 		result.Warnings = append(result.Warnings, "No modules found to analyze")
 	}

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -194,6 +194,43 @@ func TestCommunityAnalysisService_RiskScore_BridgeWorseThanSeparated(t *testing.
 	assert.LessOrEqual(t, *separated.RiskScore, 10)
 }
 
+// Risk scoring must not depend on the bridge-module reporting option: disabling
+// report_bridge_modules omits the emitted list but must leave the score intact.
+func TestCommunityAnalysisService_RiskScore_IndependentOfBridgeReporting(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_bridge"))
+	require.NoError(t, err)
+
+	fileReader := NewFileReader()
+	files, err := fileReader.CollectPythonFiles([]string{fixtureRoot}, true, nil, nil)
+	require.NoError(t, err)
+
+	service := NewCommunityAnalysisService()
+	base := domain.CommunityAnalysisRequest{
+		Paths:            files,
+		SourcePaths:      []string{fixtureRoot},
+		MinCommunitySize: 2,
+	}
+
+	withReport := base
+	withReport.ReportBridgeModules = domain.BoolPtr(true)
+	reported, err := service.Analyze(context.Background(), withReport)
+	require.NoError(t, err)
+
+	withoutReport := base
+	withoutReport.ReportBridgeModules = domain.BoolPtr(false)
+	suppressed, err := service.Analyze(context.Background(), withoutReport)
+	require.NoError(t, err)
+
+	// The emitted list differs, but the analysis bridge count and risk score must not.
+	assert.NotEmpty(t, reported.BridgeModules)
+	assert.Empty(t, suppressed.BridgeModules)
+	assert.Equal(t, reported.BridgeModuleCount, suppressed.BridgeModuleCount)
+	assert.Positive(t, suppressed.BridgeModuleCount)
+	require.NotNil(t, reported.RiskScore)
+	require.NotNil(t, suppressed.RiskScore)
+	assert.Equal(t, *reported.RiskScore, *suppressed.RiskScore)
+}
+
 func TestCommunityAnalysisService_Analyze_Deterministic(t *testing.T) {
 	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_bridge"))
 	require.NoError(t, err)

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -155,6 +155,45 @@ func TestCommunityAnalysisService_Analyze_PackageMismatch_MixedFixture(t *testin
 	}
 }
 
+// analyzeCommunityFixtureForRisk runs community analysis against a fixture and
+// returns the scored result (RiskScore and per-community risk levels populated).
+func analyzeCommunityFixtureForRisk(t *testing.T, fixture string) *domain.CommunityAnalysisResult {
+	t.Helper()
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", fixture))
+	require.NoError(t, err)
+
+	fileReader := NewFileReader()
+	files, err := fileReader.CollectPythonFiles([]string{fixtureRoot}, true, nil, nil)
+	require.NoError(t, err)
+
+	service := NewCommunityAnalysisService()
+	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
+		Paths:            files,
+		SourcePaths:      []string{fixtureRoot},
+		MinCommunitySize: 2,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+// A high-bridge / low-Q project must carry more community risk (a lower
+// community score) than a cleanly separated one.
+func TestCommunityAnalysisService_RiskScore_BridgeWorseThanSeparated(t *testing.T) {
+	bridge := analyzeCommunityFixtureForRisk(t, "community_bridge")
+	separated := analyzeCommunityFixtureForRisk(t, "community_separated")
+
+	require.NotNil(t, bridge.RiskScore, "bridge fixture should be scored (>= 2 communities)")
+	require.NotNil(t, separated.RiskScore, "separated fixture should be scored (>= 2 communities)")
+
+	assert.Greater(t, *bridge.RiskScore, *separated.RiskScore,
+		"high-bridge/low-Q fixture (Q=%.3f) should score riskier than clean separation (Q=%.3f)",
+		bridge.Modularity, separated.Modularity)
+
+	// The cleanly separated fixture should be essentially risk-free.
+	assert.LessOrEqual(t, *separated.RiskScore, 10)
+}
+
 func TestCommunityAnalysisService_Analyze_Deterministic(t *testing.T) {
 	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "community_bridge"))
 	require.NoError(t, err)

--- a/service/community_formatter.go
+++ b/service/community_formatter.go
@@ -116,6 +116,9 @@ func (f *CommunityFormatter) writeTextSummary(builder *strings.Builder, response
 	if response.LayerAlignmentScore != nil {
 		stats["Layer Alignment"] = fmt.Sprintf("%.3f", *response.LayerAlignmentScore)
 	}
+	if response.RiskScore != nil {
+		stats["Risk Score"] = fmt.Sprintf("%d/100", *response.RiskScore)
+	}
 	builder.WriteString(utils.FormatSummaryStats(stats))
 
 	if len(response.CrossLayerCommunities) > 0 || len(response.LayerBridgeModules) > 0 {

--- a/service/testdata/golden/community_analysis.json
+++ b/service/testdata/golden/community_analysis.json
@@ -22,7 +22,8 @@
       "size": 3,
       "dominant_package": "mod",
       "package_count": 1,
-      "package_alignment": 1
+      "package_alignment": 1,
+      "risk_level": "low"
     },
     {
       "id": "community_2",
@@ -41,7 +42,8 @@
       "size": 2,
       "dominant_package": "mod",
       "package_count": 1,
-      "package_alignment": 1
+      "package_alignment": 1,
+      "risk_level": "medium"
     }
   ],
   "bridge_modules": [
@@ -66,6 +68,7 @@
   "split_packages": [
     "mod"
   ],
+  "community_risk_score": 65,
   "generated_at": "2026-01-15T12:00:00Z",
   "version": "0.0.0-test",
   "config": {


### PR DESCRIPTION
Closes #602. Part of #564 (Phase 2), builds on the package (#600) and layer (#601) mismatch metrics.

## What

Adds a single community health signal and wires it into the overall health score.

### Scoring
- **`community_risk_score`** (0-100, higher = worse): a weighted blend of low modularity Q, cross-community edge ratio, bridge-module count, and — when available — package/layer alignment. The weighted average is renormalised over whichever factors exist.
- **`CommunityScore`** (0-100 category quality, the inverse) added to `AnalyzeSummary` category scores.
- Bounded penalty (max 10) folded into `CalculateHealthScore()`. **Backward compatible**: only applies when communities ran with ≥2 communities; otherwise scores 100 / risk 0, so existing grades are unaffected.
- Per-community **`risk_level`** (`low`/`medium`/`high`) using documented thresholds.

### Reporting
- HTML Overview shows real `CommunityScore`/100 (replaces the hardcoded `score-good` 100% bar).
- CSV summary rows for community score + risk score.
- Text summary surfaces the risk score.
- MCP `get_health_score` / `analyze_code` summaries include the community score when enabled.

### Docs
- `docs/ANALYZE_SCORING.md`: Communities penalty row, risk-factor weights table, and per-community `risk_level` thresholds.

## Tests
- Table-driven `TestAnalyzeSummary_CommunityScoring` (disabled, single-community, clean, tangled, alignment factors).
- Fixture test: high-bridge/low-Q (`community_bridge`) scores riskier than clean separation (`community_separated`).
- Updated `community_analysis.json` golden.

Verified end-to-end on `community_bridge`: score 35/100, risk 65, levels `[low, medium]`, consistent across JSON/HTML/CSV.