### PR TITLE
closed: Cython provenance requires module binding analysis

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -790,6 +790,9 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 	if className == "" {
 		return false
 	}
+	if a.isCythonPrimitive(className) {
+		return false
+	}
 
 	// Check exclude patterns
 	for _, pattern := range a.options.ExcludePatterns {
@@ -807,6 +810,35 @@ func (a *CBOAnalyzer) shouldIncludeDependency(className string) bool {
 	}
 
 	return true
+}
+
+var cythonPrimitiveTypes = map[string]bool{
+	"int":       true,
+	"float":     true,
+	"long":      true,
+	"uint":      true,
+	"ulong":     true,
+	"ulonglong": true,
+	"ushort":    true,
+	"double":    true,
+}
+
+// isCythonPrimitive reports whether className resolves through this file's
+// imports to a Cython C-level primitive. Import provenance matters: a different
+// module aliased as "cython" must not be filtered, while aliases of the real
+// cython module must be handled.
+func (a *CBOAnalyzer) isCythonPrimitive(className string) bool {
+	canonicalName := ""
+	if importedName, ok := a.importedNames[className]; ok {
+		canonicalName = importedName
+	} else if qualifier, member, ok := strings.Cut(className, "."); ok {
+		if importedModule, exists := a.importedNames[qualifier]; exists {
+			canonicalName = importedModule + "." + member
+		}
+	}
+
+	module, primitive, ok := strings.Cut(canonicalName, ".")
+	return ok && module == "cython" && cythonPrimitiveTypes[primitive]
 }
 
 // callDependencyName returns the portion of a called dotted name that refers
@@ -1350,9 +1382,6 @@ func (a *CBOAnalyzer) initializeBuiltinTypes() {
 		"Exception", "BaseException", "ValueError", "TypeError", "KeyError",
 		"IndexError", "AttributeError", "NameError", "RuntimeError",
 		"memoryview", "slice",
-		// Cython primitive type qualifiers
-		"cython.int", "cython.float", "cython.long", "cython.uint",
-		"cython.ulong", "cython.ulonglong", "cython.ushort", "cython.double",
 	}
 
 	// Built-in functions (never counted as dependencies)

--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -75,6 +75,7 @@ type CBOAnalyzer struct {
 	standardLibs     map[string]bool
 	importedNames    map[string]string         // alias -> module.name mapping
 	namespaceAliases map[string]string         // module.name -> alias mapping (only for alias imports)
+	cythonImports    map[string]string         // module-scope bindings visible to the class being analyzed
 	regexCache       map[string]*regexp.Regexp // pattern -> compiled regex cache
 
 	// futureAnnotations is true when the file being analyzed has
@@ -133,6 +134,7 @@ func NewCBOAnalyzer(options *CBOOptions) *CBOAnalyzer {
 		standardLibs:     make(map[string]bool),
 		importedNames:    make(map[string]string),
 		namespaceAliases: make(map[string]string),
+		cythonImports:    make(map[string]string),
 		regexCache:       make(map[string]*regexp.Regexp),
 	}
 
@@ -162,6 +164,10 @@ func (a *CBOAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*CBOR
 
 	// Second pass: analyze coupling for each class
 	for _, classNode := range classes {
+		// Cython primitive resolution must use bindings visible when the class
+		// body executes. A later import inside an unrelated function is a local
+		// binding and must not overwrite the module binding used by this class.
+		a.cythonImports = a.collectModuleImportsBefore(ast, classNode.Location.StartLine)
 		result, err := a.analyzeClass(classNode, filePath, classes)
 		if err != nil {
 			// Log warning but continue with other classes
@@ -668,6 +674,63 @@ func (a *CBOAnalyzer) collectImports(ast *parser.Node) cboImportMaps {
 	return imports
 }
 
+// collectModuleImportsBefore returns import bindings established at module
+// scope before the given source line. It intentionally does not descend into
+// classes or functions: those imports belong to different lexical scopes.
+func (a *CBOAnalyzer) collectModuleImportsBefore(ast *parser.Node, beforeLine int) map[string]string {
+	imports := make(map[string]string)
+	for _, node := range ast.Body {
+		if node == nil {
+			continue
+		}
+		if beforeLine > 0 && node.Location.StartLine > 0 && node.Location.StartLine >= beforeLine {
+			continue
+		}
+
+		switch node.Type {
+		case parser.NodeImport:
+			aliasedNames := make(map[string]bool)
+			for _, child := range node.Children {
+				if child == nil || child.Type != parser.NodeAlias {
+					continue
+				}
+				module := child.Name
+				alias := importBindingName(module)
+				if aliasStr, ok := child.Value.(string); ok {
+					alias = aliasStr
+					aliasedNames[module] = true
+				}
+				imports[alias] = module
+			}
+			for _, name := range node.Names {
+				if !aliasedNames[name] {
+					imports[importBindingName(name)] = name
+				}
+			}
+		case parser.NodeImportFrom:
+			aliasedNames := make(map[string]bool)
+			for _, child := range node.Children {
+				if child == nil || child.Type != parser.NodeAlias {
+					continue
+				}
+				name := child.Name
+				alias := name
+				if aliasStr, ok := child.Value.(string); ok {
+					alias = aliasStr
+					aliasedNames[name] = true
+				}
+				imports[alias] = node.Module + "." + name
+			}
+			for _, name := range node.Names {
+				if !aliasedNames[name] {
+					imports[name] = node.Module + "." + name
+				}
+			}
+		}
+	}
+	return imports
+}
+
 // hasFutureAnnotations reports whether the module contains
 // `from __future__ import annotations` (PEP 563). When present, every
 // annotation in the file is evaluated as a string at runtime rather than
@@ -829,10 +892,10 @@ var cythonPrimitiveTypes = map[string]bool{
 // cython module must be handled.
 func (a *CBOAnalyzer) isCythonPrimitive(className string) bool {
 	canonicalName := ""
-	if importedName, ok := a.importedNames[className]; ok {
+	if importedName, ok := a.cythonImports[className]; ok {
 		canonicalName = importedName
 	} else if qualifier, member, ok := strings.Cut(className, "."); ok {
-		if importedModule, exists := a.importedNames[qualifier]; exists {
+		if importedModule, exists := a.cythonImports[qualifier]; exists {
 			canonicalName = importedModule + "." + member
 		}
 	}

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -381,6 +381,20 @@ class MyClass:
 			includeBuiltins: true,
 			includedClasses: []string{"cython.int"},
 		},
+		{
+			name: "function-local Cython import does not overwrite module binding",
+			pythonCode: `
+import other_types as cython
+
+class MyClass:
+    x: cython.int = 0
+
+def unrelated_function():
+    import cython
+`,
+			includeBuiltins: true,
+			includedClasses: []string{"cython.int"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -316,66 +316,92 @@ class MyClass:
 }
 
 func TestCBOAnalyzer_CythonPrimitiveExclusion(t *testing.T) {
-	pythonCode := `
+	tests := []struct {
+		name            string
+		pythonCode      string
+		includeBuiltins bool
+		excludedClasses []string
+		includedClasses []string
+	}{
+		{
+			name: "exclude direct Cython primitives by default",
+			pythonCode: `
 import cython
-import numpy as np
 
-@cython.cclass
 class MyClass:
     x: cython.int = 0
     y: cython.float = 0.0
-    data: np.ndarray
-
-    def __init__(self):
-        self.data = np.zeros(10)
-`
-
-	tests := []struct {
-		name            string
-		includeBuiltins bool
-		minExpectedCBO  int
-		maxExpectedCBO  int
-	}{
-		{
-			name:            "exclude Cython primitives by default",
+`,
 			includeBuiltins: false,
-			minExpectedCBO:  0,
-			maxExpectedCBO:  1,
+			excludedClasses: []string{"cython.int", "cython.float"},
 		},
 		{
-			name:            "include Cython primitives when IncludeBuiltins",
+			name: "exclude direct Cython primitives when builtins are included",
+			pythonCode: `
+import cython
+
+class MyClass:
+    x: cython.int = 0
+    y: cython.float = 0.0
+`,
 			includeBuiltins: true,
-			minExpectedCBO:  3,
-			maxExpectedCBO:  9,
+			excludedClasses: []string{"cython.int", "cython.float"},
+		},
+		{
+			name: "exclude primitives through a Cython module alias",
+			pythonCode: `
+import cython as cy
+
+class MyClass:
+    x: cy.int = 0
+    y: cy.double = 0.0
+`,
+			includeBuiltins: true,
+			excludedClasses: []string{"cy.int", "cy.double"},
+		},
+		{
+			name: "exclude primitives imported by name",
+			pythonCode: `
+from cython import int as cyint
+
+class MyClass:
+    x: cyint = 0
+`,
+			includeBuiltins: true,
+			excludedClasses: []string{"cyint"},
+		},
+		{
+			name: "preserve a different module aliased as Cython",
+			pythonCode: `
+import other_types as cython
+
+class MyClass:
+    x: cython.int = 0
+`,
+			includeBuiltins: true,
+			includedClasses: []string{"cython.int"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ast, err := parseCode(pythonCode)
+			ast, err := parseCode(tt.pythonCode)
 			require.NoError(t, err)
 
 			options := DefaultCBOOptions()
 			options.IncludeBuiltins = tt.includeBuiltins
+			options.GroupNamespaceImports = false
 
 			analyzer := NewCBOAnalyzer(options)
 			results, err := analyzer.AnalyzeClasses(ast, "test.py")
 			require.NoError(t, err)
 
 			require.Len(t, results, 1)
-			cbo := results[0].CouplingCount
-
-			if cbo < tt.minExpectedCBO || cbo > tt.maxExpectedCBO {
-				t.Errorf("CBO = %d, expected between %d and %d. DependentClasses: %v",
-					cbo, tt.minExpectedCBO, tt.maxExpectedCBO, results[0].DependentClasses)
+			for _, className := range tt.excludedClasses {
+				assert.NotContains(t, results[0].DependentClasses, className)
 			}
-
-			if !tt.includeBuiltins {
-				for _, dep := range results[0].DependentClasses {
-					if strings.HasPrefix(dep, "cython.") {
-						t.Errorf("cython primitive %q should not appear in DependentClasses when IncludeBuiltins=false", dep)
-					}
-				}
+			for _, className := range tt.includedClasses {
+				assert.Contains(t, results[0].DependentClasses, className)
 			}
 		})
 	}


### PR DESCRIPTION
> **Closed — no action required.** This draft does not model Python module bindings safely enough to merge. #646 is unchanged.

The implementation handles direct imports but misses module-level conditional imports and later rebinding. A correct follow-up needs conservative module-scope binding analysis across assignments, deletes, imports, and control-flow branches.
