### PR TITLE
fix: make dependency analysis scale

### DIFF
--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -202,21 +202,26 @@ Dependency depth measures the length of the longest chain of transitive dependen
 
 ### Calculation
 
-The algorithm performs a recursive DFS from each root module (modules with `OutDegree == 0`), tracking the maximum depth reached. Cycles are handled by maintaining a visited set to prevent infinite recursion.
+The analyzer first condenses every strongly connected component (SCC) into one
+node. It then calculates the longest path through the resulting directed
+acyclic graph in a single topological pass.
 
 ```
-function findMaxDepthFrom(module, visited):
-    if module in visited: return 0
-    visited.add(module)
+components = stronglyConnectedComponents(dependencyGraph)
+dag = condense(dependencyGraph, components)
+depth = zeroes(len(components))
 
-    maxChildDepth = 0
-    for each dependency of module:
-        childDepth = findMaxDepthFrom(dependency, visited)
-        maxChildDepth = max(maxChildDepth, childDepth)
+for component in topologicalOrder(dag):
+    for dependency in dag.dependencies(component):
+        depth[dependency] = max(depth[dependency], depth[component] + 1)
 
-    visited.remove(module)
-    return maxChildDepth + 1
+maxDepth = max(depth)
 ```
+
+Depth counts edges between components. A project with one module has depth
+zero; `A -> B -> C` has depth two. Modules in a cycle form one component
+because the circular dependency is reported separately. The calculation is
+`O(V + E)` in the number of modules and dependencies.
 
 ### Expected Depth
 
@@ -329,7 +334,7 @@ The `SystemMetrics` struct aggregates module-level metrics into project-wide ind
 | Average Abstractness | sum(A) / N | System-wide average abstractness |
 | Main Sequence Deviation | sum(D) / N | Average distance from main sequence |
 | Cyclic Dependencies | count of modules in SCCs | Number of modules involved in cycles |
-| Max Dependency Depth | longest chain length | Maximum transitive dependency depth |
+| Max Dependency Depth | longest SCC-DAG path in edges | Maximum transitive dependency depth |
 
 ### Modularity Index
 

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -228,7 +228,8 @@ keeps the top paths from each component, so the reported top 10 are ranked
 globally rather than selected by traversal order. Component transitions are
 expanded back into real module-to-module dependency paths. When a path crosses
 a cyclic component, the analyzer uses a deterministic internal path between
-the incoming and outgoing modules.
+the incoming and outgoing modules. Coupling metrics consume the same topology
+result instead of rebuilding or traversing the dependency graph again.
 
 ### Expected Depth
 

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -223,6 +223,13 @@ zero; `A -> B -> C` has depth two. Modules in a cycle form one component
 because the circular dependency is reported separately. The calculation is
 `O(V + E)` in the number of modules and dependencies.
 
+Longest-chain reporting uses the same condensed DAG. A bounded dynamic program
+keeps the top paths from each component, so the reported top 10 are ranked
+globally rather than selected by traversal order. Component transitions are
+expanded back into real module-to-module dependency paths. When a path crosses
+a cyclic component, the analyzer uses a deterministic internal path between
+the incoming and outgoing modules.
+
 ### Expected Depth
 
 The expected maximum depth for a well-structured project of N modules is approximately:

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -198,13 +198,16 @@ The system generates actionable refactoring suggestions:
 
 ## Dependency Depth Analysis
 
-Dependency depth measures the length of the longest chain of transitive dependencies starting from any module.
+Dependency depth measures the length of the longest chain of load-time
+dependencies starting from any module. Lazy function and method imports remain
+part of coupling, dependency-matrix, and architecture analysis, but are excluded
+from topology because they cannot form module-load cycles.
 
 ### Calculation
 
-The analyzer first condenses every strongly connected component (SCC) into one
-node. It then calculates the longest path through the resulting directed
-acyclic graph in a single topological pass.
+The analyzer first condenses every strongly connected component (SCC) in the
+load-time dependency graph into one node. It then calculates the longest path
+through the resulting directed acyclic graph in a single topological pass.
 
 ```
 components = stronglyConnectedComponents(dependencyGraph)
@@ -342,7 +345,7 @@ The `SystemMetrics` struct aggregates module-level metrics into project-wide ind
 | Average Abstractness | sum(A) / N | System-wide average abstractness |
 | Main Sequence Deviation | sum(D) / N | Average distance from main sequence |
 | Cyclic Dependencies | count of modules in SCCs | Number of modules involved in cycles |
-| Max Dependency Depth | longest SCC-DAG path in edges | Maximum transitive dependency depth |
+| Max Dependency Depth | longest load-time SCC-DAG path in edges | Maximum transitive dependency depth |
 
 ### Modularity Index
 

--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -119,8 +119,8 @@ type DependencyAnalysisResult struct {
 	CouplingAnalysis *CouplingAnalysis // Detailed coupling analysis
 
 	// Dependency chains
-	LongestChains []DependencyPath // Longest paths through the SCC-condensed dependency graph
-	MaxDepth      int              // Maximum SCC-condensed dependency depth in edges
+	LongestChains []DependencyPath // Longest paths through the load-time SCC-condensed dependency graph
+	MaxDepth      int              // Maximum load-time SCC-condensed dependency depth in edges
 }
 
 // ModuleDependencyMetrics contains dependency metrics for a single module

--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -119,8 +119,8 @@ type DependencyAnalysisResult struct {
 	CouplingAnalysis *CouplingAnalysis // Detailed coupling analysis
 
 	// Dependency chains
-	LongestChains []DependencyPath // Longest dependency chains
-	MaxDepth      int              // Maximum dependency depth
+	LongestChains []DependencyPath // Longest paths through the SCC-condensed dependency graph
+	MaxDepth      int              // Maximum SCC-condensed dependency depth in edges
 }
 
 // ModuleDependencyMetrics contains dependency metrics for a single module

--- a/internal/analyzer/circular_detector.go
+++ b/internal/analyzer/circular_detector.go
@@ -27,7 +27,7 @@ func (g loadTimeDependencyGraph) Successors(moduleName string) []string {
 
 	dependencies := make([]string, 0, len(node.Dependencies))
 	for dependency := range node.Dependencies {
-		if !node.LazyDependencies[dependency] {
+		if node.hasLoadTimeDependency(dependency) {
 			dependencies = append(dependencies, dependency)
 		}
 	}
@@ -45,7 +45,7 @@ func (g loadTimeDependencyGraph) Predecessors(moduleName string) []string {
 	dependents := make([]string, 0, len(node.Dependents))
 	for dependent := range node.Dependents {
 		dependentNode := g.Nodes[dependent]
-		if dependentNode != nil && !dependentNode.LazyDependencies[moduleName] {
+		if dependentNode.hasLoadTimeDependency(moduleName) {
 			dependents = append(dependents, dependent)
 		}
 	}
@@ -185,8 +185,8 @@ func (cdd *CircularDependencyDetector) findDependencyChains(modules []string) []
 	for _, from := range modules {
 		if node := cdd.graph.Nodes[from]; node != nil {
 			for to := range node.Dependencies {
-				if node.LazyDependencies[to] {
-					continue // lazy edges are not load-time dependencies (#460)
+				if !node.hasLoadTimeDependency(to) {
+					continue
 				}
 				if moduleSet[to] {
 					// Find the shortest path from 'from' to 'to' within the component
@@ -226,8 +226,8 @@ func (cdd *CircularDependencyDetector) findPathInComponent(from, to string, modu
 
 		if node := cdd.graph.Nodes[current]; node != nil {
 			for dependency := range node.Dependencies {
-				if node.LazyDependencies[dependency] {
-					continue // lazy edges are not load-time dependencies (#460)
+				if !node.hasLoadTimeDependency(dependency) {
+					continue
 				}
 				if !moduleSet[dependency] {
 					continue // Skip modules outside the component
@@ -414,8 +414,8 @@ func FindSimpleCycles(graph *DependencyGraph) []*CircularDependency {
 			// Check if A depends on B and B depends on A at load time.
 			// Lazy (function-body) imports are excluded: they cannot form a
 			// load-time cycle. See issue #460.
-			aToB := nodeA.Dependencies[moduleB] && !nodeA.LazyDependencies[moduleB]
-			bToA := nodeB.Dependencies[moduleA] && !nodeB.LazyDependencies[moduleA]
+			aToB := nodeA.hasLoadTimeDependency(moduleB)
+			bToA := nodeB.hasLoadTimeDependency(moduleA)
 			if aToB && bToA {
 				cycle := &CircularDependency{
 					Modules:     []string{moduleA, moduleB},

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -210,7 +210,7 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics(
 		systemMetrics.AverageInstability,
 	)
 
-	systemMetrics.MaxDependencyDepth = topology.MaxDepth
+	systemMetrics.MaxDependencyDepth = topology.maxDepth
 
 	// Identify refactoring priorities
 	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities(moduleMetrics)

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -80,15 +80,20 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics(
 		return fmt.Errorf("calculate coupling metrics: dependency topology belongs to another graph")
 	}
 
-	config := coregraph.CouplingConfig{}
-	if calc.includeAbstractness {
-		config.AbstractnessFunc = func(moduleName string) (float64, error) {
+	config := coregraph.CouplingConfig{
+		AbstractnessFunc: func(moduleName string) (float64, error) {
+			if err := ctx.Err(); err != nil {
+				return 0, err
+			}
+			if !calc.includeAbstractness {
+				return 0, nil
+			}
 			node := calc.graph.Nodes[moduleName]
 			if node == nil {
 				return 0, fmt.Errorf("calculate abstractness: module %q not found", moduleName)
 			}
 			return calc.calculateAbstractness(node), nil
-		}
+		},
 	}
 
 	coreMetrics, err := coregraph.ComputeCouplingMetrics(calc.graph, config)

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -61,8 +62,8 @@ func NewCouplingMetricsCalculator(graph *DependencyGraph, options *CouplingMetri
 	}
 }
 
-// CalculateMetrics calculates all metrics for the dependency graph
-func (calc *CouplingMetricsCalculator) CalculateMetrics() error {
+// CalculateMetrics calculates all metrics for the dependency graph.
+func (calc *CouplingMetricsCalculator) CalculateMetrics(ctx context.Context) error {
 	config := coregraph.CouplingConfig{}
 	if calc.includeAbstractness {
 		config.AbstractnessFunc = func(moduleName string) (float64, error) {
@@ -103,9 +104,7 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics() error {
 	}
 
 	// Calculate system-level metrics
-	calc.calculateSystemMetrics()
-
-	return nil
+	return calc.calculateSystemMetrics(ctx)
 }
 
 // calculateAbstractness calculates the abstractness of a module
@@ -117,8 +116,8 @@ func (calc *CouplingMetricsCalculator) calculateAbstractness(node *ModuleNode) f
 	return float64(node.AbstractClassCount) / float64(node.ClassCount)
 }
 
-// calculateSystemMetrics calculates system-wide metrics
-func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
+// calculateSystemMetrics calculates system-wide metrics.
+func (calc *CouplingMetricsCalculator) calculateSystemMetrics(ctx context.Context) error {
 	systemMetrics := calc.graph.SystemMetrics
 
 	// Basic counts
@@ -127,7 +126,7 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
 	systemMetrics.PackageCount = len(calc.graph.GetPackages())
 
 	if systemMetrics.TotalModules == 0 {
-		return
+		return nil
 	}
 
 	// Aggregate metrics
@@ -162,7 +161,11 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
 	systemMetrics.SystemComplexity = calc.calculateSystemComplexity()
 
 	// Calculate max dependency depth
-	systemMetrics.MaxDependencyDepth = calc.calculateMaxDependencyDepth()
+	maxDependencyDepth, err := CalculateMaxDependencyDepth(ctx, calc.graph)
+	if err != nil {
+		return fmt.Errorf("calculate dependency depth: %w", err)
+	}
+	systemMetrics.MaxDependencyDepth = maxDependencyDepth
 
 	// Identify refactoring priorities
 	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities()
@@ -171,6 +174,8 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics() {
 	systemMetrics.ZoneOfPain = calc.modulesMatching(isZoneOfPain)
 	systemMetrics.ZoneOfUselessness = calc.modulesMatching(isZoneOfUselessness)
 	systemMetrics.MainSequence = calc.modulesMatching(isOnMainSequence)
+
+	return nil
 }
 
 func isStableModule(metrics *ModuleMetrics) bool {
@@ -298,48 +303,6 @@ func (calc *CouplingMetricsCalculator) calculateSystemComplexity() float64 {
 	return structuralComplexity*0.4 + sizeComplexity*0.3 + couplingComplexity*0.3
 }
 
-// calculateMaxDependencyDepth calculates the maximum depth of dependency chains
-func (calc *CouplingMetricsCalculator) calculateMaxDependencyDepth() int {
-	maxDepth := 0
-
-	// Start from root modules (no dependencies) and find longest paths
-	rootModules := calc.graph.GetRootModules()
-
-	for _, root := range rootModules {
-		depth := calc.findMaxDepthFrom(root, make(map[string]bool))
-		if depth > maxDepth {
-			maxDepth = depth
-		}
-	}
-
-	return maxDepth
-}
-
-// findMaxDepthFrom finds the maximum depth from a given module
-func (calc *CouplingMetricsCalculator) findMaxDepthFrom(module string, visited map[string]bool) int {
-	if visited[module] {
-		return 0 // Avoid infinite recursion in cycles
-	}
-
-	visited[module] = true
-	defer func() { visited[module] = false }()
-
-	node := calc.graph.Nodes[module]
-	if node == nil {
-		return 0
-	}
-
-	maxChildDepth := 0
-	for dependency := range node.Dependencies {
-		childDepth := calc.findMaxDepthFrom(dependency, visited)
-		if childDepth > maxChildDepth {
-			maxChildDepth = childDepth
-		}
-	}
-
-	return maxChildDepth + 1
-}
-
 // identifyRefactoringPriorities identifies modules that need refactoring most urgently
 func (calc *CouplingMetricsCalculator) identifyRefactoringPriorities() []string {
 	type refactoringCandidate struct {
@@ -406,8 +369,8 @@ func (calc *CouplingMetricsCalculator) isModuleInCycle(moduleName string) bool {
 	return false
 }
 
-// CalculateCouplingMetrics is a convenience function for calculating metrics
-func CalculateCouplingMetrics(graph *DependencyGraph, options *CouplingMetricsOptions) error {
+// CalculateCouplingMetrics is a convenience function for calculating metrics.
+func CalculateCouplingMetrics(ctx context.Context, graph *DependencyGraph, options *CouplingMetricsOptions) error {
 	calculator := NewCouplingMetricsCalculator(graph, options)
-	return calculator.CalculateMetrics()
+	return calculator.CalculateMetrics(ctx)
 }

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -64,6 +64,13 @@ func NewCouplingMetricsCalculator(graph *DependencyGraph, options *CouplingMetri
 
 // CalculateMetrics calculates all metrics for the dependency graph.
 func (calc *CouplingMetricsCalculator) CalculateMetrics(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("calculate coupling metrics: %w", err)
+	}
+
 	config := coregraph.CouplingConfig{}
 	if calc.includeAbstractness {
 		config.AbstractnessFunc = func(moduleName string) (float64, error) {
@@ -79,8 +86,15 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics(ctx context.Context) err
 	if err != nil {
 		return fmt.Errorf("calculate coupling metrics: %w", err)
 	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("calculate coupling metrics: %w", err)
+	}
 
+	moduleMetrics := make(map[string]*ModuleMetrics, len(coreMetrics))
 	for moduleName, coupling := range coreMetrics {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("calculate coupling metrics: %w", err)
+		}
 		node := calc.graph.Nodes[moduleName]
 		if node == nil {
 			return fmt.Errorf("calculate module metrics: module %q not found", moduleName)
@@ -100,11 +114,20 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics(ctx context.Context) err
 		if complexity, exists := calc.complexityData[moduleName]; exists {
 			metrics.CyclomaticComplexity = complexity
 		}
-		calc.graph.ModuleMetrics[moduleName] = metrics
+		moduleMetrics[moduleName] = metrics
 	}
 
-	// Calculate system-level metrics
-	return calc.calculateSystemMetrics(ctx)
+	systemMetrics, err := calc.calculateSystemMetrics(ctx, moduleMetrics)
+	if err != nil {
+		return fmt.Errorf("calculate system metrics: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("calculate coupling metrics: %w", err)
+	}
+
+	calc.graph.ModuleMetrics = moduleMetrics
+	calc.graph.SystemMetrics = systemMetrics
+	return nil
 }
 
 // calculateAbstractness calculates the abstractness of a module
@@ -116,24 +139,29 @@ func (calc *CouplingMetricsCalculator) calculateAbstractness(node *ModuleNode) f
 	return float64(node.AbstractClassCount) / float64(node.ClassCount)
 }
 
-// calculateSystemMetrics calculates system-wide metrics.
-func (calc *CouplingMetricsCalculator) calculateSystemMetrics(ctx context.Context) error {
-	systemMetrics := calc.graph.SystemMetrics
-
-	// Basic counts
-	systemMetrics.TotalModules = calc.graph.TotalModules
-	systemMetrics.TotalDependencies = calc.graph.TotalEdges
-	systemMetrics.PackageCount = len(calc.graph.GetPackages())
+// calculateSystemMetrics calculates system-wide metrics without mutating the graph.
+func (calc *CouplingMetricsCalculator) calculateSystemMetrics(
+	ctx context.Context,
+	moduleMetrics map[string]*ModuleMetrics,
+) (*SystemMetrics, error) {
+	systemMetrics := &SystemMetrics{
+		TotalModules:      calc.graph.TotalModules,
+		TotalDependencies: calc.graph.TotalEdges,
+		PackageCount:      len(calc.graph.GetPackages()),
+	}
 
 	if systemMetrics.TotalModules == 0 {
-		return nil
+		return systemMetrics, nil
 	}
 
 	// Aggregate metrics
 	var totalFanIn, totalFanOut float64
 	var totalInstability, totalAbstractness, totalDistance float64
 
-	for _, metrics := range calc.graph.ModuleMetrics {
+	for _, metrics := range moduleMetrics {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		totalFanIn += float64(metrics.AfferentCoupling)
 		totalFanOut += float64(metrics.EfferentCoupling)
 		totalInstability += metrics.Instability
@@ -158,24 +186,27 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics(ctx context.Contex
 	systemMetrics.CyclicDependencies = len(calc.graph.GetModulesInCycles())
 
 	// Calculate system complexity
-	systemMetrics.SystemComplexity = calc.calculateSystemComplexity()
+	systemMetrics.SystemComplexity = calc.calculateSystemComplexity(
+		moduleMetrics,
+		systemMetrics.AverageInstability,
+	)
 
 	// Calculate max dependency depth
 	maxDependencyDepth, err := CalculateMaxDependencyDepth(ctx, calc.graph)
 	if err != nil {
-		return fmt.Errorf("calculate dependency depth: %w", err)
+		return nil, fmt.Errorf("calculate dependency depth: %w", err)
 	}
 	systemMetrics.MaxDependencyDepth = maxDependencyDepth
 
 	// Identify refactoring priorities
-	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities()
-	systemMetrics.StableModules = calc.modulesMatching(isStableModule)
-	systemMetrics.InstableModules = calc.modulesMatching(isInstableModule)
-	systemMetrics.ZoneOfPain = calc.modulesMatching(isZoneOfPain)
-	systemMetrics.ZoneOfUselessness = calc.modulesMatching(isZoneOfUselessness)
-	systemMetrics.MainSequence = calc.modulesMatching(isOnMainSequence)
+	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities(moduleMetrics)
+	systemMetrics.StableModules = modulesMatching(moduleMetrics, isStableModule)
+	systemMetrics.InstableModules = modulesMatching(moduleMetrics, isInstableModule)
+	systemMetrics.ZoneOfPain = modulesMatching(moduleMetrics, isZoneOfPain)
+	systemMetrics.ZoneOfUselessness = modulesMatching(moduleMetrics, isZoneOfUselessness)
+	systemMetrics.MainSequence = modulesMatching(moduleMetrics, isOnMainSequence)
 
-	return nil
+	return systemMetrics, nil
 }
 
 func isStableModule(metrics *ModuleMetrics) bool {
@@ -203,9 +234,9 @@ func isOnMainSequence(metrics *ModuleMetrics) bool {
 	return metrics.Distance <= mainSequenceMaxDistance
 }
 
-func (calc *CouplingMetricsCalculator) modulesMatching(match func(*ModuleMetrics) bool) []string {
+func modulesMatching(moduleMetrics map[string]*ModuleMetrics, match func(*ModuleMetrics) bool) []string {
 	modules := make([]string, 0)
-	for moduleName, metrics := range calc.graph.ModuleMetrics {
+	for moduleName, metrics := range moduleMetrics {
 		if metrics != nil && match(metrics) {
 			modules = append(modules, moduleName)
 		}
@@ -265,8 +296,11 @@ func (calc *CouplingMetricsCalculator) calculateModularityIndex() float64 {
 	return cohesionRatio * cyclePenalty
 }
 
-// calculateSystemComplexity calculates overall system complexity
-func (calc *CouplingMetricsCalculator) calculateSystemComplexity() float64 {
+// calculateSystemComplexity calculates overall system complexity.
+func (calc *CouplingMetricsCalculator) calculateSystemComplexity(
+	moduleMetrics map[string]*ModuleMetrics,
+	averageInstability float64,
+) float64 {
 	if calc.graph.TotalModules == 0 {
 		return 0.0
 	}
@@ -285,16 +319,15 @@ func (calc *CouplingMetricsCalculator) calculateSystemComplexity() float64 {
 
 	// Coupling complexity (variance in instability)
 	var instabilityVariance float64
-	if len(calc.graph.ModuleMetrics) > 1 {
-		mean := calc.graph.SystemMetrics.AverageInstability
+	if len(moduleMetrics) > 1 {
 		var sumSquaredDiffs float64
 
-		for _, metrics := range calc.graph.ModuleMetrics {
-			diff := metrics.Instability - mean
+		for _, metrics := range moduleMetrics {
+			diff := metrics.Instability - averageInstability
 			sumSquaredDiffs += diff * diff
 		}
 
-		instabilityVariance = sumSquaredDiffs / float64(len(calc.graph.ModuleMetrics))
+		instabilityVariance = sumSquaredDiffs / float64(len(moduleMetrics))
 	}
 
 	couplingComplexity := math.Sqrt(instabilityVariance) * 10 // Scale to reasonable range
@@ -303,8 +336,10 @@ func (calc *CouplingMetricsCalculator) calculateSystemComplexity() float64 {
 	return structuralComplexity*0.4 + sizeComplexity*0.3 + couplingComplexity*0.3
 }
 
-// identifyRefactoringPriorities identifies modules that need refactoring most urgently
-func (calc *CouplingMetricsCalculator) identifyRefactoringPriorities() []string {
+// identifyRefactoringPriorities identifies modules that need refactoring most urgently.
+func (calc *CouplingMetricsCalculator) identifyRefactoringPriorities(
+	moduleMetrics map[string]*ModuleMetrics,
+) []string {
 	type refactoringCandidate struct {
 		module   string
 		priority float64
@@ -312,7 +347,7 @@ func (calc *CouplingMetricsCalculator) identifyRefactoringPriorities() []string 
 
 	var candidates []refactoringCandidate
 
-	for moduleName, metrics := range calc.graph.ModuleMetrics {
+	for moduleName, metrics := range moduleMetrics {
 		priority := 0.0
 
 		// High priority for poor architectural position
@@ -340,6 +375,9 @@ func (calc *CouplingMetricsCalculator) identifyRefactoringPriorities() []string 
 
 	// Sort by priority (highest first)
 	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].priority == candidates[j].priority {
+			return candidates[i].module < candidates[j].module
+		}
 		return candidates[i].priority > candidates[j].priority
 	})
 

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -79,6 +79,10 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics(
 	if topology.graph != calc.graph {
 		return fmt.Errorf("calculate coupling metrics: dependency topology belongs to another graph")
 	}
+	if topology.totalModules != calc.graph.TotalModules ||
+		topology.totalEdges != calc.graph.TotalEdges {
+		return fmt.Errorf("calculate coupling metrics: dependency graph changed after topology analysis")
+	}
 
 	config := coregraph.CouplingConfig{
 		AbstractnessFunc: func(moduleName string) (float64, error) {

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -63,12 +63,21 @@ func NewCouplingMetricsCalculator(graph *DependencyGraph, options *CouplingMetri
 }
 
 // CalculateMetrics calculates all metrics for the dependency graph.
-func (calc *CouplingMetricsCalculator) CalculateMetrics(ctx context.Context) error {
+func (calc *CouplingMetricsCalculator) CalculateMetrics(
+	ctx context.Context,
+	topology *DependencyTopology,
+) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("calculate coupling metrics: %w", err)
+	}
+	if topology == nil {
+		return fmt.Errorf("calculate coupling metrics: dependency topology is required")
+	}
+	if topology.graph != calc.graph {
+		return fmt.Errorf("calculate coupling metrics: dependency topology belongs to another graph")
 	}
 
 	config := coregraph.CouplingConfig{}
@@ -117,7 +126,7 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics(ctx context.Context) err
 		moduleMetrics[moduleName] = metrics
 	}
 
-	systemMetrics, err := calc.calculateSystemMetrics(ctx, moduleMetrics)
+	systemMetrics, err := calc.calculateSystemMetrics(ctx, moduleMetrics, topology)
 	if err != nil {
 		return fmt.Errorf("calculate system metrics: %w", err)
 	}
@@ -143,6 +152,7 @@ func (calc *CouplingMetricsCalculator) calculateAbstractness(node *ModuleNode) f
 func (calc *CouplingMetricsCalculator) calculateSystemMetrics(
 	ctx context.Context,
 	moduleMetrics map[string]*ModuleMetrics,
+	topology *DependencyTopology,
 ) (*SystemMetrics, error) {
 	systemMetrics := &SystemMetrics{
 		TotalModules:      calc.graph.TotalModules,
@@ -191,12 +201,7 @@ func (calc *CouplingMetricsCalculator) calculateSystemMetrics(
 		systemMetrics.AverageInstability,
 	)
 
-	// Calculate max dependency depth
-	maxDependencyDepth, err := CalculateMaxDependencyDepth(ctx, calc.graph)
-	if err != nil {
-		return nil, fmt.Errorf("calculate dependency depth: %w", err)
-	}
-	systemMetrics.MaxDependencyDepth = maxDependencyDepth
+	systemMetrics.MaxDependencyDepth = topology.MaxDepth
 
 	// Identify refactoring priorities
 	systemMetrics.RefactoringPriority = calc.identifyRefactoringPriorities(moduleMetrics)
@@ -408,7 +413,12 @@ func (calc *CouplingMetricsCalculator) isModuleInCycle(moduleName string) bool {
 }
 
 // CalculateCouplingMetrics is a convenience function for calculating metrics.
-func CalculateCouplingMetrics(ctx context.Context, graph *DependencyGraph, options *CouplingMetricsOptions) error {
+func CalculateCouplingMetrics(
+	ctx context.Context,
+	graph *DependencyGraph,
+	topology *DependencyTopology,
+	options *CouplingMetricsOptions,
+) error {
 	calculator := NewCouplingMetricsCalculator(graph, options)
-	return calculator.CalculateMetrics(ctx)
+	return calculator.CalculateMetrics(ctx, topology)
 }

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -62,7 +62,7 @@ func NewCouplingMetricsCalculator(graph *DependencyGraph, options *CouplingMetri
 	}
 }
 
-// CalculateMetrics calculates all metrics for the dependency graph.
+// CalculateMetrics calculates all metrics using topology from the same graph.
 func (calc *CouplingMetricsCalculator) CalculateMetrics(
 	ctx context.Context,
 	topology *DependencyTopology,

--- a/internal/analyzer/coupling_metrics.go
+++ b/internal/analyzer/coupling_metrics.go
@@ -79,8 +79,7 @@ func (calc *CouplingMetricsCalculator) CalculateMetrics(
 	if topology.graph != calc.graph {
 		return fmt.Errorf("calculate coupling metrics: dependency topology belongs to another graph")
 	}
-	if topology.totalModules != calc.graph.TotalModules ||
-		topology.totalEdges != calc.graph.TotalEdges {
+	if topology.graphRevision != calc.graph.topologyRevision {
 		return fmt.Errorf("calculate coupling metrics: dependency graph changed after topology analysis")
 	}
 

--- a/internal/analyzer/dependency_chains.go
+++ b/internal/analyzer/dependency_chains.go
@@ -20,26 +20,22 @@ func FindLongestDependencyChains(
 	graph *DependencyGraph,
 	limit int,
 ) ([]DependencyChain, error) {
-	if graph == nil {
-		return nil, fmt.Errorf("dependency graph is required")
+	topology, err := AnalyzeDependencyTopology(ctx, graph, limit)
+	if err != nil {
+		return nil, fmt.Errorf("analyze dependency topology: %w", err)
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
+	return topology.LongestChains, nil
+}
+
+func findLongestDependencyChains(
+	ctx context.Context,
+	graph *DependencyGraph,
+	condensed *condensedDependencyGraph,
+	order []int,
+	limit int,
+) ([]DependencyChain, error) {
 	if limit <= 0 || len(graph.Nodes) == 0 {
 		return nil, nil
-	}
-
-	condensed, err := buildCondensedDependencyGraph(ctx, graph)
-	if err != nil {
-		return nil, fmt.Errorf("build condensed dependency graph: %w", err)
-	}
-	order, err := condensed.topologicalOrder(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("order condensed dependency graph: %w", err)
 	}
 
 	bestByComponent := make([][]*componentPath, len(condensed.dependencies))

--- a/internal/analyzer/dependency_chains.go
+++ b/internal/analyzer/dependency_chains.go
@@ -1,0 +1,225 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+type componentPath struct {
+	component int
+	next      *componentPath
+	length    int
+}
+
+// FindLongestDependencyChains returns the longest paths through the
+// SCC-condensed dependency graph. The result is bounded by limit and ordered
+// by component depth, then lexicographically for deterministic ties.
+func FindLongestDependencyChains(
+	ctx context.Context,
+	graph *DependencyGraph,
+	limit int,
+) ([]DependencyChain, error) {
+	if graph == nil {
+		return nil, fmt.Errorf("dependency graph is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || len(graph.Nodes) == 0 {
+		return nil, nil
+	}
+
+	condensed, err := buildCondensedDependencyGraph(ctx, graph)
+	if err != nil {
+		return nil, err
+	}
+	order, err := condensed.topologicalOrder(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	bestByComponent := make([][]*componentPath, len(condensed.dependencies))
+	for index := len(order) - 1; index >= 0; index-- {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		component := order[index]
+		candidates := make([]*componentPath, 0)
+		if len(condensed.dependencies[component]) == 0 {
+			candidates = append(candidates, &componentPath{
+				component: component,
+				length:    1,
+			})
+		} else {
+			for dependency := range condensed.dependencies[component] {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
+				for _, suffix := range bestByComponent[dependency] {
+					candidates = append(candidates, &componentPath{
+						component: component,
+						next:      suffix,
+						length:    suffix.length + 1,
+					})
+				}
+			}
+		}
+		sortComponentPaths(candidates, condensed.componentNames)
+		if len(candidates) > limit {
+			candidates = candidates[:limit]
+		}
+		bestByComponent[component] = candidates
+	}
+
+	candidates := make([]*componentPath, 0, len(condensed.dependencies)*limit)
+	for _, paths := range bestByComponent {
+		for _, path := range paths {
+			if path.length > 1 {
+				candidates = append(candidates, path)
+			}
+		}
+	}
+	sortComponentPaths(candidates, condensed.componentNames)
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	chains := make([]DependencyChain, 0, len(candidates))
+	for _, candidate := range candidates {
+		path, err := expandComponentPath(ctx, graph, condensed, candidate)
+		if err != nil {
+			return nil, err
+		}
+		chains = append(chains, DependencyChain{
+			From:   path[0],
+			To:     path[len(path)-1],
+			Path:   path,
+			Length: len(path),
+		})
+	}
+	return chains, nil
+}
+
+func sortComponentPaths(paths []*componentPath, componentNames []string) {
+	sort.Slice(paths, func(left, right int) bool {
+		return componentPathLess(paths[left], paths[right], componentNames)
+	})
+}
+
+func componentPathLess(left, right *componentPath, componentNames []string) bool {
+	if left.length != right.length {
+		return left.length > right.length
+	}
+	for left != nil && right != nil {
+		leftName := componentNames[left.component]
+		rightName := componentNames[right.component]
+		if leftName != rightName {
+			return leftName < rightName
+		}
+		left = left.next
+		right = right.next
+	}
+	return false
+}
+
+func expandComponentPath(
+	ctx context.Context,
+	graph *DependencyGraph,
+	condensed *condensedDependencyGraph,
+	path *componentPath,
+) ([]string, error) {
+	firstEdge := condensed.dependencies[path.component][path.next.component]
+	modules := []string{firstEdge.fromModule, firstEdge.toModule}
+	currentModule := firstEdge.toModule
+	path = path.next
+
+	for path.next != nil {
+		edge := condensed.dependencies[path.component][path.next.component]
+		connector, err := findComponentPath(
+			ctx,
+			graph,
+			condensed.componentByModule,
+			path.component,
+			currentModule,
+			edge.fromModule,
+		)
+		if err != nil {
+			return nil, err
+		}
+		modules = append(modules, connector[1:]...)
+		modules = append(modules, edge.toModule)
+		currentModule = edge.toModule
+		path = path.next
+	}
+
+	return modules, nil
+}
+
+func findComponentPath(
+	ctx context.Context,
+	graph *DependencyGraph,
+	componentByModule map[string]int,
+	component int,
+	fromModule string,
+	toModule string,
+) ([]string, error) {
+	if fromModule == toModule {
+		return []string{fromModule}, nil
+	}
+
+	queue := []string{fromModule}
+	previous := map[string]string{fromModule: ""}
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		current := queue[0]
+		queue = queue[1:]
+
+		dependencies := make([]string, 0, len(graph.Nodes[current].Dependencies))
+		for dependency := range graph.Nodes[current].Dependencies {
+			if componentByModule[dependency] == component {
+				dependencies = append(dependencies, dependency)
+			}
+		}
+		sort.Strings(dependencies)
+
+		for _, dependency := range dependencies {
+			if _, visited := previous[dependency]; visited {
+				continue
+			}
+			previous[dependency] = current
+			if dependency == toModule {
+				return reconstructDependencyPath(previous, fromModule, toModule), nil
+			}
+			queue = append(queue, dependency)
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"component %d has no path from %q to %q",
+		component,
+		fromModule,
+		toModule,
+	)
+}
+
+func reconstructDependencyPath(
+	previous map[string]string,
+	fromModule string,
+	toModule string,
+) []string {
+	path := []string{toModule}
+	for current := toModule; current != fromModule; {
+		current = previous[current]
+		path = append(path, current)
+	}
+	for left, right := 0, len(path)-1; left < right; left, right = left+1, right-1 {
+		path[left], path[right] = path[right], path[left]
+	}
+	return path
+}

--- a/internal/analyzer/dependency_chains.go
+++ b/internal/analyzer/dependency_chains.go
@@ -12,21 +12,6 @@ type componentPath struct {
 	length    int
 }
 
-// FindLongestDependencyChains returns the longest paths through the
-// SCC-condensed dependency graph. The result is bounded by limit and ordered
-// by component depth, then lexicographically for deterministic ties.
-func FindLongestDependencyChains(
-	ctx context.Context,
-	graph *DependencyGraph,
-	limit int,
-) ([]DependencyChain, error) {
-	topology, err := AnalyzeDependencyTopology(ctx, graph, limit)
-	if err != nil {
-		return nil, fmt.Errorf("analyze dependency topology: %w", err)
-	}
-	return topology.LongestChains, nil
-}
-
 func findLongestDependencyChains(
 	ctx context.Context,
 	graph *DependencyGraph,

--- a/internal/analyzer/dependency_chains.go
+++ b/internal/analyzer/dependency_chains.go
@@ -163,7 +163,8 @@ func findComponentPath(
 
 		dependencies := make([]string, 0, len(graph.Nodes[current].Dependencies))
 		for dependency := range graph.Nodes[current].Dependencies {
-			if componentByModule[dependency] == component {
+			if graph.Nodes[current].hasLoadTimeDependency(dependency) &&
+				componentByModule[dependency] == component {
 				dependencies = append(dependencies, dependency)
 			}
 		}

--- a/internal/analyzer/dependency_chains.go
+++ b/internal/analyzer/dependency_chains.go
@@ -35,11 +35,11 @@ func FindLongestDependencyChains(
 
 	condensed, err := buildCondensedDependencyGraph(ctx, graph)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("build condensed dependency graph: %w", err)
 	}
 	order, err := condensed.topologicalOrder(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("order condensed dependency graph: %w", err)
 	}
 
 	bestByComponent := make([][]*componentPath, len(condensed.dependencies))
@@ -92,7 +92,7 @@ func FindLongestDependencyChains(
 	for _, candidate := range candidates {
 		path, err := expandComponentPath(ctx, graph, condensed, candidate)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("expand dependency chain: %w", err)
 		}
 		chains = append(chains, DependencyChain{
 			From:   path[0],

--- a/internal/analyzer/dependency_graph.go
+++ b/internal/analyzer/dependency_graph.go
@@ -46,6 +46,16 @@ type ModuleNode struct {
 	PublicNames        []string // Public names exported by this module
 }
 
+// hasLoadTimeDependency reports whether dependency executes while the module
+// is loading. Lazy-only function and method imports remain runtime dependencies
+// for coupling and architecture analysis, but do not participate in load-time
+// topology.
+func (node *ModuleNode) hasLoadTimeDependency(dependency string) bool {
+	return node != nil &&
+		node.Dependencies[dependency] &&
+		!node.LazyDependencies[dependency]
+}
+
 // DependencyEdge represents a dependency relationship between modules
 type DependencyEdge struct {
 	From       string             // Source module name
@@ -94,6 +104,8 @@ type DependencyGraph struct {
 	CyclicGroups  [][]string                // Strongly connected components (cycles)
 	ModuleMetrics map[string]*ModuleMetrics // Module-level metrics
 	SystemMetrics *SystemMetrics            // System-wide metrics
+
+	topologyRevision uint64
 }
 
 // ModuleMetrics contains metrics for a single module
@@ -192,6 +204,7 @@ func (g *DependencyGraph) AddModule(moduleName, filePath string) *ModuleNode {
 
 	g.Nodes[moduleName] = node
 	g.TotalModules++
+	g.topologyRevision++
 	return node
 }
 
@@ -222,6 +235,7 @@ func (g *DependencyGraph) AddDependency(from, to string, edgeType DependencyEdge
 			if edge := g.findEdge(from, to); edge != nil {
 				edge.IsLazy = false
 			}
+			g.topologyRevision++
 		}
 		return
 	}
@@ -236,6 +250,7 @@ func (g *DependencyGraph) AddDependency(from, to string, edgeType DependencyEdge
 	}
 	g.Edges = append(g.Edges, edge)
 	g.TotalEdges++
+	g.topologyRevision++
 
 	// Update node relationships
 	fromNode.Dependencies[to] = true
@@ -549,6 +564,7 @@ func (g *DependencyGraph) Clone() *DependencyGraph {
 
 	clone.TotalModules = g.TotalModules
 	clone.TotalEdges = g.TotalEdges
+	clone.topologyRevision = g.topologyRevision
 
 	return clone
 }

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -17,33 +17,78 @@ type condensedDependencyGraph struct {
 	inDegree          []int
 }
 
-// CalculateMaxDependencyDepth returns the maximum number of edges between
-// strongly connected components in the dependency graph. Modules in a cycle
-// form one component because circular dependencies are reported separately.
-func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (int, error) {
+// DependencyTopology is the canonical structural analysis of one dependency
+// graph. MaxDepth and LongestChains share the same SCC condensation.
+type DependencyTopology struct {
+	MaxDepth      int
+	LongestChains []DependencyChain
+
+	graph *DependencyGraph
+}
+
+// AnalyzeDependencyTopology condenses a dependency graph and calculates its
+// maximum depth and globally ranked dependency chains in one pass.
+func AnalyzeDependencyTopology(
+	ctx context.Context,
+	graph *DependencyGraph,
+	chainLimit int,
+) (*DependencyTopology, error) {
 	if graph == nil {
-		return 0, fmt.Errorf("dependency graph is required")
+		return nil, fmt.Errorf("dependency graph is required")
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return 0, err
-	}
-	if len(graph.Nodes) == 0 {
-		return 0, nil
+		return nil, fmt.Errorf("analyze dependency topology: %w", err)
 	}
 
 	condensed, err := buildCondensedDependencyGraph(ctx, graph)
 	if err != nil {
-		return 0, err
+		return nil, fmt.Errorf("build condensed dependency graph: %w", err)
 	}
-
 	order, err := condensed.topologicalOrder(ctx)
 	if err != nil {
-		return 0, err
+		return nil, fmt.Errorf("order condensed dependency graph: %w", err)
+	}
+	maxDepth, err := calculateMaxDependencyDepth(ctx, condensed, order)
+	if err != nil {
+		return nil, fmt.Errorf("calculate dependency depth: %w", err)
+	}
+	longestChains, err := findLongestDependencyChains(
+		ctx,
+		graph,
+		condensed,
+		order,
+		chainLimit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find dependency chains: %w", err)
 	}
 
+	return &DependencyTopology{
+		MaxDepth:      maxDepth,
+		LongestChains: longestChains,
+		graph:         graph,
+	}, nil
+}
+
+// CalculateMaxDependencyDepth returns the maximum number of edges between
+// strongly connected components in the dependency graph. Modules in a cycle
+// form one component because circular dependencies are reported separately.
+func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (int, error) {
+	topology, err := AnalyzeDependencyTopology(ctx, graph, 0)
+	if err != nil {
+		return 0, fmt.Errorf("analyze dependency topology: %w", err)
+	}
+	return topology.MaxDepth, nil
+}
+
+func calculateMaxDependencyDepth(
+	ctx context.Context,
+	condensed *condensedDependencyGraph,
+	order []int,
+) (int, error) {
 	depth := make([]int, len(condensed.dependencies))
 	maxDepth := 0
 	for _, component := range order {

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -73,17 +73,6 @@ func AnalyzeDependencyTopology(
 	}, nil
 }
 
-// CalculateMaxDependencyDepth returns the maximum number of edges between
-// strongly connected components in the dependency graph. Modules in a cycle
-// form one component because circular dependencies are reported separately.
-func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (int, error) {
-	topology, err := AnalyzeDependencyTopology(ctx, graph, 0)
-	if err != nil {
-		return 0, fmt.Errorf("analyze dependency topology: %w", err)
-	}
-	return topology.MaxDepth, nil
-}
-
 func calculateMaxDependencyDepth(
 	ctx context.Context,
 	condensed *condensedDependencyGraph,

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -5,6 +5,18 @@ import (
 	"fmt"
 )
 
+type componentDependency struct {
+	fromModule string
+	toModule   string
+}
+
+type condensedDependencyGraph struct {
+	componentByModule map[string]int
+	componentNames    []string
+	dependencies      []map[int]componentDependency
+	inDegree          []int
+}
+
 // CalculateMaxDependencyDepth returns the maximum number of edges between
 // strongly connected components in the dependency graph. Modules in a cycle
 // form one component because circular dependencies are reported separately.
@@ -22,55 +34,23 @@ func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (i
 		return 0, nil
 	}
 
-	componentByModule, componentCount, err := dependencyComponents(ctx, graph)
+	condensed, err := buildCondensedDependencyGraph(ctx, graph)
 	if err != nil {
-		return 0, fmt.Errorf("calculate dependency components: %w", err)
+		return 0, err
 	}
 
-	dependencies := make([]map[int]struct{}, componentCount)
-	inDegree := make([]int, componentCount)
-	for index := range dependencies {
-		dependencies[index] = make(map[int]struct{})
+	order, err := condensed.topologicalOrder(ctx)
+	if err != nil {
+		return 0, err
 	}
 
-	for moduleName, node := range graph.Nodes {
-		if err := ctx.Err(); err != nil {
-			return 0, err
-		}
-		fromComponent := componentByModule[moduleName]
-		for dependency := range node.Dependencies {
-			toComponent := componentByModule[dependency]
-			if fromComponent == toComponent {
-				continue
-			}
-			if _, exists := dependencies[fromComponent][toComponent]; exists {
-				continue
-			}
-			dependencies[fromComponent][toComponent] = struct{}{}
-			inDegree[toComponent]++
-		}
-	}
-
-	queue := make([]int, 0, componentCount)
-	for component, degree := range inDegree {
-		if degree == 0 {
-			queue = append(queue, component)
-		}
-	}
-
-	depth := make([]int, componentCount)
+	depth := make([]int, len(condensed.dependencies))
 	maxDepth := 0
-	processed := 0
-	for len(queue) > 0 {
+	for _, component := range order {
 		if err := ctx.Err(); err != nil {
 			return 0, err
 		}
-
-		component := queue[0]
-		queue = queue[1:]
-		processed++
-
-		for dependency := range dependencies[component] {
+		for dependency := range condensed.dependencies[component] {
 			candidateDepth := depth[component] + 1
 			if candidateDepth > depth[dependency] {
 				depth[dependency] = candidateDepth
@@ -78,6 +58,86 @@ func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (i
 					maxDepth = candidateDepth
 				}
 			}
+		}
+	}
+
+	return maxDepth, nil
+}
+
+func buildCondensedDependencyGraph(
+	ctx context.Context,
+	graph *DependencyGraph,
+) (*condensedDependencyGraph, error) {
+	componentByModule, componentCount, err := dependencyComponents(ctx, graph)
+	if err != nil {
+		return nil, fmt.Errorf("calculate dependency components: %w", err)
+	}
+
+	condensed := &condensedDependencyGraph{
+		componentByModule: componentByModule,
+		componentNames:    make([]string, componentCount),
+		dependencies:      make([]map[int]componentDependency, componentCount),
+		inDegree:          make([]int, componentCount),
+	}
+	for component := range condensed.dependencies {
+		condensed.dependencies[component] = make(map[int]componentDependency)
+	}
+	for moduleName, component := range componentByModule {
+		if condensed.componentNames[component] == "" ||
+			moduleName < condensed.componentNames[component] {
+			condensed.componentNames[component] = moduleName
+		}
+	}
+
+	for moduleName, node := range graph.Nodes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		fromComponent := componentByModule[moduleName]
+		for dependency := range node.Dependencies {
+			toComponent := componentByModule[dependency]
+			if fromComponent == toComponent {
+				continue
+			}
+
+			candidate := componentDependency{
+				fromModule: moduleName,
+				toModule:   dependency,
+			}
+			existing, exists := condensed.dependencies[fromComponent][toComponent]
+			if exists {
+				if dependencyEdgeLess(candidate, existing) {
+					condensed.dependencies[fromComponent][toComponent] = candidate
+				}
+				continue
+			}
+			condensed.dependencies[fromComponent][toComponent] = candidate
+			condensed.inDegree[toComponent]++
+		}
+	}
+
+	return condensed, nil
+}
+
+func (graph *condensedDependencyGraph) topologicalOrder(ctx context.Context) ([]int, error) {
+	inDegree := append([]int(nil), graph.inDegree...)
+	queue := make([]int, 0, len(inDegree))
+	for component, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, component)
+		}
+	}
+
+	order := make([]int, 0, len(inDegree))
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		component := queue[0]
+		queue = queue[1:]
+		order = append(order, component)
+
+		for dependency := range graph.dependencies[component] {
 			inDegree[dependency]--
 			if inDegree[dependency] == 0 {
 				queue = append(queue, dependency)
@@ -85,10 +145,17 @@ func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (i
 		}
 	}
 
-	if processed != componentCount {
-		return 0, fmt.Errorf("condensed dependency graph contains a cycle")
+	if len(order) != len(inDegree) {
+		return nil, fmt.Errorf("condensed dependency graph contains a cycle")
 	}
-	return maxDepth, nil
+	return order, nil
+}
+
+func dependencyEdgeLess(left, right componentDependency) bool {
+	if left.fromModule != right.fromModule {
+		return left.fromModule < right.fromModule
+	}
+	return left.toModule < right.toModule
 }
 
 func dependencyComponents(

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -3,8 +3,6 @@ package analyzer
 import (
 	"context"
 	"fmt"
-
-	coregraph "github.com/ludo-technologies/polyscan/core/graph"
 )
 
 // CalculateMaxDependencyDepth returns the maximum number of edges between
@@ -24,12 +22,11 @@ func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (i
 		return 0, nil
 	}
 
-	cycles := coregraph.NewCycleDetector().DetectCycles(graph).Cycles
-	if err := ctx.Err(); err != nil {
-		return 0, err
+	componentByModule, componentCount, err := dependencyComponents(ctx, graph)
+	if err != nil {
+		return 0, fmt.Errorf("calculate dependency components: %w", err)
 	}
 
-	componentByModule, componentCount := dependencyComponents(graph, cycles)
 	dependencies := make([]map[int]struct{}, componentCount)
 	inDegree := make([]int, componentCount)
 	for index := range dependencies {
@@ -94,24 +91,85 @@ func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (i
 	return maxDepth, nil
 }
 
-func dependencyComponents(graph *DependencyGraph, cycles [][]string) (map[string]int, int) {
+func dependencyComponents(
+	ctx context.Context,
+	graph *DependencyGraph,
+) (map[string]int, int, error) {
 	componentByModule := make(map[string]int, len(graph.Nodes))
+	indexByModule := make(map[string]int, len(graph.Nodes))
+	lowLinkByModule := make(map[string]int, len(graph.Nodes))
+	onStack := make(map[string]bool, len(graph.Nodes))
+	stack := make([]string, 0, len(graph.Nodes))
+	nextIndex := 0
 	componentCount := 0
 
-	for _, cycle := range cycles {
-		for _, moduleName := range cycle {
-			componentByModule[moduleName] = componentCount
+	var visit func(string) error
+	visit = func(moduleName string) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		node := graph.Nodes[moduleName]
+		if node == nil {
+			return fmt.Errorf("module %q has no graph node", moduleName)
+		}
+
+		indexByModule[moduleName] = nextIndex
+		lowLinkByModule[moduleName] = nextIndex
+		nextIndex++
+		stack = append(stack, moduleName)
+		onStack[moduleName] = true
+
+		for dependency := range node.Dependencies {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if _, exists := graph.Nodes[dependency]; !exists {
+				return fmt.Errorf(
+					"module %q depends on unknown module %q",
+					moduleName,
+					dependency,
+				)
+			}
+
+			dependencyIndex, visited := indexByModule[dependency]
+			if !visited {
+				if err := visit(dependency); err != nil {
+					return err
+				}
+				if lowLinkByModule[dependency] < lowLinkByModule[moduleName] {
+					lowLinkByModule[moduleName] = lowLinkByModule[dependency]
+				}
+			} else if onStack[dependency] && dependencyIndex < lowLinkByModule[moduleName] {
+				lowLinkByModule[moduleName] = dependencyIndex
+			}
+		}
+
+		if lowLinkByModule[moduleName] != indexByModule[moduleName] {
+			return nil
+		}
+
+		for {
+			stackIndex := len(stack) - 1
+			member := stack[stackIndex]
+			stack = stack[:stackIndex]
+			onStack[member] = false
+			componentByModule[member] = componentCount
+			if member == moduleName {
+				break
+			}
 		}
 		componentCount++
+		return nil
 	}
 
 	for moduleName := range graph.Nodes {
-		if _, assigned := componentByModule[moduleName]; assigned {
+		if _, visited := indexByModule[moduleName]; visited {
 			continue
 		}
-		componentByModule[moduleName] = componentCount
-		componentCount++
+		if err := visit(moduleName); err != nil {
+			return nil, 0, err
+		}
 	}
 
-	return componentByModule, componentCount
+	return componentByModule, componentCount, nil
 }

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -19,8 +19,9 @@ type condensedDependencyGraph struct {
 
 // DependencyTopology is the canonical structural analysis of one dependency
 // graph. MaxDepth and LongestChains share the same SCC condensation. A result
-// belongs to the exact graph state passed to AnalyzeDependencyTopology and is
-// invalidated by subsequent structural mutations.
+// belongs to the exact graph instance passed to AnalyzeDependencyTopology.
+// Structural mutations through AddModule or AddDependency invalidate it;
+// directly mutating DependencyGraph storage is unsupported.
 type DependencyTopology struct {
 	maxDepth      int
 	longestChains []DependencyChain

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -22,12 +22,26 @@ type condensedDependencyGraph struct {
 // belongs to the exact graph state passed to AnalyzeDependencyTopology and is
 // invalidated by subsequent structural mutations.
 type DependencyTopology struct {
-	MaxDepth      int
-	LongestChains []DependencyChain
+	maxDepth      int
+	longestChains []DependencyChain
+	graph         *DependencyGraph
+	totalModules  int
+	totalEdges    int
+}
 
-	graph        *DependencyGraph
-	totalModules int
-	totalEdges   int
+// MaxDepth returns the maximum number of edges between SCCs.
+func (topology *DependencyTopology) MaxDepth() int {
+	return topology.maxDepth
+}
+
+// LongestChains returns a defensive copy of the ranked dependency chains.
+func (topology *DependencyTopology) LongestChains() []DependencyChain {
+	chains := make([]DependencyChain, len(topology.longestChains))
+	copy(chains, topology.longestChains)
+	for index := range chains {
+		chains[index].Path = append([]string(nil), chains[index].Path...)
+	}
+	return chains
 }
 
 // AnalyzeDependencyTopology condenses a dependency graph and calculates its
@@ -71,8 +85,8 @@ func AnalyzeDependencyTopology(
 	}
 
 	return &DependencyTopology{
-		MaxDepth:      maxDepth,
-		LongestChains: longestChains,
+		maxDepth:      maxDepth,
+		longestChains: longestChains,
 		graph:         graph,
 		totalModules:  graph.TotalModules,
 		totalEdges:    graph.TotalEdges,

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -1,0 +1,117 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+
+	coregraph "github.com/ludo-technologies/polyscan/core/graph"
+)
+
+// CalculateMaxDependencyDepth returns the maximum number of edges between
+// strongly connected components in the dependency graph. Modules in a cycle
+// form one component because circular dependencies are reported separately.
+func CalculateMaxDependencyDepth(ctx context.Context, graph *DependencyGraph) (int, error) {
+	if graph == nil {
+		return 0, fmt.Errorf("dependency graph is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(graph.Nodes) == 0 {
+		return 0, nil
+	}
+
+	cycles := coregraph.NewCycleDetector().DetectCycles(graph).Cycles
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	componentByModule, componentCount := dependencyComponents(graph, cycles)
+	dependencies := make([]map[int]struct{}, componentCount)
+	inDegree := make([]int, componentCount)
+	for index := range dependencies {
+		dependencies[index] = make(map[int]struct{})
+	}
+
+	for moduleName, node := range graph.Nodes {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		fromComponent := componentByModule[moduleName]
+		for dependency := range node.Dependencies {
+			toComponent := componentByModule[dependency]
+			if fromComponent == toComponent {
+				continue
+			}
+			if _, exists := dependencies[fromComponent][toComponent]; exists {
+				continue
+			}
+			dependencies[fromComponent][toComponent] = struct{}{}
+			inDegree[toComponent]++
+		}
+	}
+
+	queue := make([]int, 0, componentCount)
+	for component, degree := range inDegree {
+		if degree == 0 {
+			queue = append(queue, component)
+		}
+	}
+
+	depth := make([]int, componentCount)
+	maxDepth := 0
+	processed := 0
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+
+		component := queue[0]
+		queue = queue[1:]
+		processed++
+
+		for dependency := range dependencies[component] {
+			candidateDepth := depth[component] + 1
+			if candidateDepth > depth[dependency] {
+				depth[dependency] = candidateDepth
+				if candidateDepth > maxDepth {
+					maxDepth = candidateDepth
+				}
+			}
+			inDegree[dependency]--
+			if inDegree[dependency] == 0 {
+				queue = append(queue, dependency)
+			}
+		}
+	}
+
+	if processed != componentCount {
+		return 0, fmt.Errorf("condensed dependency graph contains a cycle")
+	}
+	return maxDepth, nil
+}
+
+func dependencyComponents(graph *DependencyGraph, cycles [][]string) (map[string]int, int) {
+	componentByModule := make(map[string]int, len(graph.Nodes))
+	componentCount := 0
+
+	for _, cycle := range cycles {
+		for _, moduleName := range cycle {
+			componentByModule[moduleName] = componentCount
+		}
+		componentCount++
+	}
+
+	for moduleName := range graph.Nodes {
+		if _, assigned := componentByModule[moduleName]; assigned {
+			continue
+		}
+		componentByModule[moduleName] = componentCount
+		componentCount++
+	}
+
+	return componentByModule, componentCount
+}

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -18,7 +18,8 @@ type condensedDependencyGraph struct {
 }
 
 // DependencyTopology is the canonical structural analysis of one dependency
-// graph. MaxDepth and LongestChains share the same SCC condensation.
+// graph. MaxDepth and LongestChains share the same SCC condensation. A result
+// belongs to the exact graph instance passed to AnalyzeDependencyTopology.
 type DependencyTopology struct {
 	MaxDepth      int
 	LongestChains []DependencyChain

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -17,17 +17,17 @@ type condensedDependencyGraph struct {
 	inDegree          []int
 }
 
-// DependencyTopology is the canonical structural analysis of one dependency
-// graph. MaxDepth and LongestChains share the same SCC condensation. A result
-// belongs to the exact graph instance passed to AnalyzeDependencyTopology.
-// Structural mutations through AddModule or AddDependency invalidate it;
-// directly mutating DependencyGraph storage is unsupported.
+// DependencyTopology is the canonical load-time structural analysis of one
+// dependency graph. MaxDepth and LongestChains share the same SCC condensation.
+// A result belongs to the exact graph instance passed to
+// AnalyzeDependencyTopology. Structural mutations through AddModule or
+// AddDependency invalidate it; directly mutating DependencyGraph storage is
+// unsupported.
 type DependencyTopology struct {
 	maxDepth      int
 	longestChains []DependencyChain
 	graph         *DependencyGraph
-	totalModules  int
-	totalEdges    int
+	graphRevision uint64
 }
 
 // MaxDepth returns the maximum number of edges between SCCs.
@@ -45,8 +45,9 @@ func (topology *DependencyTopology) LongestChains() []DependencyChain {
 	return chains
 }
 
-// AnalyzeDependencyTopology condenses a dependency graph and calculates its
-// maximum depth and globally ranked chains from one shared SCC condensation.
+// AnalyzeDependencyTopology condenses the graph's load-time dependencies and
+// calculates maximum depth and globally ranked chains from one shared SCC
+// condensation. Lazy-only imports remain available to other graph analyses.
 func AnalyzeDependencyTopology(
 	ctx context.Context,
 	graph *DependencyGraph,
@@ -89,8 +90,7 @@ func AnalyzeDependencyTopology(
 		maxDepth:      maxDepth,
 		longestChains: longestChains,
 		graph:         graph,
-		totalModules:  graph.TotalModules,
-		totalEdges:    graph.TotalEdges,
+		graphRevision: graph.topologyRevision,
 	}, nil
 }
 
@@ -150,6 +150,9 @@ func buildCondensedDependencyGraph(
 		}
 		fromComponent := componentByModule[moduleName]
 		for dependency := range node.Dependencies {
+			if !node.hasLoadTimeDependency(dependency) {
+				continue
+			}
 			toComponent := componentByModule[dependency]
 			if fromComponent == toComponent {
 				continue
@@ -254,6 +257,9 @@ func dependencyComponents(
 					moduleName,
 					dependency,
 				)
+			}
+			if !node.hasLoadTimeDependency(dependency) {
+				continue
 			}
 
 			dependencyIndex, visited := indexByModule[dependency]

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -27,7 +27,7 @@ type DependencyTopology struct {
 }
 
 // AnalyzeDependencyTopology condenses a dependency graph and calculates its
-// maximum depth and globally ranked dependency chains in one pass.
+// maximum depth and globally ranked chains from one shared SCC condensation.
 func AnalyzeDependencyTopology(
 	ctx context.Context,
 	graph *DependencyGraph,
@@ -192,6 +192,9 @@ func dependencyEdgeLess(left, right componentDependency) bool {
 	return left.toModule < right.toModule
 }
 
+// dependencyComponents owns topology SCC construction because the core cycle
+// detector reports only non-singleton cycles and cannot observe cancellation.
+// Topology requires a complete, cancellable partition including singletons.
 func dependencyComponents(
 	ctx context.Context,
 	graph *DependencyGraph,

--- a/internal/analyzer/dependency_topology.go
+++ b/internal/analyzer/dependency_topology.go
@@ -19,12 +19,15 @@ type condensedDependencyGraph struct {
 
 // DependencyTopology is the canonical structural analysis of one dependency
 // graph. MaxDepth and LongestChains share the same SCC condensation. A result
-// belongs to the exact graph instance passed to AnalyzeDependencyTopology.
+// belongs to the exact graph state passed to AnalyzeDependencyTopology and is
+// invalidated by subsequent structural mutations.
 type DependencyTopology struct {
 	MaxDepth      int
 	LongestChains []DependencyChain
 
-	graph *DependencyGraph
+	graph        *DependencyGraph
+	totalModules int
+	totalEdges   int
 }
 
 // AnalyzeDependencyTopology condenses a dependency graph and calculates its
@@ -71,6 +74,8 @@ func AnalyzeDependencyTopology(
 		MaxDepth:      maxDepth,
 		LongestChains: longestChains,
 		graph:         graph,
+		totalModules:  graph.TotalModules,
+		totalEdges:    graph.TotalEdges,
 	}, nil
 }
 

--- a/internal/analyzer/dependency_topology_bench_test.go
+++ b/internal/analyzer/dependency_topology_bench_test.go
@@ -39,11 +39,11 @@ func BenchmarkAnalyzeDependencyTopologyBranchingGraph(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				if topology.MaxDepth != moduleCount-1 {
+				if topology.MaxDepth() != moduleCount-1 {
 					b.Fatalf(
 						"expected depth %d, got %d",
 						moduleCount-1,
-						topology.MaxDepth,
+						topology.MaxDepth(),
 					)
 				}
 			}

--- a/internal/analyzer/dependency_topology_bench_test.go
+++ b/internal/analyzer/dependency_topology_bench_test.go
@@ -1,0 +1,52 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkAnalyzeDependencyTopologyBranchingGraph(b *testing.B) {
+	for _, moduleCount := range []int{44, 1000} {
+		b.Run(fmt.Sprintf("modules_%d", moduleCount), func(b *testing.B) {
+			moduleNames := make([]string, moduleCount)
+			for index := range moduleNames {
+				moduleNames[index] = fmt.Sprintf("module_%04d", index)
+			}
+			graph := dependencyGraphWithModules(moduleNames...)
+			for index, moduleName := range moduleNames {
+				if index+1 < moduleCount {
+					graph.AddDependency(
+						moduleName,
+						moduleNames[index+1],
+						DependencyEdgeImport,
+						nil,
+					)
+				}
+				if index+2 < moduleCount {
+					graph.AddDependency(
+						moduleName,
+						moduleNames[index+2],
+						DependencyEdgeImport,
+						nil,
+					)
+				}
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				topology, err := AnalyzeDependencyTopology(context.Background(), graph, 10)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if topology.MaxDepth != moduleCount-1 {
+					b.Fatalf(
+						"expected depth %d, got %d",
+						moduleCount-1,
+						topology.MaxDepth,
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -85,6 +85,34 @@ func TestCouplingMetricsHonorsCancellation(t *testing.T) {
 	assert.Zero(t, graph.SystemMetrics.TotalModules)
 }
 
+func TestCouplingMetricsRejectsTopologyFromAnotherGraph(t *testing.T) {
+	topologyGraph := dependencyGraphWithModules("topology")
+	topology, err := AnalyzeDependencyTopology(context.Background(), topologyGraph, 0)
+	require.NoError(t, err)
+
+	metricsGraph := dependencyGraphWithModules("metrics")
+	calculator := NewCouplingMetricsCalculator(metricsGraph, DefaultCouplingMetricsOptions())
+	err = calculator.CalculateMetrics(context.Background(), topology)
+
+	require.ErrorContains(t, err, "dependency topology belongs to another graph")
+	assert.Empty(t, metricsGraph.ModuleMetrics)
+}
+
+func TestCouplingMetricsCanDisableAbstractness(t *testing.T) {
+	graph := dependencyGraphWithModules("abstract")
+	graph.Nodes["abstract"].ClassCount = 1
+	graph.Nodes["abstract"].AbstractClassCount = 1
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
+	require.NoError(t, err)
+
+	options := DefaultCouplingMetricsOptions()
+	options.IncludeAbstractness = false
+	calculator := NewCouplingMetricsCalculator(graph, options)
+	require.NoError(t, calculator.CalculateMetrics(context.Background(), topology))
+
+	assert.Zero(t, graph.ModuleMetrics["abstract"].Abstractness)
+}
+
 func TestAnalyzeDependencyTopologyRanksDeepBranchAfterShallowBranches(t *testing.T) {
 	moduleNames := []string{"root", "z_deep", "z_middle", "z_leaf"}
 	for index := 0; index < 10; index++ {

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -44,6 +44,17 @@ func TestCalculateMaxDependencyDepthHonorsCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestCouplingMetricsUsesDependencyTopologyDepth(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "middle", "leaf")
+	graph.AddDependency("entry", "middle", DependencyEdgeImport, nil)
+	graph.AddDependency("middle", "leaf", DependencyEdgeImport, nil)
+
+	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
+	require.NoError(t, calculator.CalculateMetrics(context.Background()))
+
+	assert.Equal(t, 2, graph.SystemMetrics.MaxDependencyDepth)
+}
+
 func dependencyGraphWithModules(moduleNames ...string) *DependencyGraph {
 	graph := NewDependencyGraph("/project")
 	for _, moduleName := range moduleNames {

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -45,6 +45,15 @@ func TestCalculateMaxDependencyDepthHonorsCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestCalculateMaxDependencyDepthRejectsUnknownDependencies(t *testing.T) {
+	graph := dependencyGraphWithModules("entry")
+	graph.Nodes["entry"].Dependencies["missing"] = true
+
+	_, err := CalculateMaxDependencyDepth(context.Background(), graph)
+
+	require.ErrorContains(t, err, `module "entry" depends on unknown module "missing"`)
+}
+
 func TestCouplingMetricsUsesDependencyTopologyDepth(t *testing.T) {
 	graph := dependencyGraphWithModules("entry", "middle", "leaf")
 	graph.AddDependency("entry", "middle", DependencyEdgeImport, nil)

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -1,0 +1,53 @@
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateMaxDependencyDepthCountsDAGEdges(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "left", "right", "leaf")
+	graph.AddDependency("entry", "left", DependencyEdgeImport, nil)
+	graph.AddDependency("entry", "right", DependencyEdgeImport, nil)
+	graph.AddDependency("left", "leaf", DependencyEdgeImport, nil)
+	graph.AddDependency("right", "leaf", DependencyEdgeImport, nil)
+
+	depth, err := CalculateMaxDependencyDepth(context.Background(), graph)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, depth)
+}
+
+func TestCalculateMaxDependencyDepthCollapsesCycles(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "cycle_a", "cycle_b", "leaf")
+	graph.AddDependency("entry", "cycle_a", DependencyEdgeImport, nil)
+	graph.AddDependency("cycle_a", "cycle_b", DependencyEdgeImport, nil)
+	graph.AddDependency("cycle_b", "cycle_a", DependencyEdgeImport, nil)
+	graph.AddDependency("cycle_b", "leaf", DependencyEdgeImport, nil)
+
+	depth, err := CalculateMaxDependencyDepth(context.Background(), graph)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, depth)
+}
+
+func TestCalculateMaxDependencyDepthHonorsCancellation(t *testing.T) {
+	graph := dependencyGraphWithModules("module")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := CalculateMaxDependencyDepth(ctx, graph)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func dependencyGraphWithModules(moduleNames ...string) *DependencyGraph {
+	graph := NewDependencyGraph("/project")
+	for _, moduleName := range moduleNames {
+		graph.AddModule(moduleName, "/project/"+moduleName+".py")
+	}
+	return graph
+}

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -132,6 +132,34 @@ func TestFindLongestDependencyChainsExpandsCycleComponents(t *testing.T) {
 	assert.Equal(t, []string{"entry", "cycle_a", "cycle_b", "leaf"}, chains[0].Path)
 }
 
+func TestFindLongestDependencyChainsExpandsMultipleCycleComponents(t *testing.T) {
+	graph := dependencyGraphWithModules(
+		"entry",
+		"first_a",
+		"first_b",
+		"second_a",
+		"second_b",
+		"leaf",
+	)
+	graph.AddDependency("entry", "first_a", DependencyEdgeImport, nil)
+	graph.AddDependency("first_a", "first_b", DependencyEdgeImport, nil)
+	graph.AddDependency("first_b", "first_a", DependencyEdgeImport, nil)
+	graph.AddDependency("first_b", "second_a", DependencyEdgeImport, nil)
+	graph.AddDependency("second_a", "second_b", DependencyEdgeImport, nil)
+	graph.AddDependency("second_b", "second_a", DependencyEdgeImport, nil)
+	graph.AddDependency("second_b", "leaf", DependencyEdgeImport, nil)
+
+	chains, err := FindLongestDependencyChains(context.Background(), graph, 1)
+
+	require.NoError(t, err)
+	require.Len(t, chains, 1)
+	assert.Equal(
+		t,
+		[]string{"entry", "first_a", "first_b", "second_a", "second_b", "leaf"},
+		chains[0].Path,
+	)
+}
+
 func TestFindLongestDependencyChainsHonorsCancellation(t *testing.T) {
 	graph := dependencyGraphWithModules("module")
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -98,6 +98,19 @@ func TestCouplingMetricsRejectsTopologyFromAnotherGraph(t *testing.T) {
 	assert.Empty(t, metricsGraph.ModuleMetrics)
 }
 
+func TestCouplingMetricsRejectsStaleTopology(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "leaf")
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
+	require.NoError(t, err)
+	graph.AddDependency("entry", "leaf", DependencyEdgeImport, nil)
+
+	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
+	err = calculator.CalculateMetrics(context.Background(), topology)
+
+	require.ErrorContains(t, err, "dependency graph changed after topology analysis")
+	assert.Empty(t, graph.ModuleMetrics)
+}
+
 func TestCouplingMetricsCanDisableAbstractness(t *testing.T) {
 	graph := dependencyGraphWithModules("abstract")
 	graph.Nodes["abstract"].ClassCount = 1

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -55,6 +55,17 @@ func TestCouplingMetricsUsesDependencyTopologyDepth(t *testing.T) {
 	assert.Equal(t, 2, graph.SystemMetrics.MaxDependencyDepth)
 }
 
+func TestCouplingMetricsHonorsCancellation(t *testing.T) {
+	graph := dependencyGraphWithModules("module")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
+	err := calculator.CalculateMetrics(ctx)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func dependencyGraphWithModules(moduleNames ...string) *DependencyGraph {
 	graph := NewDependencyGraph("/project")
 	for _, moduleName := range moduleNames {

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -19,10 +19,14 @@ func TestAnalyzeDependencyTopologyReportsDepthAndChains(t *testing.T) {
 	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 2)
 
 	require.NoError(t, err)
-	assert.Equal(t, 2, topology.MaxDepth)
-	require.Len(t, topology.LongestChains, 2)
-	assert.Equal(t, []string{"entry", "left", "leaf"}, topology.LongestChains[0].Path)
-	assert.Equal(t, []string{"entry", "right", "leaf"}, topology.LongestChains[1].Path)
+	assert.Equal(t, 2, topology.MaxDepth())
+	chains := topology.LongestChains()
+	require.Len(t, chains, 2)
+	assert.Equal(t, []string{"entry", "left", "leaf"}, chains[0].Path)
+	assert.Equal(t, []string{"entry", "right", "leaf"}, chains[1].Path)
+
+	chains[0].Path[0] = "changed"
+	assert.Equal(t, "entry", topology.LongestChains()[0].Path[0])
 }
 
 func TestAnalyzeDependencyTopologyCollapsesCycles(t *testing.T) {
@@ -35,7 +39,7 @@ func TestAnalyzeDependencyTopologyCollapsesCycles(t *testing.T) {
 	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
 
 	require.NoError(t, err)
-	assert.Equal(t, 2, topology.MaxDepth)
+	assert.Equal(t, 2, topology.MaxDepth())
 }
 
 func TestAnalyzeDependencyTopologyHonorsCancellation(t *testing.T) {
@@ -147,11 +151,12 @@ func TestAnalyzeDependencyTopologyRanksDeepBranchAfterShallowBranches(t *testing
 	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 10)
 
 	require.NoError(t, err)
-	require.NotEmpty(t, topology.LongestChains)
+	chains := topology.LongestChains()
+	require.NotEmpty(t, chains)
 	assert.Equal(
 		t,
 		[]string{"root", "z_deep", "z_middle", "z_leaf"},
-		topology.LongestChains[0].Path,
+		chains[0].Path,
 	)
 }
 
@@ -165,11 +170,12 @@ func TestAnalyzeDependencyTopologyExpandsCycleComponents(t *testing.T) {
 	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 1)
 
 	require.NoError(t, err)
-	require.Len(t, topology.LongestChains, 1)
+	chains := topology.LongestChains()
+	require.Len(t, chains, 1)
 	assert.Equal(
 		t,
 		[]string{"entry", "cycle_a", "cycle_b", "leaf"},
-		topology.LongestChains[0].Path,
+		chains[0].Path,
 	)
 }
 
@@ -193,11 +199,12 @@ func TestAnalyzeDependencyTopologyExpandsMultipleCycleComponents(t *testing.T) {
 	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 1)
 
 	require.NoError(t, err)
-	require.Len(t, topology.LongestChains, 1)
+	chains := topology.LongestChains()
+	require.Len(t, chains, 1)
 	assert.Equal(
 		t,
 		[]string{"entry", "first_a", "first_b", "second_a", "second_b", "leaf"},
-		topology.LongestChains[0].Path,
+		chains[0].Path,
 	)
 }
 

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -25,47 +25,34 @@ func TestAnalyzeDependencyTopologyReportsDepthAndChains(t *testing.T) {
 	assert.Equal(t, []string{"entry", "right", "leaf"}, topology.LongestChains[1].Path)
 }
 
-func TestCalculateMaxDependencyDepthCountsDAGEdges(t *testing.T) {
-	graph := dependencyGraphWithModules("entry", "left", "right", "leaf")
-	graph.AddDependency("entry", "left", DependencyEdgeImport, nil)
-	graph.AddDependency("entry", "right", DependencyEdgeImport, nil)
-	graph.AddDependency("left", "leaf", DependencyEdgeImport, nil)
-	graph.AddDependency("right", "leaf", DependencyEdgeImport, nil)
-
-	depth, err := CalculateMaxDependencyDepth(context.Background(), graph)
-
-	require.NoError(t, err)
-	assert.Equal(t, 2, depth)
-}
-
-func TestCalculateMaxDependencyDepthCollapsesCycles(t *testing.T) {
+func TestAnalyzeDependencyTopologyCollapsesCycles(t *testing.T) {
 	graph := dependencyGraphWithModules("entry", "cycle_a", "cycle_b", "leaf")
 	graph.AddDependency("entry", "cycle_a", DependencyEdgeImport, nil)
 	graph.AddDependency("cycle_a", "cycle_b", DependencyEdgeImport, nil)
 	graph.AddDependency("cycle_b", "cycle_a", DependencyEdgeImport, nil)
 	graph.AddDependency("cycle_b", "leaf", DependencyEdgeImport, nil)
 
-	depth, err := CalculateMaxDependencyDepth(context.Background(), graph)
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
 
 	require.NoError(t, err)
-	assert.Equal(t, 2, depth)
+	assert.Equal(t, 2, topology.MaxDepth)
 }
 
-func TestCalculateMaxDependencyDepthHonorsCancellation(t *testing.T) {
+func TestAnalyzeDependencyTopologyHonorsCancellation(t *testing.T) {
 	graph := dependencyGraphWithModules("module")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := CalculateMaxDependencyDepth(ctx, graph)
+	_, err := AnalyzeDependencyTopology(ctx, graph, 0)
 
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestCalculateMaxDependencyDepthRejectsUnknownDependencies(t *testing.T) {
+func TestAnalyzeDependencyTopologyRejectsUnknownDependencies(t *testing.T) {
 	graph := dependencyGraphWithModules("entry")
 	graph.Nodes["entry"].Dependencies["missing"] = true
 
-	_, err := CalculateMaxDependencyDepth(context.Background(), graph)
+	_, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
 
 	require.ErrorContains(t, err, `module "entry" depends on unknown module "missing"`)
 }
@@ -98,22 +85,7 @@ func TestCouplingMetricsHonorsCancellation(t *testing.T) {
 	assert.Zero(t, graph.SystemMetrics.TotalModules)
 }
 
-func TestFindLongestDependencyChainsReturnsActualLongestPath(t *testing.T) {
-	graph := dependencyGraphWithModules("entry", "left", "right", "leaf")
-	graph.AddDependency("entry", "left", DependencyEdgeImport, nil)
-	graph.AddDependency("entry", "right", DependencyEdgeImport, nil)
-	graph.AddDependency("left", "leaf", DependencyEdgeImport, nil)
-	graph.AddDependency("right", "leaf", DependencyEdgeImport, nil)
-
-	chains, err := FindLongestDependencyChains(context.Background(), graph, 2)
-
-	require.NoError(t, err)
-	require.Len(t, chains, 2)
-	assert.Equal(t, []string{"entry", "left", "leaf"}, chains[0].Path)
-	assert.Equal(t, []string{"entry", "right", "leaf"}, chains[1].Path)
-}
-
-func TestFindLongestDependencyChainsRanksDeepBranchAfterShallowBranches(t *testing.T) {
+func TestAnalyzeDependencyTopologyRanksDeepBranchAfterShallowBranches(t *testing.T) {
 	moduleNames := []string{"root", "z_deep", "z_middle", "z_leaf"}
 	for index := 0; index < 10; index++ {
 		moduleNames = append(moduleNames, fmt.Sprintf("a_shallow_%02d", index))
@@ -131,28 +103,36 @@ func TestFindLongestDependencyChainsRanksDeepBranchAfterShallowBranches(t *testi
 	graph.AddDependency("z_deep", "z_middle", DependencyEdgeImport, nil)
 	graph.AddDependency("z_middle", "z_leaf", DependencyEdgeImport, nil)
 
-	chains, err := FindLongestDependencyChains(context.Background(), graph, 10)
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 10)
 
 	require.NoError(t, err)
-	require.NotEmpty(t, chains)
-	assert.Equal(t, []string{"root", "z_deep", "z_middle", "z_leaf"}, chains[0].Path)
+	require.NotEmpty(t, topology.LongestChains)
+	assert.Equal(
+		t,
+		[]string{"root", "z_deep", "z_middle", "z_leaf"},
+		topology.LongestChains[0].Path,
+	)
 }
 
-func TestFindLongestDependencyChainsExpandsCycleComponents(t *testing.T) {
+func TestAnalyzeDependencyTopologyExpandsCycleComponents(t *testing.T) {
 	graph := dependencyGraphWithModules("entry", "cycle_a", "cycle_b", "leaf")
 	graph.AddDependency("entry", "cycle_a", DependencyEdgeImport, nil)
 	graph.AddDependency("cycle_a", "cycle_b", DependencyEdgeImport, nil)
 	graph.AddDependency("cycle_b", "cycle_a", DependencyEdgeImport, nil)
 	graph.AddDependency("cycle_b", "leaf", DependencyEdgeImport, nil)
 
-	chains, err := FindLongestDependencyChains(context.Background(), graph, 1)
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 1)
 
 	require.NoError(t, err)
-	require.Len(t, chains, 1)
-	assert.Equal(t, []string{"entry", "cycle_a", "cycle_b", "leaf"}, chains[0].Path)
+	require.Len(t, topology.LongestChains, 1)
+	assert.Equal(
+		t,
+		[]string{"entry", "cycle_a", "cycle_b", "leaf"},
+		topology.LongestChains[0].Path,
+	)
 }
 
-func TestFindLongestDependencyChainsExpandsMultipleCycleComponents(t *testing.T) {
+func TestAnalyzeDependencyTopologyExpandsMultipleCycleComponents(t *testing.T) {
 	graph := dependencyGraphWithModules(
 		"entry",
 		"first_a",
@@ -169,23 +149,23 @@ func TestFindLongestDependencyChainsExpandsMultipleCycleComponents(t *testing.T)
 	graph.AddDependency("second_b", "second_a", DependencyEdgeImport, nil)
 	graph.AddDependency("second_b", "leaf", DependencyEdgeImport, nil)
 
-	chains, err := FindLongestDependencyChains(context.Background(), graph, 1)
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 1)
 
 	require.NoError(t, err)
-	require.Len(t, chains, 1)
+	require.Len(t, topology.LongestChains, 1)
 	assert.Equal(
 		t,
 		[]string{"entry", "first_a", "first_b", "second_a", "second_b", "leaf"},
-		chains[0].Path,
+		topology.LongestChains[0].Path,
 	)
 }
 
-func TestFindLongestDependencyChainsHonorsCancellation(t *testing.T) {
+func TestAnalyzeDependencyTopologyChainSearchHonorsCancellation(t *testing.T) {
 	graph := dependencyGraphWithModules("module")
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := FindLongestDependencyChains(ctx, graph, 1)
+	_, err := AnalyzeDependencyTopology(ctx, graph, 1)
 
 	require.ErrorIs(t, err, context.Canceled)
 }

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -64,6 +64,8 @@ func TestCouplingMetricsHonorsCancellation(t *testing.T) {
 	err := calculator.CalculateMetrics(ctx)
 
 	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, graph.ModuleMetrics)
+	assert.Zero(t, graph.SystemMetrics.TotalModules)
 }
 
 func dependencyGraphWithModules(moduleNames ...string) *DependencyGraph {

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,6 +67,70 @@ func TestCouplingMetricsHonorsCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Empty(t, graph.ModuleMetrics)
 	assert.Zero(t, graph.SystemMetrics.TotalModules)
+}
+
+func TestFindLongestDependencyChainsReturnsActualLongestPath(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "left", "right", "leaf")
+	graph.AddDependency("entry", "left", DependencyEdgeImport, nil)
+	graph.AddDependency("entry", "right", DependencyEdgeImport, nil)
+	graph.AddDependency("left", "leaf", DependencyEdgeImport, nil)
+	graph.AddDependency("right", "leaf", DependencyEdgeImport, nil)
+
+	chains, err := FindLongestDependencyChains(context.Background(), graph, 2)
+
+	require.NoError(t, err)
+	require.Len(t, chains, 2)
+	assert.Equal(t, []string{"entry", "left", "leaf"}, chains[0].Path)
+	assert.Equal(t, []string{"entry", "right", "leaf"}, chains[1].Path)
+}
+
+func TestFindLongestDependencyChainsRanksDeepBranchAfterShallowBranches(t *testing.T) {
+	moduleNames := []string{"root", "z_deep", "z_middle", "z_leaf"}
+	for index := 0; index < 10; index++ {
+		moduleNames = append(moduleNames, fmt.Sprintf("a_shallow_%02d", index))
+	}
+	graph := dependencyGraphWithModules(moduleNames...)
+	for index := 0; index < 10; index++ {
+		graph.AddDependency(
+			"root",
+			fmt.Sprintf("a_shallow_%02d", index),
+			DependencyEdgeImport,
+			nil,
+		)
+	}
+	graph.AddDependency("root", "z_deep", DependencyEdgeImport, nil)
+	graph.AddDependency("z_deep", "z_middle", DependencyEdgeImport, nil)
+	graph.AddDependency("z_middle", "z_leaf", DependencyEdgeImport, nil)
+
+	chains, err := FindLongestDependencyChains(context.Background(), graph, 10)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, chains)
+	assert.Equal(t, []string{"root", "z_deep", "z_middle", "z_leaf"}, chains[0].Path)
+}
+
+func TestFindLongestDependencyChainsExpandsCycleComponents(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "cycle_a", "cycle_b", "leaf")
+	graph.AddDependency("entry", "cycle_a", DependencyEdgeImport, nil)
+	graph.AddDependency("cycle_a", "cycle_b", DependencyEdgeImport, nil)
+	graph.AddDependency("cycle_b", "cycle_a", DependencyEdgeImport, nil)
+	graph.AddDependency("cycle_b", "leaf", DependencyEdgeImport, nil)
+
+	chains, err := FindLongestDependencyChains(context.Background(), graph, 1)
+
+	require.NoError(t, err)
+	require.Len(t, chains, 1)
+	assert.Equal(t, []string{"entry", "cycle_a", "cycle_b", "leaf"}, chains[0].Path)
+}
+
+func TestFindLongestDependencyChainsHonorsCancellation(t *testing.T) {
+	graph := dependencyGraphWithModules("module")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := FindLongestDependencyChains(ctx, graph, 1)
+
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func dependencyGraphWithModules(moduleNames ...string) *DependencyGraph {

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -42,6 +42,33 @@ func TestAnalyzeDependencyTopologyCollapsesCycles(t *testing.T) {
 	assert.Equal(t, 2, topology.MaxDepth())
 }
 
+func TestAnalyzeDependencyTopologyExcludesLazyImports(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "dependency")
+	graph.AddDependency("entry", "dependency", DependencyEdgeImport, nil)
+	graph.AddDependency(
+		"dependency",
+		"entry",
+		DependencyEdgeFromImport,
+		&ImportInfo{IsLazy: true},
+	)
+
+	cycles := NewCircularDependencyDetector(graph).DetectCircularDependencies()
+	require.False(t, cycles.HasCircularDependencies)
+
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, topology.MaxDepth())
+	chains := topology.LongestChains()
+	require.Len(t, chains, 1)
+	assert.Equal(t, []string{"entry", "dependency"}, chains[0].Path)
+
+	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
+	require.NoError(t, calculator.CalculateMetrics(context.Background(), topology))
+	assert.Equal(t, 2, graph.SystemMetrics.TotalDependencies)
+	assert.Equal(t, 1, graph.SystemMetrics.MaxDependencyDepth)
+}
+
 func TestAnalyzeDependencyTopologyHonorsCancellation(t *testing.T) {
 	graph := dependencyGraphWithModules("module")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -107,6 +134,26 @@ func TestCouplingMetricsRejectsStaleTopology(t *testing.T) {
 	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
 	require.NoError(t, err)
 	graph.AddDependency("entry", "leaf", DependencyEdgeImport, nil)
+
+	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
+	err = calculator.CalculateMetrics(context.Background(), topology)
+
+	require.ErrorContains(t, err, "dependency graph changed after topology analysis")
+	assert.Empty(t, graph.ModuleMetrics)
+}
+
+func TestCouplingMetricsRejectsTopologyAfterLazyImportPromotion(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "dependency")
+	graph.AddDependency(
+		"entry",
+		"dependency",
+		DependencyEdgeImport,
+		&ImportInfo{IsLazy: true},
+	)
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
+	require.NoError(t, err)
+
+	graph.AddDependency("entry", "dependency", DependencyEdgeImport, nil)
 
 	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
 	err = calculator.CalculateMetrics(context.Background(), topology)

--- a/internal/analyzer/dependency_topology_test.go
+++ b/internal/analyzer/dependency_topology_test.go
@@ -9,6 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAnalyzeDependencyTopologyReportsDepthAndChains(t *testing.T) {
+	graph := dependencyGraphWithModules("entry", "left", "right", "leaf")
+	graph.AddDependency("entry", "left", DependencyEdgeImport, nil)
+	graph.AddDependency("entry", "right", DependencyEdgeImport, nil)
+	graph.AddDependency("left", "leaf", DependencyEdgeImport, nil)
+	graph.AddDependency("right", "leaf", DependencyEdgeImport, nil)
+
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 2)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, topology.MaxDepth)
+	require.Len(t, topology.LongestChains, 2)
+	assert.Equal(t, []string{"entry", "left", "leaf"}, topology.LongestChains[0].Path)
+	assert.Equal(t, []string{"entry", "right", "leaf"}, topology.LongestChains[1].Path)
+}
+
 func TestCalculateMaxDependencyDepthCountsDAGEdges(t *testing.T) {
 	graph := dependencyGraphWithModules("entry", "left", "right", "leaf")
 	graph.AddDependency("entry", "left", DependencyEdgeImport, nil)
@@ -59,19 +75,23 @@ func TestCouplingMetricsUsesDependencyTopologyDepth(t *testing.T) {
 	graph.AddDependency("entry", "middle", DependencyEdgeImport, nil)
 	graph.AddDependency("middle", "leaf", DependencyEdgeImport, nil)
 
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
+	require.NoError(t, err)
 	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
-	require.NoError(t, calculator.CalculateMetrics(context.Background()))
+	require.NoError(t, calculator.CalculateMetrics(context.Background(), topology))
 
 	assert.Equal(t, 2, graph.SystemMetrics.MaxDependencyDepth)
 }
 
 func TestCouplingMetricsHonorsCancellation(t *testing.T) {
 	graph := dependencyGraphWithModules("module")
+	topology, err := AnalyzeDependencyTopology(context.Background(), graph, 0)
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	calculator := NewCouplingMetricsCalculator(graph, DefaultCouplingMetricsOptions())
-	err := calculator.CalculateMetrics(ctx)
+	err = calculator.CalculateMetrics(ctx, topology)
 
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Empty(t, graph.ModuleMetrics)

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -375,9 +375,14 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
 
+	topology, err := analyzer.AnalyzeDependencyTopology(ctx, graph, 10)
+	if err != nil {
+		return nil, fmt.Errorf("analyze dependency topology: %w", err)
+	}
+
 	// Calculate coupling metrics
 	metricsCalculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-	if err := metricsCalculator.CalculateMetrics(ctx); err != nil {
+	if err := metricsCalculator.CalculateMetrics(ctx, topology); err != nil {
 		return nil, err
 	}
 	couplingResults := graph.SystemMetrics
@@ -391,12 +396,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
 
-	// Find longest dependency chains
-	dependencyChains, err := analyzer.FindLongestDependencyChains(ctx, graph, 10)
-	if err != nil {
-		return nil, fmt.Errorf("find dependency chains: %w", err)
-	}
-	longestChains := s.convertDependencyChains(dependencyChains)
+	longestChains := s.convertDependencyChains(topology.LongestChains)
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
@@ -418,7 +418,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		CircularDependencies: s.convertCircularResults(circularResult),
 		CouplingAnalysis:     s.convertCouplingResults(couplingResults),
 		LongestChains:        longestChains,
-		MaxDepth:             couplingResults.MaxDependencyDepth,
+		MaxDepth:             topology.MaxDepth,
 	}
 
 	return result, nil

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -402,6 +402,10 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
+	maxDepth, err := analyzer.CalculateMaxDependencyDepth(ctx, graph)
+	if err != nil {
+		return nil, fmt.Errorf("calculate dependency depth: %w", err)
+	}
 
 	// Create dependency analysis result
 	result := &domain.DependencyAnalysisResult{
@@ -414,7 +418,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		CircularDependencies: s.convertCircularResults(circularResult),
 		CouplingAnalysis:     s.convertCouplingResults(couplingResults),
 		LongestChains:        longestChains,
-		MaxDepth:             s.calculateMaxDepth(graph),
+		MaxDepth:             maxDepth,
 	}
 
 	return result, nil

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -368,7 +368,8 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		}, nil
 	}
 
-	// Detect circular dependencies
+	// Circular-import reporting excludes lazy imports, while structural
+	// topology intentionally includes every dependency edge.
 	circularDetector := analyzer.NewCircularDependencyDetector(graph)
 	circularResult := circularDetector.DetectCircularDependencies()
 	if err := ctx.Err(); err != nil {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -1392,15 +1392,12 @@ func (s *SystemAnalysisServiceImpl) findLongestChains(ctx context.Context, graph
 			moduleName,
 			make(map[string]bool),
 			[]string{moduleName},
-			limit-len(chains),
+			limit,
 		)
 		if err != nil {
 			return nil, err
 		}
 		chains = append(chains, paths...)
-		if len(chains) >= limit {
-			break
-		}
 	}
 
 	// Sort by length (descending), then by first module name for deterministic results

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -392,7 +392,10 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 	}
 
 	// Find longest dependency chains
-	longestChains := s.findLongestChains(graph, 10) // Top 10 chains
+	longestChains, err := s.findLongestChains(ctx, graph, 10) // Top 10 chains
+	if err != nil {
+		return nil, fmt.Errorf("find dependency chains: %w", err)
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
@@ -1363,13 +1366,41 @@ func (s *SystemAnalysisServiceImpl) buildDependencyMatrix(graph *analyzer.Depend
 	return matrix
 }
 
-func (s *SystemAnalysisServiceImpl) findLongestChains(graph *analyzer.DependencyGraph, limit int) []domain.DependencyPath {
+func (s *SystemAnalysisServiceImpl) findLongestChains(ctx context.Context, graph *analyzer.DependencyGraph, limit int) ([]domain.DependencyPath, error) {
 	var chains []domain.DependencyPath
 
-	// Find all paths using simple DFS
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit <= 0 {
+		return chains, nil
+	}
+
+	moduleNames := make([]string, 0, len(graph.Nodes))
 	for moduleName := range graph.Nodes {
-		paths := s.findPathsFromModule(graph, moduleName, make(map[string]bool), []string{moduleName}, limit)
+		moduleNames = append(moduleNames, moduleName)
+	}
+	sort.Strings(moduleNames)
+
+	for _, moduleName := range moduleNames {
+		paths, err := s.findPathsFromModule(
+			ctx,
+			graph,
+			moduleName,
+			make(map[string]bool),
+			[]string{moduleName},
+			limit-len(chains),
+		)
+		if err != nil {
+			return nil, err
+		}
 		chains = append(chains, paths...)
+		if len(chains) >= limit {
+			break
+		}
 	}
 
 	// Sort by length (descending), then by first module name for deterministic results
@@ -1386,14 +1417,24 @@ func (s *SystemAnalysisServiceImpl) findLongestChains(graph *analyzer.Dependency
 		chains = chains[:limit]
 	}
 
-	return chains
+	return chains, nil
 }
 
-func (s *SystemAnalysisServiceImpl) findPathsFromModule(graph *analyzer.DependencyGraph, current string, visited map[string]bool, path []string, maxPaths int) []domain.DependencyPath {
+func (s *SystemAnalysisServiceImpl) findPathsFromModule(
+	ctx context.Context,
+	graph *analyzer.DependencyGraph,
+	current string,
+	visited map[string]bool,
+	path []string,
+	maxPaths int,
+) ([]domain.DependencyPath, error) {
 	var paths []domain.DependencyPath
 
-	if len(paths) >= maxPaths {
-		return paths
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if maxPaths <= 0 {
+		return paths, nil
 	}
 
 	visited[current] = true
@@ -1401,12 +1442,21 @@ func (s *SystemAnalysisServiceImpl) findPathsFromModule(graph *analyzer.Dependen
 
 	node := graph.Nodes[current]
 	if node == nil {
-		return paths
+		return paths, nil
 	}
 
-	for dep := range node.Dependencies {
+	dependencies := make([]string, 0, len(node.Dependencies))
+	for dependency := range node.Dependencies {
+		dependencies = append(dependencies, dependency)
+	}
+	sort.Strings(dependencies)
+
+	for _, dep := range dependencies {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if !visited[dep] {
-			newPath := append([]string{}, path...)
+			newPath := append([]string(nil), path...)
 			newPath = append(newPath, dep)
 
 			// Add this path
@@ -1418,9 +1468,15 @@ func (s *SystemAnalysisServiceImpl) findPathsFromModule(graph *analyzer.Dependen
 					Length: len(newPath),
 				})
 			}
+			if len(paths) >= maxPaths {
+				break
+			}
 
 			// Continue searching
-			subPaths := s.findPathsFromModule(graph, dep, visited, newPath, maxPaths-len(paths))
+			subPaths, err := s.findPathsFromModule(ctx, graph, dep, visited, newPath, maxPaths-len(paths))
+			if err != nil {
+				return nil, err
+			}
 			paths = append(paths, subPaths...)
 
 			if len(paths) >= maxPaths {
@@ -1429,7 +1485,7 @@ func (s *SystemAnalysisServiceImpl) findPathsFromModule(graph *analyzer.Dependen
 		}
 	}
 
-	return paths
+	return paths, nil
 }
 
 func (s *SystemAnalysisServiceImpl) convertCouplingResults(results *analyzer.SystemMetrics) *domain.CouplingAnalysis {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -368,8 +368,8 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		}, nil
 	}
 
-	// Circular-import reporting excludes lazy imports, while structural
-	// topology intentionally includes every dependency edge.
+	// Circular-import reporting and structural topology share the same
+	// load-time dependency contract. Other analyses retain lazy runtime edges.
 	circularDetector := analyzer.NewCircularDependencyDetector(graph)
 	circularResult := circularDetector.DetectCircularDependencies()
 	if err := ctx.Err(); err != nil {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -380,7 +380,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 	if err := metricsCalculator.CalculateMetrics(ctx); err != nil {
 		return nil, err
 	}
-	couplingResults := s.extractCouplingResult(graph)
+	couplingResults := graph.SystemMetrics
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
@@ -1432,42 +1432,6 @@ func (s *SystemAnalysisServiceImpl) findPathsFromModule(graph *analyzer.Dependen
 	return paths
 }
 
-func (s *SystemAnalysisServiceImpl) calculateMaxDepth(graph *analyzer.DependencyGraph) int {
-	maxDepth := 0
-
-	for moduleName := range graph.Nodes {
-		depth := s.calculateDepthFromModule(graph, moduleName, make(map[string]bool), 0)
-		if depth > maxDepth {
-			maxDepth = depth
-		}
-	}
-
-	return maxDepth
-}
-
-func (s *SystemAnalysisServiceImpl) calculateDepthFromModule(graph *analyzer.DependencyGraph, current string, visited map[string]bool, currentDepth int) int {
-	if visited[current] {
-		return currentDepth
-	}
-
-	visited[current] = true
-	defer delete(visited, current)
-
-	maxSubDepth := currentDepth
-	node := graph.Nodes[current]
-
-	if node != nil {
-		for dep := range node.Dependencies {
-			depth := s.calculateDepthFromModule(graph, dep, visited, currentDepth+1)
-			if depth > maxSubDepth {
-				maxSubDepth = depth
-			}
-		}
-	}
-
-	return maxSubDepth
-}
-
 func (s *SystemAnalysisServiceImpl) convertCouplingResults(results *analyzer.SystemMetrics) *domain.CouplingAnalysis {
 	if results == nil {
 		return nil
@@ -1560,62 +1524,6 @@ func (s *SystemAnalysisServiceImpl) convertDependencyChains(chains []analyzer.De
 	}
 
 	return deps
-}
-
-// extractCouplingResult extracts coupling analysis from the dependency graph
-func (s *SystemAnalysisServiceImpl) extractCouplingResult(graph *analyzer.DependencyGraph) *analyzer.SystemMetrics {
-	// If SystemMetrics is already calculated in the graph, use it
-	if graph.SystemMetrics != nil && graph.SystemMetrics.RefactoringPriority != nil {
-		return graph.SystemMetrics
-	}
-
-	// Otherwise, calculate basic metrics
-	metrics := &analyzer.SystemMetrics{
-		TotalModules:      graph.TotalModules,
-		TotalDependencies: graph.TotalEdges,
-	}
-
-	if graph.TotalModules > 0 {
-		// Calculate averages from module metrics
-		var totalFanIn, totalFanOut float64
-		var totalInstability, totalAbstractness, totalDistance float64
-		var refactoringCandidates []string
-
-		if graph.ModuleMetrics != nil {
-			for moduleName, moduleMetrics := range graph.ModuleMetrics {
-				totalFanIn += float64(moduleMetrics.AfferentCoupling)
-				totalFanOut += float64(moduleMetrics.EfferentCoupling)
-				totalInstability += moduleMetrics.Instability
-				totalAbstractness += moduleMetrics.Abstractness
-				totalDistance += moduleMetrics.Distance
-
-				// Identify refactoring priorities based on distance
-				if moduleMetrics.Distance > 0.5 {
-					refactoringCandidates = append(refactoringCandidates, moduleName)
-				}
-			}
-		}
-
-		moduleCount := float64(graph.TotalModules)
-		metrics.AverageFanIn = totalFanIn / moduleCount
-		metrics.AverageFanOut = totalFanOut / moduleCount
-		metrics.AverageInstability = totalInstability / moduleCount
-		metrics.AverageAbstractness = totalAbstractness / moduleCount
-		metrics.MainSequenceDeviation = totalDistance / moduleCount
-		metrics.SystemComplexity = float64(graph.TotalModules * 2)
-		metrics.MaxDependencyDepth = s.calculateMaxDepth(graph)
-		metrics.RefactoringPriority = refactoringCandidates
-
-		// Modularity index approximation
-		if graph.TotalEdges > 0 {
-			metrics.ModularityIndex = 1.0 - (float64(graph.TotalEdges) / float64(graph.TotalModules*graph.TotalModules))
-			if metrics.ModularityIndex < 0 {
-				metrics.ModularityIndex = 0
-			}
-		}
-	}
-
-	return metrics
 }
 
 func minSystemAnalysis(a, b int) int {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -377,7 +377,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 
 	// Calculate coupling metrics
 	metricsCalculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-	if err := metricsCalculator.CalculateMetrics(); err != nil {
+	if err := metricsCalculator.CalculateMetrics(ctx); err != nil {
 		return nil, err
 	}
 	couplingResults := s.extractCouplingResult(graph)
@@ -402,10 +402,6 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
-	maxDepth, err := analyzer.CalculateMaxDependencyDepth(ctx, graph)
-	if err != nil {
-		return nil, fmt.Errorf("calculate dependency depth: %w", err)
-	}
 
 	// Create dependency analysis result
 	result := &domain.DependencyAnalysisResult{
@@ -418,7 +414,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		CircularDependencies: s.convertCircularResults(circularResult),
 		CouplingAnalysis:     s.convertCouplingResults(couplingResults),
 		LongestChains:        longestChains,
-		MaxDepth:             maxDepth,
+		MaxDepth:             couplingResults.MaxDependencyDepth,
 	}
 
 	return result, nil

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -397,7 +397,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
 
-	longestChains := s.convertDependencyChains(topology.LongestChains)
+	longestChains := s.convertDependencyChains(topology.LongestChains())
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
@@ -419,7 +419,7 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		CircularDependencies: s.convertCircularResults(circularResult),
 		CouplingAnalysis:     s.convertCouplingResults(couplingResults),
 		LongestChains:        longestChains,
-		MaxDepth:             topology.MaxDepth,
+		MaxDepth:             topology.MaxDepth(),
 	}
 
 	return result, nil

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -392,10 +392,11 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 	}
 
 	// Find longest dependency chains
-	longestChains, err := s.findLongestChains(ctx, graph, 10) // Top 10 chains
+	dependencyChains, err := analyzer.FindLongestDependencyChains(ctx, graph, 10)
 	if err != nil {
 		return nil, fmt.Errorf("find dependency chains: %w", err)
 	}
+	longestChains := s.convertDependencyChains(dependencyChains)
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("dependency analysis cancelled: %w", err)
 	}
@@ -1364,125 +1365,6 @@ func (s *SystemAnalysisServiceImpl) buildDependencyMatrix(graph *analyzer.Depend
 	}
 
 	return matrix
-}
-
-func (s *SystemAnalysisServiceImpl) findLongestChains(ctx context.Context, graph *analyzer.DependencyGraph, limit int) ([]domain.DependencyPath, error) {
-	var chains []domain.DependencyPath
-
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	if limit <= 0 {
-		return chains, nil
-	}
-
-	moduleNames := make([]string, 0, len(graph.Nodes))
-	for moduleName := range graph.Nodes {
-		moduleNames = append(moduleNames, moduleName)
-	}
-	sort.Strings(moduleNames)
-
-	for _, moduleName := range moduleNames {
-		paths, err := s.findPathsFromModule(
-			ctx,
-			graph,
-			moduleName,
-			make(map[string]bool),
-			[]string{moduleName},
-			limit,
-		)
-		if err != nil {
-			return nil, err
-		}
-		chains = append(chains, paths...)
-	}
-
-	// Sort by length (descending), then by first module name for deterministic results
-	sort.Slice(chains, func(i, j int) bool {
-		if chains[i].Length != chains[j].Length {
-			return chains[i].Length > chains[j].Length
-		}
-		// Tie-breaker: compare first module name for deterministic results
-		return chains[i].Path[0] < chains[j].Path[0]
-	})
-
-	// Return top chains
-	if len(chains) > limit {
-		chains = chains[:limit]
-	}
-
-	return chains, nil
-}
-
-func (s *SystemAnalysisServiceImpl) findPathsFromModule(
-	ctx context.Context,
-	graph *analyzer.DependencyGraph,
-	current string,
-	visited map[string]bool,
-	path []string,
-	maxPaths int,
-) ([]domain.DependencyPath, error) {
-	var paths []domain.DependencyPath
-
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	if maxPaths <= 0 {
-		return paths, nil
-	}
-
-	visited[current] = true
-	defer delete(visited, current)
-
-	node := graph.Nodes[current]
-	if node == nil {
-		return paths, nil
-	}
-
-	dependencies := make([]string, 0, len(node.Dependencies))
-	for dependency := range node.Dependencies {
-		dependencies = append(dependencies, dependency)
-	}
-	sort.Strings(dependencies)
-
-	for _, dep := range dependencies {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		if !visited[dep] {
-			newPath := append([]string(nil), path...)
-			newPath = append(newPath, dep)
-
-			// Add this path
-			if len(newPath) >= 2 {
-				paths = append(paths, domain.DependencyPath{
-					From:   newPath[0],
-					To:     dep,
-					Path:   newPath,
-					Length: len(newPath),
-				})
-			}
-			if len(paths) >= maxPaths {
-				break
-			}
-
-			// Continue searching
-			subPaths, err := s.findPathsFromModule(ctx, graph, dep, visited, newPath, maxPaths-len(paths))
-			if err != nil {
-				return nil, err
-			}
-			paths = append(paths, subPaths...)
-
-			if len(paths) >= maxPaths {
-				break
-			}
-		}
-	}
-
-	return paths, nil
 }
 
 func (s *SystemAnalysisServiceImpl) convertCouplingResults(results *analyzer.SystemMetrics) *domain.CouplingAnalysis {

--- a/service/system_analysis_service_helpers_test.go
+++ b/service/system_analysis_service_helpers_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -246,11 +247,25 @@ func TestDependencyMatrixAndLongestChains(t *testing.T) {
 	require.True(t, matrix["moduleA"]["moduleD"])
 	require.False(t, matrix["moduleB"]["moduleA"])
 
-	chains := service.findLongestChains(graph, 5)
+	chains, err := service.findLongestChains(context.Background(), graph, 5)
+	require.NoError(t, err)
 	require.NotEmpty(t, chains)
 	assert.Equal(t, 4, chains[0].Length)
 	assert.Equal(t, []string{"moduleA", "moduleB", "moduleC", "moduleD"}, chains[0].Path)
 	assert.LessOrEqual(t, len(chains), 5)
+}
+
+func TestFindLongestChainsHonorsCancellation(t *testing.T) {
+	service := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	graph.AddModule("moduleA", "/project/moduleA.py")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := service.findLongestChains(ctx, graph, 5)
+
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestConvertCouplingResults(t *testing.T) {

--- a/service/system_analysis_service_helpers_test.go
+++ b/service/system_analysis_service_helpers_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -227,7 +226,7 @@ func TestAutoDetectArchitecture_FlatUnderscoreModules(t *testing.T) {
 	assert.Contains(t, layerPackages["infrastructure"], "user_repository")
 }
 
-func TestDependencyMatrixAndLongestChains(t *testing.T) {
+func TestDependencyMatrix(t *testing.T) {
 	service := NewSystemAnalysisService()
 	graph := analyzer.NewDependencyGraph("/project")
 
@@ -246,44 +245,6 @@ func TestDependencyMatrixAndLongestChains(t *testing.T) {
 	require.True(t, matrix["moduleA"]["moduleB"])
 	require.True(t, matrix["moduleA"]["moduleD"])
 	require.False(t, matrix["moduleB"]["moduleA"])
-
-	chains, err := service.findLongestChains(context.Background(), graph, 5)
-	require.NoError(t, err)
-	require.NotEmpty(t, chains)
-	assert.Equal(t, 4, chains[0].Length)
-	assert.Equal(t, []string{"moduleA", "moduleB", "moduleC", "moduleD"}, chains[0].Path)
-	assert.LessOrEqual(t, len(chains), 5)
-}
-
-func TestFindLongestChainsHonorsCancellation(t *testing.T) {
-	service := NewSystemAnalysisService()
-	graph := analyzer.NewDependencyGraph("/project")
-	graph.AddModule("moduleA", "/project/moduleA.py")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err := service.findLongestChains(ctx, graph, 5)
-
-	require.ErrorIs(t, err, context.Canceled)
-}
-
-func TestFindLongestChainsConsidersLaterDeepRoots(t *testing.T) {
-	service := NewSystemAnalysisService()
-	graph := analyzer.NewDependencyGraph("/project")
-	for _, moduleName := range []string{"a_shallow", "b_leaf", "z_deep", "z_middle", "z_lower", "z_leaf"} {
-		graph.AddModule(moduleName, "/project/"+moduleName+".py")
-	}
-	graph.AddDependency("a_shallow", "b_leaf", analyzer.DependencyEdgeImport, nil)
-	graph.AddDependency("z_deep", "z_middle", analyzer.DependencyEdgeImport, nil)
-	graph.AddDependency("z_middle", "z_lower", analyzer.DependencyEdgeImport, nil)
-	graph.AddDependency("z_lower", "z_leaf", analyzer.DependencyEdgeImport, nil)
-
-	chains, err := service.findLongestChains(context.Background(), graph, 3)
-
-	require.NoError(t, err)
-	require.NotEmpty(t, chains)
-	assert.Equal(t, []string{"z_deep", "z_middle", "z_lower", "z_leaf"}, chains[0].Path)
 }
 
 func TestConvertCouplingResults(t *testing.T) {

--- a/service/system_analysis_service_helpers_test.go
+++ b/service/system_analysis_service_helpers_test.go
@@ -268,6 +268,24 @@ func TestFindLongestChainsHonorsCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestFindLongestChainsConsidersLaterDeepRoots(t *testing.T) {
+	service := NewSystemAnalysisService()
+	graph := analyzer.NewDependencyGraph("/project")
+	for _, moduleName := range []string{"a_shallow", "b_leaf", "z_deep", "z_middle", "z_lower", "z_leaf"} {
+		graph.AddModule(moduleName, "/project/"+moduleName+".py")
+	}
+	graph.AddDependency("a_shallow", "b_leaf", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("z_deep", "z_middle", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("z_middle", "z_lower", analyzer.DependencyEdgeImport, nil)
+	graph.AddDependency("z_lower", "z_leaf", analyzer.DependencyEdgeImport, nil)
+
+	chains, err := service.findLongestChains(context.Background(), graph, 3)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, chains)
+	assert.Equal(t, []string{"z_deep", "z_middle", "z_lower", "z_leaf"}, chains[0].Path)
+}
+
 func TestConvertCouplingResults(t *testing.T) {
 	service := NewSystemAnalysisService()
 

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -39,7 +39,7 @@ func TestAnalyzeDependencies_CompletesBranchingGraphBeforeDeadline(t *testing.T)
 		paths = append(paths, path)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	response, err := NewSystemAnalysisService().AnalyzeDependencies(ctx, domain.SystemAnalysisRequest{

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -2,16 +2,54 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/ludo-technologies/pyscn/internal/analyzer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAnalyzeDependencies_CompletesBranchingGraphBeforeDeadline(t *testing.T) {
+	const moduleCount = 36
+
+	dir := t.TempDir()
+	paths := make([]string, 0, moduleCount+1)
+	initPath := filepath.Join(dir, "__init__.py")
+	require.NoError(t, os.WriteFile(initPath, nil, 0o644))
+	paths = append(paths, initPath)
+
+	for index := 0; index < moduleCount; index++ {
+		var source strings.Builder
+		if index+1 < moduleCount {
+			fmt.Fprintf(&source, "from . import m%d\n", index+1)
+		}
+		if index+2 < moduleCount {
+			fmt.Fprintf(&source, "from . import m%d\n", index+2)
+		}
+		fmt.Fprintf(&source, "def f%d(): return %d\n", index, index)
+
+		path := filepath.Join(dir, fmt.Sprintf("m%d.py", index))
+		require.NoError(t, os.WriteFile(path, []byte(source.String()), 0o644))
+		paths = append(paths, path)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	response, err := NewSystemAnalysisService().AnalyzeDependencies(ctx, domain.SystemAnalysisRequest{
+		Paths:             paths,
+		IncludeThirdParty: domain.BoolPtr(false),
+	})
+	require.NoError(t, err)
+	require.NoError(t, ctx.Err(), "branching dependency analysis exceeded its deadline")
+	assert.Equal(t, moduleCount-1, response.MaxDepth)
+}
 
 func TestAnalyzeDependenciesReportsMainSequenceMetricsFromPythonProject(t *testing.T) {
 	dir := t.TempDir()

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -39,7 +39,7 @@ func TestAnalyzeDependencies_CompletesBranchingGraphBeforeDeadline(t *testing.T)
 		paths = append(paths, path)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	response, err := NewSystemAnalysisService().AnalyzeDependencies(ctx, domain.SystemAnalysisRequest{

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -49,6 +49,8 @@ func TestAnalyzeDependencies_CompletesBranchingGraphBeforeDeadline(t *testing.T)
 	require.NoError(t, err)
 	require.NoError(t, ctx.Err(), "branching dependency analysis exceeded its deadline")
 	assert.Equal(t, moduleCount-1, response.MaxDepth)
+	require.NotEmpty(t, response.LongestChains)
+	assert.Equal(t, moduleCount, response.LongestChains[0].Length)
 }
 
 func TestAnalyzeDependenciesReportsMainSequenceMetricsFromPythonProject(t *testing.T) {

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAnalyzeDependencies_CompletesBranchingGraphBeforeDeadline(t *testing.T) {
-	const moduleCount = 36
+	const moduleCount = 44
 
 	dir := t.TempDir()
 	paths := make([]string, 0, moduleCount+1)

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -39,7 +39,7 @@ func TestAnalyzeDependencies_CompletesBranchingGraphBeforeDeadline(t *testing.T)
 		paths = append(paths, path)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	response, err := NewSystemAnalysisService().AnalyzeDependencies(ctx, domain.SystemAnalysisRequest{

--- a/service/system_metrics_test.go
+++ b/service/system_metrics_test.go
@@ -29,10 +29,7 @@ func TestCouplingMetricsVaryWithGraphs(t *testing.T) {
 				graph.AddDependency("moduleA", "moduleB", analyzer.DependencyEdgeImport, nil)
 				graph.AddDependency("moduleB", "moduleC", analyzer.DependencyEdgeImport, nil)
 
-				// Calculate metrics
-				calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-				err := calculator.CalculateMetrics(context.Background())
-				require.NoError(t, err)
+				calculateCouplingMetrics(t, graph)
 
 				return graph
 			},
@@ -70,10 +67,7 @@ func TestCouplingMetricsVaryWithGraphs(t *testing.T) {
 				detector := analyzer.NewCircularDependencyDetector(graph)
 				detector.DetectCircularDependencies()
 
-				// Calculate metrics
-				calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-				err := calculator.CalculateMetrics(context.Background())
-				require.NoError(t, err)
+				calculateCouplingMetrics(t, graph)
 
 				return graph
 			},
@@ -109,10 +103,7 @@ func TestCouplingMetricsVaryWithGraphs(t *testing.T) {
 				// Inter-package dependency (less good)
 				graph.AddDependency("packageA.module1", "packageB.module1", analyzer.DependencyEdgeImport, nil)
 
-				// Calculate metrics
-				calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-				err := calculator.CalculateMetrics(context.Background())
-				require.NoError(t, err)
+				calculateCouplingMetrics(t, graph)
 
 				return graph
 			},
@@ -149,10 +140,7 @@ func TestCouplingMetricsPopulatesGraphMetrics(t *testing.T) {
 	graph.AddDependency("module1", "module2", analyzer.DependencyEdgeImport, nil)
 	graph.AddDependency("module2", "module3", analyzer.DependencyEdgeImport, nil)
 
-	// Calculate metrics using CouplingMetricsCalculator
-	calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-	err := calculator.CalculateMetrics(context.Background())
-	require.NoError(t, err)
+	calculateCouplingMetrics(t, graph)
 
 	result := graph.SystemMetrics
 	assert.NotNil(t, result)
@@ -196,9 +184,7 @@ func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
 	graph.AddDependency("balanced.client", "balanced.service", analyzer.DependencyEdgeImport, nil)
 	graph.AddDependency("balanced.service", "balanced.dep", analyzer.DependencyEdgeImport, nil)
 
-	calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-	err := calculator.CalculateMetrics(context.Background())
-	require.NoError(t, err)
+	calculateCouplingMetrics(t, graph)
 
 	result := service.convertCouplingResults(graph.SystemMetrics)
 	require.NotNil(t, result)
@@ -216,9 +202,7 @@ func TestCouplingMetricsDifferBetweenGraphs(t *testing.T) {
 	// Graph 1: Low complexity
 	graph1 := analyzer.NewDependencyGraph("/test/project1")
 	graph1.AddModule("simple", "/test/simple.py")
-	calculator1 := analyzer.NewCouplingMetricsCalculator(graph1, analyzer.DefaultCouplingMetricsOptions())
-	err := calculator1.CalculateMetrics(context.Background())
-	require.NoError(t, err)
+	calculateCouplingMetrics(t, graph1)
 	metrics1 := graph1.SystemMetrics
 
 	// Graph 2: Higher complexity
@@ -231,9 +215,7 @@ func TestCouplingMetricsDifferBetweenGraphs(t *testing.T) {
 			graph2.AddDependency(fmt.Sprintf("module%d", i-1), moduleName, analyzer.DependencyEdgeImport, nil)
 		}
 	}
-	calculator2 := analyzer.NewCouplingMetricsCalculator(graph2, analyzer.DefaultCouplingMetricsOptions())
-	err = calculator2.CalculateMetrics(context.Background())
-	require.NoError(t, err)
+	calculateCouplingMetrics(t, graph2)
 	metrics2 := graph2.SystemMetrics
 
 	// Verify metrics are different
@@ -247,4 +229,16 @@ func TestCouplingMetricsDifferBetweenGraphs(t *testing.T) {
 	assert.Greater(t, metrics2.TotalDependencies, metrics1.TotalDependencies)
 	assert.Greater(t, metrics2.SystemComplexity, metrics1.SystemComplexity)
 	assert.GreaterOrEqual(t, metrics2.MaxDependencyDepth, metrics1.MaxDependencyDepth)
+}
+
+func calculateCouplingMetrics(t *testing.T, graph *analyzer.DependencyGraph) {
+	t.Helper()
+
+	topology, err := analyzer.AnalyzeDependencyTopology(context.Background(), graph, 0)
+	require.NoError(t, err)
+	calculator := analyzer.NewCouplingMetricsCalculator(
+		graph,
+		analyzer.DefaultCouplingMetricsOptions(),
+	)
+	require.NoError(t, calculator.CalculateMetrics(context.Background(), topology))
 }

--- a/service/system_metrics_test.go
+++ b/service/system_metrics_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractCouplingResult_VariesWithGraphs(t *testing.T) {
+func TestCouplingMetricsVaryWithGraphs(t *testing.T) {
 	tests := []struct {
 		name          string
 		setupGraph    func() *analyzer.DependencyGraph
@@ -128,22 +128,16 @@ func TestExtractCouplingResult_VariesWithGraphs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Setup
-			service := &SystemAnalysisServiceImpl{}
 			graph := tt.setupGraph()
 
-			// Extract metrics
-			result := service.extractCouplingResult(graph)
-
-			// Verify metrics
+			result := graph.SystemMetrics
 			require.NotNil(t, result)
 			tt.expectedCheck(t, result)
 		})
 	}
 }
 
-func TestExtractCouplingResult_UsesCalculatedMetrics(t *testing.T) {
-	service := &SystemAnalysisServiceImpl{}
+func TestCouplingMetricsPopulatesGraphMetrics(t *testing.T) {
 	graph := analyzer.NewDependencyGraph("/test/project")
 
 	// Add some modules
@@ -160,11 +154,7 @@ func TestExtractCouplingResult_UsesCalculatedMetrics(t *testing.T) {
 	err := calculator.CalculateMetrics(context.Background())
 	require.NoError(t, err)
 
-	// Extract results
-	result := service.extractCouplingResult(graph)
-
-	// Verify it uses the calculated SystemMetrics
-	assert.Equal(t, graph.SystemMetrics, result)
+	result := graph.SystemMetrics
 	assert.NotNil(t, result)
 	assert.Equal(t, 3, result.TotalModules)
 	assert.Equal(t, 2, result.TotalDependencies)
@@ -222,16 +212,14 @@ func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
 	assert.NotContains(t, result.ZoneOfPain, "balanced.dep")
 }
 
-func TestExtractCouplingResult_DifferentGraphsProduceDifferentMetrics(t *testing.T) {
-	service := &SystemAnalysisServiceImpl{}
-
+func TestCouplingMetricsDifferBetweenGraphs(t *testing.T) {
 	// Graph 1: Low complexity
 	graph1 := analyzer.NewDependencyGraph("/test/project1")
 	graph1.AddModule("simple", "/test/simple.py")
 	calculator1 := analyzer.NewCouplingMetricsCalculator(graph1, analyzer.DefaultCouplingMetricsOptions())
 	err := calculator1.CalculateMetrics(context.Background())
 	require.NoError(t, err)
-	metrics1 := service.extractCouplingResult(graph1)
+	metrics1 := graph1.SystemMetrics
 
 	// Graph 2: Higher complexity
 	graph2 := analyzer.NewDependencyGraph("/test/project2")
@@ -246,7 +234,7 @@ func TestExtractCouplingResult_DifferentGraphsProduceDifferentMetrics(t *testing
 	calculator2 := analyzer.NewCouplingMetricsCalculator(graph2, analyzer.DefaultCouplingMetricsOptions())
 	err = calculator2.CalculateMetrics(context.Background())
 	require.NoError(t, err)
-	metrics2 := service.extractCouplingResult(graph2)
+	metrics2 := graph2.SystemMetrics
 
 	// Verify metrics are different
 	assert.NotEqual(t, metrics1.TotalModules, metrics2.TotalModules)

--- a/service/system_metrics_test.go
+++ b/service/system_metrics_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestExtractCouplingResult_VariesWithGraphs(t *testing.T) {
 
 				// Calculate metrics
 				calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-				err := calculator.CalculateMetrics()
+				err := calculator.CalculateMetrics(context.Background())
 				require.NoError(t, err)
 
 				return graph
@@ -71,7 +72,7 @@ func TestExtractCouplingResult_VariesWithGraphs(t *testing.T) {
 
 				// Calculate metrics
 				calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-				err := calculator.CalculateMetrics()
+				err := calculator.CalculateMetrics(context.Background())
 				require.NoError(t, err)
 
 				return graph
@@ -110,7 +111,7 @@ func TestExtractCouplingResult_VariesWithGraphs(t *testing.T) {
 
 				// Calculate metrics
 				calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-				err := calculator.CalculateMetrics()
+				err := calculator.CalculateMetrics(context.Background())
 				require.NoError(t, err)
 
 				return graph
@@ -156,7 +157,7 @@ func TestExtractCouplingResult_UsesCalculatedMetrics(t *testing.T) {
 
 	// Calculate metrics using CouplingMetricsCalculator
 	calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-	err := calculator.CalculateMetrics()
+	err := calculator.CalculateMetrics(context.Background())
 	require.NoError(t, err)
 
 	// Extract results
@@ -206,7 +207,7 @@ func TestExtractCouplingResult_ClassifiesMainSequenceZones(t *testing.T) {
 	graph.AddDependency("balanced.service", "balanced.dep", analyzer.DependencyEdgeImport, nil)
 
 	calculator := analyzer.NewCouplingMetricsCalculator(graph, analyzer.DefaultCouplingMetricsOptions())
-	err := calculator.CalculateMetrics()
+	err := calculator.CalculateMetrics(context.Background())
 	require.NoError(t, err)
 
 	result := service.convertCouplingResults(graph.SystemMetrics)
@@ -228,7 +229,7 @@ func TestExtractCouplingResult_DifferentGraphsProduceDifferentMetrics(t *testing
 	graph1 := analyzer.NewDependencyGraph("/test/project1")
 	graph1.AddModule("simple", "/test/simple.py")
 	calculator1 := analyzer.NewCouplingMetricsCalculator(graph1, analyzer.DefaultCouplingMetricsOptions())
-	err := calculator1.CalculateMetrics()
+	err := calculator1.CalculateMetrics(context.Background())
 	require.NoError(t, err)
 	metrics1 := service.extractCouplingResult(graph1)
 
@@ -243,7 +244,7 @@ func TestExtractCouplingResult_DifferentGraphsProduceDifferentMetrics(t *testing
 		}
 	}
 	calculator2 := analyzer.NewCouplingMetricsCalculator(graph2, analyzer.DefaultCouplingMetricsOptions())
-	err = calculator2.CalculateMetrics()
+	err = calculator2.CalculateMetrics(context.Background())
 	require.NoError(t, err)
 	metrics2 := service.extractCouplingResult(graph2)
 

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -624,7 +624,7 @@ Mirrors `domain.SystemAnalysisResponse`. Nested field names are Go PascalCase.
 | `DependencyMatrix`     | object  | Map from module to map of module to boolean.                         |
 | `CircularDependencies` | object  | Cycle detection results; contains `Cycles` (array) and `TotalCycles` (integer). |
 | `CouplingAnalysis`     | object  | Per-module coupling metrics: `Ca`, `Ce`, `Instability`, `Abstractness`, `Distance`. |
-| `LongestChains`        | array   | Array of `DependencyPath` objects.                                   |
+| `LongestChains`        | array   | Top SCC-condensed paths, expanded to real module dependency paths.    |
 | `MaxDepth`             | integer | Maximum SCC-condensed dependency depth, counted in edges.             |
 
 ### `ModuleDependencyMetrics` object

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -130,7 +130,7 @@ Mirrors `domain.AnalyzeSummary`. All numeric counters default to `0` when the co
 | ------------------------------ | ------- | -------------------------------------------------------------- |
 | `deps_total_modules`           | integer | Total modules analyzed.                                        |
 | `deps_modules_in_cycles`       | integer | Modules participating in at least one circular dependency.     |
-| `deps_max_depth`               | integer | Longest SCC-condensed dependency path, counted in edges.       |
+| `deps_max_depth`               | integer | Longest load-time SCC-condensed dependency path, counted in edges. |
 | `deps_main_sequence_deviation` | number  | Average distance from Martin's main sequence, `0`–`1`.         |
 
 ### Architecture metrics
@@ -624,8 +624,8 @@ Mirrors `domain.SystemAnalysisResponse`. Nested field names are Go PascalCase.
 | `DependencyMatrix`     | object  | Map from module to map of module to boolean.                         |
 | `CircularDependencies` | object  | Cycle detection results; contains `Cycles` (array) and `TotalCycles` (integer). |
 | `CouplingAnalysis`     | object  | Per-module coupling metrics: `Ca`, `Ce`, `Instability`, `Abstractness`, `Distance`. |
-| `LongestChains`        | array   | Top SCC-condensed paths, expanded to real module dependency paths.    |
-| `MaxDepth`             | integer | Maximum SCC-condensed dependency depth, counted in edges.             |
+| `LongestChains`        | array   | Top load-time SCC-condensed paths, expanded to real module dependency paths. |
+| `MaxDepth`             | integer | Maximum load-time SCC-condensed dependency depth, counted in edges.   |
 
 ### `ModuleDependencyMetrics` object
 

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -130,7 +130,7 @@ Mirrors `domain.AnalyzeSummary`. All numeric counters default to `0` when the co
 | ------------------------------ | ------- | -------------------------------------------------------------- |
 | `deps_total_modules`           | integer | Total modules analyzed.                                        |
 | `deps_modules_in_cycles`       | integer | Modules participating in at least one circular dependency.     |
-| `deps_max_depth`               | integer | Longest dependency chain length.                               |
+| `deps_max_depth`               | integer | Longest SCC-condensed dependency path, counted in edges.       |
 | `deps_main_sequence_deviation` | number  | Average distance from Martin's main sequence, `0`–`1`.         |
 
 ### Architecture metrics
@@ -625,7 +625,7 @@ Mirrors `domain.SystemAnalysisResponse`. Nested field names are Go PascalCase.
 | `CircularDependencies` | object  | Cycle detection results; contains `Cycles` (array) and `TotalCycles` (integer). |
 | `CouplingAnalysis`     | object  | Per-module coupling metrics: `Ca`, `Ce`, `Instability`, `Abstractness`, `Distance`. |
 | `LongestChains`        | array   | Array of `DependencyPath` objects.                                   |
-| `MaxDepth`             | integer | Maximum dependency depth.                                            |
+| `MaxDepth`             | integer | Maximum SCC-condensed dependency depth, counted in edges.             |
 
 ### `ModuleDependencyMetrics` object
 


### PR DESCRIPTION
Fixes #689.

Replaces exhaustive path enumeration with a cancellable SCC-condensed topology pass shared by depth, coupling, and bounded longest-chain analysis. Lazy-only imports remain available to coupling and architecture checks but are excluded from load-time topology. Django dependency analysis completes in about 1.2s across 908 Python files.

Breaking behavior: cycles now count as one component, so MaxDepth, dependency health scores, and LongestChains can change for cyclic graphs.

Validated with tests, race detector, vet, lint, and the strict docs build.