### PR TITLE
fix: expose CBO value in class JSON output

### DIFF
--- a/domain/cbo.go
+++ b/domain/cbo.go
@@ -66,7 +66,8 @@ type ClassCoupling struct {
 	EndLine   int
 
 	// CBO metrics
-	Metrics CBOMetrics
+	CouplingBetweenObjects int
+	Metrics                CBOMetrics
 
 	// Risk assessment
 	RiskLevel RiskLevel

--- a/service/cbo_formatter_test.go
+++ b/service/cbo_formatter_test.go
@@ -16,9 +16,10 @@ func createTestCBOResponse() *domain.CBOResponse {
 	return &domain.CBOResponse{
 		Classes: []domain.ClassCoupling{
 			{
-				Name:      "MyClass",
-				FilePath:  "test.py",
-				StartLine: 10,
+				Name:                   "MyClass",
+				FilePath:               "test.py",
+				StartLine:              10,
+				CouplingBetweenObjects: 5,
 				Metrics: domain.CBOMetrics{
 					CouplingCount:    5,
 					DependentClasses: []string{"ClassA", "ClassB", "ClassC"},
@@ -116,6 +117,7 @@ func TestCBOFormatter_Format_JSON(t *testing.T) {
 	assert.Equal(t, response.Summary.TotalClasses, decoded.Summary.TotalClasses)
 	assert.Equal(t, response.Summary.AverageCBO, decoded.Summary.AverageCBO)
 	assert.Len(t, decoded.Classes, 2)
+	assert.Equal(t, 5, decoded.Classes[0].CouplingBetweenObjects)
 }
 
 func TestCBOFormatter_Format_YAML(t *testing.T) {

--- a/service/cbo_service.go
+++ b/service/cbo_service.go
@@ -231,10 +231,11 @@ func (s *CBOServiceImpl) convertCBOResults(cboResults []*analyzer.CBOResult) []d
 
 	for _, cboResult := range cboResults {
 		class := domain.ClassCoupling{
-			Name:      cboResult.ClassName,
-			FilePath:  cboResult.FilePath,
-			StartLine: cboResult.StartLine,
-			EndLine:   cboResult.EndLine,
+			Name:                   cboResult.ClassName,
+			FilePath:               cboResult.FilePath,
+			StartLine:              cboResult.StartLine,
+			EndLine:                cboResult.EndLine,
+			CouplingBetweenObjects: cboResult.CouplingCount,
 			Metrics: domain.CBOMetrics{
 				CouplingCount:               cboResult.CouplingCount,
 				InheritanceDependencies:     cboResult.InheritanceDependencies,

--- a/service/cbo_service_test.go
+++ b/service/cbo_service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/ludo-technologies/pyscn/internal/analyzer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -278,6 +279,20 @@ func TestCBOService_AnalyzeFile(t *testing.T) {
 		assert.NotNil(t, response)
 		assert.Equal(t, 1, response.Summary.FilesAnalyzed)
 	})
+}
+
+func TestCBOService_ConvertCBOResultsExposesTopLevelCBO(t *testing.T) {
+	service := NewCBOService()
+	classes := service.convertCBOResults([]*analyzer.CBOResult{
+		{
+			ClassName:     "Example",
+			CouplingCount: 4,
+		},
+	})
+
+	require.Len(t, classes, 1)
+	assert.Equal(t, 4, classes[0].CouplingBetweenObjects)
+	assert.Equal(t, classes[0].Metrics.CouplingCount, classes[0].CouplingBetweenObjects)
 }
 
 func TestCBOService_FilterClasses(t *testing.T) {


### PR DESCRIPTION
## Summary
- expose `CouplingBetweenObjects` as a numeric per-class JSON field
- populate it from the same analyzer result as `Metrics.CouplingCount`

## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
Fixes #643

## Changes
- add the top-level CBO field to class results
- add conversion and JSON regression coverage

## Testing
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --timeout=10m`
- [x] `go build ./cmd/pyscn`
- [x] JSON CLI reproduction confirms both CBO fields report `1`

## Documentation
- [x] No documentation changes needed
