### PR TITLE
fix(mcp): publish implemented output controls

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -273,6 +273,8 @@ Field notes:
 - `min_complexity` (optional): Minimum complexity to report (default: `1`)
 - `max_complexity` (optional): Maximum allowed complexity, 0 = no limit (default: `0`)
 - `show_details` (optional): Include detailed metrics (default: `true`)
+- `output_mode` (optional): `"summary"`, `"detailed"`, or `"full"` (default: `"summary"`)
+- `max_results` (optional): Maximum findings in summary or detailed output; `0` means unlimited (default: `0`)
 
 **Example**:
 ```
@@ -310,6 +312,8 @@ Check complexity of functions with complexity > 10 in src/
 - `similarity_threshold` (optional): Minimum similarity 0.0-1.0 (default: `0.8`)
 - `min_lines` (optional): Minimum lines to consider (default: `5`)
 - `group_clones` (optional): Group related clones (default: `true`)
+- `output_mode` (optional): `"summary"`, `"detailed"`, or `"full"` (default: `"summary"`)
+- `max_results` (optional): Maximum findings in summary or detailed output; `0` means unlimited (default: `0`)
 
 **Example**:
 ```
@@ -348,6 +352,9 @@ Find duplicate code with similarity > 0.85 in my project
 
 **Parameters**:
 - `path` (required): Path to Python code
+- `min_cbo` (optional): Minimum CBO for high-coupling findings (default: `10`)
+- `output_mode` (optional): `"summary"`, `"detailed"`, or `"full"` (default: `"summary"`)
+- `max_results` (optional): Maximum findings in summary or detailed output; `0` means unlimited (default: `0`)
 
 **Example**:
 ```
@@ -373,6 +380,15 @@ Check the coupling of classes in src/
 }
 ```
 
+### check_cohesion
+
+**Description**: Analyze class cohesion using LCOM4
+
+**Parameters**:
+- `path` (required): Path to Python code
+- `output_mode` (optional): `"summary"`, `"detailed"`, or `"full"` (default: `"summary"`)
+- `max_results` (optional): Maximum findings in summary or detailed output; `0` means unlimited (default: `0`)
+
 ### find_dead_code
 
 **Description**: Find unreachable code using CFG analysis
@@ -380,6 +396,8 @@ Check the coupling of classes in src/
 **Parameters**:
 - `path` (required): Path to Python code
 - `min_severity` (optional): Minimum severity: `info`, `warning`, `error` (default: `warning`)
+- `output_mode` (optional): `"summary"`, `"detailed"`, or `"full"` (default: `"summary"`)
+- `max_results` (optional): Maximum findings in summary or detailed output; `0` means unlimited (default: `0`)
 
 **Example**:
 ```

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -35,6 +35,12 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Description("Maximum allowed complexity, 0 = no limit (default: 0)")),
 		mcp.WithBoolean("show_details",
 			mcp.Description("Include detailed metrics (default: true)")),
+		mcp.WithString("output_mode",
+			mcp.Enum("summary", "detailed", "full"),
+			mcp.Description("Response detail level (default: summary)")),
+		mcp.WithNumber("max_results",
+			mcp.Min(0),
+			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleCheckComplexity)
 
 	// Tool 3: detect_clones - Code clone detection
@@ -49,6 +55,12 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Description("Minimum lines to consider as clone (default: 5)")),
 		mcp.WithBoolean("group_clones",
 			mcp.Description("Group related clones together (default: true)")),
+		mcp.WithString("output_mode",
+			mcp.Enum("summary", "detailed", "full"),
+			mcp.Description("Response detail level (default: summary)")),
+		mcp.WithNumber("max_results",
+			mcp.Min(0),
+			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleDetectClones)
 
 	// Tool 4: check_coupling - Class coupling analysis
@@ -57,6 +69,15 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to Python code to analyze")),
+		mcp.WithNumber("min_cbo",
+			mcp.Min(0),
+			mcp.Description("Minimum CBO for high-coupling findings (default: 10)")),
+		mcp.WithString("output_mode",
+			mcp.Enum("summary", "detailed", "full"),
+			mcp.Description("Response detail level (default: summary)")),
+		mcp.WithNumber("max_results",
+			mcp.Min(0),
+			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleCheckCoupling)
 
 	// Tool 5: check_cohesion - Class cohesion (LCOM4) analysis
@@ -65,6 +86,12 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to Python code to analyze")),
+		mcp.WithString("output_mode",
+			mcp.Enum("summary", "detailed", "full"),
+			mcp.Description("Response detail level (default: summary)")),
+		mcp.WithNumber("max_results",
+			mcp.Min(0),
+			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleCheckCohesion)
 
 	// Tool 6: find_dead_code - Dead code detection
@@ -75,6 +102,12 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 			mcp.Description("Path to Python code to analyze")),
 		mcp.WithString("min_severity",
 			mcp.Description("Minimum severity: info, warning, error (default: warning)")),
+		mcp.WithString("output_mode",
+			mcp.Enum("summary", "detailed", "full"),
+			mcp.Description("Response detail level (default: summary)")),
+		mcp.WithNumber("max_results",
+			mcp.Min(0),
+			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleFindDeadCode)
 
 	// Tool 7: get_health_score - Overall code health score

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -38,7 +38,7 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("output_mode",
 			mcp.Enum("summary", "detailed", "full"),
 			mcp.Description("Response detail level (default: summary)")),
-		mcp.WithNumber("max_results",
+		mcp.WithInteger("max_results",
 			mcp.Min(0),
 			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleCheckComplexity)
@@ -58,7 +58,7 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("output_mode",
 			mcp.Enum("summary", "detailed", "full"),
 			mcp.Description("Response detail level (default: summary)")),
-		mcp.WithNumber("max_results",
+		mcp.WithInteger("max_results",
 			mcp.Min(0),
 			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleDetectClones)
@@ -69,13 +69,13 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to Python code to analyze")),
-		mcp.WithNumber("min_cbo",
+		mcp.WithInteger("min_cbo",
 			mcp.Min(0),
 			mcp.Description("Minimum CBO for high-coupling findings (default: 10)")),
 		mcp.WithString("output_mode",
 			mcp.Enum("summary", "detailed", "full"),
 			mcp.Description("Response detail level (default: summary)")),
-		mcp.WithNumber("max_results",
+		mcp.WithInteger("max_results",
 			mcp.Min(0),
 			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleCheckCoupling)
@@ -89,7 +89,7 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("output_mode",
 			mcp.Enum("summary", "detailed", "full"),
 			mcp.Description("Response detail level (default: summary)")),
-		mcp.WithNumber("max_results",
+		mcp.WithInteger("max_results",
 			mcp.Min(0),
 			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleCheckCohesion)
@@ -105,7 +105,7 @@ func RegisterTools(s *server.MCPServer, handlers *HandlerSet) {
 		mcp.WithString("output_mode",
 			mcp.Enum("summary", "detailed", "full"),
 			mcp.Description("Response detail level (default: summary)")),
-		mcp.WithNumber("max_results",
+		mcp.WithInteger("max_results",
 			mcp.Min(0),
 			mcp.Description("Maximum findings in summary or detailed output; 0 means unlimited (default: 0)")),
 	), handlers.HandleFindDeadCode)

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -38,7 +38,13 @@ func TestRegisterTools_AdvertisesImplementedOutputControls(t *testing.T) {
 			assert.ElementsMatch(t, []interface{}{"summary", "detailed", "full"}, outputMode["enum"])
 
 			maxResults := properties["max_results"].(map[string]interface{})
+			assert.Equal(t, "integer", maxResults["type"])
 			assert.Equal(t, float64(0), maxResults["minimum"])
+
+			if minCBO, ok := properties["min_cbo"].(map[string]interface{}); ok {
+				assert.Equal(t, "integer", minCBO["type"])
+				assert.Equal(t, float64(0), minCBO["minimum"])
+			}
 		})
 	}
 }

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterTools_AdvertisesImplementedOutputControls(t *testing.T) {
+	s := server.NewMCPServer("test", "test")
+	RegisterTools(s, &HandlerSet{})
+
+	tests := map[string][]string{
+		"check_complexity": {"output_mode", "max_results"},
+		"detect_clones":    {"output_mode", "max_results"},
+		"check_coupling":   {"min_cbo", "output_mode", "max_results"},
+		"check_cohesion":   {"output_mode", "max_results"},
+		"find_dead_code":   {"output_mode", "max_results"},
+	}
+
+	for toolName, propertyNames := range tests {
+		toolName := toolName
+		propertyNames := propertyNames
+		t.Run(toolName, func(t *testing.T) {
+			registered := s.GetTool(toolName)
+			require.NotNil(t, registered)
+
+			properties := schemaProperties(t, registered.Tool.InputSchema)
+			for _, propertyName := range propertyNames {
+				assert.Contains(t, properties, propertyName)
+			}
+
+			outputMode := properties["output_mode"].(map[string]interface{})
+			assert.ElementsMatch(t, []interface{}{"summary", "detailed", "full"}, outputMode["enum"])
+
+			maxResults := properties["max_results"].(map[string]interface{})
+			assert.Equal(t, float64(0), maxResults["minimum"])
+		})
+	}
+}
+
+func schemaProperties(t *testing.T, schema mcplib.ToolInputSchema) map[string]interface{} {
+	t.Helper()
+	data, err := json.Marshal(schema)
+	require.NoError(t, err)
+
+	var decoded struct {
+		Properties map[string]interface{} `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	return decoded.Properties
+}


### PR DESCRIPTION
## Summary

- publish the already-implemented `output_mode` and `max_results` controls in MCP tool schemas
- publish `min_cbo` for `check_coupling`
- constrain output modes and non-negative result limits in JSON Schema
- expose count and threshold controls as integers, matching handler semantics
- document the controls, including the previously undocumented `check_cohesion` tool section

## Root cause

The handlers implemented these arguments, but the registered MCP schemas and README did not expose them. Schema-driven clients therefore could not discover supported functionality. Publishing count controls as generic numbers would also admit fractional values that handlers truncate.

## Impact

Default handler behavior is unchanged. Clients gain discoverable access to existing summary, detailed, and full output modes, while schema validation rejects fractional counts.

## Validation

- `go test -count=1 ./...`
- schema regression tests for every affected tool
- output-mode enum, non-negative minimum, and integer-type assertions
