### PR TITLE
feat(communities): AI-agent context map + MCP docs

### DIFF
--- a/.claude-plugin/pyscn-mcp/skills/SKILL.md
+++ b/.claude-plugin/pyscn-mcp/skills/SKILL.md
@@ -28,12 +28,15 @@ Use the pyscn MCP tools for Python code quality analysis.
 | "Find duplicate code" | `detect_clones` |
 | "Find dead code" | `find_dead_code` |
 | "Check class coupling" | `check_coupling` |
+| "Which files should I review together?" | `analyze_code` (`analyses: ["communities"]`, `output_mode: "full"`) |
+| "Map the module architecture" | `analyze_code` (`analyses: ["communities"]`, `output_mode: "full"`) |
 
 ## Common Parameters
 
 - `path` (required): Path to Python file or directory
 - `recursive` (analyze_code): Recursively analyze directories (default: true)
-- `analyses` (analyze_code): Array of analyses to run - `complexity`, `dead_code`, `clone`, `cbo`, `deps`
+- `analyses` (analyze_code): Array of analyses to run - `complexity`, `dead_code`, `clone`, `cbo`, `lcom`, `deps`, `communities`
+- `output_mode` (analyze_code): `summary` (default, health score + high-level metrics) or `full` (complete report, including the module `community_context_map`)
 
 ## Examples
 
@@ -58,5 +61,15 @@ Use `check_complexity` with:
 Use `detect_clones` with:
 - `similarity_threshold`: 0.0-1.0 (default: 0.8)
 - `min_lines`: Minimum lines to consider (default: 5)
+
+### Module Communities (context map for agents)
+Module community detection is **opt-in**. Request it explicitly and use `output_mode: "full"`:
+- `analyses: ["communities"]`, `output_mode: "full"`
+
+The full response includes `community_analysis.community_context_map`, a compact, deterministic map telling you which modules to inspect together:
+- `bundles[]`: clusters of modules that change together. Each has `modules`, `packages`, `risk_level`, the cluster's `bridge_modules`, an optional `suggested_review_scope` (path prefix to focus a review on), and a one-line `summary`. Large bundles cap the module list with a `... +N more` marker (`module_count` always holds the true total).
+- `bridge_modules[]`: modules that couple two or more communities (`module`, the communities it `connects`, and a `reason`). Widen the review scope to include these when touching a bundle they connect.
+
+Use the map to scope reviews and refactors: load all modules in a bundle together, and pull in connected bridge modules before changing cluster boundaries.
 
 Always explain results and suggest improvements based on findings.

--- a/domain/community.go
+++ b/domain/community.go
@@ -2,8 +2,11 @@ package domain
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
+	"sort"
+	"strings"
 )
 
 // CommunityAnalysisRequest represents a request for module community detection.
@@ -73,6 +76,206 @@ type CommunityMetrics struct {
 	RiskLevel string `json:"risk_level,omitempty" yaml:"risk_level,omitempty"`
 }
 
+// CommunityContextMapVersion is the schema version of CommunityContextMap.
+// Bump it when the shape of the context map changes in a breaking way.
+const CommunityContextMapVersion = 1
+
+// CommunityContextMapModuleLimit caps how many modules are listed per bundle
+// before the remainder is collapsed into a "... +N more" marker, keeping the
+// map token-efficient for AI agents on large repositories.
+const CommunityContextMapModuleLimit = 10
+
+// CommunityContextMap is a compact, agent-optimized view of the community
+// analysis. It tells AI coding/review agents which modules to inspect together
+// and which modules bridge otherwise-separate clusters. It is derived entirely
+// from CommunityAnalysisResult and carries no LLM-generated content.
+type CommunityContextMap struct {
+	Version       int                   `json:"version" yaml:"version"`
+	Bundles       []CommunityBundle     `json:"bundles" yaml:"bundles"`
+	BridgeModules []ContextBridgeModule `json:"bridge_modules" yaml:"bridge_modules"`
+}
+
+// CommunityBundle is a single cluster of modules an agent should review together.
+type CommunityBundle struct {
+	CommunityID          string   `json:"community_id" yaml:"community_id"`
+	Modules              []string `json:"modules" yaml:"modules"`
+	ModuleCount          int      `json:"module_count" yaml:"module_count"`
+	Packages             []string `json:"packages" yaml:"packages"`
+	RiskLevel            string   `json:"risk_level" yaml:"risk_level"`
+	BridgeModules        []string `json:"bridge_modules" yaml:"bridge_modules"`
+	SuggestedReviewScope string   `json:"suggested_review_scope,omitempty" yaml:"suggested_review_scope,omitempty"`
+	Summary              string   `json:"summary" yaml:"summary"`
+}
+
+// ContextBridgeModule is a module that couples two or more communities, surfaced
+// at the top level so agents widen review scope across cluster boundaries.
+type ContextBridgeModule struct {
+	Module   string   `json:"module" yaml:"module"`
+	Connects []string `json:"connects" yaml:"connects"`
+	Reason   string   `json:"reason" yaml:"reason"`
+}
+
+// BuildCommunityContextMap derives a compact, deterministic context map from a
+// scored community analysis result. It returns nil when there is nothing to map
+// (no result or no communities). Call ScoreCommunityResult first so per-community
+// risk levels are populated.
+func BuildCommunityContextMap(result *CommunityAnalysisResult) *CommunityContextMap {
+	if result == nil || len(result.Communities) == 0 {
+		return nil
+	}
+
+	// Group bridge modules by their owning community for per-bundle listing.
+	bridgesByCommunity := make(map[string][]string, len(result.BridgeModules))
+	for _, b := range result.BridgeModules {
+		bridgesByCommunity[b.Community] = append(bridgesByCommunity[b.Community], b.Module)
+	}
+
+	bundles := make([]CommunityBundle, 0, len(result.Communities))
+	for i := range result.Communities {
+		c := &result.Communities[i]
+
+		modules := append([]string(nil), c.Modules...)
+		sort.Strings(modules)
+		packages := append([]string(nil), c.Packages...)
+		sort.Strings(packages)
+
+		bridges := append([]string(nil), bridgesByCommunity[c.ID]...)
+		sort.Strings(bridges)
+
+		bundles = append(bundles, CommunityBundle{
+			CommunityID:          c.ID,
+			Modules:              capModuleList(modules, CommunityContextMapModuleLimit),
+			ModuleCount:          len(modules),
+			Packages:             packages,
+			RiskLevel:            c.RiskLevel,
+			BridgeModules:        bridges,
+			SuggestedReviewScope: suggestedReviewScope(modules),
+			Summary:              bundleSummary(c, len(bridges)),
+		})
+	}
+	sort.Slice(bundles, func(i, j int) bool {
+		return bundles[i].CommunityID < bundles[j].CommunityID
+	})
+
+	bridgeModules := make([]ContextBridgeModule, 0, len(result.BridgeModules))
+	for _, b := range result.BridgeModules {
+		connects := append([]string{b.Community}, b.TargetCommunities...)
+		connects = sortedUnique(connects)
+		bridgeModules = append(bridgeModules, ContextBridgeModule{
+			Module:   b.Module,
+			Connects: connects,
+			Reason:   pluralizeEdges(b.CrossCommunityEdges, "cross-community import edge"),
+		})
+	}
+	sort.Slice(bridgeModules, func(i, j int) bool {
+		return bridgeModules[i].Module < bridgeModules[j].Module
+	})
+
+	return &CommunityContextMap{
+		Version:       CommunityContextMapVersion,
+		Bundles:       bundles,
+		BridgeModules: bridgeModules,
+	}
+}
+
+// capModuleList truncates a sorted module list to limit entries, appending a
+// "... +N more" marker when modules are omitted. A non-positive limit disables
+// truncation.
+func capModuleList(modules []string, limit int) []string {
+	if limit <= 0 || len(modules) <= limit {
+		return modules
+	}
+	out := append([]string(nil), modules[:limit]...)
+	return append(out, fmt.Sprintf("... +%d more", len(modules)-limit))
+}
+
+// suggestedReviewScope derives a filesystem-style review scope from the longest
+// common dotted prefix of the member modules (e.g. ["app.orders.service",
+// "app.orders.repository"] -> "app/orders/"). For a single module it drops the
+// leaf so the scope points at the containing package. Returns "" when modules
+// share no common package prefix.
+func suggestedReviewScope(modules []string) string {
+	if len(modules) == 0 {
+		return ""
+	}
+
+	split := func(m string) []string { return strings.Split(m, ".") }
+	common := split(modules[0])
+	for _, m := range modules[1:] {
+		common = commonPrefix(common, split(m))
+		if len(common) == 0 {
+			return ""
+		}
+	}
+
+	// A single module's "common prefix" is the whole module; drop the leaf to
+	// land on its package directory.
+	if len(modules) == 1 && len(common) > 0 {
+		common = common[:len(common)-1]
+	}
+	if len(common) == 0 {
+		return ""
+	}
+	return strings.Join(common, "/") + "/"
+}
+
+func commonPrefix(a, b []string) []string {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return a[:i]
+}
+
+// bundleSummary produces a short, deterministic, fact-based description of a
+// community for agent consumption (no natural-language inference).
+func bundleSummary(c *CommunityMetrics, bridgeCount int) string {
+	cross := c.IncomingCrossCommunityEdges + c.OutgoingCrossCommunityEdges
+	parts := []string{
+		pluralize(c.Size, "module"),
+		pluralize(len(c.Packages), "package"),
+		fmt.Sprintf("risk %s", riskLevelOrUnknown(c.RiskLevel)),
+		pluralizeEdges(cross, "cross-community edge"),
+	}
+	if bridgeCount > 0 {
+		parts = append(parts, pluralize(bridgeCount, "bridge module"))
+	}
+	return strings.Join(parts, "; ") + "."
+}
+
+func riskLevelOrUnknown(level string) string {
+	if level == "" {
+		return "unknown"
+	}
+	return level
+}
+
+func pluralize(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+func pluralizeEdges(n int, noun string) string {
+	return pluralize(n, noun)
+}
+
+func sortedUnique(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // CommunityModuleDependency is a directed module dependency edge used for graph export.
 type CommunityModuleDependency struct {
 	From string
@@ -111,6 +314,11 @@ type CommunityAnalysisResult struct {
 	// detected (no meaningful modular structure to score).
 	RiskScore *int `json:"community_risk_score,omitempty" yaml:"community_risk_score,omitempty"`
 
+	// ContextMap is a compact, agent-optimized view of the communities (which
+	// modules to inspect together, which modules bridge clusters). Populated by
+	// ScoreCommunityResult whenever at least one community was detected.
+	ContextMap *CommunityContextMap `json:"community_context_map,omitempty" yaml:"community_context_map,omitempty"`
+
 	// ModuleDependencies holds directed edges for DOT export and is omitted from JSON/YAML.
 	ModuleDependencies []CommunityModuleDependency `json:"-" yaml:"-"`
 
@@ -141,6 +349,9 @@ func ScoreCommunityResult(result *CommunityAnalysisResult) {
 	for i := range result.Communities {
 		result.Communities[i].RiskLevel = communityRiskLevel(&result.Communities[i])
 	}
+
+	// Build the agent-facing context map once risk levels are populated.
+	result.ContextMap = BuildCommunityContextMap(result)
 
 	// The system risk score needs at least two communities to be meaningful.
 	if result.TotalCommunities < 2 {

--- a/domain/community_context_map_test.go
+++ b/domain/community_context_map_test.go
@@ -1,0 +1,106 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCommunityContextMap_NilOrEmpty(t *testing.T) {
+	assert.Nil(t, BuildCommunityContextMap(nil))
+	assert.Nil(t, BuildCommunityContextMap(&CommunityAnalysisResult{}))
+}
+
+func TestBuildCommunityContextMap_BridgeFixture(t *testing.T) {
+	result := &CommunityAnalysisResult{
+		TotalCommunities: 2,
+		Communities: []CommunityMetrics{
+			{
+				ID:                          "community_1",
+				Modules:                     []string{"mod.b", "bridge", "mod.a"}, // unsorted on purpose
+				Packages:                    []string{"mod"},
+				Size:                        3,
+				OutgoingCrossCommunityEdges: 1,
+				RiskLevel:                   "low",
+			},
+			{
+				ID:                          "community_2",
+				Modules:                     []string{"mod.d", "mod.c"},
+				Packages:                    []string{"mod"},
+				Size:                        2,
+				IncomingCrossCommunityEdges: 1,
+				RiskLevel:                   "medium",
+			},
+		},
+		BridgeModules: []BridgeModule{
+			{Module: "bridge", Community: "community_1", CrossCommunityEdges: 1, TargetCommunities: []string{"community_2"}},
+			{Module: "mod.c", Community: "community_2", CrossCommunityEdges: 1, TargetCommunities: []string{"community_1"}},
+		},
+	}
+
+	cm := BuildCommunityContextMap(result)
+	require.NotNil(t, cm)
+	assert.Equal(t, CommunityContextMapVersion, cm.Version)
+	require.Len(t, cm.Bundles, 2)
+
+	// Bundle ordering is deterministic by community ID, modules are sorted.
+	b1 := cm.Bundles[0]
+	assert.Equal(t, "community_1", b1.CommunityID)
+	assert.Equal(t, []string{"bridge", "mod.a", "mod.b"}, b1.Modules)
+	assert.Equal(t, 3, b1.ModuleCount)
+	assert.Equal(t, []string{"bridge"}, b1.BridgeModules)
+	assert.Equal(t, "low", b1.RiskLevel)
+	// "bridge" and "mod.*" share no common package prefix.
+	assert.Empty(t, b1.SuggestedReviewScope)
+	assert.Equal(t, "3 modules; 1 package; risk low; 1 cross-community edge; 1 bridge module.", b1.Summary)
+
+	b2 := cm.Bundles[1]
+	assert.Equal(t, "community_2", b2.CommunityID)
+	assert.Equal(t, "mod/", b2.SuggestedReviewScope)
+
+	// Top-level bridge modules are sorted and connect both communities.
+	require.Len(t, cm.BridgeModules, 2)
+	assert.Equal(t, "bridge", cm.BridgeModules[0].Module)
+	assert.Equal(t, []string{"community_1", "community_2"}, cm.BridgeModules[0].Connects)
+	assert.Equal(t, "1 cross-community import edge", cm.BridgeModules[0].Reason)
+}
+
+func TestBuildCommunityContextMap_ModuleCapAndScope(t *testing.T) {
+	modules := make([]string, 0, CommunityContextMapModuleLimit+5)
+	for i := range CommunityContextMapModuleLimit + 5 {
+		// Zero-padded so lexical sort matches numeric order.
+		modules = append(modules, "pkg.sub.m"+string(rune('a'+i)))
+	}
+	result := &CommunityAnalysisResult{
+		TotalCommunities: 1,
+		Communities: []CommunityMetrics{
+			{ID: "community_1", Modules: modules, Packages: []string{"pkg.sub"}, Size: len(modules), RiskLevel: "high"},
+		},
+	}
+
+	cm := BuildCommunityContextMap(result)
+	require.NotNil(t, cm)
+	require.Len(t, cm.Bundles, 1)
+	b := cm.Bundles[0]
+
+	assert.Equal(t, len(modules), b.ModuleCount)
+	// Listed modules are capped at the limit plus one "... +N more" marker.
+	assert.Len(t, b.Modules, CommunityContextMapModuleLimit+1)
+	assert.Equal(t, "... +5 more", b.Modules[CommunityContextMapModuleLimit])
+	// Common prefix across all members yields the package directory.
+	assert.Equal(t, "pkg/sub/", b.SuggestedReviewScope)
+}
+
+func TestSuggestedReviewScope_SingleModuleDropsLeaf(t *testing.T) {
+	result := &CommunityAnalysisResult{
+		TotalCommunities: 1,
+		Communities: []CommunityMetrics{
+			{ID: "community_1", Modules: []string{"app.orders.service"}, Size: 1, RiskLevel: "low"},
+		},
+	}
+	cm := BuildCommunityContextMap(result)
+	require.NotNil(t, cm)
+	require.Len(t, cm.Bundles, 1)
+	assert.Equal(t, "app/orders/", cm.Bundles[0].SuggestedReviewScope)
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -180,9 +180,10 @@ Try asking your AI assistant:
 **Parameters**:
 - `path` (required): Path to Python code (file or directory)
 - `analyses` (optional): Array of analyses to run
-  - Options: `["complexity", "dead_code", "clone", "cbo", "deps"]`
-  - Default: All analyses
+  - Options: `["complexity", "dead_code", "clone", "cbo", "lcom", "deps", "communities"]`
+  - Default: all analyses except `communities` (community detection is opt-in)
 - `recursive` (optional): Recursively analyze directories (default: `true`)
+- `output_mode` (optional): `"summary"` (default) returns the health score and high-level metrics; `"full"` returns the complete report, including `community_analysis` and its `community_context_map` when `analyses` includes `communities`
 
 **Example**:
 ```
@@ -206,6 +207,51 @@ Analyze the code at /home/user/project with all metrics
   }
 }
 ```
+
+#### Module communities (context map for AI agents)
+
+Community detection groups modules into clusters by their import structure so an agent knows which files to inspect together. It is opt-in — request it explicitly with `analyses: ["communities"]` and `output_mode: "full"`.
+
+**Example**:
+```
+Map the module architecture of /home/user/project and tell me which files to review together
+```
+
+The full response embeds a compact, deterministic `community_context_map` under `community_analysis`:
+```json
+{
+  "community_analysis": {
+    "total_communities": 2,
+    "community_risk_score": 65,
+    "community_context_map": {
+      "version": 1,
+      "bundles": [
+        {
+          "community_id": "community_1",
+          "modules": ["app.orders.service", "app.orders.repository"],
+          "module_count": 2,
+          "packages": ["app.orders"],
+          "risk_level": "low",
+          "bridge_modules": [],
+          "suggested_review_scope": "app/orders/",
+          "summary": "2 modules; 1 package; risk low; 0 cross-community edges."
+        }
+      ],
+      "bridge_modules": [
+        {
+          "module": "app.core.hub",
+          "connects": ["community_1", "community_3"],
+          "reason": "3 cross-community import edges"
+        }
+      ]
+    }
+  }
+}
+```
+
+Field notes:
+- `bundles[]` are clusters to review together. `modules` is capped for large clusters with a `... +N more` marker; `module_count` always holds the true total. `suggested_review_scope` (a path prefix) is omitted when members share no common package.
+- `bridge_modules[]` couple two or more communities. Pull them into the review scope before changing cluster boundaries.
 
 ### check_complexity
 

--- a/mcp/handlers_test.go
+++ b/mcp/handlers_test.go
@@ -153,6 +153,37 @@ func TestHandleAnalyzeCode(t *testing.T) {
 				},
 			},
 		},
+		"communities_full_context_map": {
+			args: args{
+				setupFS: func(t *testing.T) string {
+					rootDir, err := os.Getwd()
+					require.NoError(t, err)
+					return filepath.Join(filepath.Dir(rootDir), "testdata", "python", "community_bridge")
+				},
+				arguments: map[string]interface{}{
+					"analyses":    []interface{}{"communities"},
+					"output_mode": "full",
+				},
+			},
+			want: want{
+				isError: &errFalse,
+				check: func(t *testing.T, res *mcplib.CallToolResult) {
+					text := mcplib.GetTextFromContent(res.Content[0])
+					var result map[string]interface{}
+					require.NoError(t, json.Unmarshal([]byte(text), &result))
+
+					community, ok := result["community_analysis"].(map[string]interface{})
+					require.True(t, ok, "expected community_analysis in full output")
+
+					contextMap, ok := community["community_context_map"].(map[string]interface{})
+					require.True(t, ok, "expected community_context_map in community_analysis")
+					assert.Equal(t, float64(1), contextMap["version"])
+					bundles, ok := contextMap["bundles"].([]interface{})
+					require.True(t, ok)
+					assert.NotEmpty(t, bundles)
+				},
+			},
+		},
 		"analyses_complexity_only": {
 			args: args{
 				setupFS: func(t *testing.T) string { return setupTestFile(t, "classes.py") },

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -18,6 +18,9 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps, communities. Default: all analyses except communities (opt-in)")),
 		mcp.WithBoolean("recursive",
 			mcp.Description("Recursively analyze directories (default: true)")),
+		mcp.WithString("output_mode",
+			mcp.Enum("summary", "full"),
+			mcp.Description("Response detail level. \"summary\" (default) returns health score and high-level metrics. \"full\" returns the complete report including, when analyses=[\"communities\"], the community_analysis result and its compact community_context_map (which modules to inspect together, which modules bridge clusters) for AI agents")),
 	), handlers.HandleAnalyzeCode)
 
 	// Tool 2: check_complexity - Cyclomatic complexity analysis

--- a/service/testdata/golden/community_analysis.json
+++ b/service/testdata/golden/community_analysis.json
@@ -69,6 +69,63 @@
     "mod"
   ],
   "community_risk_score": 65,
+  "community_context_map": {
+    "version": 1,
+    "bundles": [
+      {
+        "community_id": "community_1",
+        "modules": [
+          "bridge",
+          "mod.a",
+          "mod.b"
+        ],
+        "module_count": 3,
+        "packages": [
+          "mod"
+        ],
+        "risk_level": "low",
+        "bridge_modules": [
+          "bridge"
+        ],
+        "summary": "3 modules; 1 package; risk low; 1 cross-community edge; 1 bridge module."
+      },
+      {
+        "community_id": "community_2",
+        "modules": [
+          "mod.c",
+          "mod.d"
+        ],
+        "module_count": 2,
+        "packages": [
+          "mod"
+        ],
+        "risk_level": "medium",
+        "bridge_modules": [
+          "mod.c"
+        ],
+        "suggested_review_scope": "mod/",
+        "summary": "2 modules; 1 package; risk medium; 1 cross-community edge; 1 bridge module."
+      }
+    ],
+    "bridge_modules": [
+      {
+        "module": "bridge",
+        "connects": [
+          "community_1",
+          "community_2"
+        ],
+        "reason": "1 cross-community import edge"
+      },
+      {
+        "module": "mod.c",
+        "connects": [
+          "community_1",
+          "community_2"
+        ],
+        "reason": "1 cross-community import edge"
+      }
+    ]
+  },
   "generated_at": "2026-01-15T12:00:00Z",
   "version": "0.0.0-test",
   "config": {

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -733,6 +733,8 @@ Mirrors `domain.CommunityAnalysisResult`. Emitted as a top-level field in unifie
 | `layer_alignment_score` | number \| absent | Share of configured layers whose modules all reside in one community (0–1). Omitted when architecture layers are not configured. |
 | `cross_layer_communities` | array \| absent | Community ids containing modules from two or more configured layers (sorted). |
 | `layer_bridge_modules` | array \| absent | Bridge modules coupling communities mapped to different layers (sorted). |
+| `community_risk_score` | integer \| absent | System-level community risk score (0–100, higher = worse). Absent when fewer than two communities were detected. |
+| `community_context_map` | object \| absent | Compact, agent-optimized map of which modules to inspect together. See [`community_context_map`](#community-context-map-object). Absent when no communities were detected. |
 | `warnings`          | array \| absent | Non-fatal analysis warnings.                              |
 | `errors`            | array \| absent | Fatal analysis errors.                                    |
 | `generated_at`      | string (RFC 3339) | Community analysis completion time.                 |
@@ -759,6 +761,7 @@ Mirrors `domain.CommunityAnalysisResult`. Emitted as a top-level field in unifie
 | `layer_count`                      | integer \| absent | Distinct configured layers represented in this community. |
 | `layers`                           | array \| absent | Configured layer names present in this community (sorted). |
 | `layer_alignment`                  | number \| absent | Cohesion within the community: share of internal edges whose endpoints share a layer, or dominant-layer module ratio when no qualifying internal edges exist. |
+| `risk_level`                       | string \| absent | Per-community risk classification (`low`, `medium`, `high`). |
 
 ### `bridge_module` object { #bridge-module-object }
 
@@ -768,6 +771,37 @@ Mirrors `domain.CommunityAnalysisResult`. Emitted as a top-level field in unifie
 | `community`            | string  | Home community id for the module.                     |
 | `cross_community_edges`| integer | Edges that connect to other communities.              |
 | `target_communities`   | array   | Destination community ids (sorted for stable diffs).  |
+
+### `community_context_map` object { #community-context-map-object }
+
+A compact, deterministic view of the communities optimized for AI coding/review agents: which modules to inspect together, and which modules bridge otherwise-separate clusters. Derived entirely from the community analysis (no LLM-generated content).
+
+| Field           | Type   | Description                                              |
+| --------------- | ------ | -------------------------------------------------------- |
+| `version`       | integer | Schema version of the context map (currently `1`).     |
+| `bundles`       | array  | Module clusters to review together. See [`context_bundle`](#context-bundle-object). |
+| `bridge_modules`| array  | Modules coupling two or more communities. See [`context_bridge_module`](#context-bridge-module-object). |
+
+#### `context_bundle` object { #context-bundle-object }
+
+| Field                    | Type            | Description                                              |
+| ------------------------ | --------------- | -------------------------------------------------------- |
+| `community_id`           | string          | Community identifier this bundle maps to.               |
+| `modules`                | array           | Member module names (sorted). Capped at 10 entries; the remainder is collapsed into a `... +N more` marker. |
+| `module_count`           | integer         | True number of modules in the community (before capping). |
+| `packages`               | array           | Package names represented in the community (sorted).    |
+| `risk_level`             | string          | Per-community risk classification (`low`, `medium`, `high`). |
+| `bridge_modules`         | array           | Member modules that bridge to other communities (sorted). |
+| `suggested_review_scope` | string \| absent | Filesystem-style path prefix derived from the longest common module prefix (e.g. `app/orders/`). Omitted when members share no common package. |
+| `summary`                | string          | One-line, fact-based description of the cluster.        |
+
+#### `context_bridge_module` object { #context-bridge-module-object }
+
+| Field      | Type   | Description                                              |
+| ---------- | ------ | -------------------------------------------------------- |
+| `module`   | string | Module name acting as a bridge.                         |
+| `connects` | array  | Community ids this module couples (sorted, includes its home community). |
+| `reason`   | string | Human-readable reason (e.g. `3 cross-community import edges`). |
 
 ### Determinism
 


### PR DESCRIPTION
Closes #604.

## Summary

Adds a compact, deterministic **`community_context_map`** to community analysis, optimized for AI coding/review agents — it tells an agent which modules to inspect together and which modules bridge otherwise-separate clusters.

- New domain types `CommunityContextMap` / `CommunityBundle` / `ContextBridgeModule` and `BuildCommunityContextMap()`.
- Built inside `ScoreCommunityResult` (the single scoring entry point), so it surfaces consistently in the standalone community report, nested under `community_analysis` in unified `analyze`, and in MCP `output_mode: "full"` output. Nil/omitted when no communities are detected.

### Bundle shape
Each bundle is a cluster to review together: sorted `modules` (capped at 10 with a `... +N more` marker; `module_count` keeps the true total), `packages`, `risk_level`, the cluster's `bridge_modules`, a heuristic `suggested_review_scope` (longest common module prefix → e.g. `app/orders/`, omitted when none), and a one-line fact-based `summary`. Top-level `bridge_modules` carry `module`, `connects`, and `reason`.

## MCP

- Documented the `output_mode` parameter (`summary`/`full`) on `analyze_code`. The context map flows through `full` mode automatically (it's part of `CommunityAnalysisResult`), so no dedicated `get_community_map` tool was needed.
- Updated `SKILL.md` (communities use cases + parameters) and `mcp/README.md` (full example + field notes).
- Added `community_context_map`, `community_risk_score`, and `risk_level` to `website/docs/output/schemas.md` (the latter two were previously undocumented).

## Tests

- Golden JSON for the `community_bridge` fixture (extends existing integration golden test).
- `domain/community_context_map_test.go`: builder unit tests (bridge fixture, module cap + scope, single-module leaf-drop, nil/empty).
- MCP handler test: `analyses=["communities"]` + `output_mode=full` returns the context map.

All tests pass (`domain`, `mcp`, `integration`, `service`, `app`, `cmd`); `go vet` clean.