### PR TITLE
docs: update CHANGELOG for v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.28.0] - 2026-07-25
+
+### Added
+- List the pyscn MCP server in the official MCP Registry and Glama (#682)
+
+### Changed
+- Point the cross-language link to polyscan instead of the archived jscan (#681)
+
 ## [1.27.0] - 2026-07-25
 
 ### Added


### PR DESCRIPTION
Update CHANGELOG for the v1.28.0 release.

Since v1.27.0:
- #682 — list the pyscn MCP server in the official MCP Registry and Glama
- #681 — point the cross-language link to polyscan instead of the archived jscan

Note: tagging `v1.28.0` is the first release that runs the new `publish-mcp-registry` job. It pauses for a manual approval on the `mcp-registry` environment before publishing.