### PR TITLE
fix: deduplicate clone pairs before reporting

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -1258,8 +1258,10 @@ func (cd *CloneDetector) tryCreateClonePair(i, j int, minSimilarity float64) *Cl
 	return nil
 }
 
-// limitAndSortClonePairs ensures final results are sorted and limited
+// limitAndSortClonePairs ensures final results are unique, sorted, and limited.
 func (cd *CloneDetector) limitAndSortClonePairs(maxPairs int) {
+	cd.clonePairs = dedupeClonePairs(cd.clonePairs)
+
 	// Sort clone pairs by similarity (descending)
 	sort.Slice(cd.clonePairs, func(i, j int) bool {
 		return cd.clonePairs[i].Similarity > cd.clonePairs[j].Similarity
@@ -1269,6 +1271,36 @@ func (cd *CloneDetector) limitAndSortClonePairs(maxPairs int) {
 	if len(cd.clonePairs) > maxPairs {
 		cd.clonePairs = cd.clonePairs[:maxPairs]
 	}
+}
+
+func dedupeClonePairs(pairs []*ClonePair) []*ClonePair {
+	if len(pairs) < 2 {
+		return pairs
+	}
+
+	byLocation := make(map[string]*ClonePair, len(pairs))
+	order := make([]string, 0, len(pairs))
+	for _, pair := range pairs {
+		if pair == nil || pair.Fragment1 == nil || pair.Fragment2 == nil {
+			continue
+		}
+		key := pairKey(pair.Fragment1, pair.Fragment2)
+		existing, ok := byLocation[key]
+		if !ok {
+			byLocation[key] = pair
+			order = append(order, key)
+			continue
+		}
+		if pair.Similarity > existing.Similarity {
+			byLocation[key] = pair
+		}
+	}
+
+	unique := make([]*ClonePair, 0, len(order))
+	for _, key := range order {
+		unique = append(unique, byLocation[key])
+	}
+	return unique
 }
 
 // Helper functions

--- a/internal/analyzer/clone_detector_test.go
+++ b/internal/analyzer/clone_detector_test.go
@@ -540,6 +540,37 @@ func TestCloneDetector_CalculateConfidence(t *testing.T) {
 	assert.LessOrEqual(t, confidence, 1.0, "Confidence should not exceed 1.0")
 }
 
+func TestCloneDetector_limitAndSortClonePairs_DeduplicatesByLocation(t *testing.T) {
+	fragmentA := &CodeFragment{
+		Location: &CodeLocation{FilePath: "type_checking.py", StartLine: 44, EndLine: 58},
+		Size:     12,
+	}
+	fragmentB := &CodeFragment{
+		Location: &CodeLocation{FilePath: "type_checking.py", StartLine: 61, EndLine: 76},
+		Size:     12,
+	}
+	fragmentC := &CodeFragment{
+		Location: &CodeLocation{FilePath: "type_checking.py", StartLine: 79, EndLine: 93},
+		Size:     12,
+	}
+
+	detector := NewCloneDetector(DefaultCloneDetectorConfig())
+	detector.clonePairs = []*ClonePair{
+		{Fragment1: fragmentA, Fragment2: fragmentB, Similarity: 0.91, CloneType: Type4Clone},
+		{Fragment1: fragmentB, Fragment2: fragmentC, Similarity: 0.88, CloneType: Type4Clone},
+		{Fragment1: fragmentB, Fragment2: fragmentA, Similarity: 0.93, CloneType: Type4Clone},
+	}
+
+	detector.limitAndSortClonePairs(10)
+
+	require.Len(t, detector.clonePairs, 2)
+	assert.Same(t, fragmentB, detector.clonePairs[0].Fragment1)
+	assert.Same(t, fragmentA, detector.clonePairs[0].Fragment2)
+	assert.Equal(t, 0.93, detector.clonePairs[0].Similarity)
+	assert.Same(t, fragmentB, detector.clonePairs[1].Fragment1)
+	assert.Same(t, fragmentC, detector.clonePairs[1].Fragment2)
+}
+
 func TestCloneDetector_GetStatistics(t *testing.T) {
 	config := DefaultCloneDetectorConfig()
 	detector := NewCloneDetector(config)


### PR DESCRIPTION
## Summary
Deduplicate clone pairs by canonical fragment location before sorting and limiting results.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Closes #626

## Changes
- Keep one reported clone pair per unordered fragment-location pair.
- Prefer the higher-similarity pair when duplicates are produced.
- Add regression coverage for duplicate and reversed clone-pair entries.

## Testing
- [x] `go test ./internal/analyzer -run 'TestCloneDetector_limitAndSortClonePairs_DeduplicatesByLocation|TestCloneDetector_GetStatistics'`
- [x] `go test ./internal/analyzer`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go build -v ./cmd/pyscn`
- [x] `golangci-lint run --timeout=10m`

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (if needed)

## Additional Context
