### PR TITLE
fix: drop clone groups without backing pairs

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -1194,7 +1194,7 @@ func (cd *CloneDetector) groupClonesWithStrategy(strategy GroupingStrategy) {
 	}
 	memberResult := dedupeStrictSubsetGroupMembers(strategy.GroupClones(cd.clonePairs), cd.clonePairs)
 	groupResult := dedupeCoveredGroups(memberResult.groups)
-	cd.cloneGroups = groupResult.groups
+	cd.cloneGroups = filterCloneGroupsWithoutBackingPairs(groupResult.groups, cd.clonePairs)
 	for fragment := range memberResult.suppressed {
 		groupResult.suppressed[fragment] = struct{}{}
 	}

--- a/internal/analyzer/group_dedup.go
+++ b/internal/analyzer/group_dedup.go
@@ -293,6 +293,25 @@ func refreshGroupMetadata(group *CloneGroup, similarities map[string]float64, cl
 	group.CloneType = majorityCloneType(cloneTypes, similarities, group.Fragments)
 }
 
+func filterCloneGroupsWithoutBackingPairs(groups []*CloneGroup, pairs []*ClonePair) []*CloneGroup {
+	if len(groups) == 0 {
+		return groups
+	}
+	similarities, cloneTypes := clonePairMetadata(pairs)
+	out := make([]*CloneGroup, 0, len(groups))
+	for _, group := range groups {
+		if group == nil || len(group.Fragments) < 2 {
+			continue
+		}
+		refreshGroupMetadata(group, similarities, cloneTypes)
+		if group.Similarity <= 0 {
+			continue
+		}
+		out = append(out, group)
+	}
+	return out
+}
+
 func filterClonePairsWithSuppressedMembers(pairs []*ClonePair, suppressed map[*CodeFragment]struct{}) []*ClonePair {
 	if len(pairs) == 0 || len(suppressed) == 0 {
 		return pairs

--- a/internal/analyzer/group_dedup_test.go
+++ b/internal/analyzer/group_dedup_test.go
@@ -216,6 +216,27 @@ func TestDedupe_RecomputesMetadataAfterSuppression(t *testing.T) {
 	}
 }
 
+func TestFilterCloneGroupsWithoutBackingPairs_DropsUnbackedGroup(t *testing.T) {
+	a := gf("x.py", 1, 10)
+	b := gf("x.py", 20, 30)
+	c := gf("y.py", 1, 10)
+	unbacked := makeGroup(1, a, b)
+	backed := makeGroup(2, a, c)
+	pairs := []*ClonePair{gpType(a, c, 0.92, Type4Clone)}
+
+	out := filterCloneGroupsWithoutBackingPairs([]*CloneGroup{unbacked, backed}, pairs)
+
+	if len(out) != 1 {
+		t.Fatalf("expected only the backed group to remain, got %d groups", len(out))
+	}
+	if out[0] != backed {
+		t.Fatalf("expected backed group to remain")
+	}
+	if !almostEqual(out[0].Similarity, 0.92) {
+		t.Fatalf("expected refreshed similarity 0.92, got %.3f", out[0].Similarity)
+	}
+}
+
 // TestGroupClonesWithStrategy_FiltersSuppressedClonePairs verifies pair output
 // cannot keep reporting a strict-subset member hidden from clone groups.
 func TestGroupClonesWithStrategy_FiltersSuppressedClonePairs(t *testing.T) {


### PR DESCRIPTION
## Summary
- Drops clone groups whose remaining members no longer have any backing clone pair after group deduplication.
- Refreshes final group metadata from surviving pairs so unbacked groups do not report similarity 0.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Fixes #539

## Changes
- Recompute final clone group metadata after group deduplication.
- Filter clone groups that have no backing pair among remaining members.
- Add a regression test for unbacked clone groups.

## Testing
- [x] `go test ./internal/analyzer -run 'TestFilterCloneGroupsWithoutBackingPairs|TestGroupClonesWithStrategy_FiltersSuppressedClonePairs|TestCloneDetector_PairsPromotedToGroups' -v`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build -v ./cmd/pyscn`
- [x] `golangci-lint run --timeout=10m`
- [x] `go run ./cmd/pyscn analyze --json --no-open /tmp/tlslite-ng`
- [x] `git diff --check`

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (if needed)
