### PR TITLE
fix(domain): preserve architecture suggestion identity

### DIFF
--- a/domain/suggestion.go
+++ b/domain/suggestion.go
@@ -430,7 +430,7 @@ func generateSystemSuggestions(resp *SystemAnalysisResponse) []Suggestion {
 	// Architecture violations (own limit, independent of dependency count)
 	if resp.ArchitectureAnalysis != nil {
 		archCount := 0
-		seenModules := make(map[string]bool)
+		seenSuggestions := make(map[architectureSuggestionKey]bool)
 		for _, v := range resp.ArchitectureAnalysis.Violations {
 			if archCount >= maxSuggestionsPerCategory {
 				break
@@ -438,11 +438,6 @@ func generateSystemSuggestions(resp *SystemAnalysisResponse) []Suggestion {
 			if v.Suggestion == "" {
 				continue
 			}
-			if seenModules[v.Module] {
-				continue
-			}
-			seenModules[v.Module] = true
-
 			sev := mapViolationSeverity(v.Severity)
 			effort := SuggestionEffortModerate
 			if sev == SuggestionSeverityCritical {
@@ -461,20 +456,52 @@ func generateSystemSuggestions(resp *SystemAnalysisResponse) []Suggestion {
 				}
 			}
 
-			suggestions = append(suggestions, Suggestion{
+			description := v.Suggestion
+			if v.Target != "" {
+				description = fmt.Sprintf("%s (target: %s)", description, v.Target)
+			}
+
+			suggestion := Suggestion{
 				Category:    SuggestionCategoryArchitecture,
 				Severity:    sev,
 				Effort:      effort,
 				Title:       fmt.Sprintf("Fix architecture violation in '%s'", v.Module),
-				Description: v.Suggestion,
+				Description: description,
 				FilePath:    filePath,
 				StartLine:   startLine,
-			})
+			}
+			key := newArchitectureSuggestionKey(suggestion)
+			if seenSuggestions[key] {
+				continue
+			}
+			seenSuggestions[key] = true
+
+			suggestions = append(suggestions, suggestion)
 			archCount++
 		}
 	}
 
 	return suggestions
+}
+
+type architectureSuggestionKey struct {
+	severity    SuggestionSeverity
+	effort      SuggestionEffort
+	title       string
+	description string
+	filePath    string
+	startLine   int
+}
+
+func newArchitectureSuggestionKey(s Suggestion) architectureSuggestionKey {
+	return architectureSuggestionKey{
+		severity:    s.Severity,
+		effort:      s.Effort,
+		title:       s.Title,
+		description: s.Description,
+		filePath:    s.FilePath,
+		startLine:   s.StartLine,
+	}
 }
 
 // sortSuggestions sorts suggestions by priority:

--- a/domain/suggestion.go
+++ b/domain/suggestion.go
@@ -429,12 +429,9 @@ func generateSystemSuggestions(resp *SystemAnalysisResponse) []Suggestion {
 
 	// Architecture violations (own limit, independent of dependency count)
 	if resp.ArchitectureAnalysis != nil {
-		archCount := 0
-		seenSuggestions := make(map[architectureSuggestionKey]bool)
+		architectureSuggestions := make([]Suggestion, 0, len(resp.ArchitectureAnalysis.Violations))
+		seenSuggestions := make(map[architectureSuggestionKey]struct{})
 		for _, v := range resp.ArchitectureAnalysis.Violations {
-			if archCount >= maxSuggestionsPerCategory {
-				break
-			}
 			if v.Suggestion == "" {
 				continue
 			}
@@ -471,14 +468,31 @@ func generateSystemSuggestions(resp *SystemAnalysisResponse) []Suggestion {
 				StartLine:   startLine,
 			}
 			key := newArchitectureSuggestionKey(suggestion)
-			if seenSuggestions[key] {
+			if _, seen := seenSuggestions[key]; seen {
 				continue
 			}
-			seenSuggestions[key] = true
+			seenSuggestions[key] = struct{}{}
 
-			suggestions = append(suggestions, suggestion)
-			archCount++
+			architectureSuggestions = append(architectureSuggestions, suggestion)
 		}
+
+		// Apply the category cap only after generation and deduplication. Severity
+		// takes precedence for admission to the capped set so a critical finding
+		// is never discarded merely because it requires more effort than an
+		// earlier warning. GenerateSuggestions applies the normal presentation
+		// ordering to the retained suggestions afterward.
+		sort.SliceStable(architectureSuggestions, func(i, j int) bool {
+			iSeverity := suggestionSeverityPriority(architectureSuggestions[i].Severity)
+			jSeverity := suggestionSeverityPriority(architectureSuggestions[j].Severity)
+			if iSeverity != jSeverity {
+				return iSeverity < jSeverity
+			}
+			return suggestionPriority(architectureSuggestions[i]) < suggestionPriority(architectureSuggestions[j])
+		})
+		if len(architectureSuggestions) > maxSuggestionsPerCategory {
+			architectureSuggestions = architectureSuggestions[:maxSuggestionsPerCategory]
+		}
+		suggestions = append(suggestions, architectureSuggestions...)
 	}
 
 	return suggestions
@@ -551,6 +565,17 @@ func suggestionPriority(s Suggestion) int {
 		return 6 + effortWeight
 	}
 	return sevWeight*2 + effortWeight
+}
+
+func suggestionSeverityPriority(severity SuggestionSeverity) int {
+	switch severity {
+	case SuggestionSeverityCritical:
+		return 0
+	case SuggestionSeverityWarning:
+		return 1
+	default:
+		return 2
+	}
 }
 
 // Helper functions

--- a/domain/suggestion_test.go
+++ b/domain/suggestion_test.go
@@ -595,6 +595,43 @@ func TestGenerateSuggestions_SystemArchViolation_Deduplication(t *testing.T) {
 	}
 }
 
+func TestGenerateSuggestions_SystemArchViolation_DistinctIdentityFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		violations []ArchitectureViolation
+	}{
+		{
+			name: "target only differs",
+			violations: []ArchitectureViolation{
+				{Module: "service.users", Target: "database.primary", Severity: ViolationSeverityWarning, Suggestion: "Use an adapter"},
+				{Module: "service.users", Target: "database.replica", Severity: ViolationSeverityWarning, Suggestion: "Use an adapter"},
+			},
+		},
+		{
+			name: "severity only differs",
+			violations: []ArchitectureViolation{
+				{Module: "service.users", Target: "database.primary", Severity: ViolationSeverityWarning, Suggestion: "Use an adapter"},
+				{Module: "service.users", Target: "database.primary", Severity: ViolationSeverityCritical, Suggestion: "Use an adapter"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &AnalyzeResponse{
+				System: &SystemAnalysisResponse{
+					ArchitectureAnalysis: &ArchitectureAnalysisResult{Violations: tt.violations},
+				},
+			}
+
+			suggestions := GenerateSuggestions(resp)
+			if len(suggestions) != 2 {
+				t.Fatalf("expected both distinct violations, got %d suggestions", len(suggestions))
+			}
+		})
+	}
+}
+
 func TestGenerateSuggestions_SystemArchViolation_CriticalSurvivesLimit(t *testing.T) {
 	violations := make([]ArchitectureViolation, 0, maxSuggestionsPerCategory+1)
 	for i := 0; i < maxSuggestionsPerCategory; i++ {

--- a/domain/suggestion_test.go
+++ b/domain/suggestion_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -592,6 +593,39 @@ func TestGenerateSuggestions_SystemArchViolation_Deduplication(t *testing.T) {
 	if warning.Severity != SuggestionSeverityWarning {
 		t.Errorf("expected warning severity, got %s", warning.Severity)
 	}
+}
+
+func TestGenerateSuggestions_SystemArchViolation_CriticalSurvivesLimit(t *testing.T) {
+	violations := make([]ArchitectureViolation, 0, maxSuggestionsPerCategory+1)
+	for i := 0; i < maxSuggestionsPerCategory; i++ {
+		violations = append(violations, ArchitectureViolation{
+			Module:     fmt.Sprintf("warning_%d", i),
+			Severity:   ViolationSeverityWarning,
+			Suggestion: "Fix warning",
+		})
+	}
+	violations = append(violations, ArchitectureViolation{
+		Module:     "critical_last",
+		Severity:   ViolationSeverityCritical,
+		Suggestion: "Fix critical violation",
+	})
+
+	resp := &AnalyzeResponse{
+		System: &SystemAnalysisResponse{
+			ArchitectureAnalysis: &ArchitectureAnalysisResult{Violations: violations},
+		},
+	}
+
+	suggestions := GenerateSuggestions(resp)
+	if len(suggestions) != maxSuggestionsPerCategory {
+		t.Fatalf("expected %d architecture suggestions, got %d", maxSuggestionsPerCategory, len(suggestions))
+	}
+	for _, suggestion := range suggestions {
+		if suggestion.Title == "Fix architecture violation in 'critical_last'" {
+			return
+		}
+	}
+	t.Fatal("critical architecture suggestion was dropped by the category limit")
 }
 
 func TestGenerateSuggestions_SystemArchViolation_FilePathFromMetrics(t *testing.T) {

--- a/domain/suggestion_test.go
+++ b/domain/suggestion_test.go
@@ -539,11 +539,19 @@ func TestGenerateSuggestions_SystemArchViolation_Deduplication(t *testing.T) {
 				Violations: []ArchitectureViolation{
 					{
 						Module:     "service.users",
+						Target:     "database.primary",
 						Severity:   ViolationSeverityCritical,
 						Suggestion: "Fix A",
 					},
 					{
 						Module:     "service.users",
+						Target:     "database.primary",
+						Severity:   ViolationSeverityCritical,
+						Suggestion: "Fix A",
+					},
+					{
+						Module:     "service.users",
+						Target:     "events.publisher",
 						Severity:   ViolationSeverityWarning,
 						Suggestion: "Fix B",
 					},
@@ -558,21 +566,31 @@ func TestGenerateSuggestions_SystemArchViolation_Deduplication(t *testing.T) {
 	}
 
 	suggestions := GenerateSuggestions(resp)
-	if len(suggestions) != 2 {
-		t.Fatalf("expected 2 suggestions (duplicate module deduplicated), got %d", len(suggestions))
+	if len(suggestions) != 3 {
+		t.Fatalf("expected only the exact duplicate to be removed, got %d suggestions", len(suggestions))
 	}
-	modules := make(map[string]bool)
+	serviceSuggestions := make(map[string]Suggestion)
 	for _, s := range suggestions {
 		if strings.Contains(s.Title, "service.users") {
-			modules["service.users"] = true
-		}
-		if strings.Contains(s.Title, "utils.helpers") {
-			modules["utils.helpers"] = true
+			serviceSuggestions[s.Description] = s
 		}
 	}
-	if !modules["service.users"] || !modules["utils.helpers"] {
-		t.Errorf("expected both module suggestions to appear, got service.users=%v utils.helpers=%v",
-			modules["service.users"], modules["utils.helpers"])
+	if len(serviceSuggestions) != 2 {
+		t.Fatalf("expected both distinct service.users violations, got %#v", serviceSuggestions)
+	}
+	critical, ok := serviceSuggestions["Fix A (target: database.primary)"]
+	if !ok {
+		t.Fatal("expected database.primary violation to be retained")
+	}
+	if critical.Severity != SuggestionSeverityCritical {
+		t.Errorf("expected critical severity, got %s", critical.Severity)
+	}
+	warning, ok := serviceSuggestions["Fix B (target: events.publisher)"]
+	if !ok {
+		t.Fatal("expected events.publisher violation to be retained")
+	}
+	if warning.Severity != SuggestionSeverityWarning {
+		t.Errorf("expected warning severity, got %s", warning.Severity)
 	}
 }
 


### PR DESCRIPTION
> **Stacked on #648.** Merge this PR into #648's branch first, then merge #648 into `main`. No retarget or rebase is needed.

## Summary

- preserve distinct architecture violations instead of deduplicating by source module alone
- include dependency targets in suggestion descriptions
- deduplicate and prioritize all candidates before applying the ten-item limit
- keep a later critical violation from being displaced by earlier warnings

This keeps #648's navigation fix while distinguishing targets, severities, remediations, and locations.

## Validation

- `go test -count=1 ./...`
- exact-duplicate coverage
- independent target-only and severity-only cases
- ten warnings followed by a critical violation
