### PR TITLE
Graduate community detection default analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- Run module community detection in default `pyscn analyze`; use `--skip-communities` or `[communities] enabled = false` to opt out (#605).
+
 ## [1.24.3] - 2026-06-21
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GREEN := \033[0;32m
 YELLOW := \033[1;33m
 NC := \033[0m # No Color
 
-.PHONY: all build test clean install run version help build-python python-wheel python-test python-clean build-mcp install-mcp clean-mcp docs-serve docs-build
+.PHONY: all build test clean install run version help build-python python-wheel python-test python-clean build-mcp install-mcp clean-mcp docs-serve docs-build bench-communities
 
 ## help: Show this help message
 help:
@@ -47,6 +47,11 @@ test:
 bench:
 	@printf "$(GREEN)Running benchmarks...$(NC)\n"
 	go test -bench=. -benchmem ./...
+
+## bench-communities: Run community detection graduation benchmarks
+bench-communities:
+	@printf "$(GREEN)Running community detection benchmarks...$(NC)\n"
+	go test -run '^$$' -bench 'BenchmarkDetectCommunitiesLeiden_MediumGraph' -benchmem -count=10 ./internal/analyzer
 
 ## coverage: Generate coverage report
 coverage:

--- a/app/analyze_selection.go
+++ b/app/analyze_selection.go
@@ -1,0 +1,38 @@
+package app
+
+import "strings"
+
+// ApplyAnalyzeSelection applies explicit analyzer selection to the use-case
+// config. It is shared by CLI and MCP entrypoints so selection semantics stay
+// consistent across transports.
+func ApplyAnalyzeSelection(config AnalyzeUseCaseConfig, analyses []string) AnalyzeUseCaseConfig {
+	selected := normalizeAnalyzeSelection(analyses)
+	config.SelectAnalysesUsed = len(selected) > 0
+	if !config.SelectAnalysesUsed {
+		return config
+	}
+
+	config.SkipComplexity = !selected["complexity"]
+	config.SkipDeadCode = !selected["deadcode"]
+	config.SkipClones = !selected["clones"]
+	config.SkipCBO = !selected["cbo"]
+	config.SkipLCOM = !selected["lcom"]
+	config.SkipSystem = !selected["deps"]
+	config.SkipCommunities = !selected["communities"]
+	return config
+}
+
+func normalizeAnalyzeSelection(analyses []string) map[string]bool {
+	selected := make(map[string]bool, len(analyses))
+	for _, analysis := range analyses {
+		switch strings.ToLower(analysis) {
+		case "dead_code":
+			selected["deadcode"] = true
+		case "clone":
+			selected["clones"] = true
+		default:
+			selected[strings.ToLower(analysis)] = true
+		}
+	}
+	return selected
+}

--- a/app/analyze_selection_test.go
+++ b/app/analyze_selection_test.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyAnalyzeSelection_DefaultLeavesAnalyzersEnabled(t *testing.T) {
+	config := ApplyAnalyzeSelection(AnalyzeUseCaseConfig{}, nil)
+
+	assert.False(t, config.SelectAnalysesUsed)
+	assert.False(t, config.SkipComplexity)
+	assert.False(t, config.SkipDeadCode)
+	assert.False(t, config.SkipClones)
+	assert.False(t, config.SkipSystem)
+	assert.False(t, config.SkipCommunities)
+}
+
+func TestApplyAnalyzeSelection_CLIAnalyzerNames(t *testing.T) {
+	config := ApplyAnalyzeSelection(AnalyzeUseCaseConfig{}, []string{"complexity", "deadcode", "clones", "deps", "communities"})
+
+	assert.True(t, config.SelectAnalysesUsed)
+	assert.False(t, config.SkipComplexity)
+	assert.False(t, config.SkipDeadCode)
+	assert.False(t, config.SkipClones)
+	assert.False(t, config.SkipSystem)
+	assert.False(t, config.SkipCommunities)
+	assert.True(t, config.SkipCBO)
+	assert.True(t, config.SkipLCOM)
+}
+
+func TestApplyAnalyzeSelection_MCPAnalyzerAliases(t *testing.T) {
+	config := ApplyAnalyzeSelection(AnalyzeUseCaseConfig{}, []string{"dead_code", "clone", "communities"})
+
+	assert.True(t, config.SelectAnalysesUsed)
+	assert.False(t, config.SkipDeadCode)
+	assert.False(t, config.SkipClones)
+	assert.False(t, config.SkipCommunities)
+	assert.True(t, config.SkipComplexity)
+	assert.True(t, config.SkipSystem)
+}

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -237,8 +237,8 @@ func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCase
 		useCaseCfg.SkipSystem = true
 	}
 
-	if !useCaseCfg.SelectAnalysesUsed && executionCfg.CommunitiesEnabled {
-		useCaseCfg.SkipCommunities = false
+	if !useCaseCfg.SelectAnalysesUsed && executionCfg.CommunitiesEnabledExplicit {
+		useCaseCfg.SkipCommunities = !executionCfg.CommunitiesEnabled
 	}
 	if useCaseCfg.SkipCommunitiesExplicit {
 		useCaseCfg.SkipCommunities = true
@@ -481,7 +481,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 		})
 	}
 
-	// Community detection task (opt-in via SkipCommunities until CLI/config #583)
+	// Community detection task.
 	if uc.communityUseCase != nil {
 		tasks = append(tasks, &AnalysisTask{
 			Name:    taskNameCommunities,

--- a/app/analyze_usecase_community_test.go
+++ b/app/analyze_usecase_community_test.go
@@ -97,6 +97,52 @@ enabled = true
 	require.NotNil(t, response.Communities)
 }
 
+func TestAnalyzeUseCase_CommunityDisabledFromConfig(t *testing.T) {
+	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
+	require.NoError(t, err)
+
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, ".pyscn.toml")
+	configContent := `[communities]
+enabled = false
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
+
+	communityUC, err := NewCommunityUseCaseBuilder().
+		WithService(service.NewCommunityAnalysisService()).
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(noopCommunityFormatter{}).
+		WithConfigLoader(service.NewCommunityConfigurationLoader()).
+		Build()
+	require.NoError(t, err)
+
+	useCase, err := NewAnalyzeUseCaseBuilder().
+		WithFileReader(service.NewFileReader()).
+		WithFormatter(service.NewAnalyzeFormatter()).
+		WithConfigLoader(service.NewAnalyzeConfigurationLoader()).
+		WithCommunityUseCase(communityUC).
+		Build()
+	require.NoError(t, err)
+
+	config := AnalyzeUseCaseConfig{
+		SkipComplexity:  true,
+		SkipDeadCode:    true,
+		SkipClones:      true,
+		SkipCBO:         true,
+		SkipLCOM:        true,
+		SkipSystem:      true,
+		SkipCommunities: false,
+		ConfigFile:      configPath,
+	}
+
+	response, err := useCase.Execute(context.Background(), config, []string{fixtureRoot})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	assert.False(t, response.Summary.CommunitiesEnabled)
+	assert.Nil(t, response.Communities)
+}
+
 func TestAnalyzeUseCase_CommunityConfigSkippedWhenSelectOmitsCommunities(t *testing.T) {
 	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
 	require.NoError(t, err)

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -132,7 +132,7 @@ Examples:
 	cmd.Flags().BoolVar(&c.skipCBO, "skip-cbo", false, "Skip class coupling (CBO) analysis")
 	cmd.Flags().BoolVar(&c.skipLCOM, "skip-lcom", false, "Skip class cohesion (LCOM4) analysis")
 	cmd.Flags().BoolVar(&c.skipSystem, "skip-deps", false, "Skip module dependencies and architecture analysis")
-	cmd.Flags().BoolVar(&c.skipCommunities, "skip-communities", false, "Skip module community detection (overrides config-enabled communities)")
+	cmd.Flags().BoolVar(&c.skipCommunities, "skip-communities", false, "Skip module community detection")
 	cmd.Flags().StringSliceVar(&c.selectAnalyses, "select", []string{}, "Only run specified analyses (complexity,deadcode,clones,cbo,lcom,deps,communities)")
 
 	// Quick filter flags
@@ -205,22 +205,13 @@ func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 		CloneSimilarity:         c.cloneSimilarity,
 		MinCBO:                  c.minCBO,
 		EnableDFA:               c.enableDFA,
-		SkipCommunities:         true, // opt-in: enable via --select communities or [communities] enabled=true
-		SelectAnalysesUsed:      len(c.selectAnalyses) > 0,
+		SkipCommunities:         false,
 		SkipCommunitiesExplicit: c.skipCommunities,
 	}
+	config = app.ApplyAnalyzeSelection(config, c.selectAnalyses)
 
 	// Handle analysis selection
-	if len(c.selectAnalyses) > 0 {
-		// If --select is used, only run selected analyses
-		config.SkipComplexity = !c.containsAnalysis("complexity")
-		config.SkipDeadCode = !c.containsAnalysis("deadcode")
-		config.SkipClones = !c.containsAnalysis("clones")
-		config.SkipCBO = !c.containsAnalysis("cbo")
-		config.SkipLCOM = !c.containsAnalysis("lcom")
-		config.SkipSystem = !c.containsAnalysis("deps")
-		config.SkipCommunities = !c.containsAnalysis("communities")
-	} else {
+	if len(c.selectAnalyses) == 0 {
 		// Otherwise use skip flags
 		config.SkipComplexity = c.skipComplexity
 		config.SkipDeadCode = c.skipDeadCode

--- a/cmd/pyscn/new_commands_test.go
+++ b/cmd/pyscn/new_commands_test.go
@@ -353,6 +353,25 @@ func TestAnalyzeCommandSelectCommunitiesEnablesAnalysis(t *testing.T) {
 	}
 }
 
+func TestAnalyzeCommandDefaultEnablesCommunities(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+
+	config := analyzeCmd.createUseCaseConfig()
+	if config.SkipCommunities {
+		t.Fatal("expected default analyze to enable community analysis")
+	}
+}
+
+func TestAnalyzeCommandSelectWithoutCommunitiesSkipsAnalysis(t *testing.T) {
+	analyzeCmd := NewAnalyzeCommand()
+	analyzeCmd.selectAnalyses = []string{"complexity", "deps"}
+
+	config := analyzeCmd.createUseCaseConfig()
+	if !config.SkipCommunities {
+		t.Fatal("expected --select without communities to disable community analysis")
+	}
+}
+
 func TestAnalyzeCommandSelectDepsCommunities(t *testing.T) {
 	analyzeCmd := NewAnalyzeCommand()
 	analyzeCmd.selectAnalyses = []string{"deps", "communities"}

--- a/docs/ANALYZE_SCORING.md
+++ b/docs/ANALYZE_SCORING.md
@@ -28,7 +28,7 @@ When a category is disabled (e.g., `--skip-clones`), its penalty is zero and the
 
 ## Community Risk Score
 
-Community detection is opt-in. The community penalty only applies when communities ran **and** at least two communities were detected; otherwise the category scores 100 with a zero penalty, so enabling or disabling communities never changes existing grades (backward compatible).
+Community detection runs in default analyze unless disabled. The community penalty only applies when communities ran **and** at least two communities were detected; otherwise the category scores 100 with a zero penalty, so disabling communities or analyzing trivial graphs never changes existing grades (backward compatible).
 
 The system-level **community risk score** (`community_risk_score`, 0–100, higher = worse) is a weighted blend of normalised risk factors. The category quality score is its inverse: `CommunityScore = 100 - community_risk_score`. The health-score penalty is `round(riskRatio * 10)`.
 

--- a/docs/COMMUNITY_DETECTION_GRADUATION.md
+++ b/docs/COMMUNITY_DETECTION_GRADUATION.md
@@ -1,0 +1,114 @@
+# Community Detection Graduation
+
+Issue #605 graduates module community detection into the default `pyscn analyze`
+run. The default-on decision is based on the Phase 2 scoring and output work:
+community risk is deterministic, bounded, and does not penalize users when
+community detection is disabled or produces fewer than two communities.
+
+## Default Behavior
+
+- `pyscn analyze <path>` runs community detection with the other default
+  analyses.
+- `pyscn analyze --select ...` runs communities only when `communities` appears
+  in the selected list.
+- `pyscn analyze --skip-communities <path>` disables community detection for the
+  run.
+- `[communities] enabled = false` in `.pyscn.toml` or
+  `[tool.pyscn.communities]` disables community detection for default analyze
+  runs. `--select communities` remains an explicit per-run request.
+- MCP `analyze_code` follows the same selection rule: omitted `analyses` runs
+  communities; an explicit list must include `communities`.
+
+## Graduation Criteria
+
+Run these checks before changing community defaults, thresholds, graph
+construction, or score weights.
+
+### Performance
+
+Reference target:
+
+- `testdata/python/community_bridge`
+- One medium open-source Python snapshot used by release validation
+
+Budget:
+
+- Community detection p95 latency must stay within 10% of the previous release
+  baseline on both references.
+- The benchmark should not allocate asymptotically more memory on the medium
+  graph fixture.
+
+Commands:
+
+```sh
+make bench-communities
+go test -run '^$' -bench 'BenchmarkDetectCommunitiesLeiden_MediumGraph' -benchmem -count=10 ./internal/analyzer
+```
+
+For end-to-end fixture timing, build once and run the same command repeatedly
+against the fixed fixture:
+
+```sh
+make build
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  ./pyscn analyze --json testdata/python/community_bridge >/tmp/pyscn-community-bridge-$i.json
+done
+```
+
+Use the previous release's numbers as the baseline; record the p95 and the
+machine class in the issue or release notes.
+
+### Signal Quality
+
+Community mismatch and risk scores must keep the expected ordering on known
+fixtures:
+
+- `testdata/python/community_separated` should remain lower risk than
+  `testdata/python/community_bridge`.
+- Package mismatch fixtures should populate `split_packages` and
+  `mixed_communities`.
+- Layer mismatch fixtures should populate `cross_layer_communities` and
+  `layer_bridge_modules` when architecture layers are configured.
+
+Commands:
+
+```sh
+go test ./internal/analyzer ./service ./domain -run 'Community|AnalyzeScore'
+go test ./app ./cmd/pyscn ./mcp -run 'Community|Communities'
+```
+
+### Backward Compatibility
+
+- Disabled communities must not change Health Score category penalties.
+- Trivial community results with fewer than two communities must score as
+  `community_score=100` and `community_risk_score=0`.
+- `--skip-communities` and explicit `[communities] enabled = false` must keep
+  community output absent.
+- Report size impact should be checked on the medium OSS snapshot when JSON or
+  HTML report size is release-sensitive.
+
+### CI Noise
+
+- JSON/YAML community fields must remain sorted by stable identifiers.
+- HTML graph payloads must be deterministic for a fixed fixture and
+  configuration.
+- Repeated runs on `testdata/python/community_bridge` must produce stable
+  community ids, bridge modules, mismatch lists, and rounded numeric fields.
+
+Command:
+
+```sh
+go test ./service ./cmd/pyscn ./mcp -run 'Community|Communities|AnalyzeCommand'
+```
+
+## Decision Record
+
+Decision for issue #605: flip the default to on.
+
+Rationale:
+
+- Community scoring is bounded and only affects the Health Score when the
+  analyzer ran and detected at least two communities.
+- The CLI, config, and MCP selection semantics now have explicit opt-out paths.
+- Existing Phase 2 fixtures cover package mismatch, layer mismatch, bridge
+  modules, risk-score ordering, and deterministic JSON/HTML output.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ reference, configuration), see:
 | [`COMMIT_CONVENTION.md`](COMMIT_CONVENTION.md) | Commit message format. |
 | [`BRANCHING.md`](BRANCHING.md)                 | Branching and release flow. |
 | [`ANALYZE_SCORING.md`](ANALYZE_SCORING.md)     | Health Score design rationale. See also the user-facing spec page. |
+| [`COMMUNITY_DETECTION_GRADUATION.md`](COMMUNITY_DETECTION_GRADUATION.md) | Default-on graduation criteria and benchmarks for module community detection. |
 | [`MCP_INTEGRATION.md`](MCP_INTEGRATION.md)     | MCP server design. |
 | [`algorithms/`](algorithms/)                   | Per-analyzer algorithm descriptions (CFG, APTED, LSH, Main Sequence, etc.). |
 | [`algorithms/architecture-presets.md`](algorithms/architecture-presets.md) | Architecture style presets (layered/hexagonal/clean/mvc) and `allow`/`deny`/`warn` rule semantics. |

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -39,7 +39,8 @@ type AnalyzeExecutionConfig struct {
 	SystemAnalyzeDependencies bool
 	SystemAnalyzeArchitecture bool
 
-	CommunitiesEnabled bool
+	CommunitiesEnabled         bool
+	CommunitiesEnabledExplicit bool
 }
 
 // AnalyzeConfigurationLoader resolves and loads configuration for AnalyzeUseCase.
@@ -86,7 +87,7 @@ const (
 	MaxArchPenalty     = 12 // Increased from 8 for stricter scoring
 	MaxMSDPenalty      = 3  // Increased from 2 for stricter scoring
 
-	// Community detection scoring (opt-in; only applied when communities ran
+	// Community detection scoring only applies when communities ran
 	// with at least two detected communities). The risk score is a weighted
 	// blend of the factors below; the health-score penalty is bounded at
 	// MaxCommunityPenalty so disabling communities cannot move existing grades.

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -428,8 +428,9 @@ func DefaultPyscnConfig() *PyscnConfig {
 		SystemAnalysisUseDeadCodeData:       domain.BoolPtr(true),
 		SystemAnalysisGenerateUnifiedReport: domain.BoolPtr(true),
 
-		// Communities defaults (from [communities] section)
-		CommunitiesEnabled:             domain.BoolPtr(false), // Disabled by default - opt-in
+		// Communities defaults (from [communities] section). Analyze treats this
+		// value as an override only when the config file sets it explicitly.
+		CommunitiesEnabled:             domain.BoolPtr(false),
 		CommunitiesAlgorithm:           domain.DefaultCommunityAlgorithm,
 		CommunitiesScope:               domain.DefaultCommunityScope,
 		CommunitiesMinCommunitySize:    2,

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -181,9 +181,9 @@ Try asking your AI assistant:
 - `path` (required): Path to Python code (file or directory)
 - `analyses` (optional): Array of analyses to run
   - Options: `["complexity", "dead_code", "clone", "cbo", "lcom", "deps", "communities"]`
-  - Default: all analyses except `communities` (community detection is opt-in)
+  - Default: all analyses, including `communities`
 - `recursive` (optional): Recursively analyze directories (default: `true`)
-- `output_mode` (optional): `"summary"` (default) returns the health score and high-level metrics; `"full"` returns the complete report, including `community_analysis` and its `community_context_map` when `analyses` includes `communities`
+- `output_mode` (optional): `"summary"` (default) returns the health score and high-level metrics; `"full"` returns the complete report, including `community_analysis` and its `community_context_map` when community detection runs
 
 **Example**:
 ```
@@ -210,7 +210,7 @@ Analyze the code at /home/user/project with all metrics
 
 #### Module communities (context map for AI agents)
 
-Community detection groups modules into clusters by their import structure so an agent knows which files to inspect together. It is opt-in — request it explicitly with `analyses: ["communities"]` and `output_mode: "full"`.
+Community detection groups modules into clusters by their import structure so an agent knows which files to inspect together. It runs by default; when `analyses` is provided, include `"communities"` in that list and set `output_mode: "full"` to retrieve the full context map.
 
 **Example**:
 ```

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -55,19 +55,12 @@ func (h *HandlerSet) HandleAnalyzeCode(ctx context.Context, request mcp.CallTool
 	}
 
 	// Create config for analyze use case
-	config := app.AnalyzeUseCaseConfig{
-		SkipComplexity:  !contains(analyses, "complexity") && len(analyses) > 0,
-		SkipDeadCode:    !contains(analyses, "dead_code") && len(analyses) > 0,
-		SkipClones:      !contains(analyses, "clone") && len(analyses) > 0,
-		SkipCBO:         !contains(analyses, "cbo") && len(analyses) > 0,
-		SkipLCOM:        !contains(analyses, "lcom") && len(analyses) > 0,
-		SkipSystem:      !contains(analyses, "deps") && len(analyses) > 0,
-		SkipCommunities: shouldSkipCommunitiesAnalysis(analyses),
+	config := app.ApplyAnalyzeSelection(app.AnalyzeUseCaseConfig{
 		MinComplexity:   1,
 		MinSeverity:     domain.DeadCodeSeverityWarning,
 		CloneSimilarity: 0.8,
 		ConfigFile:      h.deps.ConfigPath(),
-	}
+	}, analyses)
 	if cfg := h.deps.Config(); cfg != nil {
 		if cfg.Output.MinComplexity > 0 {
 			config.MinComplexity = cfg.Output.MinComplexity
@@ -798,21 +791,6 @@ func (h *HandlerSet) HandleGetHealthScore(ctx context.Context, request mcp.CallT
 }
 
 // Helper functions
-
-func shouldSkipCommunitiesAnalysis(analyses []string) bool {
-	// Communities remain opt-in: omitted analyses lists and explicit subsets
-	// without "communities" must not run community detection.
-	return len(analyses) == 0 || !contains(analyses, "communities")
-}
-
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}
 
 // formatComplexitySummary formats complexity results in compact summary mode
 func formatComplexitySummary(result *domain.ComplexityResponse, threshold int, maxResults int) map[string]interface{} {

--- a/mcp/handlers_test.go
+++ b/mcp/handlers_test.go
@@ -52,6 +52,18 @@ func runToolTest(
 
 	t.Helper()
 	configFile := setupConfig(t)
+	return runToolTestWithConfig(t, setupFS, arguments, configFile, handlerFunc)
+}
+
+func runToolTestWithConfig(
+	t *testing.T,
+	setupFS func(t *testing.T) string,
+	arguments interface{},
+	configFile string,
+	handlerFunc func(*mcp.HandlerSet, context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error),
+) *mcplib.CallToolResult {
+
+	t.Helper()
 	deps := mcp.NewTestDependencies(service.NewFileReader(), nil, configFile)
 	h := mcp.NewHandlerSet(deps)
 
@@ -76,6 +88,15 @@ func runToolTest(
 	require.NoError(t, err)
 
 	return res
+}
+
+func setupCommunitiesDisabledConfig(t *testing.T) string {
+	t.Helper()
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, ".pyscn.toml")
+	err := os.WriteFile(configFile, []byte("[communities]\nenabled = false\n"), 0o644)
+	require.NoError(t, err)
+	return configFile
 }
 
 func TestHandleAnalyzeCode(t *testing.T) {
@@ -230,6 +251,35 @@ func TestHandleAnalyzeCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleAnalyzeCodeExplicitCommunitiesOverrideDisabledConfig(t *testing.T) {
+	t.Parallel()
+
+	fixtureRoot := func(t *testing.T) string {
+		rootDir, err := os.Getwd()
+		require.NoError(t, err)
+		return filepath.Join(filepath.Dir(rootDir), "testdata", "python", "community_bridge")
+	}
+	arguments := map[string]interface{}{
+		"analyses":    []interface{}{"communities"},
+		"output_mode": "full",
+	}
+
+	res := runToolTestWithConfig(
+		t,
+		fixtureRoot,
+		arguments,
+		setupCommunitiesDisabledConfig(t),
+		(*mcp.HandlerSet).HandleAnalyzeCode,
+	)
+
+	require.False(t, res.IsError)
+	require.Greater(t, len(res.Content), 0)
+	text := mcplib.GetTextFromContent(res.Content[0])
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(text), &result))
+	require.Contains(t, result, "community_analysis")
 }
 
 func TestHandleCheckComplexity(t *testing.T) {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -15,12 +15,12 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Description("Path to Python code (file or directory) to analyze")),
 		mcp.WithArray("analyses",
 			mcp.WithStringEnumItems([]string{"complexity", "dead_code", "clone", "cbo", "lcom", "deps", "communities"}),
-			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps, communities. Default: all analyses except communities (opt-in)")),
+			mcp.Description("Array of analyses to run. Options: complexity, dead_code, clone, cbo, lcom, deps, communities. Default: all analyses, including communities")),
 		mcp.WithBoolean("recursive",
 			mcp.Description("Recursively analyze directories (default: true)")),
 		mcp.WithString("output_mode",
 			mcp.Enum("summary", "full"),
-			mcp.Description("Response detail level. \"summary\" (default) returns health score and high-level metrics. \"full\" returns the complete report including, when analyses=[\"communities\"], the community_analysis result and its compact community_context_map (which modules to inspect together, which modules bridge clusters) for AI agents")),
+			mcp.Description("Response detail level. \"summary\" (default) returns health score and high-level metrics. \"full\" returns the complete report including community_analysis and its compact community_context_map when community detection runs")),
 	), handlers.HandleAnalyzeCode)
 
 	// Tool 2: check_complexity - Cyclomatic complexity analysis

--- a/mcp/wiring_test.go
+++ b/mcp/wiring_test.go
@@ -11,14 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShouldSkipCommunitiesAnalysis_OptInByDefault(t *testing.T) {
-	assert.True(t, shouldSkipCommunitiesAnalysis(nil))
-	assert.True(t, shouldSkipCommunitiesAnalysis([]string{}))
-	assert.True(t, shouldSkipCommunitiesAnalysis([]string{"complexity", "deps"}))
-	assert.False(t, shouldSkipCommunitiesAnalysis([]string{"communities"}))
-	assert.False(t, shouldSkipCommunitiesAnalysis([]string{"complexity", "communities"}))
-}
-
 func TestBuildAnalyzeUseCase_WiresCommunityAnalysis(t *testing.T) {
 	fixtureRoot, err := filepath.Abs(filepath.Join("..", "testdata", "python", "mvc_app"))
 	require.NoError(t, err)

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -80,6 +80,7 @@ func defaultAnalyzeExecutionConfig() domain.AnalyzeExecutionConfig {
 		SystemAnalyzeDependencies:    true,
 		SystemAnalyzeArchitecture:    true,
 		CommunitiesEnabled:           false,
+		CommunitiesEnabledExplicit:   false,
 	}
 }
 
@@ -125,6 +126,7 @@ func analyzeExecutionConfigFromConfig(cfg *config.Config, overrides analyzeEnabl
 func applyCommunitiesEnabledOverrides(executionCfg *domain.AnalyzeExecutionConfig, overrides analyzeEnabledOverrides, cfg *config.Config) {
 	if overrides.CommunitiesEnabled != nil {
 		executionCfg.CommunitiesEnabled = *overrides.CommunitiesEnabled
+		executionCfg.CommunitiesEnabledExplicit = true
 		return
 	}
 	if cfg != nil {

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -42,7 +42,10 @@ func TestAnalyzeConfigurationLoader_LoadAnalyzeExecutionConfig(t *testing.T) {
 			t.Error("expected architecture analysis enabled by default")
 		}
 		if cfg.CommunitiesEnabled {
-			t.Error("expected communities disabled by default")
+			t.Error("expected communities config default to be false")
+		}
+		if cfg.CommunitiesEnabledExplicit {
+			t.Error("expected communities config default to be implicit")
 		}
 		defaultCloneReq := domain.DefaultCloneRequest()
 		if cfg.CloneLSHEnabled != defaultCloneReq.LSHEnabled {
@@ -166,6 +169,31 @@ enabled = true
 		}
 		if !cfg.CommunitiesEnabled {
 			t.Error("expected communities enabled from config")
+		}
+		if !cfg.CommunitiesEnabledExplicit {
+			t.Error("expected communities enabled setting to be explicit")
+		}
+	})
+
+	t.Run("loads communities disabled setting from config", func(t *testing.T) {
+		projectDir := t.TempDir()
+		configPath := filepath.Join(projectDir, ".pyscn.toml")
+		configContent := `[communities]
+enabled = false
+`
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+
+		cfg, err := loader.LoadAnalyzeExecutionConfig("", projectDir)
+		if err != nil {
+			t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
+		}
+		if cfg.CommunitiesEnabled {
+			t.Error("expected communities disabled from config")
+		}
+		if !cfg.CommunitiesEnabledExplicit {
+			t.Error("expected communities disabled setting to be explicit")
 		}
 	})
 

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -19,7 +19,7 @@ By default `analyze` runs every enabled analyzer concurrently:
 - Class cohesion (LCOM4)
 - Module dependencies
 - Architecture layer validation
-- Module community detection (opt-in)
+- Module community detection
 
 Results are combined into a single report with a [Health Score](../output/health-score.md).
 
@@ -50,7 +50,7 @@ Output files land in `.pyscn/reports/` by default, named `analyze_YYYYMMDD_HHMMS
 | `--skip-cbo`        | Skip class coupling analysis. |
 | `--skip-lcom`       | Skip class cohesion analysis. |
 | `--skip-deps`       | Skip module dependency analysis. |
-| `--skip-communities` | Skip module community detection (overrides `[communities] enabled`). |
+| `--skip-communities` | Skip module community detection. |
 
 `--select` and `--skip-*` can be combined; selection applies first, then skips.
 

--- a/website/docs/configuration/reference.md
+++ b/website/docs/configuration/reference.md
@@ -288,11 +288,11 @@ Module dependency analysis. **Opt-in** for `pyscn check`; always on for `pyscn a
 
 ## `[communities]` { #communities }
 
-Module community detection over the import dependency graph. **Opt-in** — disabled by default until you enable it here or pass `--select communities`.
+Module community detection over the import dependency graph. It runs in default `pyscn analyze`; set `enabled = false` to disable it for default analyze runs.
 
 | Key                    | Type   | Default   | Description |
 | ---------------------- | ------ | --------- | --- |
-| `enabled`              | bool   | `false`   | Run community detection in unified `pyscn analyze`. |
+| `enabled`              | bool   | `true` for default analyze | Set to `false` to disable community detection in default `pyscn analyze`. |
 | `algorithm`            | string | `"leiden"`| Community detection algorithm (currently only `leiden`). |
 | `scope`                | string | `"module"`| Graph scope. Module-level only in Phase 1. |
 | `min_community_size`   | int    | `2`       | Minimum community size; smaller partitions stay as singletons. |
@@ -302,7 +302,7 @@ Module community detection over the import dependency graph. **Opt-in** — disa
 
 ```toml
 [communities]
-enabled = true
+enabled = false
 min_community_size = 2
 report_bridge_modules = true
 ```
@@ -351,8 +351,8 @@ Flags that don't map directly to a config key (`--select`, `--skip-*`, `--no-ope
 | `--min-severity`        | `[dead_code] min_severity`        |
 | `--clone-threshold`     | `[clones] similarity_threshold`   |
 | `--min-cbo`             | `[cbo] min_cbo`                   |
-| `--select communities`  | `[communities] enabled` (per-run) |
-| `--skip-communities`    | overrides `[communities] enabled` |
+| `--select communities`  | explicit per-run selection |
+| `--skip-communities`    | disables communities for the run |
 | `--max-cycles`          | — (check command only)            |
 
 ## See also

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -29,7 +29,7 @@ pyscn analyze --no-open .       # suppress browser open
 pyscn analyze --select complexity .
 pyscn analyze --select complexity,deadcode .
 pyscn analyze --skip-clones .
-pyscn analyze --json --select communities src/   # module community detection (opt-in)
+pyscn analyze --json --select communities src/   # standalone community JSON
 ```
 
 See [`analyze`](../cli/analyze.md) for all flags. Community output: [Module Community Detection](../guides/module-community-detection.md).

--- a/website/docs/guides/module-community-detection.md
+++ b/website/docs/guides/module-community-detection.md
@@ -1,6 +1,6 @@
 ---
 title: Module Community Detection
-description: Discover natural architectural boundaries in a Python codebase from import dependencies. Learn when to run community detection, how to interpret modularity and bridge modules, and how to enable it in CI.
+description: Discover natural architectural boundaries in a Python codebase from import dependencies. Learn how to interpret modularity and bridge modules, configure community detection, and use it in CI.
 ---
 
 # Module Community Detection
@@ -14,7 +14,7 @@ Use it when you want answers like:
 - Do import communities leak dependencies across boundaries?
 - Which files should an agent or reviewer inspect together?
 
-Community detection is **opt-in**. It does not run in a default `pyscn analyze` invocation until you enable it through `--select communities` or `[communities] enabled = true`.
+Community detection runs in default `pyscn analyze` invocations. Use `--skip-communities` or `[communities] enabled = false` to disable it. When `--select` is used, include `communities` in the selected list to run only that subset with community detection.
 
 ## Quick start
 
@@ -23,16 +23,16 @@ Community detection is **opt-in**. It does not run in a default `pyscn analyze` 
 pyscn analyze --json --select communities src/
 
 # Include communities in a full unified report
-pyscn analyze --json --select deps,communities src/
+pyscn analyze --json src/
 ```
 
 Standalone `--json --select communities` writes only the `community_analysis` object to `.pyscn/reports/`. Unified `pyscn analyze --json` embeds the same object under the top-level `community_analysis` key. See [Output Schemas](../output/schemas.md#community-analysis-object).
 
-Enable by default in config:
+Disable in default analyze runs:
 
 ```toml
 [communities]
-enabled = true
+enabled = false
 ```
 
 ## How it works
@@ -92,7 +92,7 @@ This is distinct from `SystemMetrics.ModularityIndex` in dependency analysis (an
 
 When `[architecture]` layers are configured (explicit `style`, `[[architecture.layers]]`, or `[[architecture.rules]]`), community detection also compares inferred clusters to configured layer boundaries. Layer mismatch is omitted when no architecture rules are configured — community analysis still succeeds.
 
-Enable both dependency graph construction and architecture config, e.g. `pyscn analyze --select deps,communities .` or `[communities] enabled = true` with `[architecture]` configured.
+Enable both dependency graph construction and architecture config, e.g. `pyscn analyze .` with `[architecture]` configured or `pyscn analyze --select deps,communities .` when using `--select`.
 
 | Field | What it suggests |
 | --- | --- |
@@ -109,7 +109,7 @@ All keys live under `[communities]` in `.pyscn.toml` or `[tool.pyscn.communities
 
 ```toml
 [communities]
-enabled = false                  # opt-in; CLI --select communities also enables per run
+enabled = false                  # disables default analyze community detection
 algorithm = "leiden"             # currently the only supported value
 scope = "module"                 # module-level graph (function/class scope is future work)
 min_community_size = 2           # communities smaller than this remain as singleton partitions
@@ -123,10 +123,10 @@ CLI equivalents:
 | Goal | Command |
 | --- | --- |
 | Run only communities | `pyscn analyze --select communities .` |
-| Skip even if config enables | `pyscn analyze --skip-communities .` |
+| Skip communities for one run | `pyscn analyze --skip-communities .` |
 | Standalone JSON artifact | `pyscn analyze --json --select communities .` |
 
-`--select` takes precedence: `[communities] enabled = true` does not run communities unless `communities` appears in `--select` when `--select` is used.
+`--select` takes precedence: communities run only when `communities` appears in `--select` when `--select` is used.
 
 ## Determinism
 
@@ -199,7 +199,7 @@ Read this as: two natural clusters exist, and `bridge` is the coupling point bet
 
 ## Follow-up work (Phase 2 and 3)
 
-Module-level community detection is Phase 1 of [GitHub issue #564](https://github.com/ludo-technologies/pyscn/issues/564). Phase 2 mismatch scoring is available via package fields (`package_alignment_score`, `split_packages`, `mixed_communities`) and layer fields (`layer_alignment_score`, `cross_layer_communities`, `layer_bridge_modules`) when architecture layers are configured. DOT export with community-colored subgraphs and the [HTML macro-architecture visualization](#macro-architecture-visualization) are also available. Remaining planned extensions include:
+Module-level community detection is part of [GitHub issue #564](https://github.com/ludo-technologies/pyscn/issues/564). Phase 2 mismatch scoring is available via package fields (`package_alignment_score`, `split_packages`, `mixed_communities`) and layer fields (`layer_alignment_score`, `cross_layer_communities`, `layer_bridge_modules`) when architecture layers are configured. DOT export with community-colored subgraphs and the [HTML macro-architecture visualization](#macro-architecture-visualization) are also available. Remaining planned extensions include:
 - AI-agent context maps
 - Richer edge weights from call/type/reference data
 - Function- and class-level clustering

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -19,7 +19,7 @@ uvx pyscn@latest analyze .
 - **APTED + LSH clone detection** across four clone types (identical, renamed, modified, semantic).
 - **CBO / LCOM4** class coupling and cohesion metrics.
 - **Circular import detection** via Tarjan's SCC.
-- **Module community detection** (opt-in) via Leiden clustering over the import graph.
+- **Module community detection** via Leiden clustering over the import graph.
 - **Health score** (0–100) with per-category breakdown.
 - **CI-ready** with `pyscn check`, linter-style output, and deterministic exit codes.
 - **MCP server** (`pyscn-mcp`) for Claude Code, Cursor, and other MCP clients.

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -63,7 +63,7 @@ Constructor and collaborator patterns that hurt testability.
 
 Import graph problems: cycles, long chains, layer violations.
 
-Community detection (opt-in) clusters modules by import topology and surfaces bridge modules between clusters. It is an analysis, not a pass/fail rule — see [Module Community Detection](../guides/module-community-detection.md).
+Community detection clusters modules by import topology and surfaces bridge modules between clusters. It is an analysis, not a pass/fail rule — see [Module Community Detection](../guides/module-community-detection.md).
 
 | Rule | Severity |
 | ---- | -------- |


### PR DESCRIPTION
## Summary

- Run module community detection in default `pyscn analyze` and MCP default analyze flows.
- Preserve explicit opt-out behavior through `--skip-communities` and `[communities] enabled = false`.
- Add graduation criteria docs and `make bench-communities`, plus update CLI/MCP/site docs for default-on behavior.

## Rationale

Closes #605. Phase 2 community scoring is bounded and only affects the Health Score when community detection ran and detected at least two communities. This makes the default-on behavior compatible with existing opt-out and trivial-graph behavior while surfacing the agent-oriented community context by default.

Decision recorded on the issue: https://github.com/ludo-technologies/pyscn/issues/605#issuecomment-4831618204

## Validation

- `make fmt`
- `go test ./cmd/pyscn ./app ./service ./mcp ./domain -run 'Community|Communities|AnalyzeCommand|AnalyzeConfigurationLoader|AnalyzeScore'`
- `make bench-communities`
- `make test`
- `make lint` (0 issues; golangci-lint printed a stale `/private/tmp` generated_file_filter warning unrelated to this branch)