### PR TITLE
fix: report only detected clone fragments

### DIFF
--- a/service/clone_service.go
+++ b/service/clone_service.go
@@ -163,12 +163,13 @@ func (s *CloneService) buildCloneResponse(
 
 	// Convert to domain objects
 	domainClones, fragmentIDs := s.convertFragmentsToDomainClones(allFragments)
-	domainClonePairs := s.convertClonePairsToDomain(detectionResult.Pairs, req.ShowContent)
+	domainClonePairs := s.convertClonePairsToDomain(detectionResult.Pairs, req.ShowContent, fragmentIDs)
 	domainCloneGroups := s.convertCloneGroupsToDomain(detectionResult.Groups, req.ShowContent, fragmentIDs)
 
 	// Filter results based on request criteria
 	domainClonePairs = s.filterClonePairs(domainClonePairs, req)
 	domainCloneGroups = s.filterCloneGroups(domainCloneGroups, req)
+	domainClones = filterClonesToReferencedFragments(domainClones, domainClonePairs, domainCloneGroups)
 
 	// Sort results
 	s.sortResults(domainClones, domainClonePairs, domainCloneGroups, req)
@@ -335,11 +336,17 @@ func (s *CloneService) convertFragmentsToDomainClones(
 }
 
 // convertClonePairsToDomain converts analyzer clone pairs to domain clone pairs.
-func (s *CloneService) convertClonePairsToDomain(clonePairs []*analyzer.ClonePair, includeContent bool) []*domain.ClonePair {
+func (s *CloneService) convertClonePairsToDomain(
+	clonePairs []*analyzer.ClonePair,
+	includeContent bool,
+	fragmentIDs map[*analyzer.CodeFragment]int,
+) []*domain.ClonePair {
 	domainPairs := make([]*domain.ClonePair, len(clonePairs))
 
 	for i, pair := range clonePairs {
 		clone1 := &domain.Clone{
+			ID:   fragmentIDs[pair.Fragment1],
+			Type: s.convertCloneType(pair.CloneType),
 			Location: &domain.CloneLocation{
 				FilePath:  pair.Fragment1.Location.FilePath,
 				StartLine: pair.Fragment1.Location.StartLine,
@@ -352,6 +359,8 @@ func (s *CloneService) convertClonePairsToDomain(clonePairs []*analyzer.ClonePai
 			LineCount: pair.Fragment1.LineCount,
 		}
 		clone2 := &domain.Clone{
+			ID:   fragmentIDs[pair.Fragment2],
+			Type: s.convertCloneType(pair.CloneType),
 			Location: &domain.CloneLocation{
 				FilePath:  pair.Fragment2.Location.FilePath,
 				StartLine: pair.Fragment2.Location.StartLine,
@@ -380,6 +389,44 @@ func (s *CloneService) convertClonePairsToDomain(clonePairs []*analyzer.ClonePai
 	}
 
 	return domainPairs
+}
+
+// filterClonesToReferencedFragments keeps the top-level clones list aligned
+// with the clone pairs/groups returned to users. Raw extracted fragments remain
+// available via statistics.total_fragments; clones[] should contain only
+// fragments that actually participate in a detected clone result.
+func filterClonesToReferencedFragments(
+	clones []*domain.Clone,
+	pairs []*domain.ClonePair,
+	groups []*domain.CloneGroup,
+) []*domain.Clone {
+	referenced := make(map[int]struct{})
+	add := func(clone *domain.Clone) {
+		if clone != nil && clone.ID > 0 {
+			referenced[clone.ID] = struct{}{}
+		}
+	}
+
+	for _, pair := range pairs {
+		add(pair.Clone1)
+		add(pair.Clone2)
+	}
+	for _, group := range groups {
+		for _, clone := range group.Clones {
+			add(clone)
+		}
+	}
+
+	filtered := make([]*domain.Clone, 0, len(referenced))
+	for _, clone := range clones {
+		if clone == nil {
+			continue
+		}
+		if _, ok := referenced[clone.ID]; ok {
+			filtered = append(filtered, clone)
+		}
+	}
+	return filtered
 }
 
 // convertCloneGroupsToDomain converts analyzer clone groups to domain clone groups.

--- a/service/clone_service_content_test.go
+++ b/service/clone_service_content_test.go
@@ -30,12 +30,12 @@ func TestCloneService_convertClonePairsToDomain_Content(t *testing.T) {
 		},
 	}
 
-	withContent := service.convertClonePairsToDomain(pairs, true)
+	withContent := service.convertClonePairsToDomain(pairs, true, nil)
 	require.Len(t, withContent, 1)
 	assert.Equal(t, "def a():\n    return 1", withContent[0].Clone1.Content)
 	assert.Equal(t, "def b():\n    return 1", withContent[0].Clone2.Content)
 
-	withoutContent := service.convertClonePairsToDomain(pairs, false)
+	withoutContent := service.convertClonePairsToDomain(pairs, false, nil)
 	require.Len(t, withoutContent, 1)
 	assert.Empty(t, withoutContent[0].Clone1.Content)
 	assert.Empty(t, withoutContent[0].Clone2.Content)
@@ -146,7 +146,7 @@ func TestCloneService_convertClonesToDomain_Hash(t *testing.T) {
 
 	pairs := service.convertClonePairsToDomain([]*analyzer.ClonePair{
 		{Fragment1: frag0, Fragment2: frag1, Similarity: 1.0, CloneType: analyzer.Type1Clone},
-	}, false)
+	}, false, nil)
 	require.Len(t, pairs, 1)
 	assert.Equal(t, "00000000aaaaaaaa", pairs[0].Clone1.Hash)
 	assert.Equal(t, "00000000bbbbbbbb", pairs[0].Clone2.Hash)
@@ -158,4 +158,24 @@ func TestCloneService_convertClonesToDomain_Hash(t *testing.T) {
 	require.Len(t, groups[0].Clones, 2)
 	assert.Equal(t, "00000000aaaaaaaa", groups[0].Clones[0].Hash)
 	assert.Equal(t, "00000000bbbbbbbb", groups[0].Clones[1].Hash)
+}
+
+func TestCloneService_FilterClonesToReferencedFragments(t *testing.T) {
+	service := NewCloneService()
+	frag0 := &analyzer.CodeFragment{Location: &analyzer.CodeLocation{FilePath: "a.py", StartLine: 1, EndLine: 2}}
+	frag1 := &analyzer.CodeFragment{Location: &analyzer.CodeLocation{FilePath: "b.py", StartLine: 5, EndLine: 6}}
+	frag2 := &analyzer.CodeFragment{Location: &analyzer.CodeLocation{FilePath: "c.py", StartLine: 9, EndLine: 10}}
+
+	clones, fragmentIDs := service.convertFragmentsToDomainClones([]*analyzer.CodeFragment{frag0, frag1, frag2})
+	pairs := service.convertClonePairsToDomain([]*analyzer.ClonePair{
+		{Fragment1: frag0, Fragment2: frag2, Similarity: 0.95, CloneType: analyzer.Type2Clone},
+	}, false, fragmentIDs)
+
+	filtered := filterClonesToReferencedFragments(clones, pairs, nil)
+	require.Len(t, filtered, 2)
+	assert.Equal(t, []int{1, 3}, []int{filtered[0].ID, filtered[1].ID})
+	assert.Equal(t, 1, pairs[0].Clone1.ID)
+	assert.Equal(t, 3, pairs[0].Clone2.ID)
+	assert.Equal(t, domain.Type2Clone, pairs[0].Clone1.Type)
+	assert.Equal(t, domain.Type2Clone, pairs[0].Clone2.Type)
 }


### PR DESCRIPTION
## Summary
- Keep `clone.clones` limited to fragments referenced by returned clone pairs or groups.
- Preserve the raw fragment count in `statistics.total_fragments` and assign pair clone IDs from the response-wide fragment map.

## Testing
- [x] `go test ./service -run 'TestCloneService_(FilterClonesToReferencedFragments|convertClonePairsToDomain_Content|convertClonesToDomain_Hash)' -v`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/pyscn`
- [x] `golangci-lint run --timeout=10m`
- [x] `git diff --check`

Closes #631
