### PR TITLE
docs: point cross-language link to polyscan instead of archived jscan

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -20,7 +20,7 @@ Vous développez avec Cursor, Claude ou ChatGPT ? pyscn effectue une analyse str
 [![Go](https://img.shields.io/github/go-mod/go-version/ludo-technologies/pyscn?style=flat-square&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/github/license/ludo-technologies/pyscn?style=flat-square)](LICENSE)
 
-*Vous travaillez avec JavaScript/TypeScript ? Découvrez [jscan](https://github.com/ludo-technologies/jscan)*
+*Vous travaillez avec d'autres langages ? pyscn fait partie de [polyscan](https://github.com/ludo-technologies/polyscan) — des analyseurs de qualité de code pour JavaScript/TypeScript et plus encore*
 
 </div>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@ Cursor、Claude、ChatGPT で開発していますか？pyscn は構造解析に
 [![Go](https://img.shields.io/github/go-mod/go-version/ludo-technologies/pyscn?style=flat-square&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/github/license/ludo-technologies/pyscn?style=flat-square)](LICENSE)
 
-*JavaScript/TypeScript を扱っていますか？[jscan](https://github.com/ludo-technologies/jscan) をご覧ください*
+*他の言語も扱っていますか？pyscn は [polyscan](https://github.com/ludo-technologies/polyscan) の一部です — JavaScript/TypeScript ほかの言語向けのアナライザーもあります*
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Building with Cursor, Claude, or ChatGPT? pyscn performs structural analysis to 
 [![Go](https://img.shields.io/github/go-mod/go-version/ludo-technologies/pyscn?style=flat-square&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/github/license/ludo-technologies/pyscn?style=flat-square)](LICENSE)
 
-*Working with JavaScript/TypeScript? Check out [jscan](https://github.com/ludo-technologies/jscan)*
+*Working with other languages? pyscn is part of [polyscan](https://github.com/ludo-technologies/polyscan) — code quality analyzers for JavaScript/TypeScript and more*
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
 [![Go](https://img.shields.io/github/go-mod/go-version/ludo-technologies/pyscn?style=flat-square&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/github/license/ludo-technologies/pyscn?style=flat-square)](LICENSE)
 
-*使用 JavaScript/TypeScript？请查看 [jscan](https://github.com/ludo-technologies/jscan)*
+*使用其他语言？pyscn 是 [polyscan](https://github.com/ludo-technologies/polyscan) 的一部分 — 提供 JavaScript/TypeScript 等语言的代码质量分析器*
 
 </div>
 


### PR DESCRIPTION
## Summary
`ludo-technologies/jscan` is archived — jscan now ships from the polyscan monorepo. The cross-language line under the badges in each README still pointed at the old repo, so it now points at [polyscan](https://github.com/ludo-technologies/polyscan).

Before:
> *Working with JavaScript/TypeScript? Check out [jscan](https://github.com/ludo-technologies/jscan)*

After:
> *Working with other languages? pyscn is part of [polyscan](https://github.com/ludo-technologies/polyscan) — code quality analyzers for JavaScript/TypeScript and more*

Applied to all four translations (en / ja / zh-CN / fr). The historical CHANGELOG entry mentioning jscan is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)