### PR TITLE
migrate: adopt core graph analyses

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,7 +186,7 @@ type Location struct {
 
 ### 2. Analyzer Module (`internal/analyzer`)
 
-The analyzer module contains Python adapters and language-specific analysis. Language-neutral CFG, clone, and APTED kernels come from `github.com/ludo-technologies/polyscan/core`.
+The analyzer module contains Python adapters and language-specific analysis. Language-neutral CFG, dependency graph, clone, and APTED kernels come from `github.com/ludo-technologies/polyscan/core`.
 
 #### 2.1 Control Flow Graph (CFG)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,6 +53,9 @@ pyscn/
 │   │   ├── cfg.go     # Aliases for core/cfg data structures
 │   │   ├── python_cfg.go # Python classifiers for core/cfg analyses
 │   │   ├── dead_code.go # Python dead-code result enrichment
+│   │   ├── dependency_graph.go # Python module graph adapter for core/graph
+│   │   ├── circular_detector.go # Python cycle result enrichment
+│   │   ├── coupling_metrics.go # Python system metric aggregation
 │   │   ├── apted_tree.go # Python adapter for core/apted
 │   │   └── apted_cost.go # Python APTED cost model
 │   └── config/        # Configuration

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -1,6 +1,6 @@
 # Dependency Analysis
 
-This document describes the algorithms and data structures behind pyscn's module dependency analysis. The implementation lives primarily in `internal/analyzer/dependency_graph.go`, `internal/analyzer/module_analyzer.go`, `internal/analyzer/circular_detector.go`, and `internal/analyzer/coupling_metrics.go`, with domain types defined in `domain/system_analysis.go`.
+This document describes the algorithms and data structures behind pyscn's module dependency analysis. Language-neutral coupling and cycle detection come from `github.com/ludo-technologies/polyscan/core/graph`; pyscn builds the Python module graph and enriches core results in `internal/analyzer/dependency_graph.go`, `internal/analyzer/module_analyzer.go`, `internal/analyzer/circular_detector.go`, and `internal/analyzer/coupling_metrics.go`, with domain types defined in `domain/system_analysis.go`.
 
 ## Overview
 
@@ -134,7 +134,7 @@ When an `__init__.py` file imports from its own submodules (a standard Python re
 
 ### Tarjan's Strongly Connected Components
 
-Circular dependency detection uses **Tarjan's algorithm** to find all strongly connected components (SCCs) in the dependency graph. An SCC with more than one node represents a circular dependency.
+Circular dependency detection uses **Tarjan's algorithm** from `polyscan/core/graph` to find all strongly connected components (SCCs) in the dependency graph. An SCC with more than one node represents a circular dependency. pyscn supplies a load-time graph view that excludes lazy function-body imports, then enriches each core SCC with Python-specific dependency chains, severity, and descriptions.
 
 The algorithm runs in O(V + E) time where V is the number of modules and E is the number of edges.
 
@@ -230,7 +230,7 @@ Exceeding this threshold suggests that the dependency chain is deeper than neces
 
 ## Robert C. Martin's Package Metrics
 
-The coupling metrics calculator (`CouplingMetricsCalculator`) computes metrics from Robert C. Martin's package design principles for each module.
+The coupling metrics calculator (`CouplingMetricsCalculator`) delegates Robert C. Martin's per-module metrics to `polyscan/core/graph`, supplying Python abstract-class ratios through the core callback. pyscn then adds source metrics and aggregates the system-wide results described below.
 
 ### Afferent Coupling (Ca)
 
@@ -433,8 +433,9 @@ With 4 modules and no cycles:
 |---|---|
 | `internal/analyzer/dependency_graph.go` | Graph data structures (`DependencyGraph`, `ModuleNode`, `DependencyEdge`) |
 | `internal/analyzer/module_analyzer.go` | Import parsing, resolution, and graph construction |
-| `internal/analyzer/circular_detector.go` | Tarjan's SCC algorithm and cycle analysis |
-| `internal/analyzer/coupling_metrics.go` | Robert C. Martin's metrics and system-wide calculations |
+| `github.com/ludo-technologies/polyscan/core/graph` | Tarjan SCC detection and Robert C. Martin's coupling metrics |
+| `internal/analyzer/circular_detector.go` | Python load-time graph adapter and cycle result enrichment |
+| `internal/analyzer/coupling_metrics.go` | Python abstractness adapter and system-wide calculations |
 | `internal/analyzer/reexport_resolver.go` | Re-export resolution for `__init__.py` files |
 | `domain/system_analysis.go` | Domain types for analysis results |
 | `domain/analyze.go` | Health score dependency penalty calculation |

--- a/internal/analyzer/circular_detector.go
+++ b/internal/analyzer/circular_detector.go
@@ -4,21 +4,35 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	coregraph "github.com/ludo-technologies/polyscan/core/graph"
 )
 
-// CircularDependencyDetector detects circular dependencies using Tarjan's algorithm
+// CircularDependencyDetector enriches cycles detected by polyscan core.
 type CircularDependencyDetector struct {
-	graph *DependencyGraph
-
-	// Tarjan's algorithm state
-	index    int
-	stack    []string
-	inStack  map[string]bool
-	indices  map[string]int
-	lowLinks map[string]int
-
-	// Results
+	graph      *DependencyGraph
 	components [][]string // Strongly connected components
+}
+
+type loadTimeDependencyGraph struct {
+	*DependencyGraph
+}
+
+// Successors excludes lazy imports because they cannot form load-time cycles.
+func (g loadTimeDependencyGraph) Successors(moduleName string) []string {
+	node := g.Nodes[moduleName]
+	if node == nil {
+		return nil
+	}
+
+	dependencies := make([]string, 0, len(node.Dependencies))
+	for dependency := range node.Dependencies {
+		if !node.LazyDependencies[dependency] {
+			dependencies = append(dependencies, dependency)
+		}
+	}
+	sort.Strings(dependencies)
+	return dependencies
 }
 
 // CircularDependency represents a circular dependency relationship
@@ -70,21 +84,17 @@ type CircularDependencyResult struct {
 // NewCircularDependencyDetector creates a new circular dependency detector
 func NewCircularDependencyDetector(graph *DependencyGraph) *CircularDependencyDetector {
 	return &CircularDependencyDetector{
-		graph:      graph,
-		inStack:    make(map[string]bool),
-		indices:    make(map[string]int),
-		lowLinks:   make(map[string]int),
-		components: make([][]string, 0),
+		graph: graph,
 	}
 }
 
 // DetectCircularDependencies detects all circular dependencies in the graph
 func (cdd *CircularDependencyDetector) DetectCircularDependencies() *CircularDependencyResult {
-	// Reset state
-	cdd.resetState()
-
-	// Run Tarjan's algorithm to find strongly connected components
-	cdd.findStronglyConnectedComponents()
+	coreResult := coregraph.NewCycleDetector().DetectCycles(loadTimeDependencyGraph{cdd.graph})
+	cdd.components = coreResult.Cycles
+	for _, component := range cdd.components {
+		sort.Strings(component)
+	}
 
 	// Process components to identify circular dependencies
 	circularDeps := cdd.processComponents()
@@ -103,80 +113,6 @@ func (cdd *CircularDependencyDetector) DetectCircularDependencies() *CircularDep
 	cdd.updateGraphWithCycles()
 
 	return result
-}
-
-// resetState resets the detector state for a new analysis
-func (cdd *CircularDependencyDetector) resetState() {
-	cdd.index = 0
-	cdd.stack = make([]string, 0)
-	cdd.inStack = make(map[string]bool)
-	cdd.indices = make(map[string]int)
-	cdd.lowLinks = make(map[string]int)
-	cdd.components = make([][]string, 0)
-}
-
-// findStronglyConnectedComponents implements Tarjan's algorithm
-func (cdd *CircularDependencyDetector) findStronglyConnectedComponents() {
-	// Run Tarjan's algorithm on each unvisited node
-	for moduleName := range cdd.graph.Nodes {
-		if _, visited := cdd.indices[moduleName]; !visited {
-			cdd.strongConnect(moduleName)
-		}
-	}
-}
-
-// strongConnect is the core of Tarjan's algorithm
-func (cdd *CircularDependencyDetector) strongConnect(module string) {
-	// Set the depth index for this node to the smallest unused index
-	cdd.indices[module] = cdd.index
-	cdd.lowLinks[module] = cdd.index
-	cdd.index++
-
-	// Push the node onto the stack
-	cdd.stack = append(cdd.stack, module)
-	cdd.inStack[module] = true
-
-	// Consider successors of the current module
-	if node := cdd.graph.Nodes[module]; node != nil {
-		for dependency := range node.Dependencies {
-			// Lazy (function-body) imports do not run at module load time, so
-			// they cannot form a load-time cycle. Skip them. See issue #460.
-			if node.LazyDependencies[dependency] {
-				continue
-			}
-			if _, visited := cdd.indices[dependency]; !visited {
-				// Successor has not yet been visited; recurse on it
-				cdd.strongConnect(dependency)
-				cdd.lowLinks[module] = minLowLink(cdd.lowLinks[module], cdd.lowLinks[dependency])
-			} else if cdd.inStack[dependency] {
-				// Successor is in stack and hence in the current SCC
-				cdd.lowLinks[module] = minLowLink(cdd.lowLinks[module], cdd.indices[dependency])
-			}
-		}
-	}
-
-	// If this is a root node, pop the stack and create an SCC
-	if cdd.lowLinks[module] == cdd.indices[module] {
-		var component []string
-		for {
-			// Pop from stack
-			top := cdd.stack[len(cdd.stack)-1]
-			cdd.stack = cdd.stack[:len(cdd.stack)-1]
-			cdd.inStack[top] = false
-			component = append(component, top)
-
-			if top == module {
-				break
-			}
-		}
-
-		// Only add components with more than one module (cycles)
-		if len(component) > 1 {
-			// Sort component for consistent ordering
-			sort.Strings(component)
-			cdd.components = append(cdd.components, component)
-		}
-	}
 }
 
 // processComponents converts strongly connected components to circular dependencies
@@ -423,16 +359,6 @@ func (cdd *CircularDependencyDetector) severityOrder(severity CycleSeverity) int
 	default:
 		return 0
 	}
-}
-
-// Utility functions
-
-// minLowLink returns the minimum of two integers for low-link calculation
-func minLowLink(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }
 
 // DetectCircularDependencies is a convenience function for detecting cycles in a graph

--- a/internal/analyzer/circular_detector.go
+++ b/internal/analyzer/circular_detector.go
@@ -35,6 +35,24 @@ func (g loadTimeDependencyGraph) Successors(moduleName string) []string {
 	return dependencies
 }
 
+// Predecessors excludes modules whose edge to moduleName is a lazy import.
+func (g loadTimeDependencyGraph) Predecessors(moduleName string) []string {
+	node := g.Nodes[moduleName]
+	if node == nil {
+		return nil
+	}
+
+	dependents := make([]string, 0, len(node.Dependents))
+	for dependent := range node.Dependents {
+		dependentNode := g.Nodes[dependent]
+		if dependentNode != nil && !dependentNode.LazyDependencies[moduleName] {
+			dependents = append(dependents, dependent)
+		}
+	}
+	sort.Strings(dependents)
+	return dependents
+}
+
 // CircularDependency represents a circular dependency relationship
 type CircularDependency struct {
 	Modules      []string          // Modules involved in the cycle

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -1,8 +1,11 @@
 package analyzer
 
 import (
+	"fmt"
 	"math"
 	"sort"
+
+	coregraph "github.com/ludo-technologies/polyscan/core/graph"
 )
 
 const (
@@ -60,9 +63,42 @@ func NewCouplingMetricsCalculator(graph *DependencyGraph, options *CouplingMetri
 
 // CalculateMetrics calculates all metrics for the dependency graph
 func (calc *CouplingMetricsCalculator) CalculateMetrics() error {
-	// Calculate module-level metrics
-	for moduleName, node := range calc.graph.Nodes {
-		metrics := calc.calculateModuleMetrics(moduleName, node)
+	config := coregraph.CouplingConfig{}
+	if calc.includeAbstractness {
+		config.AbstractnessFunc = func(moduleName string) (float64, error) {
+			node := calc.graph.Nodes[moduleName]
+			if node == nil {
+				return 0, fmt.Errorf("calculate abstractness: module %q not found", moduleName)
+			}
+			return calc.calculateAbstractness(node), nil
+		}
+	}
+
+	coreMetrics, err := coregraph.ComputeCouplingMetrics(calc.graph, config)
+	if err != nil {
+		return fmt.Errorf("calculate coupling metrics: %w", err)
+	}
+
+	for moduleName, coupling := range coreMetrics {
+		node := calc.graph.Nodes[moduleName]
+		if node == nil {
+			return fmt.Errorf("calculate module metrics: module %q not found", moduleName)
+		}
+
+		metrics := &ModuleMetrics{
+			AfferentCoupling:   coupling.Ca,
+			EfferentCoupling:   coupling.Ce,
+			Instability:        coupling.Instability,
+			Abstractness:       coupling.Abstractness,
+			Distance:           coupling.Distance,
+			LinesOfCode:        node.LineCount,
+			ClassCount:         node.ClassCount,
+			AbstractClassCount: node.AbstractClassCount,
+			PublicInterface:    len(node.PublicNames),
+		}
+		if complexity, exists := calc.complexityData[moduleName]; exists {
+			metrics.CyclomaticComplexity = complexity
+		}
 		calc.graph.ModuleMetrics[moduleName] = metrics
 	}
 
@@ -70,44 +106,6 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics() error {
 	calc.calculateSystemMetrics()
 
 	return nil
-}
-
-// calculateModuleMetrics calculates metrics for a single module
-func (calc *CouplingMetricsCalculator) calculateModuleMetrics(moduleName string, node *ModuleNode) *ModuleMetrics {
-	metrics := &ModuleMetrics{}
-
-	// Basic coupling metrics (Robert Martin's metrics)
-	metrics.AfferentCoupling = node.InDegree  // Ca - modules that depend on this one
-	metrics.EfferentCoupling = node.OutDegree // Ce - modules this one depends on
-
-	// Calculate Instability (I = Ce / (Ca + Ce))
-	totalCoupling := metrics.AfferentCoupling + metrics.EfferentCoupling
-	if totalCoupling > 0 {
-		metrics.Instability = float64(metrics.EfferentCoupling) / float64(totalCoupling)
-	} else {
-		metrics.Instability = 0.0
-	}
-
-	// Calculate Abstractness if enabled
-	if calc.includeAbstractness {
-		metrics.Abstractness = calc.calculateAbstractness(node)
-	}
-
-	// Calculate Distance from Main Sequence (D = |A + I - 1|)
-	metrics.Distance = math.Abs(metrics.Abstractness + metrics.Instability - 1.0)
-
-	// Size metrics
-	metrics.LinesOfCode = node.LineCount
-	metrics.ClassCount = node.ClassCount
-	metrics.AbstractClassCount = node.AbstractClassCount
-	metrics.PublicInterface = len(node.PublicNames)
-
-	// Quality metrics from external data
-	if complexity, exists := calc.complexityData[moduleName]; exists {
-		metrics.CyclomaticComplexity = complexity
-	}
-
-	return metrics
 }
 
 // calculateAbstractness calculates the abstractness of a module

--- a/internal/analyzer/dependency_graph.go
+++ b/internal/analyzer/dependency_graph.go
@@ -5,7 +5,11 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	coregraph "github.com/ludo-technologies/polyscan/core/graph"
 )
+
+var _ coregraph.DirectedGraph = (*DependencyGraph)(nil)
 
 // ModuleNode represents a module in the dependency graph
 type ModuleNode struct {
@@ -285,6 +289,52 @@ func (g *DependencyGraph) GetModuleNames() []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// NodeIDs returns all module names in deterministic order for core graph analyses.
+func (g *DependencyGraph) NodeIDs() []string {
+	return g.GetModuleNames()
+}
+
+// Successors returns the modules directly imported by moduleName.
+func (g *DependencyGraph) Successors(moduleName string) []string {
+	node := g.Nodes[moduleName]
+	if node == nil {
+		return nil
+	}
+
+	dependencies := make([]string, 0, len(node.Dependencies))
+	for dependency := range node.Dependencies {
+		dependencies = append(dependencies, dependency)
+	}
+	sort.Strings(dependencies)
+	return dependencies
+}
+
+// Predecessors returns the modules that directly import moduleName.
+func (g *DependencyGraph) Predecessors(moduleName string) []string {
+	node := g.Nodes[moduleName]
+	if node == nil {
+		return nil
+	}
+
+	dependents := make([]string, 0, len(node.Dependents))
+	for dependent := range node.Dependents {
+		dependents = append(dependents, dependent)
+	}
+	sort.Strings(dependents)
+	return dependents
+}
+
+// NodeCount returns the number of modules in the graph.
+func (g *DependencyGraph) NodeCount() int {
+	return len(g.Nodes)
+}
+
+// HasNode reports whether moduleName exists in the graph.
+func (g *DependencyGraph) HasNode(moduleName string) bool {
+	_, exists := g.Nodes[moduleName]
+	return exists
 }
 
 // GetPackages returns all unique package names

--- a/internal/analyzer/module_analyzer_lazy_import_test.go
+++ b/internal/analyzer/module_analyzer_lazy_import_test.go
@@ -159,6 +159,18 @@ def use():
 		t.Errorf("foo.a -> foo.b (top-level import) should NOT be flagged lazy")
 	}
 
+	loadTimeGraph := loadTimeDependencyGraph{graph}
+	if successors := loadTimeGraph.Successors("foo.b"); len(successors) != 0 {
+		t.Errorf("load-time successors of foo.b = %v, want none", successors)
+	}
+	if predecessors := loadTimeGraph.Predecessors("foo.a"); len(predecessors) != 0 {
+		t.Errorf("load-time predecessors of foo.a = %v, want none", predecessors)
+	}
+	predecessors := loadTimeGraph.Predecessors("foo.b")
+	if len(predecessors) != 1 || predecessors[0] != "foo.a" {
+		t.Errorf("load-time predecessors of foo.b = %v, want [foo.a]", predecessors)
+	}
+
 	// Cycle detection must NOT report a cycle, because the only edge closing the
 	// loop is lazy (function-body).
 	result := NewCircularDependencyDetector(graph).DetectCircularDependencies()


### PR DESCRIPTION
## Summary
- implement the polyscan core directed graph interface on pyscn dependency graphs
- delegate coupling metrics and Tarjan SCC detection to `polyscan/core/graph`
- preserve Python-specific abstractness, lazy-import filtering, cycle enrichment, and system metrics
- document ownership of the shared graph kernels

## Testing
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/analyzer ./service`
- `git diff --check`

Tracks ludo-technologies/polyscan#12 (Graph checklist item).