### PR TITLE
fix(mcp): propagate analyze recursive override

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -46,6 +46,12 @@ type AnalyzeUseCaseConfig struct {
 	Verbose    bool
 }
 
+// AnalyzeRequestOverrides contains request-scoped values that take precedence
+// over the resolved project configuration.
+type AnalyzeRequestOverrides struct {
+	Recursive *bool
+}
+
 // AnalyzeUseCase orchestrates comprehensive analysis
 type AnalyzeUseCase struct {
 	complexityUseCase *ComplexityUseCase
@@ -225,11 +231,24 @@ type AnalysisTask struct {
 
 // Execute performs comprehensive analysis
 func (uc *AnalyzeUseCase) Execute(ctx context.Context, useCaseCfg AnalyzeUseCaseConfig, paths []string) (*domain.AnalyzeResponse, error) {
+	return uc.execute(ctx, useCaseCfg, paths, AnalyzeRequestOverrides{})
+}
+
+// ExecuteWithOverrides performs comprehensive analysis with request-scoped
+// overrides applied after project configuration is resolved.
+func (uc *AnalyzeUseCase) ExecuteWithOverrides(ctx context.Context, useCaseCfg AnalyzeUseCaseConfig, paths []string, overrides AnalyzeRequestOverrides) (*domain.AnalyzeResponse, error) {
+	return uc.execute(ctx, useCaseCfg, paths, overrides)
+}
+
+func (uc *AnalyzeUseCase) execute(ctx context.Context, useCaseCfg AnalyzeUseCaseConfig, paths []string, overrides AnalyzeRequestOverrides) (*domain.AnalyzeResponse, error) {
 	startTime := time.Now()
 
 	executionCfg, err := uc.loadExecutionConfig(useCaseCfg.ConfigFile, paths)
 	if err != nil {
 		return nil, err
+	}
+	if overrides.Recursive != nil {
+		executionCfg.Recursive = *overrides.Recursive
 	}
 	useCaseCfg.ConfigFile = executionCfg.ConfigPath
 
@@ -373,7 +392,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.DeadCodeRequest{
 					Paths:           files,
-					Recursive:       false,
+					Recursive:       executionCfg.Recursive,
 					IncludePatterns: []string{},
 					ExcludePatterns: []string{},
 					OutputFormat:    domain.OutputFormatJSON,
@@ -402,7 +421,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 			Name:    taskNameClones,
 			Enabled: !config.SkipClones,
 			Execute: func(ctx context.Context) (interface{}, error) {
-				request := uc.buildCloneTaskRequest(config, files)
+				request := uc.buildCloneTaskRequest(config, files, executionCfg)
 				return uc.cloneUseCase.ExecuteAndReturn(ctx, request)
 			},
 		})
@@ -416,7 +435,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.CBORequest{
 					Paths:           files,
-					Recursive:       nil, // Let config file values take precedence
+					Recursive:       domain.BoolPtr(executionCfg.Recursive),
 					IncludePatterns: []string{},
 					ExcludePatterns: []string{},
 					OutputFormat:    domain.OutputFormatJSON,
@@ -445,7 +464,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.LCOMRequest{
 					Paths:           files,
-					Recursive:       nil, // Let config file values take precedence
+					Recursive:       domain.BoolPtr(executionCfg.Recursive),
 					IncludePatterns: []string{},
 					ExcludePatterns: []string{},
 					OutputFormat:    domain.OutputFormatJSON,
@@ -468,7 +487,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 			Execute: func(ctx context.Context) (interface{}, error) {
 				request := domain.SystemAnalysisRequest{
 					Paths:                files,
-					Recursive:            nil, // Let config file values take precedence
+					Recursive:            domain.BoolPtr(executionCfg.Recursive),
 					IncludePatterns:      []string{},
 					ExcludePatterns:      []string{},
 					OutputFormat:         domain.OutputFormatJSON,
@@ -496,7 +515,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 				request := domain.CommunityAnalysisRequest{
 					Paths:           files,
 					SourcePaths:     append([]string(nil), sourcePaths...),
-					Recursive:       nil,
+					Recursive:       domain.BoolPtr(executionCfg.Recursive),
 					IncludePatterns: []string{},
 					ExcludePatterns: []string{},
 					OutputFormat:    domain.OutputFormatJSON,
@@ -538,7 +557,7 @@ func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig
 
 	return domain.ComplexityRequest{
 		Paths:                        files,
-		Recursive:                    false,
+		Recursive:                    executionCfg.Recursive,
 		IncludePatterns:              []string{},
 		ExcludePatterns:              []string{},
 		OutputFormat:                 domain.OutputFormatJSON,
@@ -556,11 +575,12 @@ func (uc *AnalyzeUseCase) buildComplexityTaskRequest(config AnalyzeUseCaseConfig
 	}
 }
 
-func (uc *AnalyzeUseCase) buildCloneTaskRequest(config AnalyzeUseCaseConfig, files []string) domain.CloneRequest {
+func (uc *AnalyzeUseCase) buildCloneTaskRequest(config AnalyzeUseCaseConfig, files []string, executionCfg domain.AnalyzeExecutionConfig) domain.CloneRequest {
 	// Sparse request: zero values mean "not set" and are filled from the
 	// config file (or defaults) during MergeConfig inside the use case.
 	return domain.CloneRequest{
 		Paths:               files,
+		Recursive:           domain.BoolPtr(executionCfg.Recursive),
 		OutputFormat:        domain.OutputFormatJSON,
 		OutputWriter:        io.Discard,
 		SimilarityThreshold: config.CloneSimilarity,

--- a/app/analyze_usecase_community_test.go
+++ b/app/analyze_usecase_community_test.go
@@ -248,7 +248,7 @@ func TestAnalyzeUseCase_CommunityTaskRequestUsesDiscardWriter(t *testing.T) {
 		SkipLCOM:        true,
 		SkipSystem:      true,
 		SkipCommunities: false,
-	}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, nil, domain.AnalyzeExecutionConfig{})
+	}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, []string{filepath.Join("..", "testdata", "python", "mvc_app")}, nil, domain.AnalyzeExecutionConfig{Recursive: true})
 
 	var communityTask *AnalysisTask
 	for _, task := range tasks {

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -380,7 +380,7 @@ enabled = false
 	})
 }
 
-func TestAnalyzeUseCase_buildCloneTaskRequest_ProducesSparseRequest(t *testing.T) {
+func TestAnalyzeUseCase_buildCloneTaskRequest_PropagatesExecutionConfig(t *testing.T) {
 	useCase := &AnalyzeUseCase{}
 	config := AnalyzeUseCaseConfig{
 		CloneSimilarity: 0.8,
@@ -388,10 +388,10 @@ func TestAnalyzeUseCase_buildCloneTaskRequest_ProducesSparseRequest(t *testing.T
 	}
 	files := []string{"a.py", "b.py"}
 
-	request := useCase.buildCloneTaskRequest(config, files)
+	request := useCase.buildCloneTaskRequest(config, files, domain.AnalyzeExecutionConfig{Recursive: true})
 
-	// Only the fields the CLI explicitly provides are set; the rest stay at
-	// their zero values so MergeConfig fills them from the config file/defaults.
+	// Values already resolved by the unified analyze configuration are explicit;
+	// unrelated fields stay sparse so MergeConfig can fill them as usual.
 	if len(request.Paths) != len(files) || request.Paths[0] != files[0] || request.Paths[1] != files[1] {
 		t.Fatalf("expected clone task paths %v, got %v", files, request.Paths)
 	}
@@ -406,6 +406,9 @@ func TestAnalyzeUseCase_buildCloneTaskRequest_ProducesSparseRequest(t *testing.T
 	}
 	if request.ConfigPath != config.ConfigFile {
 		t.Fatalf("expected config path %q, got %q", config.ConfigFile, request.ConfigPath)
+	}
+	if !domain.BoolValue(request.Recursive, false) {
+		t.Fatal("expected effective recursive setting to be propagated")
 	}
 	if request.MaxSimilarity != 0 {
 		t.Fatalf("expected max similarity to be unset (0), got %.2f", request.MaxSimilarity)

--- a/mcp/handlers.go
+++ b/mcp/handlers.go
@@ -54,6 +54,15 @@ func (h *HandlerSet) HandleAnalyzeCode(ctx context.Context, request mcp.CallTool
 		}
 	}
 
+	var recursiveOverride *bool
+	if rawRecursive, exists := args["recursive"]; exists {
+		recursive, ok := rawRecursive.(bool)
+		if !ok {
+			return mcp.NewToolResultError("recursive parameter must be a boolean"), nil
+		}
+		recursiveOverride = &recursive
+	}
+
 	// Create config for analyze use case
 	config := app.ApplyAnalyzeSelection(app.AnalyzeUseCaseConfig{
 		MinComplexity:   1,
@@ -88,7 +97,9 @@ func (h *HandlerSet) HandleAnalyzeCode(ctx context.Context, request mcp.CallTool
 	paths := []string{path}
 
 	// Execute analysis
-	result, err := analyzeUC.Execute(ctx, config, paths)
+	result, err := analyzeUC.ExecuteWithOverrides(ctx, config, paths, app.AnalyzeRequestOverrides{
+		Recursive: recursiveOverride,
+	})
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("analysis failed: %v", err)), nil
 	}

--- a/mcp/handlers_test.go
+++ b/mcp/handlers_test.go
@@ -43,6 +43,16 @@ func setupTestFile(t *testing.T, filename string) string {
 	return dst
 }
 
+func setupNestedTestProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	require.NoError(t, os.Mkdir(nested, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "root.py"), []byte("def root():\n    return 1\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "child.py"), []byte("def child():\n    return 2\n"), 0o644))
+	return root
+}
+
 func runToolTest(
 	t *testing.T,
 	setupFS func(t *testing.T) string,
@@ -174,6 +184,64 @@ func TestHandleAnalyzeCode(t *testing.T) {
 				},
 			},
 		},
+		"recursive_false_limits_directory_to_root": {
+			args: args{
+				setupFS: setupNestedTestProject,
+				arguments: map[string]interface{}{
+					"analyses":    []interface{}{"complexity"},
+					"output_mode": "full",
+					"recursive":   false,
+				},
+			},
+			want: want{
+				isError: &errFalse,
+				check: func(t *testing.T, res *mcplib.CallToolResult) {
+					text := mcplib.GetTextFromContent(res.Content[0])
+					var result struct {
+						Summary struct {
+							TotalFiles int `json:"total_files"`
+						} `json:"summary"`
+					}
+					require.NoError(t, json.Unmarshal([]byte(text), &result))
+					assert.Equal(t, 1, result.Summary.TotalFiles)
+				},
+			},
+		},
+		"recursive_true_includes_nested_files": {
+			args: args{
+				setupFS: setupNestedTestProject,
+				arguments: map[string]interface{}{
+					"analyses":    []interface{}{"complexity"},
+					"output_mode": "full",
+					"recursive":   true,
+				},
+			},
+			want: want{
+				isError: &errFalse,
+				check: func(t *testing.T, res *mcplib.CallToolResult) {
+					text := mcplib.GetTextFromContent(res.Content[0])
+					var result struct {
+						Summary struct {
+							TotalFiles int `json:"total_files"`
+						} `json:"summary"`
+					}
+					require.NoError(t, json.Unmarshal([]byte(text), &result))
+					assert.Equal(t, 2, result.Summary.TotalFiles)
+				},
+			},
+		},
+		"recursive_rejects_non_boolean": {
+			args: args{
+				setupFS: setupNestedTestProject,
+				arguments: map[string]interface{}{
+					"recursive": "false",
+				},
+			},
+			want: want{
+				isError:      &errTrue,
+				expectPrefix: "recursive parameter must be a boolean",
+			},
+		},
 		"communities_full_context_map": {
 			args: args{
 				setupFS: func(t *testing.T) string {
@@ -251,6 +319,69 @@ func TestHandleAnalyzeCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleAnalyzeCode_RecursiveOmittedUsesProjectConfig(t *testing.T) {
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, ".pyscn.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte("[analysis]\nrecursive = false\n"), 0o644))
+
+	arguments := map[string]interface{}{
+		"analyses":    []interface{}{"complexity"},
+		"output_mode": "full",
+	}
+	res := runToolTestWithConfig(
+		t,
+		setupNestedTestProject,
+		arguments,
+		configFile,
+		(*mcp.HandlerSet).HandleAnalyzeCode,
+	)
+	require.False(t, res.IsError)
+
+	text := mcplib.GetTextFromContent(res.Content[0])
+	var result struct {
+		Summary struct {
+			TotalFiles int `json:"total_files"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &result))
+	assert.Equal(t, 1, result.Summary.TotalFiles)
+}
+
+func TestHandleAnalyzeCode_RecursiveOverrideUpdatesFullResponse(t *testing.T) {
+	configDir := t.TempDir()
+	configFile := filepath.Join(configDir, ".pyscn.toml")
+	require.NoError(t, os.WriteFile(configFile, []byte("[analysis]\nrecursive = false\n"), 0o644))
+
+	arguments := map[string]interface{}{
+		"analyses":    []interface{}{"complexity"},
+		"output_mode": "full",
+		"recursive":   true,
+	}
+	res := runToolTestWithConfig(
+		t,
+		setupNestedTestProject,
+		arguments,
+		configFile,
+		(*mcp.HandlerSet).HandleAnalyzeCode,
+	)
+	require.False(t, res.IsError)
+
+	text := mcplib.GetTextFromContent(res.Content[0])
+	var result struct {
+		Complexity struct {
+			Request struct {
+				Recursive bool `json:"recursive"`
+			} `json:"request"`
+		} `json:"complexity"`
+		Summary struct {
+			TotalFiles int `json:"total_files"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &result))
+	assert.Equal(t, 2, result.Summary.TotalFiles)
+	assert.True(t, result.Complexity.Request.Recursive)
 }
 
 func TestHandleAnalyzeCodeExplicitCommunitiesOverrideDisabledConfig(t *testing.T) {


### PR DESCRIPTION
> **Merge first.** Draft #649 depends on this PR; I will update and retest #649 afterward.

## Summary

- honor MCP `analyze_code.recursive`
- preserve project configuration when the argument is omitted
- propagate the effective value to file collection, child requests, and full-response metadata
- reject non-boolean values at the handler boundary

## Compatibility

Existing request types and `AnalyzeUseCaseConfig` remain unchanged. The additive override API keeps this PR v1-compatible; #649 handles the separately approved breaking migration.

## Validation

- `go test -count=1 ./...`
- explicit `true`/`false`, omitted configuration, full output, and invalid-type coverage
