### PR TITLE
[codex] fix src-layout community graph edges

### DIFF
--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -16,6 +16,7 @@ import (
 // ModuleAnalyzer analyzes module-level dependencies and builds dependency graphs
 type ModuleAnalyzer struct {
 	projectRoot     string
+	moduleRoots     []string
 	pythonPath      []string
 	excludePatterns []string
 	includePatterns []string
@@ -82,13 +83,14 @@ func NewModuleAnalyzer(options *ModuleAnalysisOptions) (*ModuleAnalyzer, error) 
 
 	analyzer := &ModuleAnalyzer{
 		projectRoot:       absRoot,
-		pythonPath:        append([]string{absRoot}, options.PythonPath...),
+		moduleRoots:       moduleRoots(absRoot, options.PythonPath),
 		resolvedModules:   make(map[string]string),
-		reExportResolver:  NewReExportResolver(absRoot),
 		includeStdLib:     domain.BoolValue(options.IncludeStdLib, domain.BoolValue(defaults.IncludeStdLib, false)),
 		includeThirdParty: domain.BoolValue(options.IncludeThirdParty, domain.BoolValue(defaults.IncludeThirdParty, true)),
 		followRelative:    domain.BoolValue(options.FollowRelative, domain.BoolValue(defaults.FollowRelative, true)),
 	}
+	analyzer.pythonPath = append([]string(nil), analyzer.moduleRoots...)
+	analyzer.reExportResolver = NewReExportResolverWithRoots(absRoot, analyzer.moduleRoots)
 
 	if options.ExcludePatterns != nil {
 		analyzer.excludePatterns = append(analyzer.excludePatterns, options.ExcludePatterns...)
@@ -103,6 +105,56 @@ func NewModuleAnalyzer(options *ModuleAnalysisOptions) (*ModuleAnalyzer, error) 
 	}
 
 	return analyzer, nil
+}
+
+func moduleRoots(projectRoot string, pythonPath []string) []string {
+	roots := make([]string, 0, 2+len(pythonPath))
+	addRoot := func(path string) {
+		if path == "" {
+			return
+		}
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return
+		}
+		for _, existing := range roots {
+			if existing == abs {
+				return
+			}
+		}
+		roots = append(roots, abs)
+	}
+
+	if isSrcLayoutRoot(projectRoot) {
+		addRoot(filepath.Join(projectRoot, "src"))
+	}
+	addRoot(projectRoot)
+	for _, path := range pythonPath {
+		addRoot(path)
+	}
+
+	sort.SliceStable(roots, func(i, j int) bool {
+		return len(roots[i]) > len(roots[j])
+	})
+	return roots
+}
+
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func isSrcLayoutRoot(projectRoot string) bool {
+	srcRoot := filepath.Join(projectRoot, "src")
+	if !isDirectory(srcRoot) {
+		return false
+	}
+	for _, name := range pythonPackageInitFiles {
+		if _, err := os.Stat(filepath.Join(srcRoot, name)); err == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // AnalyzeProject analyzes all Python modules in the project and builds a dependency graph
@@ -542,11 +594,10 @@ func (ma *ModuleAnalyzer) resolveAbsoluteImportWithProject(imp *ImportInfo, from
 	currentDir := filepath.Dir(fromFile)
 
 	// Try to find the module in the same directory or project root
-	searchPaths := []string{
+	searchPaths := append([]string{
 		currentDir,               // Current directory
-		ma.projectRoot,           // Project root
 		filepath.Dir(currentDir), // Parent directory
-	}
+	}, ma.pythonPath...)
 
 	for _, searchPath := range searchPaths {
 		// Try to build module path from the import name
@@ -686,7 +737,8 @@ func (ma *ModuleAnalyzer) canonicalModuleFiles(filePaths []string) []string {
 // filePathToModuleName converts a file path to a Python module name
 func (ma *ModuleAnalyzer) filePathToModuleName(filePath string) string {
 	// Make path relative to project root
-	relPath, err := filepath.Rel(ma.projectRoot, filePath)
+	root := ma.moduleRootForFile(filePath)
+	relPath, err := filepath.Rel(root, filePath)
 	if err != nil {
 		return ""
 	}
@@ -712,11 +764,33 @@ func (ma *ModuleAnalyzer) filePathToModuleName(filePath string) string {
 
 // pathToModuleName converts a directory path to a module name
 func (ma *ModuleAnalyzer) pathToModuleName(path string) string {
-	relPath, err := filepath.Rel(ma.projectRoot, path)
+	root := ma.moduleRootForFile(path)
+	relPath, err := filepath.Rel(root, path)
 	if err != nil {
 		return ""
 	}
 	return strings.ReplaceAll(relPath, string(filepath.Separator), ".")
+}
+
+func (ma *ModuleAnalyzer) moduleRootForFile(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return ma.projectRoot
+	}
+	for _, root := range ma.moduleRoots {
+		if pathWithinRoot(absPath, root) {
+			return root
+		}
+	}
+	return ma.projectRoot
+}
+
+func pathWithinRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != "" && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != "..")
 }
 
 func (ma *ModuleAnalyzer) isAbstractClass(classNode *parser.Node) bool {

--- a/internal/analyzer/module_analyzer_import_test.go
+++ b/internal/analyzer/module_analyzer_import_test.go
@@ -725,6 +725,77 @@ func TestModuleAnalyzerDoesNotResolveStdlibImportToShadowingProjectModule(t *tes
 	}
 }
 
+func TestModuleAnalyzerResolvesSrcLayoutAbsoluteImport(t *testing.T) {
+	dir := t.TempDir()
+
+	serviceModule := filepath.Join(dir, "src", "myapp", "service.py")
+	repoModule := filepath.Join(dir, "src", "myapp", "repo.py")
+	for _, path := range []string{serviceModule, repoModule} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("failed to create directory for %s: %v", path, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "myapp", "__init__.py"), []byte(""), 0o644); err != nil {
+		t.Fatalf("failed to write package init: %v", err)
+	}
+	if err := os.WriteFile(serviceModule, []byte("from myapp import repo\n"), 0o644); err != nil {
+		t.Fatalf("failed to write service module: %v", err)
+	}
+	if err := os.WriteFile(repoModule, []byte("value = 1\n"), 0o644); err != nil {
+		t.Fatalf("failed to write repo module: %v", err)
+	}
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{ProjectRoot: dir})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	graph, err := analyzer.AnalyzeFiles([]string{serviceModule, repoModule})
+	if err != nil {
+		t.Fatalf("AnalyzeFiles failed: %v", err)
+	}
+
+	serviceNode := graph.GetModule("myapp.service")
+	if serviceNode == nil {
+		t.Fatalf("expected myapp.service module, got %v", graph.GetModuleNames())
+	}
+	if !serviceNode.Dependencies["myapp.repo"] {
+		t.Fatalf("expected myapp.service to depend on myapp.repo; dependencies: %v", serviceNode.Dependencies)
+	}
+	if graph.GetModule("src.myapp.service") != nil {
+		t.Fatalf("did not expect src-prefixed module name in src-layout graph")
+	}
+}
+
+func TestModuleAnalyzerKeepsSrcPackagePrefixWhenSrcIsPackage(t *testing.T) {
+	dir := t.TempDir()
+
+	srcInit := filepath.Join(dir, "src", "__init__.py")
+	module := filepath.Join(dir, "src", "module.py")
+	if err := os.MkdirAll(filepath.Dir(module), 0o755); err != nil {
+		t.Fatalf("failed to create src package: %v", err)
+	}
+	if err := os.WriteFile(srcInit, []byte(""), 0o644); err != nil {
+		t.Fatalf("failed to write src init: %v", err)
+	}
+	if err := os.WriteFile(module, []byte("value = 1\n"), 0o644); err != nil {
+		t.Fatalf("failed to write module: %v", err)
+	}
+
+	analyzer, err := NewModuleAnalyzer(&ModuleAnalysisOptions{ProjectRoot: dir})
+	if err != nil {
+		t.Fatalf("failed to create analyzer: %v", err)
+	}
+
+	graph, err := analyzer.AnalyzeFiles([]string{srcInit, module})
+	if err != nil {
+		t.Fatalf("AnalyzeFiles failed: %v", err)
+	}
+	if graph.GetModule("src.module") == nil {
+		t.Fatalf("expected src.module in graph, got %v", graph.GetModuleNames())
+	}
+}
+
 func collectImportsForTest(t *testing.T, analyzer *ModuleAnalyzer, path string) []*ImportInfo {
 	t.Helper()
 

--- a/internal/analyzer/reexport_resolver.go
+++ b/internal/analyzer/reexport_resolver.go
@@ -27,13 +27,34 @@ type ReExportMap struct {
 // ReExportResolver resolves re-exports in __init__.py files
 type ReExportResolver struct {
 	projectRoot string
+	roots       []string
 	cache       map[string]*ReExportMap // package name -> re-export map
 }
 
 // NewReExportResolver creates a new resolver
 func NewReExportResolver(projectRoot string) *ReExportResolver {
+	return NewReExportResolverWithRoots(projectRoot, []string{projectRoot})
+}
+
+// NewReExportResolverWithRoots creates a resolver using one or more import roots.
+func NewReExportResolverWithRoots(projectRoot string, roots []string) *ReExportResolver {
+	cleanRoots := make([]string, 0, len(roots))
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			continue
+		}
+		cleanRoots = append(cleanRoots, abs)
+	}
+	if len(cleanRoots) == 0 {
+		cleanRoots = append(cleanRoots, projectRoot)
+	}
 	return &ReExportResolver{
 		projectRoot: projectRoot,
+		roots:       cleanRoots,
 		cache:       make(map[string]*ReExportMap),
 	}
 }
@@ -89,12 +110,13 @@ func (r *ReExportResolver) ResolveReExport(packageName, importedName string) (st
 // findInitFile finds the package init file for a package.
 func (r *ReExportResolver) findInitFile(packageName string) string {
 	// Convert package name to path
-	packagePath := filepath.Join(r.projectRoot, strings.ReplaceAll(packageName, ".", string(filepath.Separator)))
-
-	for _, name := range pythonPackageInitFiles {
-		initPath := filepath.Join(packagePath, name)
-		if _, err := os.Stat(initPath); err == nil {
-			return initPath
+	for _, root := range r.roots {
+		packagePath := filepath.Join(root, strings.ReplaceAll(packageName, ".", string(filepath.Separator)))
+		for _, name := range pythonPackageInitFiles {
+			initPath := filepath.Join(packagePath, name)
+			if _, err := os.Stat(initPath); err == nil {
+				return initPath
+			}
 		}
 	}
 

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -375,9 +375,23 @@ func TestCommunityAnalysisService_Analyze_UsesSourcePathsForProjectRoot(t *testi
 	service := NewCommunityAnalysisService()
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:       []string{fileA, fileB},
-		SourcePaths: []string{srcDir},
+		SourcePaths: []string{root},
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Greater(t, result.TotalCommunities, 0)
+	assert.Contains(t, communityModuleNames(result), "myapp.service")
+	assert.Contains(t, communityModuleNames(result), "myapp.repo")
+	assert.Contains(t, result.ModuleDependencies, domain.CommunityModuleDependency{From: "myapp.service", To: "myapp.repo"})
+}
+
+func communityModuleNames(result *domain.CommunityAnalysisResult) []string {
+	if result == nil {
+		return nil
+	}
+	names := make([]string, 0)
+	for _, community := range result.Communities {
+		names = append(names, community.Modules...)
+	}
+	return names
 }


### PR DESCRIPTION
## Summary

Fix src-layout import resolution so dependency and community graphs use importable module names such as `myapp.service` instead of `src.myapp.service` for typical `src/` projects.

## Root Cause

For projects with `pyproject.toml` at the repository root and code under `src/`, module names were derived relative to the repository root. That left a synthetic `src.` prefix in graph nodes, while absolute imports resolved as `myapp...`, so internal edges were dropped. The HTML community graph could then show many modules but almost no connecting lines.

## Changes

- Detect typical src-layout roots and use `projectRoot/src` as an import/module root when `src` is not itself a Python package.
- Keep `src.*` module names when `src/__init__.py` exists, preserving real `src` packages.
- Use the same root set for re-export resolution.
- Add analyzer and community-service regression tests for src-layout absolute imports and emitted module dependencies.

## Validation

- `go test ./...`