### PR TITLE
feat(mcp): list pyscn in the MCP Registry and Glama

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -298,6 +298,39 @@ jobs:
         packages-dir: dist/
         verbose: true
 
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    # Must run after the PyPI upload: the registry verifies ownership by reading
+    # the mcp-name marker out of the published pyscn-mcp description.
+    needs: publish-mcp-pypi
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      contents: read
+      id-token: write  # OIDC token for registry authentication
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set version in server.json from the release tag
+      run: |
+        VERSION="${GITHUB_REF#refs/tags/v}"
+        jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp
+        mv server.tmp server.json
+        cat server.json
+
+    - name: Install mcp-publisher
+      run: |
+        curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+    - name: Authenticate to MCP Registry
+      run: ./mcp-publisher login github-oidc
+
+    - name: Publish server to MCP Registry
+      run: ./mcp-publisher publish
+
   publish-mcp-test-pypi:
     name: Publish pyscn-mcp to Test PyPI
     needs: [build-wheels, test-wheels]

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -306,6 +306,15 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 
+    # The registry's GitHub OIDC auth checks only the repository owner, so the
+    # token this job mints can publish or overwrite ANY server under
+    # io.github.ludo-technologies/*. Anyone able to push a v* tag could point it
+    # at a modified server.json. The protected environment gates that behind a
+    # manual approval; do not remove it without adding a tag ruleset instead.
+    environment:
+      name: mcp-registry
+      url: https://registry.modelcontextprotocol.io/v0/servers?search=pyscn
+
     permissions:
       contents: read
       id-token: write  # OIDC token for registry authentication
@@ -320,6 +329,25 @@ jobs:
         jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > server.tmp
         mv server.tmp server.json
         cat server.json
+
+    # publish-mcp-pypi only guarantees the upload returned. The registry
+    # verifies ownership against the PyPI JSON API, which lags behind by up to
+    # a few minutes, and a 404 or a stale description there fails the publish.
+    - name: Wait for PyPI to serve the new version
+      run: |
+        VERSION="${GITHUB_REF#refs/tags/v}"
+        MARKER="mcp-name: $(jq -r .name server.json)"
+        for attempt in $(seq 1 30); do
+          body=$(curl -fsSL "https://pypi.org/pypi/pyscn-mcp/${VERSION}/json" || true)
+          if [ -n "$body" ] && printf '%s' "$body" | jq -e --arg m "$MARKER" '.info.description | contains($m)' >/dev/null 2>&1; then
+            echo "PyPI is serving pyscn-mcp ${VERSION} with the ownership marker (attempt ${attempt})"
+            exit 0
+          fi
+          echo "attempt ${attempt}/30: version or marker not visible yet, retrying in 20s"
+          sleep 20
+        done
+        echo "::error::PyPI did not serve pyscn-mcp ${VERSION} with '${MARKER}' within 10 minutes"
+        exit 1
 
     - name: Install mcp-publisher
       run: |

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "DaisukeYoda"
+  ]
+}

--- a/python/README-mcp.md
+++ b/python/README-mcp.md
@@ -2,6 +2,12 @@
 
 MCP (Model Context Protocol) server for pyscn Python code analyzer.
 
+<!-- The MCP Registry reads this marker off the published PyPI description to
+     verify that we own the pyscn-mcp package. It must stay identical to the
+     "name" field in server.json, or publishing to the registry fails. -->
+
+mcp-name: io.github.ludo-technologies/pyscn
+
 ## Installation
 
 ```bash

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.ludo-technologies/pyscn",
+  "title": "pyscn",
+  "description": "Python code analysis for AI agents: complexity, dead code, clones, coupling, and a health score.",
+  "repository": {
+    "url": "https://github.com/ludo-technologies/pyscn",
+    "source": "github"
+  },
+  "websiteUrl": "https://pyscn.ludo-tech.org",
+  "version": "1.27.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "pyscn-mcp",
+      "version": "1.27.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "PYSCN_CONFIG",
+          "description": "Path to a .pyscn.toml configuration file. Defaults to the usual config discovery (.pyscn.toml, then pyproject.toml) starting from the analyzed directory.",
+          "isRequired": false,
+          "format": "filepath"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

pyscn cannot be discovered by anyone who does not already know its name.

- Official MCP Registry: searching `pyscn` returns **0 results**. Searching `repowise` returns 2 active entries.
- Glama: not registered.
- GitHub traffic (last 14 days, `traffic/views`): 626 views / **212 unique**, roughly 15 unique visitors a day. Referrers over the same window: Google 30 unique, github.com 16, HN 3, pypi.org 1.

The repo already ships an MCP server (`mcp/`, published as `pyscn-mcp` on PyPI) and a Claude Code plugin, but neither is listed in any directory where people browse for agent tooling.

## Changes

- **`server.json`** — declares the `pyscn-mcp` stdio server under the `io.github.ludo-technologies` namespace. Validated against the official `2025-12-11` schema.
- **`glama.json`** — registers the repo with the Glama MCP directory.
- **`python/README-mcp.md`** — adds the `mcp-name:` ownership marker. The registry reads this off the published PyPI description to verify we control `pyscn-mcp`. It must stay identical to `name` in `server.json`.
- **`.github/workflows/python-release.yml`** — new `publish-mcp-registry` job. Runs after `publish-mcp-pypi`, rewrites `server.json` to the release tag version, authenticates with GitHub OIDC (`id-token: write`), and publishes. Without this the listing would go stale on every release.

## Ordering constraint

The first registry publish can only succeed on the **next release**. Ownership verification reads the description PyPI currently serves, which is 1.27.0, and that does not contain the marker. Tagging `v1.28.0` ships the marker and the publish in the same run.

## Verification

- `server.json` validated against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` with `jsonschema`. The first draft failed on `description` `maxLength: 100` and was shortened to 96 chars.
- `glama.json` and `server.json` parse as JSON; workflow YAML parses and the new job's `needs` / `permissions` / step list were inspected.
- The version-sync `jq` expression was run locally against a simulated `v1.28.0` tag and correctly updates both `.version` and `.packages[0].version`.

**Not verified:** the publish itself. The OIDC auth and the registry's PyPI ownership check can only be exercised by a real tagged release.