### PR TITLE
test(analyzer): pin LCOM4 InstanceVariables regression for issue #627

### DIFF
--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -763,3 +763,117 @@ Inner._fields_ = [
 		}
 	}
 }
+
+// TestLCOMAnalyzer_Issue627Repro pins the two classes cited in
+// https://github.com/ludo-technologies/pyscn/issues/627, which claimed
+// InstanceVariables is always 0. Both already reported correct non-zero
+// values on this code path (the report did not reproduce); this guards
+// against a future regression on these real-world shapes.
+func TestLCOMAnalyzer_Issue627Repro(t *testing.T) {
+	t.Run("Point", func(t *testing.T) {
+		p := parser.New()
+		code := `
+def my_decorator(func):
+    return func
+
+class Point:
+    def __init__(self, x: int, y: int) -> None:
+        self.x = x
+        self.y = y
+
+    def abs(self) -> 'Point':
+        return Point(abs(self.x), abs(self.y))
+
+    def add(self, other: 'Point'):
+        self.x += other.x
+        self.y += other.y
+
+    def to_origin(self):
+        self.x = 0
+        self.y = 0
+
+    def ignored(self):
+        self.foo = 'bar'
+
+    def __len__(self):
+        return 0
+
+    @staticmethod
+    def from_coords(coords) -> 'Point':
+        return Point(coords[0], coords[1])
+
+    @property
+    def coords(self):
+        return self.x, self.y
+
+    @staticmethod
+    def skip_static_decorator_pragma(a: int, b: int) -> int:
+        return a + b * 2
+
+    @classmethod
+    def skip_class_decorator_pragma(cls, value: int) -> "Point":
+        return cls(value + 1, value * 2)
+
+    def skip_instance_method_pragma(self) -> int:
+        return self.x + self.y * 2
+
+    @staticmethod
+    def pragma_on_staticmethod_decorator(a: int, b: int) -> int:
+        return a + b * 2
+
+    @classmethod
+    def pragma_on_classmethod_decorator(cls, value: int) -> "Point":
+        return cls(value + 1, value * 2)
+
+    @my_decorator
+    @classmethod
+    def skip_multi_decorator(cls, value: int) -> "Point":
+        return cls(value + 1, value * 2)
+`
+		result, err := p.Parse(context.Background(), []byte(code))
+		require.NoError(t, err)
+
+		analyzer := NewLCOMAnalyzer(nil)
+		results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		r := results[0]
+		assert.Equal(t, "Point", r.ClassName)
+		assert.Equal(t, 14, r.TotalMethods)
+		assert.Equal(t, 6, r.ExcludedMethods)
+		assert.Equal(t, 3, r.InstanceVariables, "self.x, self.y, self.foo")
+		assert.Equal(t, 3, r.LCOM4)
+	})
+
+	t.Run("HammettRunner", func(t *testing.T) {
+		p := parser.New()
+		code := `
+class TestRunner:
+    pass
+
+class HammettRunner(TestRunner):
+    def __init__(self, config) -> None:
+        self.hammett_kwargs = None
+
+    def other_method(self):
+        return self.hammett_kwargs
+`
+		result, err := p.Parse(context.Background(), []byte(code))
+		require.NoError(t, err)
+
+		analyzer := NewLCOMAnalyzer(nil)
+		results, err := analyzer.AnalyzeClasses(result.AST, "test.py")
+		require.NoError(t, err)
+
+		byName := make(map[string]*LCOMResult, len(results))
+		for _, res := range results {
+			byName[res.ClassName] = res
+		}
+
+		r, ok := byName["HammettRunner"]
+		require.True(t, ok, "missing class HammettRunner")
+		assert.Equal(t, 1, r.InstanceVariables, "self.hammett_kwargs")
+		assert.Equal(t, [][]string{{"__init__", "other_method"}}, r.MethodGroups)
+	})
+}


### PR DESCRIPTION
## Summary
Investigated #627, which claimed LCOM4's `InstanceVariables` metric is always 0. It does not reproduce on current `main`. Both classes cited in the issue (`Point`, `HammettRunner`) already report correct non-zero `InstanceVariables` when analyzed with the current code. This PR adds a regression test pinning that correct behavior using the real-world class shapes from the issue.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Closes #627

## Investigation notes
- Rebuilt the exact `Point` class from the issue's cited file in mutmut (14 methods, mixing `@staticmethod`/`@classmethod`/`@property`/stacked decorators). It reproduces the issue's own claimed `LCOM4=3, TotalMethods=14` exactly, but `InstanceVariables=3`, not 0.
- The `HammettRunner(TestRunner)` class from the issue's second example reports `InstanceVariables=1`, not 0.
- `internal/analyzer/lcom.go`'s instance-variable tracking is correct: the per-method `vars` map (`collectMethods`) is scoped per method only for Union-Find edge detection, and is separately unioned into a class-scoped `allVars` map (`analyzeClass`) that feeds `result.InstanceVariables`. There's no never-initialized or always-cleared tracker.
- `internal/analyzer/lcom_test.go` already had extensive passing coverage for `InstanceVariables` (f-strings, `with`-blocks, ctypes `_fields_`, properties) before this PR.
- The raw audit JSON that produced the original bug report (still present locally under `.pyscn/audit/results/`) already showed the correct non-zero values for both classes. The auto-filed issue's "Actual Output" section did not match the tool's own recorded output.

## Changes
- Add `TestLCOMAnalyzer_Issue627Repro` to `internal/analyzer/lcom_test.go`, covering the `Point` and `HammettRunner` shapes from the issue and pinning `TotalMethods`, `ExcludedMethods`, `InstanceVariables`, `LCOM4`, and `MethodGroups`.

## Testing
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (if needed)

## Additional Context
No production code changes were needed since the reported behavior isn't reproducible. This PR is regression coverage plus a paper trail closing out the investigation.
