### PR TITLE
fix: gate all analyzed functions

### DIFF
--- a/cmd/pyscn/check.go
+++ b/cmd/pyscn/check.go
@@ -478,7 +478,7 @@ func (c *CheckCommand) checkComplexity(cmd *cobra.Command, args []string) (int, 
 	// functions that are too long. Length is orthogonal to McCabe, so a flat
 	// 200-line function is an issue on its own and both can fire at once.
 	issueCount := 0
-	for _, function := range response.Functions {
+	for _, function := range response.AnalyzedFunctions {
 		if function.Metrics.Complexity > maxComplexity {
 			issueCount++
 			if !c.quiet {

--- a/cmd/pyscn/check_complexity_test.go
+++ b/cmd/pyscn/check_complexity_test.go
@@ -84,3 +84,29 @@ func TestCheckComplexityStaysSilentBelowThreshold(t *testing.T) {
 		t.Errorf("expected no diagnostics, got: %s", output)
 	}
 }
+
+func TestCheckComplexityGatesFunctionsHiddenByDisplayFilters(t *testing.T) {
+	checkCmd := NewCheckCommand()
+	cobraCmd := checkCmd.CreateCobraCommand()
+	var stderr bytes.Buffer
+	cobraCmd.SetErr(&stderr)
+
+	path := writeLongFunctionFile(t, 120)
+	configPath := filepath.Join(t.TempDir(), ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte("[complexity]\nreport_unchanged = false\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	checkCmd.configFile = configPath
+
+	issueCount, err := checkCmd.checkComplexity(cobraCmd, []string{path})
+	if err != nil {
+		t.Fatalf("checkComplexity failed: %v", err)
+	}
+
+	if issueCount != 1 {
+		t.Errorf("expected the hidden long function to fail the gate, got %d issues", issueCount)
+	}
+	if output := stderr.String(); !strings.Contains(output, "build_table is too long (123 SLOC > 100)") {
+		t.Errorf("expected a long-function diagnostic, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- evaluate the quality gate against the complete analyzed function set
- keep display filters from hiding complexity and SLOC violations
- add regression coverage for `report_unchanged = false`

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Fixes #705

## Changes
- Use the complete function population for quality-gate checks.
- Cover a long, low-complexity function hidden from report output.

## Testing
- [x] `go test ./cmd/pyscn -run 'TestCheckComplexity' -count=1`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./cmd/pyscn`
- [x] `golangci-lint run --timeout=10m`
- [x] `git diff --check`

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (not needed)
