### PR TITLE
Fix module-qualified enum coupling

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -883,6 +883,12 @@ func (a *CBOAnalyzer) callDependencyName(className string, allClasses map[string
 		if binding := parts[0]; a.isImportedDependency(binding) && a.looksLikeClassReference(binding) {
 			return binding
 		}
+		if suppressUppercaseLeaf && len(parts) > 2 {
+			owner := strings.Join(parts[:len(parts)-1], ".")
+			if a.looksLikeClassReference(owner) {
+				return owner
+			}
+		}
 		if suppressUppercaseLeaf && isUppercaseConstant(parts[len(parts)-1]) {
 			return ""
 		}

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -1315,6 +1315,65 @@ class HardcodedRDSPasswordRule:
 	assert.Equal(t, 2, hardcoded.CouplingCount)
 }
 
+func TestCBOAnalyzer_ModuleQualifiedEnumMembersCollapseToEnumClass(t *testing.T) {
+	pythonCode := `
+from pkg import _enums as reflection
+
+class Foo:
+    def bar(self, card):
+        if card == reflection.Cardinality.One:
+            return 1
+        elif card == reflection.Cardinality.Many:
+            return 2
+        return 0
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	options := DefaultCBOOptions()
+	options.GroupNamespaceImports = false
+	results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "main.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	foo := results[0]
+	assert.Equal(t, "Foo", foo.ClassName)
+	assert.Equal(t, []string{"reflection.Cardinality"}, foo.DependentClasses)
+	assert.Equal(t, 1, foo.CouplingCount)
+}
+
+func TestCBOAnalyzer_ModuleQualifiedEnumFixPreservesOtherReferences(t *testing.T) {
+	pythonCode := `
+import models as model_types
+import settings
+from rules import DirectMode
+
+class Consumer:
+    DIRECT = DirectMode.BLOCKING
+    TIMEOUT = settings.DEFAULT_TIMEOUT
+
+    def build(self):
+        first = model_types.Widget()
+        second = model_types.Outer.Inner()
+        return model_types.Widget.create(first, second)
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	options := DefaultCBOOptions()
+	options.GroupNamespaceImports = false
+	results, err := NewCBOAnalyzer(options).AnalyzeClasses(ast, "consumer.py")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	consumer := results[0]
+	assert.Equal(t, "Consumer", consumer.ClassName)
+	assert.Equal(t, []string{"DirectMode", "model_types.Outer", "model_types.Outer.Inner", "model_types.Widget"}, consumer.DependentClasses)
+	assert.Equal(t, 4, consumer.CouplingCount)
+}
+
 func TestCBOAnalyzer_LocalClassMethodCallsCountClassCoupling(t *testing.T) {
 	pythonCode := `
 class Widget:


### PR DESCRIPTION
## Summary

- collapse module-qualified enum member reads to their owning enum class for CBO accounting
- preserve existing handling for direct imports, module constants, constructors, class methods, and nested dotted constructors
- add focused regressions for the reported `reflection.Cardinality.One` case and neighboring behaviors

## Root cause

`callDependencyName` recognized enum members when the imported binding itself looked like a class, but not when a lowercase imported module alias was followed by a class and member. The generic prefix heuristic then treated the member as another class dependency.

## Verification

- focused CBO analyzer tests
- `go test ./...`
- `go test -race ./... -count=1`
- `go vet ./...`
- `golangci-lint run`
- `git diff --check`

Fixes #667