### PR TITLE
docs: serve documentation at docs.codescan.dev

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -196,7 +196,7 @@ directory = "reports"
 
 ## Documentation
 
-📖 **[Site de documentation pyscn](https://ludo-technologies.github.io/pyscn/fr/)** — installation, catalogue de règles, référence CLI, configuration, spécification des sorties
+📖 **[Site de documentation pyscn](https://docs.codescan.dev/fr/)** — installation, catalogue de règles, référence CLI, configuration, spécification des sorties
 
 Pour les contributeurs : **[Guide de développement](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Tests](docs/TESTING.md)**
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -196,7 +196,7 @@ directory = "reports"
 
 ## ドキュメント
 
-📖 **[pyscn ドキュメントサイト](https://ludo-technologies.github.io/pyscn/ja/)** — インストール、ルールカタログ、CLI リファレンス、設定、出力仕様
+📖 **[pyscn ドキュメントサイト](https://docs.codescan.dev/ja/)** — インストール、ルールカタログ、CLI リファレンス、設定、出力仕様
 
 コントリビューター向け: **[開発ガイド](docs/DEVELOPMENT.md)** • **[アーキテクチャ](docs/ARCHITECTURE.md)** • **[テスト](docs/TESTING.md)**
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ directory = "reports"
 
 ## Documentation
 
-📖 **[pyscn documentation site](https://ludo-technologies.github.io/pyscn/)** — installation, rule catalog, CLI reference, configuration, output specification
+📖 **[pyscn documentation site](https://docs.codescan.dev/)** — installation, rule catalog, CLI reference, configuration, output specification
 
 For contributors: **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,7 +196,7 @@ directory = "reports"
 
 ## 文档
 
-📖 **[pyscn 文档站点](https://ludo-technologies.github.io/pyscn/zh/)** — 安装、规则目录、CLI 参考、配置、输出规范
+📖 **[pyscn 文档站点](https://docs.codescan.dev/zh/)** — 安装、规则目录、CLI 参考、配置、输出规范
 
 贡献者请参阅：**[开发指南](docs/DEVELOPMENT.md)** • **[架构](docs/ARCHITECTURE.md)** • **[测试](docs/TESTING.md)**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ conventions.
 **If you're looking for end-user docs** (installation, CLI usage, rule
 reference, configuration), see:
 
-- <https://ludo-technologies.github.io/pyscn/>
+- <https://docs.codescan.dev/>
 - Source: [`website/`](../website/) in this repository
 
 ## Contents
@@ -28,4 +28,4 @@ reference, configuration), see:
 | [`algorithms/architecture-presets.md`](algorithms/architecture-presets.md) | Architecture style presets (layered/hexagonal/clean/mvc) and `allow`/`deny`/`warn` rule semantics. |
 
 For the user-facing **rule catalog** (problem-based rule names and fixes), see
-<https://ludo-technologies.github.io/pyscn/rules/>.
+<https://docs.codescan.dev/rules/>.

--- a/website/docs/CNAME
+++ b/website/docs/CNAME
@@ -1,0 +1,1 @@
+docs.codescan.dev

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: pyscn
 site_description: An intelligent Python code quality analyzer with CFG-based static analysis
-site_url: https://ludo-technologies.github.io/pyscn/
+site_url: https://docs.codescan.dev/
 site_author: ludo-technologies
 repo_url: https://github.com/ludo-technologies/pyscn
 repo_name: ludo-technologies/pyscn


### PR DESCRIPTION
Moves the MkDocs site from `ludo-technologies.github.io/pyscn` to `docs.codescan.dev`, a subdomain of the polyscan project site.

## Changes

- `website/docs/CNAME` — makes `mkdocs gh-deploy` publish the custom domain, which is what tells GitHub Pages to bind the hostname to this repo
- `website/mkdocs.yml` — `site_url` now points at the new host; verified that canonical tags and `sitemap.xml` update across all four locales (en/ja/zh/fr)
- READMEs (en/ja/fr/zh-CN) and `docs/README.md` — documentation links updated

## Prerequisites (already done)

The Cloudflare DNS record is live and unproxied:

```
docs.codescan.dev  CNAME  ludo-technologies.github.io  (DNS only)
```

## After merge

1. The Documentation workflow deploys gh-pages, and GitHub Pages picks up the custom domain
2. Enable **Enforce HTTPS** in Pages settings once the certificate is provisioned
3. Add `docs.codescan.dev` as a Search Console property

GitHub Pages automatically redirects the old `ludo-technologies.github.io/pyscn` URLs to the new domain, so existing links and inbound SEO are preserved.

Verified with `mkdocs build --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)