### PR TITLE
fix: make class ranking ties deterministic

### DIFF
--- a/service/cbo_service.go
+++ b/service/cbo_service.go
@@ -289,11 +289,17 @@ func (s *CBOServiceImpl) sortClasses(classes []domain.ClassCoupling, sortBy doma
 	switch sortBy {
 	case domain.SortByCoupling:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.CouplingCount > sorted[j].Metrics.CouplingCount
+			if sorted[i].Metrics.CouplingCount != sorted[j].Metrics.CouplingCount {
+				return sorted[i].Metrics.CouplingCount > sorted[j].Metrics.CouplingCount
+			}
+			return cboClassLocationLess(sorted[i], sorted[j])
 		})
 	case domain.SortByName:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Name < sorted[j].Name
+			if sorted[i].Name != sorted[j].Name {
+				return sorted[i].Name < sorted[j].Name
+			}
+			return cboClassLocationLess(sorted[i], sorted[j])
 		})
 	case domain.SortByRisk:
 		sort.Slice(sorted, func(i, j int) bool {
@@ -302,23 +308,42 @@ func (s *CBOServiceImpl) sortClasses(classes []domain.ClassCoupling, sortBy doma
 				domain.RiskLevelMedium: 2,
 				domain.RiskLevelLow:    1,
 			}
-			return riskOrder[sorted[i].RiskLevel] > riskOrder[sorted[j].RiskLevel]
+			if riskOrder[sorted[i].RiskLevel] != riskOrder[sorted[j].RiskLevel] {
+				return riskOrder[sorted[i].RiskLevel] > riskOrder[sorted[j].RiskLevel]
+			}
+			return cboClassLocationLess(sorted[i], sorted[j])
 		})
 	case domain.SortByLocation:
 		sort.Slice(sorted, func(i, j int) bool {
 			if sorted[i].FilePath != sorted[j].FilePath {
 				return sorted[i].FilePath < sorted[j].FilePath
 			}
-			return sorted[i].StartLine < sorted[j].StartLine
+			if sorted[i].StartLine != sorted[j].StartLine {
+				return sorted[i].StartLine < sorted[j].StartLine
+			}
+			return sorted[i].Name < sorted[j].Name
 		})
 	default:
 		// Default to sorting by coupling count (descending)
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.CouplingCount > sorted[j].Metrics.CouplingCount
+			if sorted[i].Metrics.CouplingCount != sorted[j].Metrics.CouplingCount {
+				return sorted[i].Metrics.CouplingCount > sorted[j].Metrics.CouplingCount
+			}
+			return cboClassLocationLess(sorted[i], sorted[j])
 		})
 	}
 
 	return sorted
+}
+
+func cboClassLocationLess(a, b domain.ClassCoupling) bool {
+	if a.FilePath != b.FilePath {
+		return a.FilePath < b.FilePath
+	}
+	if a.StartLine != b.StartLine {
+		return a.StartLine < b.StartLine
+	}
+	return a.Name < b.Name
 }
 
 // generateSummary creates aggregate statistics
@@ -376,7 +401,10 @@ func (s *CBOServiceImpl) generateSummary(classes []domain.ClassCoupling, filesAn
 	sortedByCount := make([]domain.ClassCoupling, len(classes))
 	copy(sortedByCount, classes)
 	sort.Slice(sortedByCount, func(i, j int) bool {
-		return sortedByCount[i].Metrics.CouplingCount > sortedByCount[j].Metrics.CouplingCount
+		if sortedByCount[i].Metrics.CouplingCount != sortedByCount[j].Metrics.CouplingCount {
+			return sortedByCount[i].Metrics.CouplingCount > sortedByCount[j].Metrics.CouplingCount
+		}
+		return cboClassLocationLess(sortedByCount[i], sortedByCount[j])
 	})
 
 	maxTopClasses := 10

--- a/service/cbo_service_test.go
+++ b/service/cbo_service_test.go
@@ -40,6 +40,39 @@ func TestNewCBOService(t *testing.T) {
 	assert.NotNil(t, service.parser)
 }
 
+func TestCBOService_DeterministicTieOrdering(t *testing.T) {
+	svc := NewCBOService()
+	classes := make([]domain.ClassCoupling, 12)
+	for i := range classes {
+		classes[i] = domain.ClassCoupling{
+			Name:      fmt.Sprintf("Class%02d", i),
+			FilePath:  fmt.Sprintf("pkg/%02d.py", 11-i),
+			StartLine: 1,
+			Metrics:   domain.CBOMetrics{CouplingCount: 5},
+			RiskLevel: domain.RiskLevelMedium,
+		}
+	}
+
+	want := make([]string, 10)
+	for i := range want {
+		want[i] = fmt.Sprintf("pkg/%02d.py", i)
+	}
+
+	sorted := svc.sortClasses(classes, domain.SortByCoupling)
+	assert.Equal(t, want, cboFilePaths(sorted[:10]))
+
+	summary := svc.generateSummary(classes, 12, domain.CBORequest{})
+	assert.Equal(t, want, cboFilePaths(summary.MostCoupledClasses))
+}
+
+func cboFilePaths(classes []domain.ClassCoupling) []string {
+	paths := make([]string, len(classes))
+	for i, class := range classes {
+		paths[i] = class.FilePath
+	}
+	return paths
+}
+
 func TestCBOService_Analyze(t *testing.T) {
 	service := NewCBOService()
 	ctx := context.Background()

--- a/service/lcom_service.go
+++ b/service/lcom_service.go
@@ -261,11 +261,17 @@ func (s *LCOMServiceImpl) sortClasses(classes []domain.ClassCohesion, sortBy dom
 	switch sortBy {
 	case domain.SortByCohesion:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.LCOM4 > sorted[j].Metrics.LCOM4
+			if sorted[i].Metrics.LCOM4 != sorted[j].Metrics.LCOM4 {
+				return sorted[i].Metrics.LCOM4 > sorted[j].Metrics.LCOM4
+			}
+			return lcomClassLocationLess(sorted[i], sorted[j])
 		})
 	case domain.SortByName:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Name < sorted[j].Name
+			if sorted[i].Name != sorted[j].Name {
+				return sorted[i].Name < sorted[j].Name
+			}
+			return lcomClassLocationLess(sorted[i], sorted[j])
 		})
 	case domain.SortByRisk:
 		sort.Slice(sorted, func(i, j int) bool {
@@ -274,22 +280,41 @@ func (s *LCOMServiceImpl) sortClasses(classes []domain.ClassCohesion, sortBy dom
 				domain.RiskLevelMedium: 2,
 				domain.RiskLevelLow:    1,
 			}
-			return riskOrder[sorted[i].RiskLevel] > riskOrder[sorted[j].RiskLevel]
+			if riskOrder[sorted[i].RiskLevel] != riskOrder[sorted[j].RiskLevel] {
+				return riskOrder[sorted[i].RiskLevel] > riskOrder[sorted[j].RiskLevel]
+			}
+			return lcomClassLocationLess(sorted[i], sorted[j])
 		})
 	case domain.SortByLocation:
 		sort.Slice(sorted, func(i, j int) bool {
 			if sorted[i].FilePath != sorted[j].FilePath {
 				return sorted[i].FilePath < sorted[j].FilePath
 			}
-			return sorted[i].StartLine < sorted[j].StartLine
+			if sorted[i].StartLine != sorted[j].StartLine {
+				return sorted[i].StartLine < sorted[j].StartLine
+			}
+			return sorted[i].Name < sorted[j].Name
 		})
 	default:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.LCOM4 > sorted[j].Metrics.LCOM4
+			if sorted[i].Metrics.LCOM4 != sorted[j].Metrics.LCOM4 {
+				return sorted[i].Metrics.LCOM4 > sorted[j].Metrics.LCOM4
+			}
+			return lcomClassLocationLess(sorted[i], sorted[j])
 		})
 	}
 
 	return sorted
+}
+
+func lcomClassLocationLess(a, b domain.ClassCohesion) bool {
+	if a.FilePath != b.FilePath {
+		return a.FilePath < b.FilePath
+	}
+	if a.StartLine != b.StartLine {
+		return a.StartLine < b.StartLine
+	}
+	return a.Name < b.Name
 }
 
 // generateSummary creates aggregate LCOM statistics
@@ -344,7 +369,10 @@ func (s *LCOMServiceImpl) generateSummary(classes []domain.ClassCohesion, filesA
 	sortedByLCOM := make([]domain.ClassCohesion, len(classes))
 	copy(sortedByLCOM, classes)
 	sort.Slice(sortedByLCOM, func(i, j int) bool {
-		return sortedByLCOM[i].Metrics.LCOM4 > sortedByLCOM[j].Metrics.LCOM4
+		if sortedByLCOM[i].Metrics.LCOM4 != sortedByLCOM[j].Metrics.LCOM4 {
+			return sortedByLCOM[i].Metrics.LCOM4 > sortedByLCOM[j].Metrics.LCOM4
+		}
+		return lcomClassLocationLess(sortedByLCOM[i], sortedByLCOM[j])
 	})
 
 	maxTopClasses := 10

--- a/service/lcom_service_test.go
+++ b/service/lcom_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -30,6 +31,39 @@ func TestNewLCOMService(t *testing.T) {
 	svc := NewLCOMService()
 	assert.NotNil(t, svc)
 	assert.NotNil(t, svc.parser)
+}
+
+func TestLCOMService_DeterministicTieOrdering(t *testing.T) {
+	svc := NewLCOMService()
+	classes := make([]domain.ClassCohesion, 12)
+	for i := range classes {
+		classes[i] = domain.ClassCohesion{
+			Name:      fmt.Sprintf("Class%02d", i),
+			FilePath:  fmt.Sprintf("pkg/%02d.py", 11-i),
+			StartLine: 1,
+			Metrics:   domain.LCOMMetrics{LCOM4: 5},
+			RiskLevel: domain.RiskLevelMedium,
+		}
+	}
+
+	want := make([]string, 10)
+	for i := range want {
+		want[i] = fmt.Sprintf("pkg/%02d.py", i)
+	}
+
+	sorted := svc.sortClasses(classes, domain.SortByCohesion)
+	assert.Equal(t, want, lcomFilePaths(sorted[:10]))
+
+	summary := svc.generateSummary(classes, 12, domain.LCOMRequest{})
+	assert.Equal(t, want, lcomFilePaths(summary.LeastCohesiveClasses))
+}
+
+func lcomFilePaths(classes []domain.ClassCohesion) []string {
+	paths := make([]string, len(classes))
+	for i, class := range classes {
+		paths[i] = class.FilePath
+	}
+	return paths
 }
 
 func TestLCOMService_Analyze(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add total-order tie-breakers to CBO and LCOM class ranking paths.
- Keep top-10 membership stable when metric values tie.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Fixes #708

## Changes
- Order equal metrics by file path, start line, and class name.
- Cover deterministic top-10 membership for both class summaries.

## Testing
- [x] `go test ./service -run 'Test(CBO|LCOM)Service_DeterministicTieOrdering' -count=1`
- [x] `go test ./...`
- [x] `go test -race ./service -run 'Test(CBO|LCOM)Service_DeterministicTieOrdering' -count=10`
- [x] `go vet ./...`
- [x] `go build ./cmd/pyscn`
- [x] `golangci-lint run --timeout=10m`

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (not needed)
