### PR TITLE
chore: translate Japanese code comments to English

### DIFF
--- a/internal/analyzer/clone_detector.go
+++ b/internal/analyzer/clone_detector.go
@@ -273,9 +273,9 @@ type CloneDetectorConfig struct {
 	MaxGoroutines      int // Goroutines for parallel pair comparison (0 = all CPUs)
 
 	// Grouping configuration
-	GroupingMode      GroupingMode // デフォルト: GroupingModeConnected
-	GroupingThreshold float64      // デフォルト: Type3Threshold
-	KCoreK            int          // デフォルト: 2
+	GroupingMode      GroupingMode // Default: GroupingModeConnected
+	GroupingThreshold float64      // Default: Type3Threshold
+	KCoreK            int          // Default: 2
 
 	// LSH Configuration (optional, opt-in)
 	UseLSH                 bool    // Enable LSH acceleration

--- a/internal/analyzer/grouping_mode.go
+++ b/internal/analyzer/grouping_mode.go
@@ -10,11 +10,11 @@ import (
 type GroupingMode string
 
 const (
-	GroupingModeConnected       GroupingMode = "connected"        // 現在のデフォルト（高再現率）
-	GroupingModeStar            GroupingMode = "star"             // Star/Medoid（バランス型）
-	GroupingModeCompleteLinkage GroupingMode = "complete_linkage" // 完全連結（高精度）
-	GroupingModeKCore           GroupingMode = "k_core"           // k-core制約（スケーラブル）
-	GroupingModeCentroid        GroupingMode = "centroid"         // 重心ベース（推移的問題を回避）
+	GroupingModeConnected       GroupingMode = "connected"        // Current default (high recall)
+	GroupingModeStar            GroupingMode = "star"             // Star/medoid (balanced)
+	GroupingModeCompleteLinkage GroupingMode = "complete_linkage" // Complete linkage (high precision)
+	GroupingModeKCore           GroupingMode = "k_core"           // k-core constrained (scalable)
+	GroupingModeCentroid        GroupingMode = "centroid"         // Centroid based (avoids transitivity issues)
 )
 
 // coreMode translates a pyscn grouping mode to the core/clone grouping mode.


### PR DESCRIPTION
Comments on the clone grouping modes (`internal/analyzer/grouping_mode.go`) and the `CloneDetectorConfig` defaults (`internal/analyzer/clone_detector.go`) have been in Japanese since 2025-09. This translates them.

No behavior change.

The Japanese strings in `service/file_reader_test.go` are left as-is — they are the fixture for the UTF-8 source reading test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)