### PR TITLE
feat(communities): interactive macro-architecture graph in HTML report

### DIFF
--- a/service/community_formatter.go
+++ b/service/community_formatter.go
@@ -360,6 +360,8 @@ func (f *CommunityFormatter) writeHTMLSummary(builder *strings.Builder, response
 	}
 	builder.WriteString(`</div>`)
 
+	writeCommunityGraphHTML(builder, response)
+
 	if len(response.CrossLayerCommunities) > 0 || len(response.LayerBridgeModules) > 0 {
 		builder.WriteString(GenerateSectionHeader("Layer Mismatch"))
 		builder.WriteString(`<ul>`)

--- a/service/community_graph_assets.go
+++ b/service/community_graph_assets.go
@@ -1,0 +1,339 @@
+package service
+
+// communityGraphStyle holds the scoped CSS for the macro-architecture graph.
+const communityGraphStyle = `<style>
+.community-graph-help { margin: 4px 0 12px; color: #666; font-size: 13px; }
+.community-graph { margin-bottom: 24px; }
+.community-graph-controls {
+    display: flex; flex-wrap: wrap; gap: 16px; align-items: center;
+    margin-bottom: 8px; font-size: 13px; color: #333;
+}
+.community-graph-controls label { display: inline-flex; align-items: center; gap: 6px; }
+.community-graph-controls select { padding: 2px 6px; }
+.community-graph-count { color: #888; }
+.community-graph-canvas-wrap { position: relative; }
+#community-graph-canvas {
+    width: 100%; max-width: 100%; height: 480px;
+    border: 1px solid #e0e0e0; border-radius: 6px; background: #fafafa;
+    display: block; cursor: grab; touch-action: none;
+}
+#community-graph-canvas.dragging { cursor: grabbing; }
+.community-graph-tooltip {
+    position: absolute; pointer-events: none; z-index: 10;
+    background: rgba(33, 33, 33, 0.95); color: #fff; padding: 8px 10px;
+    border-radius: 6px; font-size: 12px; line-height: 1.5; max-width: 280px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+.community-graph-tooltip strong { color: #fff; }
+.community-graph-tooltip .cg-bridge { color: #ffb3b3; font-weight: 600; }
+.community-graph-legend {
+    display: flex; flex-wrap: wrap; gap: 14px; margin-top: 10px; font-size: 12px; color: #444;
+}
+.community-graph-legend .cg-swatch {
+    display: inline-block; width: 12px; height: 12px; border-radius: 3px;
+    margin-right: 6px; vertical-align: -1px; border: 1px solid rgba(0,0,0,0.15);
+}
+.community-graph-legend .cg-item { display: inline-flex; align-items: center; }
+</style>`
+
+// communityGraphScript holds the self-contained, dependency-free renderer for
+// the macro-architecture graph. It reads the embedded JSON blob, runs a small
+// force-directed layout on a canvas, and wires up hover/click/filter behavior.
+const communityGraphScript = `<script>
+(function () {
+    var dataEl = document.getElementById('community-graph-data');
+    var canvas = document.getElementById('community-graph-canvas');
+    if (!dataEl || !canvas) { return; }
+
+    var data;
+    try { data = JSON.parse(dataEl.textContent); } catch (e) { return; }
+    if (!data || !data.nodes || !data.nodes.length) { return; }
+
+    var ctx = canvas.getContext('2d');
+    var tooltip = document.getElementById('community-graph-tooltip');
+    var filterEl = document.getElementById('community-graph-filter');
+    var bridgesEl = document.getElementById('community-graph-bridges');
+    var isolatedEl = document.getElementById('community-graph-isolated');
+    var countEl = document.getElementById('community-graph-count');
+    var legendEl = document.getElementById('community-graph-legend');
+
+    var BRIDGE_OUTLINE = '#d9534f';
+    var CROSS_EDGE = 'rgba(217, 83, 79, 0.7)';
+    var EDGE = 'rgba(120, 120, 120, 0.35)';
+
+    var nodes = data.nodes.map(function (n, i) { return Object.assign({}, n, { idx: i, x: 0, y: 0, vx: 0, vy: 0 }); });
+    var index = {};
+    nodes.forEach(function (n) { index[n.id] = n; });
+    var edges = data.edges.filter(function (e) { return index[e.from] && index[e.to]; });
+
+    // Degree for radius scaling and isolated detection.
+    nodes.forEach(function (n) { n.degree = 0; });
+    edges.forEach(function (e) { index[e.from].degree++; index[e.to].degree++; });
+
+    // Deterministic initial layout on a circle (avoids Math.random for stable renders).
+    var N = nodes.length;
+    nodes.forEach(function (n, i) {
+        var a = (2 * Math.PI * i) / N;
+        n.x = Math.cos(a) * 180;
+        n.y = Math.sin(a) * 180;
+    });
+
+    function radius(n) {
+        if (n.group) { return Math.max(10, Math.min(34, 8 + Math.sqrt(n.count || 1) * 3)); }
+        return n.bridge ? 8 : 6;
+    }
+
+    // Populate the community filter dropdown.
+    (data.communities || []).forEach(function (c) {
+        var opt = document.createElement('option');
+        opt.value = c.id;
+        opt.textContent = c.id + ' (' + c.size + ')';
+        filterEl && filterEl.appendChild(opt);
+    });
+
+    // Legend: one swatch per community plus bridge / cross-edge markers.
+    if (legendEl) {
+        var legendHTML = (data.communities || []).map(function (c) {
+            var extra = c.dominantPackage ? (' · ' + c.dominantPackage) : (c.dominantLayer ? (' · ' + c.dominantLayer) : '');
+            return '<span class="cg-item"><span class="cg-swatch" style="background:' + c.color + '"></span>' +
+                escapeHtml(c.id + extra) + '</span>';
+        }).join('');
+        legendHTML += '<span class="cg-item"><span class="cg-swatch" style="background:#fff;border-color:' +
+            BRIDGE_OUTLINE + ';border-width:2px"></span>Bridge module</span>';
+        legendHTML += '<span class="cg-item"><span class="cg-swatch" style="background:' + CROSS_EDGE + '"></span>Cross-community edge</span>';
+        legendEl.innerHTML = legendHTML;
+    }
+
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, function (c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+
+    // ---- visibility / filtering ----
+    var visible = {};
+    function recomputeVisible() {
+        var community = filterEl ? filterEl.value : '';
+        var bridgesOnly = bridgesEl ? bridgesEl.checked : false;
+        var hideIsolated = isolatedEl ? isolatedEl.checked : false;
+
+        nodes.forEach(function (n) {
+            var show = true;
+            if (community && n.community !== community) { show = false; }
+            if (bridgesOnly && !n.bridge && !n.group) { show = false; }
+            n._show = show;
+        });
+        if (hideIsolated) {
+            var connected = {};
+            edges.forEach(function (e) {
+                if (index[e.from]._show && index[e.to]._show) { connected[e.from] = true; connected[e.to] = true; }
+            });
+            nodes.forEach(function (n) { if (!connected[n.id]) { n._show = false; } });
+        }
+        visible = {};
+        var shown = 0;
+        nodes.forEach(function (n) { if (n._show) { visible[n.id] = true; shown++; } });
+        if (countEl) {
+            countEl.textContent = shown + ' / ' + nodes.length + (data.collapsed ? ' communities' : ' modules');
+        }
+    }
+
+    // ---- force simulation ----
+    var alpha = 1;
+    var selected = null;
+
+    function tick() {
+        var k = 6000; // repulsion strength
+        for (var i = 0; i < N; i++) {
+            var a = nodes[i];
+            if (!a._show) { continue; }
+            for (var j = i + 1; j < N; j++) {
+                var b = nodes[j];
+                if (!b._show) { continue; }
+                var dx = a.x - b.x, dy = a.y - b.y;
+                var d2 = dx * dx + dy * dy || 0.01;
+                var f = k / d2;
+                var d = Math.sqrt(d2);
+                var fx = (dx / d) * f, fy = (dy / d) * f;
+                a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy;
+            }
+        }
+        edges.forEach(function (e) {
+            var a = index[e.from], b = index[e.to];
+            if (!a._show || !b._show) { return; }
+            var dx = b.x - a.x, dy = b.y - a.y;
+            var d = Math.sqrt(dx * dx + dy * dy) || 0.01;
+            var target = 70;
+            var f = (d - target) * 0.02;
+            var fx = (dx / d) * f, fy = (dy / d) * f;
+            a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy;
+        });
+        nodes.forEach(function (n) {
+            if (!n._show) { return; }
+            n.vx -= n.x * 0.002; // gravity to center
+            n.vy -= n.y * 0.002;
+            if (n === dragNode) { return; }
+            n.x += n.vx * alpha; n.y += n.vy * alpha;
+            n.vx *= 0.85; n.vy *= 0.85;
+        });
+        alpha *= 0.985;
+        if (alpha < 0.02) { alpha = 0.02; }
+    }
+
+    // ---- rendering ----
+    var dpr = window.devicePixelRatio || 1;
+    var W = 800, H = 480, cx = 400, cy = 240, scale = 1;
+
+    function resize() {
+        var rect = canvas.getBoundingClientRect();
+        W = rect.width || 800; H = rect.height || 480;
+        canvas.width = W * dpr; canvas.height = H * dpr;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        cx = W / 2; cy = H / 2;
+    }
+
+    function neighborsOf(id) {
+        var set = {};
+        set[id] = true;
+        edges.forEach(function (e) {
+            if (e.from === id) { set[e.to] = true; }
+            if (e.to === id) { set[e.from] = true; }
+        });
+        return set;
+    }
+
+    function draw() {
+        ctx.clearRect(0, 0, W, H);
+        var hl = selected ? neighborsOf(selected) : null;
+
+        edges.forEach(function (e) {
+            var a = index[e.from], b = index[e.to];
+            if (!a._show || !b._show) { return; }
+            var dim = hl && !(hl[e.from] && hl[e.to]);
+            ctx.beginPath();
+            ctx.moveTo(cx + a.x * scale, cy + a.y * scale);
+            ctx.lineTo(cx + b.x * scale, cy + b.y * scale);
+            ctx.strokeStyle = e.cross ? CROSS_EDGE : EDGE;
+            ctx.globalAlpha = dim ? 0.08 : 1;
+            ctx.lineWidth = e.weight ? Math.min(4, 1 + e.weight * 0.4) : (e.cross ? 1.5 : 1);
+            ctx.stroke();
+        });
+        ctx.globalAlpha = 1;
+
+        var showLabels = nodes.length <= 60 || data.collapsed;
+        nodes.forEach(function (n) {
+            if (!n._show) { return; }
+            var dim = hl && !hl[n.id];
+            var r = radius(n);
+            var px = cx + n.x * scale, py = cy + n.y * scale;
+            ctx.globalAlpha = dim ? 0.2 : 1;
+            ctx.beginPath();
+            ctx.arc(px, py, r, 0, 2 * Math.PI);
+            ctx.fillStyle = n.bridge ? '#ffe2e2' : n.color;
+            ctx.fill();
+            ctx.lineWidth = n.bridge ? 2.5 : 1;
+            ctx.strokeStyle = n.bridge ? BRIDGE_OUTLINE : 'rgba(0,0,0,0.25)';
+            ctx.stroke();
+            if (showLabels) {
+                ctx.globalAlpha = dim ? 0.25 : 1;
+                ctx.fillStyle = '#333';
+                ctx.font = '11px -apple-system, sans-serif';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'top';
+                ctx.fillText(n.label, px, py + r + 2);
+            }
+        });
+        ctx.globalAlpha = 1;
+    }
+
+    var running = true;
+    function frame() {
+        if (running) { tick(); }
+        draw();
+        requestAnimationFrame(frame);
+    }
+
+    function reheat() { alpha = Math.max(alpha, 0.6); running = true; }
+
+    // ---- interaction ----
+    var dragNode = null;
+    function toGraph(evt) {
+        var rect = canvas.getBoundingClientRect();
+        return { x: (evt.clientX - rect.left - cx) / scale, y: (evt.clientY - rect.top - cy) / scale };
+    }
+    function nodeAt(evt) {
+        var p = toGraph(evt);
+        var best = null, bestD = Infinity;
+        nodes.forEach(function (n) {
+            if (!n._show) { return; }
+            var dx = n.x - p.x, dy = n.y - p.y;
+            var d = Math.sqrt(dx * dx + dy * dy);
+            if (d < radius(n) + 4 && d < bestD) { best = n; bestD = d; }
+        });
+        return best;
+    }
+
+    canvas.addEventListener('mousemove', function (evt) {
+        if (dragNode) {
+            var p = toGraph(evt);
+            dragNode.x = p.x; dragNode.y = p.y; dragNode.vx = 0; dragNode.vy = 0;
+            reheat();
+            return;
+        }
+        var n = nodeAt(evt);
+        if (n && tooltip) {
+            var rect = canvas.getBoundingClientRect();
+            var html = '<strong>' + escapeHtml(n.label) + '</strong><br>Community: ' + escapeHtml(n.community);
+            if (n.group) { html += '<br>Modules: ' + n.count; }
+            if (n.bridge) {
+                html += '<br><span class="cg-bridge">Bridge module</span>';
+                if (n.crossEdges) { html += '<br>Cross edges: ' + n.crossEdges; }
+                if (n.targets && n.targets.length) { html += '<br>Targets: ' + escapeHtml(n.targets.join(', ')); }
+            }
+            if (n.dominantPackage) { html += '<br>Package: ' + escapeHtml(n.dominantPackage); }
+            if (n.dominantLayer) { html += '<br>Layer: ' + escapeHtml(n.dominantLayer); }
+            tooltip.innerHTML = html;
+            tooltip.hidden = false;
+            var tx = evt.clientX - rect.left + 12, ty = evt.clientY - rect.top + 12;
+            tooltip.style.left = Math.min(tx, W - 20) + 'px';
+            tooltip.style.top = ty + 'px';
+            canvas.style.cursor = 'pointer';
+        } else if (tooltip) {
+            tooltip.hidden = true;
+            canvas.style.cursor = 'grab';
+        }
+    });
+    canvas.addEventListener('mouseleave', function () { if (tooltip) { tooltip.hidden = true; } });
+    canvas.addEventListener('mousedown', function (evt) {
+        var n = nodeAt(evt);
+        if (n) { dragNode = n; canvas.classList.add('dragging'); }
+    });
+    window.addEventListener('mouseup', function () {
+        if (dragNode) { dragNode = null; canvas.classList.remove('dragging'); }
+    });
+    canvas.addEventListener('click', function (evt) {
+        if (dragNode) { return; }
+        var n = nodeAt(evt);
+        selected = (n && selected !== n.id) ? n.id : null;
+    });
+
+    function applyFilters() { recomputeVisible(); reheat(); }
+    filterEl && filterEl.addEventListener('change', applyFilters);
+    bridgesEl && bridgesEl.addEventListener('change', applyFilters);
+    isolatedEl && isolatedEl.addEventListener('change', applyFilters);
+
+    window.addEventListener('resize', resize);
+
+    resize();
+    recomputeVisible();
+    // The community graph may live inside a hidden tab; size it when shown.
+    var wrap = document.getElementById('community-graph');
+    if (wrap && 'IntersectionObserver' in window) {
+        var io = new IntersectionObserver(function (entries) {
+            entries.forEach(function (e) { if (e.isIntersecting) { resize(); reheat(); } });
+        });
+        io.observe(wrap);
+    }
+    requestAnimationFrame(frame);
+})();
+</script>`

--- a/service/community_graph_html.go
+++ b/service/community_graph_html.go
@@ -1,0 +1,248 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/ludo-technologies/pyscn/domain"
+)
+
+// communityGraphNodeThreshold is the default module-count limit above which the
+// macro-architecture visualization collapses module-level nodes into one node
+// per community. Keeping the rendered node count bounded keeps the client-side
+// force layout responsive on large codebases. Documented in
+// website/docs/guides/module-community-detection.md.
+const communityGraphNodeThreshold = 100
+
+// communityGraphNode is a single rendered node in the macro-architecture graph.
+// In module mode it is a module; in collapsed mode it is a whole community.
+type communityGraphNode struct {
+	ID              string   `json:"id"`
+	Label           string   `json:"label"`
+	Community       string   `json:"community"`
+	Color           string   `json:"color"`
+	Bridge          bool     `json:"bridge,omitempty"`
+	Group           bool     `json:"group,omitempty"`
+	Count           int      `json:"count,omitempty"`
+	CrossEdges      int      `json:"crossEdges,omitempty"`
+	Targets         []string `json:"targets,omitempty"`
+	DominantPackage string   `json:"dominantPackage,omitempty"`
+	DominantLayer   string   `json:"dominantLayer,omitempty"`
+}
+
+// communityGraphEdge is a directed edge between two rendered nodes.
+type communityGraphEdge struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Cross  bool   `json:"cross,omitempty"`
+	Weight int    `json:"weight,omitempty"`
+}
+
+// communityGraphCommunity describes a community for the legend / filter list.
+type communityGraphCommunity struct {
+	ID              string `json:"id"`
+	Color           string `json:"color"`
+	Size            int    `json:"size"`
+	DominantPackage string `json:"dominantPackage,omitempty"`
+	DominantLayer   string `json:"dominantLayer,omitempty"`
+}
+
+// communityGraphData is the compact JSON blob embedded in the HTML report and
+// consumed by the client-side renderer.
+type communityGraphData struct {
+	Nodes        []communityGraphNode      `json:"nodes"`
+	Edges        []communityGraphEdge      `json:"edges"`
+	Communities  []communityGraphCommunity `json:"communities"`
+	Collapsed    bool                      `json:"collapsed"`
+	Threshold    int                       `json:"threshold"`
+	TotalModules int                       `json:"totalModules"`
+}
+
+// BuildCommunityGraphData converts a community analysis result into the compact
+// graph payload used by the HTML visualization. When the module count exceeds
+// threshold, the graph collapses to one node per community so the layout stays
+// responsive. A threshold <= 0 falls back to communityGraphNodeThreshold.
+func BuildCommunityGraphData(response *domain.CommunityAnalysisResult, threshold int) communityGraphData {
+	if threshold <= 0 {
+		threshold = communityGraphNodeThreshold
+	}
+	data := communityGraphData{Threshold: threshold}
+	if response == nil {
+		return data
+	}
+
+	moduleCommunity := make(map[string]string)
+	communityColor := make(map[string]string)
+	sorted := sortedCommunitiesByID(response.Communities)
+	for i, community := range sorted {
+		color := communityDOTColors[i%len(communityDOTColors)]
+		communityColor[community.ID] = color
+		for _, module := range community.Modules {
+			moduleCommunity[module] = community.ID
+		}
+		data.Communities = append(data.Communities, communityGraphCommunity{
+			ID:              community.ID,
+			Color:           color,
+			Size:            community.Size,
+			DominantPackage: community.DominantPackage,
+			DominantLayer:   community.DominantLayer,
+		})
+	}
+	data.TotalModules = len(moduleCommunity)
+
+	bridges := make(map[string]domain.BridgeModule)
+	for _, bridge := range response.BridgeModules {
+		bridges[bridge.Module] = bridge
+	}
+
+	if data.TotalModules > threshold {
+		data.Collapsed = true
+		buildCollapsedGraph(&data, response, moduleCommunity, communityColor)
+		return data
+	}
+
+	buildModuleGraph(&data, response, sorted, moduleCommunity, communityColor, bridges)
+	return data
+}
+
+// buildModuleGraph populates module-level nodes and edges.
+func buildModuleGraph(
+	data *communityGraphData,
+	response *domain.CommunityAnalysisResult,
+	sorted []domain.CommunityMetrics,
+	moduleCommunity map[string]string,
+	communityColor map[string]string,
+	bridges map[string]domain.BridgeModule,
+) {
+	for _, community := range sorted {
+		for _, module := range sortedStringCopy(community.Modules) {
+			node := communityGraphNode{
+				ID:              module,
+				Label:           module,
+				Community:       community.ID,
+				Color:           communityColor[community.ID],
+				DominantPackage: community.DominantPackage,
+				DominantLayer:   community.DominantLayer,
+			}
+			if bridge, ok := bridges[module]; ok {
+				node.Bridge = true
+				node.CrossEdges = bridge.CrossCommunityEdges
+				node.Targets = bridge.TargetCommunities
+			}
+			data.Nodes = append(data.Nodes, node)
+		}
+	}
+
+	for _, dep := range response.ModuleDependencies {
+		fromCommunity, fromOK := moduleCommunity[dep.From]
+		toCommunity, toOK := moduleCommunity[dep.To]
+		if !fromOK || !toOK {
+			continue
+		}
+		data.Edges = append(data.Edges, communityGraphEdge{
+			From:  dep.From,
+			To:    dep.To,
+			Cross: fromCommunity != toCommunity,
+		})
+	}
+}
+
+// buildCollapsedGraph populates one node per community with aggregated
+// cross-community edges, used when the module count exceeds the threshold.
+func buildCollapsedGraph(
+	data *communityGraphData,
+	response *domain.CommunityAnalysisResult,
+	moduleCommunity map[string]string,
+	communityColor map[string]string,
+) {
+	for _, community := range sortedCommunitiesByID(response.Communities) {
+		data.Nodes = append(data.Nodes, communityGraphNode{
+			ID:              community.ID,
+			Label:           community.ID,
+			Community:       community.ID,
+			Color:           communityColor[community.ID],
+			Group:           true,
+			Count:           community.Size,
+			DominantPackage: community.DominantPackage,
+			DominantLayer:   community.DominantLayer,
+		})
+	}
+
+	weights := make(map[string]int)
+	order := make([]string, 0)
+	for _, dep := range response.ModuleDependencies {
+		from, fromOK := moduleCommunity[dep.From]
+		to, toOK := moduleCommunity[dep.To]
+		if !fromOK || !toOK || from == to {
+			continue
+		}
+		key := from + "\x00" + to
+		if _, seen := weights[key]; !seen {
+			order = append(order, key)
+		}
+		weights[key]++
+	}
+	for _, key := range order {
+		parts := strings.SplitN(key, "\x00", 2)
+		data.Edges = append(data.Edges, communityGraphEdge{
+			From:   parts[0],
+			To:     parts[1],
+			Cross:  true,
+			Weight: weights[key],
+		})
+	}
+}
+
+// writeCommunityGraphHTML renders the macro-architecture graph section: a data
+// blob, the interactive container, and a self-contained renderer script. It is
+// safe to embed in both the standalone community report and the unified analyze
+// report (the script is wrapped in an IIFE and scoped to a fixed container id).
+func writeCommunityGraphHTML(builder *strings.Builder, response *domain.CommunityAnalysisResult) {
+	if response == nil || len(response.Communities) == 0 {
+		return
+	}
+
+	data := BuildCommunityGraphData(response, communityGraphNodeThreshold)
+	payload, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+
+	builder.WriteString(GenerateSectionHeader("Macro Architecture"))
+	builder.WriteString(`<p class="community-graph-help">Module dependency graph colored by community. ` +
+		`Bridge modules are outlined in <span style="color:#d9534f;font-weight:600;">red</span>; ` +
+		`red edges cross community boundaries. Hover a node for details; click to highlight its neighbors.</p>`)
+
+	if data.Collapsed {
+		fmt.Fprintf(builder,
+			`<p class="community-graph-help"><em>%d modules exceed the %d-module display threshold; `+
+				`showing one node per community. Each node is sized by module count.</em></p>`,
+			data.TotalModules, data.Threshold,
+		)
+	}
+
+	builder.WriteString(`
+        <div id="community-graph" class="community-graph">
+            <div class="community-graph-controls">
+                <label>Community
+                    <select id="community-graph-filter"><option value="">All</option></select>
+                </label>
+                <label><input type="checkbox" id="community-graph-bridges"> Bridges only</label>
+                <label><input type="checkbox" id="community-graph-isolated"> Hide isolated</label>
+                <span id="community-graph-count" class="community-graph-count"></span>
+            </div>
+            <div class="community-graph-canvas-wrap">
+                <canvas id="community-graph-canvas" width="800" height="480" role="img"
+                    aria-label="Module community dependency graph"></canvas>
+                <div id="community-graph-tooltip" class="community-graph-tooltip" hidden></div>
+            </div>
+            <div id="community-graph-legend" class="community-graph-legend"></div>
+        </div>`)
+
+	builder.WriteString(`<script type="application/json" id="community-graph-data">`)
+	builder.Write(payload)
+	builder.WriteString(`</script>`)
+	builder.WriteString(communityGraphStyle)
+	builder.WriteString(communityGraphScript)
+}

--- a/service/community_graph_html_test.go
+++ b/service/community_graph_html_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// graphFixture builds a small 2-community + bridge result mirroring the
+// testdata/python/community_bridge fixture.
+func graphFixtureResult() *domain.CommunityAnalysisResult {
+	return &domain.CommunityAnalysisResult{
+		Algorithm:        "leiden",
+		Scope:            "module",
+		TotalCommunities: 2,
+		Modularity:       0.42,
+		Communities: []domain.CommunityMetrics{
+			{ID: "community_1", Size: 3, Modules: []string{"bridge", "mod.a", "mod.b"}},
+			{ID: "community_2", Size: 2, Modules: []string{"mod.c", "mod.d"}},
+		},
+		BridgeModules: []domain.BridgeModule{
+			{Module: "bridge", Community: "community_1", CrossCommunityEdges: 2, TargetCommunities: []string{"community_2"}},
+			{Module: "mod.c", Community: "community_2", CrossCommunityEdges: 1, TargetCommunities: []string{"community_1"}},
+		},
+		ModuleDependencies: []domain.CommunityModuleDependency{
+			{From: "mod.a", To: "mod.b"},
+			{From: "bridge", To: "mod.c"},
+			{From: "mod.c", To: "mod.d"},
+			{From: "mod.b", To: "bridge"},
+		},
+	}
+}
+
+func extractGraphData(t *testing.T, html string) communityGraphData {
+	t.Helper()
+	re := regexp.MustCompile(`(?s)<script type="application/json" id="community-graph-data">(.*?)</script>`)
+	m := re.FindStringSubmatch(html)
+	require.Len(t, m, 2, "embedded graph data blob not found")
+	var data communityGraphData
+	require.NoError(t, json.Unmarshal([]byte(m[1]), &data))
+	return data
+}
+
+func TestBuildCommunityGraphData_ModuleLevel(t *testing.T) {
+	data := BuildCommunityGraphData(graphFixtureResult(), 0)
+
+	assert.False(t, data.Collapsed)
+	assert.Equal(t, 100, data.Threshold)
+	assert.Equal(t, 5, data.TotalModules)
+	assert.Len(t, data.Nodes, 5)
+	assert.Len(t, data.Edges, 4)
+	assert.Len(t, data.Communities, 2)
+
+	bridges := map[string]bool{}
+	colors := map[string]string{}
+	for _, n := range data.Nodes {
+		if n.Bridge {
+			bridges[n.ID] = true
+		}
+		colors[n.ID] = n.Color
+	}
+	assert.True(t, bridges["bridge"], "bridge module should be flagged")
+	assert.True(t, bridges["mod.c"], "mod.c should be flagged as bridge")
+	assert.False(t, bridges["mod.a"])
+	// Nodes in the same community share a color; different communities differ.
+	assert.Equal(t, colors["mod.a"], colors["mod.b"])
+	assert.NotEqual(t, colors["mod.a"], colors["mod.c"])
+
+	// The bridge -> mod.c edge crosses communities.
+	var crossFound bool
+	for _, e := range data.Edges {
+		if e.From == "bridge" && e.To == "mod.c" {
+			crossFound = e.Cross
+		}
+	}
+	assert.True(t, crossFound, "bridge->mod.c should be a cross-community edge")
+}
+
+func TestBuildCommunityGraphData_CollapsedAboveThreshold(t *testing.T) {
+	// Threshold of 3 forces the 5-module fixture to collapse to communities.
+	data := BuildCommunityGraphData(graphFixtureResult(), 3)
+
+	assert.True(t, data.Collapsed)
+	assert.Len(t, data.Nodes, 2, "collapsed graph has one node per community")
+	for _, n := range data.Nodes {
+		assert.True(t, n.Group)
+		assert.Greater(t, n.Count, 0)
+	}
+	// Only cross-community edges survive collapse, aggregated with weights.
+	require.NotEmpty(t, data.Edges)
+	for _, e := range data.Edges {
+		assert.True(t, e.Cross)
+		assert.Greater(t, e.Weight, 0)
+	}
+}
+
+func TestCommunityFormatter_HTML_ContainsGraph(t *testing.T) {
+	formatter := NewCommunityFormatter()
+	html, err := formatter.Format(graphFixtureResult(), domain.OutputFormatHTML)
+	require.NoError(t, err)
+
+	assert.Contains(t, html, `id="community-graph"`)
+	assert.Contains(t, html, `id="community-graph-canvas"`)
+	assert.Contains(t, html, `id="community-graph-data"`)
+	assert.Contains(t, html, "Macro Architecture")
+	// Existing accessible tables remain.
+	assert.Contains(t, html, "Bridge Modules")
+
+	data := extractGraphData(t, html)
+	assert.Equal(t, 5, len(data.Nodes), "node count should match the fixture")
+	assert.False(t, data.Collapsed)
+
+	var bridgeMarked bool
+	for _, n := range data.Nodes {
+		if n.ID == "bridge" {
+			bridgeMarked = n.Bridge
+		}
+	}
+	assert.True(t, bridgeMarked, "bridge module must be marked in the graph data")
+}
+
+func TestBuildCommunityGraphData_Nil(t *testing.T) {
+	data := BuildCommunityGraphData(nil, 0)
+	assert.Empty(t, data.Nodes)
+	assert.Equal(t, 100, data.Threshold)
+}
+
+func TestWriteCommunityGraphHTML_EmptyCommunitiesNoOutput(t *testing.T) {
+	var b strings.Builder
+	writeCommunityGraphHTML(&b, &domain.CommunityAnalysisResult{})
+	assert.Empty(t, b.String(), "no graph section when there are no communities")
+}

--- a/website/docs/guides/module-community-detection.md
+++ b/website/docs/guides/module-community-detection.md
@@ -157,6 +157,23 @@ There is no random seed or sampling step in the current Leiden implementation.
 
 Field-level schema documentation: [community_analysis object](../output/schemas.md#community-analysis-object).
 
+## Macro-architecture visualization
+
+When communities are enabled, the unified HTML report's **Communities** tab includes an interactive macro-architecture graph above the existing metric cards and tables (the tables stay for accessibility and CI assertions).
+
+- **Nodes** are modules, colored by community.
+- **Bridge modules** are outlined in red and filled with a light tint so coupling points stand out.
+- **Edges** that cross community boundaries are drawn in red; intra-community edges are gray.
+- **Hover** a node for its name, community id, bridge flag, cross-edge count, target communities, and the dominant package/layer (when package/layer mismatch data is available).
+- **Click** a node to highlight it and its direct neighbors; click again to clear.
+- **Drag** a node to reposition it.
+
+Filters above the canvas let you focus on one community, show only bridge modules, or hide isolated nodes.
+
+The graph is rendered client-side from a compact JSON blob embedded in the report (`<script id="community-graph-data">`), so reports stay self-contained and work offline. No external graph viewer is required, and `--no-open` behavior is unchanged.
+
+**Performance guard.** To keep the layout responsive, the graph collapses to one node per community (sized by module count) when a project exceeds the display threshold of `100` modules. Below that, every module is rendered individually. This visualization complements—and does not replace—the [DOT export](#output-formats), which remains available for large graphs and external tooling.
+
 ## Example interpretation
 
 Given a bridge fixture where `bridge.py` imports one cluster and is imported by another:
@@ -182,9 +199,7 @@ Read this as: two natural clusters exist, and `bridge` is the coupling point bet
 
 ## Follow-up work (Phase 2 and 3)
 
-Module-level community detection is Phase 1 of [GitHub issue #564](https://github.com/ludo-technologies/pyscn/issues/564). Phase 2 mismatch scoring is available via package fields (`package_alignment_score`, `split_packages`, `mixed_communities`) and layer fields (`layer_alignment_score`, `cross_layer_communities`, `layer_bridge_modules`) when architecture layers are configured. Remaining planned extensions include:
-- DOT export with community-colored subgraphs
-- HTML macro-architecture visualization
+Module-level community detection is Phase 1 of [GitHub issue #564](https://github.com/ludo-technologies/pyscn/issues/564). Phase 2 mismatch scoring is available via package fields (`package_alignment_score`, `split_packages`, `mixed_communities`) and layer fields (`layer_alignment_score`, `cross_layer_communities`, `layer_bridge_modules`) when architecture layers are configured. DOT export with community-colored subgraphs and the [HTML macro-architecture visualization](#macro-architecture-visualization) are also available. Remaining planned extensions include:
 - AI-agent context maps
 - Richer edge weights from call/type/reference data
 - Function- and class-level clustering


### PR DESCRIPTION
Closes #603. Part of #564 (Phase 2).

## What

Adds an interactive macro-architecture visualization to the **Communities** tab of the unified analyze HTML report (and the standalone community HTML report — both share `writeHTMLSummary`). The existing metric cards and tables are kept for accessibility and CI assertions; the graph sits above them.

## Behavior

- **Nodes** = modules, colored by community (reuses the DOT color palette — those graphviz names are valid CSS colors).
- **Bridge modules** outlined in red with a light tint.
- **Edges** crossing community boundaries drawn red; intra-community gray.
- **Hover** a node: name, community id, bridge flag, cross-edge count, target communities, and dominant package/layer when mismatch data exists.
- **Click** to highlight a node and its neighbors; **drag** to reposition.
- **Filters**: focus one community, bridges-only, hide-isolated.
- Rendered client-side from a compact JSON blob embedded in the report (`<script id="community-graph-data">`), so reports stay self-contained and offline. `--no-open` behavior unchanged.
- **Performance guard**: collapses to one node per community (sized by module count) above a 100-module threshold; complements, does not replace, the DOT export.

## Implementation

- `service/community_graph_html.go` — `BuildCommunityGraphData` + section renderer (module-level vs. collapsed graph).
- `service/community_graph_assets.go` — scoped CSS and a dependency-free canvas force-directed renderer, wrapped in an IIFE (no conflict with the report's existing `showTab` script). An IntersectionObserver sizes the canvas when the hidden tab is first shown.
- `service/community_formatter.go` — one line wiring the section in after the metric grid.
- `website/docs/guides/module-community-detection.md` — new "Macro-architecture visualization" section + follow-up list update.

## Tests

- `service/community_graph_html_test.go`: module-level data, collapse-above-threshold, nil/empty inputs, and the acceptance checks (HTML contains the graph container, node count matches the `community_bridge` fixture, bridge module marked).
- Full `go test ./...` passes; golangci-lint clean on new files.
- Renderer JS additionally validated with `node --check` and a DOM/canvas stub harness (ran several animation frames without runtime errors).

> Note: a live browser screenshot wasn't captured — the Chrome extension lacked permission for the local server port, so visual confirmation was done via the JS simulation harness. Reviewers can open a generated report to view the graph directly.