### PR TITLE
docs(website): document Agent Skills as a recommended AI integration

### DIFF
--- a/website/docs/fr/index.md
+++ b/website/docs/fr/index.md
@@ -21,7 +21,7 @@ uvx pyscn@latest analyze .
 - **Détection des imports circulaires** via l'algorithme SCC de Tarjan.
 - **Score de santé** (0–100) avec décomposition par catégorie.
 - **Prêt pour la CI** grâce à `pyscn check`, une sortie de type linter et des codes de sortie déterministes.
-- **Serveur MCP** (`pyscn-mcp`) pour Claude Code, Cursor et autres clients MCP.
+- **Agent Skills** et **serveur MCP** (`pyscn-mcp`) pour Claude Code, Cursor et autres agents de codage IA.
 
 Écrit en Go. Plus de 100 000 lignes/s sur du matériel courant. Aucune dépendance d'exécution Python.
 
@@ -45,3 +45,11 @@ pyscn init                              # génère .pyscn.toml
 ```
 
 Voir [Démarrage rapide](getting-started/quick-start.md) et le [Catalogue de règles](rules/index.md).
+
+## Intégration avec les agents IA
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+Installe des Agent Skills qui apprennent à Claude Code, Cursor, Codex, Gemini CLI et autres agents de codage quand et comment lancer chaque analyse. Voir [Agent Skills](integrations/skills.md), ou utilisez le [serveur MCP](integrations/mcp.md) pour des appels d'outils structurés.

--- a/website/docs/fr/integrations/index.md
+++ b/website/docs/fr/integrations/index.md
@@ -1,5 +1,6 @@
 # Intégrations
 
-- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI.
+- **[Skills](skills.md)** — Agent Skills pour Claude Code, Cursor, Codex et autres agents de codage (recommandé).
 - **[MCP](mcp.md)** — Claude Code, Cursor et autres clients MCP.
+- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI.
 - **[Empaquetage Python](python-packaging.md)** — détails sur pip, pipx, uv et la distribution de wheels.

--- a/website/docs/fr/integrations/skills.md
+++ b/website/docs/fr/integrations/skills.md
@@ -1,0 +1,51 @@
+# Intégration Agent Skills
+
+pyscn est livré avec 4 Agent Skills qui apprennent aux agents de codage quand et comment lancer chaque analyse, sans avoir besoin de configurer un serveur MCP.
+
+## Installation
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+Installe les Skills dans votre projet. Compatible avec Claude Code, Cursor, Codex, Gemini CLI et [de nombreux autres agents](https://github.com/ludo-technologies/add-skills) (ajoutez `--agent cursor` pour cibler un agent en particulier, `--global` pour tous les projets).
+
+## Liste des Skills
+
+| Skill | À utiliser quand |
+| --- | --- |
+| `health-check` | « Ce code est-il sain ? », un aperçu de la qualité, une comparaison avant/après |
+| `refactoring` | Trouver des cibles de refactoring — code dupliqué, points chauds de complexité, code mort |
+| `architecture-review` | Structure des modules, couplage, dépendances circulaires, fichiers à revoir ensemble |
+| `cli-analysis` | Garde-fous CI/CD, rapports partageables, configuration du projet |
+
+Chaque Skill exécute en interne `uvx pyscn@latest <command>` — aucune installation préalable n'est nécessaire.
+
+## Exemples d'invites
+
+> Analyse la qualité du code du répertoire app/
+
+> Trouve le code dupliqué et aide-moi à le refactoriser
+
+> Montre-moi le code complexe et aide-moi à le simplifier
+
+> Vérifie s'il y a des dépendances circulaires avant que je merge
+
+## Plugin Claude Code
+
+Installe le serveur MCP et les Skills ensemble :
+
+```bash
+claude plugin marketplace add ludo-technologies/pyscn
+claude plugin install pyscn-mcp@pyscn-marketplace
+```
+
+## Skills vs. MCP
+
+Les Agent Skills apprennent à un agent quand recourir à pyscn et quelle commande CLI exécuter ; elles ne nécessitent aucun serveur et fonctionnent avec tout agent prenant en charge le format Skill. Le [serveur MCP](mcp.md) expose au contraire les mêmes analyses comme des appels d'outils structurés — utilisez-le si vous voulez des résultats JSON typés directement intégrés au client plutôt qu'une sortie shell. Les deux sont complémentaires et peuvent être installés ensemble via le plugin Claude Code ci-dessus.
+
+## Voir aussi
+
+- [Intégration MCP](mcp.md)
+- [Référence CLI](../cli/index.md)
+- [add-skills](https://github.com/ludo-technologies/add-skills)

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -22,7 +22,7 @@ uvx pyscn@latest analyze .
 - **Module community detection** via Leiden clustering over the import graph.
 - **Health score** (0–100) with per-category breakdown.
 - **CI-ready** with `pyscn check`, linter-style output, and deterministic exit codes.
-- **MCP server** (`pyscn-mcp`) for Claude Code, Cursor, and other MCP clients.
+- **Agent Skills** and an **MCP server** (`pyscn-mcp`) for Claude Code, Cursor, and other AI coding agents.
 
 Written in Go. 100,000+ lines/sec on typical hardware. No Python runtime dependencies.
 
@@ -46,3 +46,11 @@ pyscn init                              # generate .pyscn.toml
 ```
 
 See [Quick Start](getting-started/quick-start.md) and the [Rule catalog](rules/index.md).
+
+## AI agent integration
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+Installs Agent Skills that teach Claude Code, Cursor, Codex, Gemini CLI, and other coding agents when and how to run each analysis. See [Agent Skills](integrations/skills.md), or use the [MCP server](integrations/mcp.md) for structured tool calls instead.

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -1,5 +1,6 @@
 # Integrations
 
-- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI.
+- **[Skills](skills.md)** — Agent Skills for Claude Code, Cursor, Codex, and other coding agents (recommended).
 - **[MCP](mcp.md)** — Claude Code, Cursor, and other MCP clients.
+- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI.
 - **[Python Packaging](python-packaging.md)** — pip, pipx, uv, and wheel distribution details.

--- a/website/docs/integrations/skills.md
+++ b/website/docs/integrations/skills.md
@@ -1,0 +1,51 @@
+# Agent Skills
+
+pyscn ships 4 Agent Skills that teach coding agents when and how to run each analysis — no MCP server required.
+
+## Installation
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+Installs the Skills into your project. Works with Claude Code, Cursor, Codex, Gemini CLI, and [many other agents](https://github.com/ludo-technologies/add-skills) (add `--agent cursor` etc. to target one, `--global` for all projects).
+
+## Skills
+
+| Skill | Use it when |
+| --- | --- |
+| `health-check` | "How healthy is this code?", a quality overview, a before/after comparison |
+| `refactoring` | Finding refactoring targets — duplicate code, complexity hotspots, dead code |
+| `architecture-review` | Module structure, coupling, circular dependencies, which files to review together |
+| `cli-analysis` | CI/CD quality gates, shareable reports, project configuration |
+
+Each Skill runs `uvx pyscn@latest <command>` under the hood — no install required to try it.
+
+## Example prompts
+
+> Analyze the code quality of the app/ directory
+
+> Find duplicate code and help me refactor it
+
+> Show me complex code and help me simplify it
+
+> Check for circular dependencies before I merge this
+
+## Claude Code plugin
+
+Installs the MCP server and the Skills together:
+
+```bash
+claude plugin marketplace add ludo-technologies/pyscn
+claude plugin install pyscn-mcp@pyscn-marketplace
+```
+
+## Skills vs. MCP
+
+Skills teach an agent when to reach for pyscn and which CLI command to run; they need no server and work with any agent that supports the Skill format. The [MCP server](mcp.md) instead exposes the same analyses as structured tool calls — use it when you want typed JSON results wired directly into the client rather than shell output. The two are complementary and can be installed together via the Claude Code plugin above.
+
+## See also
+
+- [MCP Integration](mcp.md)
+- [CLI Reference](../cli/index.md)
+- [add-skills](https://github.com/ludo-technologies/add-skills)

--- a/website/docs/ja/index.md
+++ b/website/docs/ja/index.md
@@ -21,7 +21,7 @@ uvx pyscn@latest analyze .
 - **循環インポート検出** — Tarjan の SCC アルゴリズムで循環依存を発見します。
 - **ヘルススコア**（0〜100）— カテゴリごとの内訳付き。
 - **CI 対応** — `pyscn check` によるリンター形式の出力と確定的な終了コード。
-- **MCP サーバー**（`pyscn-mcp`）— Claude Code、Cursor、その他の MCP クライアントから利用できます。
+- **Agent Skills** と **MCP サーバー**（`pyscn-mcp`）— Claude Code、Cursor、その他の AI コーディングエージェントから利用できます。
 
 Go で実装されています。一般的なハードウェアで 100,000 行/秒以上の解析速度です。Python ランタイムへの依存はありません。
 
@@ -45,3 +45,11 @@ pyscn init                              # generate .pyscn.toml
 ```
 
 詳しくは [Quick Start](getting-started/quick-start.md) と [Rule catalog](rules/index.md) をご覧ください。
+
+## AI エージェント連携
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+Claude Code, Cursor, Codex, Gemini CLI、その他のコーディングエージェントに、各分析の使いどころを教える Agent Skills をインストールします。詳しくは [Agent Skills](integrations/skills.md) をご覧ください。構造化されたツール呼び出しが必要な場合は [MCP サーバー](integrations/mcp.md) を使用してください。

--- a/website/docs/ja/integrations/index.md
+++ b/website/docs/ja/integrations/index.md
@@ -1,5 +1,6 @@
 # 連携
 
-- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI。
+- **[Skills](skills.md)** — Claude Code, Cursor, Codex、その他のコーディングエージェント向けの Agent Skills（推奨）。
 - **[MCP](mcp.md)** — Claude Code, Cursor、その他の MCP クライアント。
+- **[CI/CD](ci-cd.md)** — GitHub Actions, pre-commit, GitLab CI。
 - **[Python パッケージング](python-packaging.md)** — pip, pipx, uv、および wheel 配布の詳細。

--- a/website/docs/ja/integrations/skills.md
+++ b/website/docs/ja/integrations/skills.md
@@ -1,0 +1,51 @@
+# Agent Skills 連携
+
+pyscn は 4 つの Agent Skills を同梱しています。コーディングエージェントに「いつ・どの分析を実行すべきか」を教えるもので、MCP サーバーのセットアップは不要です。
+
+## インストール
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+プロジェクトに Skills をインストールします。Claude Code, Cursor, Codex, Gemini CLI、その他[多数のエージェント](https://github.com/ludo-technologies/add-skills)に対応しています（特定のエージェントだけに導入する場合は `--agent cursor` のように指定、全プロジェクトに導入する場合は `--global` を指定）。
+
+## Skills 一覧
+
+| Skill | 使うタイミング |
+| --- | --- |
+| `health-check` | 「このコードは健全か?」品質の概要確認、リファクタリング前後の比較 |
+| `refactoring` | リファクタリング対象の検出 — 重複コード、複雑度のホットスポット、デッドコード |
+| `architecture-review` | モジュール構造、結合度、循環依存、一緒にレビューすべきファイルの特定 |
+| `cli-analysis` | CI/CD の品質ゲート、共有可能なレポート、プロジェクト設定 |
+
+各 Skill は内部で `uvx pyscn@latest <command>` を実行します。事前のインストールは不要です。
+
+## プロンプト例
+
+> app/ ディレクトリのコード品質を分析して
+
+> 重複コードを見つけてリファクタリングを手伝って
+
+> 複雑なコードを教えて、シンプルにするのを手伝って
+
+> マージする前に循環依存がないか確認して
+
+## Claude Code プラグイン
+
+MCP サーバーと Skills をまとめてセットアップします:
+
+```bash
+claude plugin marketplace add ludo-technologies/pyscn
+claude plugin install pyscn-mcp@pyscn-marketplace
+```
+
+## Skills と MCP の違い
+
+Agent Skills は、エージェントに「いつ pyscn を使うか」「どの CLI コマンドを実行するか」を教えるものです。サーバー不要で、Skill 形式に対応した任意のエージェントで動作します。一方 [MCP サーバー](mcp.md)は同じ分析を構造化されたツール呼び出しとして公開します。シェル出力ではなく型付きの JSON 結果をクライアントに直接組み込みたい場合はこちらを使ってください。両者は補完関係にあり、上記の Claude Code プラグインでまとめて導入できます。
+
+## 関連項目
+
+- [MCP 連携](mcp.md)
+- [CLI リファレンス](../cli/index.md)
+- [add-skills](https://github.com/ludo-technologies/add-skills)

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -21,7 +21,7 @@ uvx pyscn@latest analyze .
 - **循环导入检测**，基于 Tarjan 强连通分量算法。
 - **健康评分**（0-100），按类别分项评估。
 - **CI 就绪**，提供 `pyscn check` 命令、linter 风格输出和确定性退出码。
-- **MCP 服务器**（`pyscn-mcp`），支持 Claude Code、Cursor 及其他 MCP 客户端。
+- **Agent Skills** 和 **MCP 服务器**（`pyscn-mcp`），支持 Claude Code、Cursor 及其他 AI 编码代理。
 
 使用 Go 编写。在常见硬件上分析速度超过 100,000 行/秒。无 Python 运行时依赖。
 
@@ -45,3 +45,11 @@ pyscn init                              # 生成 .pyscn.toml
 ```
 
 详见[快速开始](getting-started/quick-start.md)和[规则目录](rules/index.md)。
+
+## AI 代理集成
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+安装 Agent Skills，教 Claude Code、Cursor、Codex、Gemini CLI 及其他编码代理何时以及如何运行每种分析。详见 [Agent Skills](integrations/skills.md)；如需结构化的工具调用，可改用 [MCP 服务器](integrations/mcp.md)。

--- a/website/docs/zh/integrations/index.md
+++ b/website/docs/zh/integrations/index.md
@@ -1,5 +1,6 @@
 # 集成
 
-- **[CI/CD](ci-cd.md)** — GitHub Actions、pre-commit、GitLab CI。
+- **[Skills](skills.md)** — 面向 Claude Code、Cursor、Codex 及其他编码代理的 Agent Skills（推荐）。
 - **[MCP](mcp.md)** — Claude Code、Cursor 及其他 MCP 客户端。
+- **[CI/CD](ci-cd.md)** — GitHub Actions、pre-commit、GitLab CI。
 - **[Python 打包](python-packaging.md)** — pip、pipx、uv 及 wheel 分发详情。

--- a/website/docs/zh/integrations/skills.md
+++ b/website/docs/zh/integrations/skills.md
@@ -1,0 +1,51 @@
+# Agent Skills 集成
+
+pyscn 附带 4 个 Agent Skills，用于教编码代理"何时以及如何"运行每种分析，无需搭建 MCP 服务器。
+
+## 安装
+
+```bash
+uvx add-skills ludo-technologies/pyscn
+```
+
+将 Skills 安装到你的项目中。支持 Claude Code、Cursor、Codex、Gemini CLI 及[其他多种代理](https://github.com/ludo-technologies/add-skills)（使用 `--agent cursor` 等指定单个代理，使用 `--global` 应用到所有项目）。
+
+## Skills 列表
+
+| Skill | 使用场景 |
+| --- | --- |
+| `health-check` | "这段代码健康吗？"、质量概览、重构前后对比 |
+| `refactoring` | 查找重构目标 — 重复代码、复杂度热点、死代码 |
+| `architecture-review` | 模块结构、耦合度、循环依赖、应一起审查的文件 |
+| `cli-analysis` | CI/CD 质量门禁、可分享的报告、项目配置 |
+
+每个 Skill 内部都会运行 `uvx pyscn@latest <command>`，无需提前安装。
+
+## 示例提示词
+
+> 分析 app/ 目录的代码质量
+
+> 找出重复代码并帮我重构
+
+> 找出复杂的代码并帮我简化
+
+> 合并前检查一下有没有循环依赖
+
+## Claude Code 插件
+
+同时安装 MCP 服务器和 Skills：
+
+```bash
+claude plugin marketplace add ludo-technologies/pyscn
+claude plugin install pyscn-mcp@pyscn-marketplace
+```
+
+## Skills 与 MCP 的区别
+
+Agent Skills 教代理"何时使用 pyscn"以及"运行哪条 CLI 命令"，无需服务器，适用于任何支持 Skill 格式的代理。而 [MCP 服务器](mcp.md)将相同的分析暴露为结构化的工具调用——如果你希望客户端直接获得类型化的 JSON 结果而不是 shell 输出，请使用它。两者可以互补，并通过上面的 Claude Code 插件一起安装。
+
+## 另请参阅
+
+- [MCP 集成](mcp.md)
+- [CLI 参考](../cli/index.md)
+- [add-skills](https://github.com/ludo-technologies/add-skills)

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -99,6 +99,7 @@ plugins:
             Schemas: スキーマ
             Health Score: ヘルススコア
             Integrations: インテグレーション
+            Skills: Skills
             CI/CD: CI/CD
             MCP: MCP
             Python Packaging: Python パッケージ
@@ -134,6 +135,7 @@ plugins:
             Schemas: 结构
             Health Score: 健康评分
             Integrations: 集成
+            Skills: Skills
             Python Packaging: Python 打包
             FAQ: 常见问题
         - locale: fr
@@ -167,6 +169,7 @@ plugins:
             Schemas: Schémas
             Health Score: Score de santé
             Integrations: Intégrations
+            Skills: Skills
             CI/CD: CI/CD
             MCP: MCP
             Python Packaging: Packaging Python
@@ -286,7 +289,8 @@ nav:
       - Health Score: output/health-score.md
   - Integrations:
       - integrations/index.md
-      - CI/CD: integrations/ci-cd.md
+      - Skills: integrations/skills.md
       - MCP: integrations/mcp.md
+      - CI/CD: integrations/ci-cd.md
       - Python Packaging: integrations/python-packaging.md
   - FAQ: faq.md


### PR DESCRIPTION
## Summary
- README already recommends Agent Skills (`uvx add-skills ludo-technologies/pyscn`) as the primary AI agent integration, ahead of the MCP server, but the public docs site (`website/docs/`) never mentioned Skills anywhere — not on the homepage, not in the Integrations nav.
- Add a new `Integrations → Skills` page documenting installation, the 4 shipped Skills (`health-check`, `refactoring`, `architecture-review`, `cli-analysis`), example prompts, the Claude Code plugin, and how Skills relate to the MCP server.
- Link Skills from the homepage ("AI agent integration" section) and list it first in the Integrations index, matching README's "(Recommended)" framing.
- Mirrored across all four locales (en/ja/zh/fr) for nav, homepage, and integrations index parity.

## Test plan
- [x] `mkdocs build --strict` succeeds (via `uvx --with mkdocs-material --with mkdocs-static-i18n mkdocs build --strict`) with no new warnings/errors introduced by this change
- [x] Verified new nav entries resolve correctly in en/ja/zh/fr builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)