### PR TITLE
fix: reject missing complexity function population

### DIFF
--- a/app/complexity_usecase.go
+++ b/app/complexity_usecase.go
@@ -259,6 +259,12 @@ func (uc *ComplexityUseCase) AnalyzeFile(ctx context.Context, filePath string, r
 }
 
 func attachDirectoryComplexity(response *domain.ComplexityResponse, projectRoot string) error {
+	if response == nil {
+		return fmt.Errorf("complexity response is required")
+	}
+	if response.AnalyzedFunctions == nil {
+		return fmt.Errorf("complete analyzed function population is required")
+	}
 	byDirectory, err := aggregateComplexityByDirectory(response.AnalyzedFunctions, projectRoot)
 	if err != nil {
 		return err

--- a/app/directory_complexity_test.go
+++ b/app/directory_complexity_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -56,7 +57,7 @@ func TestAggregateComplexityByDirectory_UsesAnalyzedFunctions(t *testing.T) {
 	}
 }
 
-func TestAttachDirectoryComplexity_DoesNotFallbackToReportedFunctions(t *testing.T) {
+func TestAttachDirectoryComplexity_RejectsMissingAnalyzedFunctions(t *testing.T) {
 	root := t.TempDir()
 	response := &domain.ComplexityResponse{
 		Functions: []domain.FunctionComplexity{
@@ -68,11 +69,25 @@ func TestAttachDirectoryComplexity_DoesNotFallbackToReportedFunctions(t *testing
 		},
 	}
 
-	if err := attachDirectoryComplexity(response, root); err != nil {
-		t.Fatalf("attach directory complexity: %v", err)
+	err := attachDirectoryComplexity(response, root)
+	if err == nil {
+		t.Fatal("expected missing analyzed function population to be rejected")
 	}
-	if len(response.ByDirectory) != 0 {
-		t.Fatalf("expected no rollups without the complete analyzed population, got %+v", response.ByDirectory)
+	if !strings.Contains(err.Error(), "complete analyzed function population is required") {
+		t.Fatalf("expected analyzed function population error, got %v", err)
+	}
+}
+
+func TestAttachDirectoryComplexity_AcceptsInitializedEmptyAnalyzedFunctions(t *testing.T) {
+	response := &domain.ComplexityResponse{
+		AnalyzedFunctions: []domain.FunctionComplexity{},
+	}
+
+	if err := attachDirectoryComplexity(response, t.TempDir()); err != nil {
+		t.Fatalf("attach empty directory complexity: %v", err)
+	}
+	if response.ByDirectory == nil {
+		t.Fatal("expected an empty directory collection, got nil")
 	}
 }
 

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -28,7 +28,7 @@ func NewComplexityService() *ComplexityServiceImpl {
 
 // Analyze performs complexity analysis on multiple files
 func (s *ComplexityServiceImpl) Analyze(ctx context.Context, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
-	var allFunctions []domain.FunctionComplexity
+	allFunctions := make([]domain.FunctionComplexity, 0)
 	var allRawMetrics []domain.RawMetrics
 	var rawMetricResults []*analyzer.RawMetricsResult
 	var warnings []string
@@ -103,7 +103,7 @@ func (s *ComplexityServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *P
 		return nil, fmt.Errorf("project snapshot cannot be nil")
 	}
 
-	var allFunctions []domain.FunctionComplexity
+	allFunctions := make([]domain.FunctionComplexity, 0)
 	var allRawMetrics []domain.RawMetrics
 	var rawMetricResults []*analyzer.RawMetricsResult
 	var warnings []string

--- a/service/complexity_service_test.go
+++ b/service/complexity_service_test.go
@@ -381,6 +381,8 @@ def handle(value):
 
 		require.NoError(t, err)
 		require.NotNil(t, response)
+		require.NotNil(t, response.AnalyzedFunctions)
+		assert.Empty(t, response.AnalyzedFunctions)
 		assert.Empty(t, response.Functions)
 		assert.Len(t, response.RawMetrics, 1)
 		require.NotNil(t, response.RawMetricsSummary)


### PR DESCRIPTION
## Summary
- Reject complexity responses that omit the complete function population before directory rollups.
- Preserve valid empty populations for files that only produce raw metrics.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring

## Related Issues
Refs #706

## Changes
- Initialize service responses with a non-nil complete function collection.
- Return an explicit invariant error when the complete collection is missing.
- Cover missing and valid empty populations with regression tests.

## Testing
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run --allow-parallel-runners --timeout=10m`
- [x] `go build ./cmd/pyscn`
- [x] Added tests for new functionality

## Documentation
- [ ] Updated godoc comments
- [ ] Updated README or other docs (not needed)
