### PR TITLE
fix(parser): reject legacy syntax no Python 3 release accepts

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -39,8 +39,8 @@ func (p *Parser) Parse(ctx context.Context, source []byte) (*ParseResult, error)
 	}
 
 	rootNode := tree.RootNode()
-	if p.HasSyntaxErrors(rootNode) {
-		return nil, fmt.Errorf("syntax errors found in source code")
+	if err := p.CheckSyntax(rootNode, source); err != nil {
+		return nil, err
 	}
 
 	// Build internal AST representation
@@ -104,16 +104,18 @@ func (p *Parser) FindNodes(node *sitter.Node, nodeType string) []*sitter.Node {
 	return nodes
 }
 
-// HasSyntaxErrors checks if the parsed tree contains any syntax errors
-func (p *Parser) HasSyntaxErrors(node *sitter.Node) bool {
-	hasError := false
-
-	_ = p.WalkTree(node, func(n *sitter.Node) error {
+// CheckSyntax returns an error describing the first syntax problem in the parsed
+// tree, or nil when the source is valid Python 3. Beyond the ERROR and MISSING
+// nodes tree-sitter reports, it also rejects legacy constructs that the grammar
+// still accepts but no Python 3 release compiles (see python3_syntax.go).
+func (p *Parser) CheckSyntax(node *sitter.Node, source []byte) error {
+	return p.WalkTree(node, func(n *sitter.Node) error {
 		if n.IsError() || n.IsMissing() {
-			hasError = true
+			return fmt.Errorf("syntax errors found in source code")
+		}
+		if reason := invalidInPython3(n, source); reason != "" {
+			return fmt.Errorf("line %d: %s is not valid Python 3", int(n.StartPoint().Row)+1, reason)
 		}
 		return nil
 	})
-
-	return hasError
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -338,6 +338,12 @@ func TestParseRejectsSyntaxInvalidInEveryPython3(t *testing.T) {
 		{"raise with argument list", "raise ValueError, 'msg'\n"},
 		{"raise with traceback", "raise ValueError, 'msg', tb\n"},
 		{"backtick repr", "x = `y`\n"},
+		{"tuple parameter unpacking", "def f((a, b)):\n    return a\n"},
+		{"tuple parameter among normal ones", "def f(x, (a, b), y=1):\n    return a\n"},
+		{"nested tuple parameter", "def f(((a, b), c)):\n    return a\n"},
+		{"defaulted tuple parameter", "def f((a, b)=(1, 2)):\n    return a\n"},
+		{"lambda tuple parameter", "g = lambda (x, y): x\n"},
+		{"lambda tuple parameter among normal ones", "g = lambda a, (x, y): x\n"},
 		{"bare octal literal", "mode = 0777\n"},
 		{"leading zero decimal", "n = 08\n"},
 		{"long literal", "n = 10L\n"},
@@ -391,6 +397,20 @@ func TestParseAcceptsValidPython3(t *testing.T) {
 		{"prefixed literals", "o = 0o777\nb = 0b1010\nh = 0xFF\n"},
 		{"complex and float literals", "c = 10j\nz = 0j\nf = 1e10\n"},
 		{"not equal operator", "if a != b:\n    pass\n"},
+		// tuple_pattern is only a syntax error in a parameter list; these are
+		// the legal positions for the same node.
+		{"tuple for target", "for (a, b) in items:\n    pass\n"},
+		{"list for target", "for [a, b] in items:\n    pass\n"},
+		{"tuple assignment target", "(a, b) = t\n"},
+		{"nested tuple assignment target", "(a, (b, c)) = t\n"},
+		{"starred tuple assignment target", "(a, *rest) = t\n"},
+		{"list assignment target", "[a, b] = t\n"},
+		{"tuple comprehension target", "z = [a for (a, b) in items]\n"},
+		{"tuple with-as target", "with ctx() as (a, b):\n    pass\n"},
+		{"tuple default value", "def f(x=(1, 2)):\n    return x\n"},
+		{"normal parameters", "def f(x, y=1, *args, **kw):\n    return x\n"},
+		{"typed parameters", "def f(x: int, *, y: str = 'a') -> int:\n    return x\n"},
+		{"normal lambda parameters", "g = lambda x, y=1: x\n"},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -276,7 +276,7 @@ class MyClass:
 	}
 }
 
-func TestHasSyntaxErrors(t *testing.T) {
+func TestCheckSyntax(t *testing.T) {
 	parser := New()
 	ctx := context.Background()
 
@@ -307,9 +307,96 @@ func TestHasSyntaxErrors(t *testing.T) {
 			tree, _ := parser.parser.ParseCtx(ctx, nil, []byte(tt.source))
 			rootNode := tree.RootNode()
 
-			hasErrors := parser.HasSyntaxErrors(rootNode)
-			if hasErrors != tt.hasErrors {
-				t.Errorf("HasSyntaxErrors() = %v, want %v", hasErrors, tt.hasErrors)
+			err := parser.CheckSyntax(rootNode, []byte(tt.source))
+			if (err != nil) != tt.hasErrors {
+				t.Errorf("CheckSyntax() error = %v, want error = %v", err, tt.hasErrors)
+			}
+		})
+	}
+}
+
+// The tree-sitter Python grammar accepts these legacy constructs without
+// producing an ERROR node, so they used to be analyzed as if they were valid.
+// Every case here is a SyntaxError on both Python 3.13 and 3.14.
+func TestParseRejectsSyntaxInvalidInEveryPython3(t *testing.T) {
+	parser := New()
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{"print statement", "print 'hello'\n"},
+		{"print statement with a name", "x = 1\nprint x\n"},
+		{"print statement with a tuple", "print 1, 2\n"},
+		{"exec statement", "exec 'code'\n"},
+		{"exec statement with in", "exec 'code' in {}\n"},
+		{
+			name:   "exception list bound with as",
+			source: "try:\n    pass\nexcept OSError, TypeError as e:\n    pass\n",
+		},
+		{"raise with argument list", "raise ValueError, 'msg'\n"},
+		{"raise with traceback", "raise ValueError, 'msg', tb\n"},
+		{"backtick repr", "x = `y`\n"},
+		{"bare octal literal", "mode = 0777\n"},
+		{"leading zero decimal", "n = 08\n"},
+		{"long literal", "n = 10L\n"},
+		{"<> operator", "if a <> b:\n    pass\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parser.Parse(ctx, []byte(tt.source))
+			if err == nil {
+				t.Fatalf("Parse() succeeded for invalid source, want error (got %d AST children)", len(result.AST.Body))
+			}
+			if !strings.Contains(err.Error(), "not valid Python 3") {
+				t.Errorf("Parse() error = %q, want it to mention it is not valid Python 3", err)
+			}
+		})
+	}
+}
+
+// Every case here compiles on Python 3.13 and/or 3.14, so pyscn must analyze it
+// rather than reject it. The unparenthesized `except A, B:` list became valid in
+// Python 3.14 (PEP 758), and `print >>f, x` parses as a shift plus a tuple.
+func TestParseAcceptsValidPython3(t *testing.T) {
+	parser := New()
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{"print function", "print('hello')\n"},
+		{"print function with keywords", "import sys\nprint('a', file=sys.stderr, sep='')\n"},
+		{"print as an identifier", "print = 5\nvalue = print\n"},
+		{"print shifted into a stream", "import sys\nprint >>sys.stderr, 'oops'\n"},
+		{"print subscripted", "print [1]\n"},
+		{"print negated", "print -1\n"},
+		{"exec function", "exec('code')\n"},
+		{"exec subscripted", "exec [1]\n"},
+		{
+			name:   "unparenthesized exception list is valid since PEP 758",
+			source: "def f(x):\n    try:\n        return x\n    except OSError, TypeError:\n        return None\n",
+		},
+		{"parenthesized exception list", "try:\n    pass\nexcept (OSError, TypeError):\n    pass\n"},
+		{"parenthesized exception list with as", "try:\n    pass\nexcept (OSError, TypeError) as e:\n    pass\n"},
+		{"except with as", "try:\n    pass\nexcept OSError as e:\n    pass\n"},
+		{"except group", "try:\n    pass\nexcept* OSError:\n    pass\n"},
+		{"raise from", "raise ValueError('x') from err\n"},
+		{"raise with call arguments", "raise SomeExc(1, 2)\n"},
+		{"bare raise", "try:\n    pass\nexcept OSError:\n    raise\n"},
+		{"zero literals", "x = 0\ny = 00\nz = 0_0\n"},
+		{"prefixed literals", "o = 0o777\nb = 0b1010\nh = 0xFF\n"},
+		{"complex and float literals", "c = 10j\nz = 0j\nf = 1e10\n"},
+		{"not equal operator", "if a != b:\n    pass\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parser.Parse(ctx, []byte(tt.source)); err != nil {
+				t.Errorf("Parse() error = %v, want valid Python 3 to parse", err)
 			}
 		})
 	}

--- a/internal/parser/python3_syntax.go
+++ b/internal/parser/python3_syntax.go
@@ -49,6 +49,13 @@ func invalidInPython3(tsNode *sitter.Node, source []byte) string {
 		if start := tsNode.Child(0); start != nil && start.Content(source) == "`" {
 			return "backtick repr (Python 3 requires repr(...))"
 		}
+	case "tuple_pattern":
+		// `def f((a, b))` / `lambda (x, y): ...`, removed by PEP 3113. The same
+		// node is legal as a for target, an assignment target or a nested
+		// pattern, so only a parameter position is a syntax error.
+		if isParameterPosition(tsNode.Parent()) {
+			return "tuple parameter unpacking (removed in Python 3 by PEP 3113)"
+		}
 	case "integer":
 		return invalidPython3Integer(tsNode.Content(source))
 	}
@@ -84,6 +91,20 @@ func isLegacyOctal(text string) bool {
 			// 0x/0b/0o prefixes and the j complex suffix are valid Python 3.
 			return false
 		}
+	}
+	return false
+}
+
+// isParameterPosition reports whether tsNode is a function or lambda parameter
+// list. A defaulted parameter (`def f((a, b)=(1, 2))`) nests the pattern one
+// level deeper, and default_parameter only ever occurs inside such a list.
+func isParameterPosition(tsNode *sitter.Node) bool {
+	if tsNode == nil {
+		return false
+	}
+	switch tsNode.Type() {
+	case "parameters", "lambda_parameters", "default_parameter":
+		return true
 	}
 	return false
 }

--- a/internal/parser/python3_syntax.go
+++ b/internal/parser/python3_syntax.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// The tree-sitter Python grammar still accepts a number of legacy Python 2
+// constructs, so a file using them parses into a clean tree with no ERROR or
+// MISSING node. Relying on tree-sitter alone therefore lets a file CPython
+// refuses to compile be analyzed as if it were valid, and reported as healthy.
+//
+// pyscn has no target Python version, so these checks only reject constructs
+// that every Python 3 release rejects. Anything a current release accepts is
+// left alone, because flagging valid code as broken is the worse failure. In
+// particular `except A, B:` is deliberately NOT rejected: PEP 758 made the
+// unparenthesized exception list valid in Python 3.14, and only the `as` form
+// (`except A, B as e:`) remains a syntax error everywhere.
+
+// invalidInPython3 reports why every Python 3 release rejects the construct at
+// tsNode, or an empty string when the node is accepted.
+func invalidInPython3(tsNode *sitter.Node, source []byte) string {
+	switch tsNode.Type() {
+	case "print_statement":
+		// `print >>f, x` is the Python 2 redirect form, but Python 3 still
+		// parses it as `print >> f` followed by a tuple, so it stays valid.
+		if firstChildOfType(tsNode, "chevron") != nil {
+			return ""
+		}
+		return "the print statement (Python 3 requires print(...))"
+	case "exec_statement":
+		return "the exec statement (Python 3 requires exec(...))"
+	case "<>":
+		return "the <> operator (Python 3 requires !=)"
+	case "except_clause":
+		// An unparenthesized exception list is allowed since PEP 758, but never
+		// together with `as`, which the grammar nests as an as_pattern.
+		if firstChildOfType(tsNode, ",") != nil && firstChildOfType(tsNode, "as_pattern") != nil {
+			return "an unparenthesized exception list bound with `as` (multiple exception types must be parenthesized when using `as`)"
+		}
+	case "raise_statement":
+		// `raise E, v` / `raise E, v, tb`. A valid Python 3 raise carries a
+		// single expression, optionally followed by `from`.
+		if firstChildOfType(tsNode, "expression_list") != nil {
+			return "raise with a comma-separated argument list (Python 3 requires raise Exc(msg))"
+		}
+	case "string":
+		if start := tsNode.Child(0); start != nil && start.Content(source) == "`" {
+			return "backtick repr (Python 3 requires repr(...))"
+		}
+	case "integer":
+		return invalidPython3Integer(tsNode.Content(source))
+	}
+	return ""
+}
+
+// invalidPython3Integer reports why Python 3 rejects the integer literal text,
+// or an empty string when the literal is accepted.
+func invalidPython3Integer(text string) string {
+	if strings.HasSuffix(text, "L") || strings.HasSuffix(text, "l") {
+		return "an L-suffixed long literal (Python 3 has a single int type)"
+	}
+	if isLegacyOctal(text) {
+		return "a bare leading-zero octal literal (Python 3 requires the 0o prefix)"
+	}
+	return ""
+}
+
+// isLegacyOctal reports whether text is a Python 2 octal literal such as 0777.
+// Python 3 tolerates a leading zero only when every remaining digit is also zero
+// (0, 00, 0_0); any other value needs the explicit 0o prefix.
+func isLegacyOctal(text string) bool {
+	if !strings.HasPrefix(text, "0") {
+		return false
+	}
+	for _, r := range text[1:] {
+		switch {
+		case r == '0' || r == '_':
+			continue
+		case r >= '1' && r <= '9':
+			return true
+		default:
+			// 0x/0b/0o prefixes and the j complex suffix are valid Python 3.
+			return false
+		}
+	}
+	return false
+}
+
+// firstChildOfType returns the first direct child of tsNode with the given type,
+// or nil when there is none.
+func firstChildOfType(tsNode *sitter.Node, childType string) *sitter.Node {
+	childCount := int(tsNode.ChildCount())
+	for i := 0; i < childCount; i++ {
+		if child := tsNode.Child(i); child != nil && child.Type() == childType {
+			return child
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Refs #677

## Summary

The tree-sitter Python grammar still accepts a number of Python 2 constructs, so a file using them parses into a tree with **no `ERROR` or `MISSING` node**. `HasSyntaxErrors` only looked for those nodes, so such a file was analyzed as if it were valid, functions were extracted from it, and it was graded as healthy — with no signal anywhere that the analysis was unsound.

This replaces `HasSyntaxErrors` with `CheckSyntax`, which also rejects constructs the grammar accepts but no Python 3 release compiles, and reports the offending line and reason rather than a bare message.

Detected: `print` / `exec` statements, `except A, B as e:`, `raise E, v[, tb]`, backtick repr, tuple parameter unpacking (`def f((a, b))`, `lambda (x, y): x`), bare leading-zero octals (`0777`), `L`-suffixed longs, and `<>`.

The tuple-unpacking check is context-sensitive: `tuple_pattern` is also the node for legal `for` targets, assignment targets, comprehension targets and nested patterns, so only a parameter-list position is rejected.

## The reported repro is actually valid Python 3

Worth flagging before review: the specific construct in #677 — `except OSError, TypeError:` — is **valid Python 3.14** under [PEP 758](https://peps.python.org/pep-0758/), which allows unparenthesized exception lists. It is only a `SyntaxError` on 3.13 and earlier.

The repo cited there as evidence, `gi0baro/tonio`, declares `requires-python = '>=3.14'`, so `_socket.py:486` compiles fine and pyscn was **correct** to analyze it. Rejecting that file would itself have been a P1 false positive.

So this PR fixes the bug class the audit surfaced, but deliberately does **not** reject the construct as filed.

## Design rule

pyscn has no target Python version, so the checks only reject syntax that **every** Python 3 release rejects. Under-reporting on a Python 2 file is better than calling valid modern code broken. Two constructs are allowed for that reason:

- `except A, B:` without `as` — valid since PEP 758, so only the `as` form (`except A, B as e:`, still a `SyntaxError` on 3.14) is rejected.
- `print >>f, x` — Python 3 still parses this as a shift followed by a tuple, so it stays valid.

## Verification

- All 51 table cases cross-checked against CPython **3.13 and 3.14**: 0 misclassified.
- False-positive sweep over the **1762-file CPython 3.13 stdlib**: 0 hits from the new checks. Two files fail via the pre-existing tree-sitter `ERROR` path, untouched here.
- tonio (79 files), requests, flask, httpx: 0 failures.
- Full `go test ./...`, `go vet`, `gofmt` clean.

End to end, `print 'legacy'` now yields:

```
[legacy.py] Parse error: line 2: the print statement (Python 3 requires print(...)) is not valid Python 3
```

in both `complexity.Errors` and `dead_code.errors`, and its functions no longer appear in the report — while a PEP 758 file still analyzes normally.

## Known gaps

This closes the constructs above, not the whole class. Still analyzed as if valid:

- **Malformed numeric literals.** tree-sitter accepts misplaced underscores that CPython rejects: `0_j`, `1_`, `10_j`, `1_.5`. (`1__2` and `0_x1` do produce an `ERROR` node and are already caught.) Detecting these needs a full numeric-literal validator rather than a legacy-syntax rule, so it is left out here.
- Any other Python 2 form the grammar accepts that is not in the list above.

Under-reporting is the sanctioned direction per the design rule, so these are gaps rather than regressions.

## Out of scope

`except* A, B:` is valid on 3.14 but tree-sitter emits an `ERROR` node for it, so pyscn reports a parse error. That is a pre-existing grammar limitation, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)