### PR TITLE
Clean up complexity reporting after PR #697

### DIFF
--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -233,15 +233,19 @@ func TestAnalyzeUseCaseExecutePreservesPartialFailureCause(t *testing.T) {
 	}
 	cause := &testAnalyzerError{operation: "build cfg"}
 	complexityUseCase := NewSnapshotComplexityUseCase(
-		failingComplexityService{response: &domain.ComplexityResponse{Failures: []domain.AnalysisFailure{
-			domain.NewAnalysisFailure(
-				domain.AnalysisKindComplexity,
-				domain.AnalysisFailureCodeExecution,
-				"source.py",
-				"CFG construction failed: "+cause.Error(),
-				cause,
-			),
-		}}},
+		failingComplexityService{response: &domain.ComplexityResponse{
+			AnalyzedFunctions:   []domain.FunctionComplexity{},
+			AnalyzedClassScopes: []domain.FunctionComplexity{},
+			Failures: []domain.AnalysisFailure{
+				domain.NewAnalysisFailure(
+					domain.AnalysisKindComplexity,
+					domain.AnalysisFailureCodeExecution,
+					"source.py",
+					"CFG construction failed: "+cause.Error(),
+					cause,
+				),
+			},
+		}},
 		service.NewFileReader(),
 		service.NewOutputFormatter(),
 		service.NewConfigurationLoader(),

--- a/app/complexity_usecase.go
+++ b/app/complexity_usecase.go
@@ -267,7 +267,13 @@ func (uc *ComplexityUseCase) AnalyzeFile(ctx context.Context, filePath string, r
 	return nil
 }
 
+// attachDirectoryComplexity rolls the complete analyzed population up by
+// directory. It rejects responses that only carry the reported subset so the
+// section cannot silently disappear.
 func attachDirectoryComplexity(response *domain.ComplexityResponse, projectRoot string) error {
+	if response.AnalyzedFunctions == nil {
+		return fmt.Errorf("complexity response has no analyzed function population")
+	}
 	byDirectory, err := aggregateComplexityByDirectory(response.AnalyzedFunctions, projectRoot)
 	if err != nil {
 		return err

--- a/app/directory_complexity_test.go
+++ b/app/directory_complexity_test.go
@@ -56,7 +56,7 @@ func TestAggregateComplexityByDirectory_UsesAnalyzedFunctions(t *testing.T) {
 	}
 }
 
-func TestAttachDirectoryComplexity_DoesNotFallbackToReportedFunctions(t *testing.T) {
+func TestAttachDirectoryComplexity_RejectsMissingAnalyzedFunctions(t *testing.T) {
 	root := t.TempDir()
 	response := &domain.ComplexityResponse{
 		Functions: []domain.FunctionComplexity{
@@ -68,8 +68,9 @@ func TestAttachDirectoryComplexity_DoesNotFallbackToReportedFunctions(t *testing
 		},
 	}
 
-	if err := attachDirectoryComplexity(response, root); err != nil {
-		t.Fatalf("attach directory complexity: %v", err)
+	err := attachDirectoryComplexity(response, root)
+	if err == nil {
+		t.Fatal("expected an error when the analyzed function population is missing")
 	}
 	if len(response.ByDirectory) != 0 {
 		t.Fatalf("expected no rollups without the complete analyzed population, got %+v", response.ByDirectory)

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -243,7 +243,9 @@ type AnalyzeSummary struct {
 	MaxClassCognitiveComplexity   int `json:"max_class_cognitive_complexity" yaml:"max_class_cognitive_complexity"`
 	MaxClassNestingDepth          int `json:"max_class_nesting_depth" yaml:"max_class_nesting_depth"`
 	HighComplexityClassScopeCount int `json:"high_complexity_class_scope_count" yaml:"high_complexity_class_scope_count"`
-	// FunctionsParsed is retained for output compatibility and matches TotalFunctions.
+	// FunctionsParsed is always equal to TotalFunctions. It is retained only
+	// for JSON/YAML schema compatibility and will be removed; consumers should
+	// read TotalFunctions.
 	FunctionsParsed            int     `json:"functions_parsed" yaml:"functions_parsed"`
 	AverageComplexity          float64 `json:"average_complexity" yaml:"average_complexity"`
 	AverageCognitiveComplexity float64 `json:"average_cognitive_complexity" yaml:"average_cognitive_complexity"`

--- a/domain/complexity.go
+++ b/domain/complexity.go
@@ -275,8 +275,9 @@ type ComplexitySummary struct {
 	MaxClassCognitiveComplexity int `json:"max_class_cognitive_complexity" yaml:"max_class_cognitive_complexity"`
 	MaxClassNestingDepth        int `json:"max_class_nesting_depth" yaml:"max_class_nesting_depth"`
 	HighRiskClassScopes         int `json:"high_risk_class_scopes" yaml:"high_risk_class_scopes"`
-	// FunctionsParsed is retained for output compatibility and describes the same
-	// complete analyzed function population as TotalFunctions.
+	// FunctionsParsed is always equal to TotalFunctions. It is retained only
+	// for JSON/YAML schema compatibility and will be removed; consumers should
+	// read TotalFunctions. The displayed subset is len(ComplexityResponse.Functions).
 	FunctionsParsed            int     `json:"functions_parsed" yaml:"functions_parsed"`
 	AverageComplexity          float64 `json:"average_complexity" yaml:"average_complexity"`
 	AverageCognitiveComplexity float64 `json:"average_cognitive_complexity" yaml:"average_cognitive_complexity"`

--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -91,7 +91,11 @@ func (f *AnalyzeFormatter) writeText(response *domain.AnalyzeResponse, writer io
 	// Analysis modules results
 	if response.Summary.ComplexityEnabled {
 		fmt.Fprint(writer, utils.FormatSectionHeader("COMPLEXITY ANALYSIS"))
-		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Total Functions", formatFunctionCoverage(response.Summary.TotalFunctions, response.Summary.FunctionsParsed)))
+		reportedFunctions := 0
+		if response.Complexity != nil {
+			reportedFunctions = len(response.Complexity.Functions)
+		}
+		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Total Functions", formatFunctionCoverage(reportedFunctions, response.Summary.TotalFunctions)))
 		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Class Scopes", response.Summary.TotalClassScopes))
 		if response.Summary.TotalClassScopes > 0 {
 			fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Max Class Complexity", response.Summary.MaxClassComplexity))

--- a/service/analyze_html_test.go
+++ b/service/analyze_html_test.go
@@ -310,3 +310,22 @@ func TestMedian(t *testing.T) {
 	assert.Equal(t, "5", formatMedian(5))
 	assert.Equal(t, "2.5", formatMedian(2.5))
 }
+
+func TestWriteAnalyzeHTML_ShowsReportedVersusParsedFunctions(t *testing.T) {
+	response := &domain.AnalyzeResponse{
+		Summary: domain.AnalyzeSummary{ComplexityEnabled: true, TotalFiles: 1, TotalFunctions: 3},
+		Complexity: &domain.ComplexityResponse{
+			Functions: []domain.FunctionComplexity{
+				{Name: "gnarly", FilePath: "pkg/a.py", Metrics: domain.ComplexityMetrics{Complexity: 12}, RiskLevel: domain.RiskLevelMedium},
+			},
+			Summary: domain.ComplexitySummary{TotalFunctions: 3, FunctionsParsed: 3, MaxComplexity: 12},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, writeAnalyzeHTML(response, &buf))
+	html := buf.String()
+
+	assert.Contains(t, html, "1 / 3")
+	assert.Contains(t, html, "reported / parsed")
+}

--- a/service/basic_service_test.go
+++ b/service/basic_service_test.go
@@ -67,9 +67,8 @@ func TestComplexityService_Basic(t *testing.T) {
 	t.Run("filterFunctions handles empty slice", func(t *testing.T) {
 		var functions []domain.FunctionComplexity
 		req := domain.ComplexityRequest{MinComplexity: 1, MaxComplexity: 10}
-		result, functionsParsed := service.filterScopes(functions, req)
+		result := service.filterScopes(functions, req)
 		assert.Equal(t, 0, len(result))
-		assert.Equal(t, 0, functionsParsed)
 	})
 
 	// Test summary generation

--- a/service/complexity_service.go
+++ b/service/complexity_service.go
@@ -27,13 +27,7 @@ func NewComplexityService() *ComplexityServiceImpl {
 
 // Analyze performs complexity analysis on multiple files
 func (s *ComplexityServiceImpl) Analyze(ctx context.Context, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
-	var allScopes []domain.FunctionComplexity
-	var allRawMetrics []domain.RawMetrics
-	var rawMetricResults []*analyzer.RawMetricsResult
-	var warnings []string
-	var issues []analysisIssue
-	filesProcessed := 0
-	filesSkipped := 0
+	var results complexityFileResults
 
 	for _, filePath := range req.Paths {
 		// Check context cancellation
@@ -43,74 +37,14 @@ func (s *ComplexityServiceImpl) Analyze(ctx context.Context, req domain.Complexi
 		default:
 		}
 
-		// Progress reporting removed - file parsing is fast
-
-		// Analyze single file
-		scopes, rawMetrics, fileWarnings, fileIssues := s.analyzeFile(ctx, filePath, req)
-
-		if rawMetrics != nil {
-			allRawMetrics = append(allRawMetrics, *s.convertRawMetrics(rawMetrics))
-			rawMetricResults = append(rawMetricResults, rawMetrics)
-		}
-
-		if len(fileIssues) > 0 {
-			issues = append(issues, fileIssues...)
-			filesSkipped++
-			continue // Skip this file but continue with others
-		}
-
-		allScopes = append(allScopes, scopes...)
-		warnings = append(warnings, fileWarnings...)
-		filesProcessed++
+		results.add(s.analyzeFile(ctx, filePath, req))
 	}
 
-	if len(allScopes) == 0 && len(allRawMetrics) == 0 {
+	if results.empty() {
 		return nil, domain.NewAnalysisError("no execution scopes found to analyze", nil)
 	}
 
-	// Filter and sort results
-	allFunctions, allClassScopes := partitionComplexityScopes(allScopes)
-	moduleRollups := domain.AggregateComplexityByModule(allFunctions)
-	filteredFunctions, _ := s.filterScopes(allFunctions, req)
-	filteredClassScopes, _ := s.filterScopes(allClassScopes, req)
-	sortedFunctions, err := domain.SortComplexityScopesBy(filteredFunctions, req.SortBy)
-	if err != nil {
-		return nil, domain.NewAnalysisError("invalid complexity sort", err)
-	}
-	sortedClassScopes, err := domain.SortComplexityScopesBy(filteredClassScopes, req.SortBy)
-	if err != nil {
-		return nil, domain.NewAnalysisError("invalid complexity sort", err)
-	}
-
-	// Generate summary over the complete population so min_complexity only
-	// affects which functions are displayed, not the aggregate metrics.
-	summary := s.generateSummary(allFunctions, allClassScopes, complexitySummaryCounts{
-		filesAnalyzed: filesProcessed,
-		filesSkipped:  filesSkipped,
-	})
-	rawMetricsSummary := s.convertAggregateRawMetrics(analyzer.CalculateAggregateRawMetrics(rawMetricResults))
-
-	response := &domain.ComplexityResponse{
-		Functions:           sortedFunctions,
-		ClassScopes:         sortedClassScopes,
-		AnalyzedFunctions:   allFunctions,
-		AnalyzedClassScopes: allClassScopes,
-		Summary:             summary,
-		ModuleRollups:       moduleRollups,
-		RawMetrics:          allRawMetrics,
-		RawMetricsSummary:   rawMetricsSummary,
-		Warnings:            warnings,
-		Errors:              analysisIssueMessages(issues),
-		Failures:            analyzerFailures(domain.AnalysisKindComplexity, issues),
-		GeneratedAt:         time.Now().Format(time.RFC3339),
-		Version:             version.Version, // Get version from version package
-		Config:              s.buildConfigForResponse(req),
-		Request:             &req,
-	}
-	if err := response.ValidateAnalyzedScopes(); err != nil {
-		return nil, domain.NewAnalysisError("invalid complexity analysis result", err)
-	}
-	return response, nil
+	return s.buildComplexityResponse(&results, req)
 }
 
 // AnalyzeSnapshot performs complexity analysis using already parsed project files.
@@ -119,13 +53,7 @@ func (s *ComplexityServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *P
 		return nil, fmt.Errorf("project snapshot cannot be nil")
 	}
 
-	var allScopes []domain.FunctionComplexity
-	var allRawMetrics []domain.RawMetrics
-	var rawMetricResults []*analyzer.RawMetricsResult
-	var warnings []string
-	var issues []analysisIssue
-	filesProcessed := 0
-	filesSkipped := 0
+	var results complexityFileResults
 	parsedFiles := 0
 
 	for _, file := range snapshot.analysisProjectFiles() {
@@ -137,44 +65,72 @@ func (s *ComplexityServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *P
 		if file.Parsed() {
 			parsedFiles++
 		}
-		scopes, rawMetrics, fileWarnings, fileIssues := s.analyzeProjectFile(file, req)
-
-		if rawMetrics != nil {
-			allRawMetrics = append(allRawMetrics, *s.convertRawMetrics(rawMetrics))
-			rawMetricResults = append(rawMetricResults, rawMetrics)
-		}
-
-		if len(fileIssues) > 0 {
-			issues = append(issues, fileIssues...)
-			filesSkipped++
-			continue
-		}
-
-		allScopes = append(allScopes, scopes...)
-		warnings = append(warnings, fileWarnings...)
-		filesProcessed++
+		results.add(s.analyzeProjectFile(file, req))
 	}
-	if parsedFiles > 0 && len(allScopes) == 0 && len(allRawMetrics) == 0 {
+	if parsedFiles > 0 && results.empty() {
 		return nil, domain.NewAnalysisError("no execution scopes found to analyze", nil)
 	}
 
-	allFunctions, allClassScopes := partitionComplexityScopes(allScopes)
+	return s.buildComplexityResponse(&results, req)
+}
+
+// complexityFileResults accumulates per-file analysis output before the
+// response is assembled.
+type complexityFileResults struct {
+	scopes           []domain.FunctionComplexity
+	rawMetricResults []*analyzer.RawMetricsResult
+	warnings         []string
+	issues           []analysisIssue
+	filesProcessed   int
+	filesSkipped     int
+}
+
+// add records one file's analysis output. Files with issues are skipped so
+// other files continue to be analyzed.
+func (r *complexityFileResults) add(scopes []domain.FunctionComplexity, rawMetrics *analyzer.RawMetricsResult, warnings []string, issues []analysisIssue) {
+	if rawMetrics != nil {
+		r.rawMetricResults = append(r.rawMetricResults, rawMetrics)
+	}
+	if len(issues) > 0 {
+		r.issues = append(r.issues, issues...)
+		r.filesSkipped++
+		return
+	}
+	r.scopes = append(r.scopes, scopes...)
+	r.warnings = append(r.warnings, warnings...)
+	r.filesProcessed++
+}
+
+func (r *complexityFileResults) empty() bool {
+	return len(r.scopes) == 0 && len(r.rawMetricResults) == 0
+}
+
+// buildComplexityResponse derives the reported scopes, summary, and module
+// rollups from the complete analyzed population.
+func (s *ComplexityServiceImpl) buildComplexityResponse(results *complexityFileResults, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
+	allFunctions, allClassScopes := partitionComplexityScopes(results.scopes)
 	moduleRollups := domain.AggregateComplexityByModule(allFunctions)
-	filteredFunctions, _ := s.filterScopes(allFunctions, req)
-	filteredClassScopes, _ := s.filterScopes(allClassScopes, req)
-	sortedFunctions, err := domain.SortComplexityScopesBy(filteredFunctions, req.SortBy)
+	sortedFunctions, err := domain.SortComplexityScopesBy(s.filterScopes(allFunctions, req), req.SortBy)
 	if err != nil {
 		return nil, domain.NewAnalysisError("invalid complexity sort", err)
 	}
-	sortedClassScopes, err := domain.SortComplexityScopesBy(filteredClassScopes, req.SortBy)
+	sortedClassScopes, err := domain.SortComplexityScopesBy(s.filterScopes(allClassScopes, req), req.SortBy)
 	if err != nil {
 		return nil, domain.NewAnalysisError("invalid complexity sort", err)
 	}
+
+	// Generate summary over the complete population so min_complexity only
+	// affects which functions are displayed, not the aggregate metrics.
 	summary := s.generateSummary(allFunctions, allClassScopes, complexitySummaryCounts{
-		filesAnalyzed: filesProcessed,
-		filesSkipped:  filesSkipped,
+		filesAnalyzed: results.filesProcessed,
+		filesSkipped:  results.filesSkipped,
 	})
-	rawMetricsSummary := s.convertAggregateRawMetrics(analyzer.CalculateAggregateRawMetrics(rawMetricResults))
+
+	var rawMetrics []domain.RawMetrics
+	for _, result := range results.rawMetricResults {
+		rawMetrics = append(rawMetrics, *s.convertRawMetrics(result))
+	}
+	rawMetricsSummary := s.convertAggregateRawMetrics(analyzer.CalculateAggregateRawMetrics(results.rawMetricResults))
 
 	response := &domain.ComplexityResponse{
 		Functions:           sortedFunctions,
@@ -183,11 +139,11 @@ func (s *ComplexityServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *P
 		AnalyzedClassScopes: allClassScopes,
 		Summary:             summary,
 		ModuleRollups:       moduleRollups,
-		RawMetrics:          allRawMetrics,
+		RawMetrics:          rawMetrics,
 		RawMetricsSummary:   rawMetricsSummary,
-		Warnings:            warnings,
-		Errors:              analysisIssueMessages(issues),
-		Failures:            analyzerFailures(domain.AnalysisKindComplexity, issues),
+		Warnings:            results.warnings,
+		Errors:              analysisIssueMessages(results.issues),
+		Failures:            analyzerFailures(domain.AnalysisKindComplexity, results.issues),
 		GeneratedAt:         time.Now().Format(time.RFC3339),
 		Version:             version.Version,
 		Config:              s.buildConfigForResponse(req),
@@ -344,20 +300,17 @@ func partitionComplexityScopes(scopes []domain.FunctionComplexity) (functions, c
 	return functions, classScopes
 }
 
-// filterScopes returns visible execution scopes and the count before min_complexity.
-// report_unchanged remains part of the reporting contract, while module rollups
-// consume the complete analyzer population before either presentation filter.
-func (s *ComplexityServiceImpl) filterScopes(functions []domain.FunctionComplexity, req domain.ComplexityRequest) ([]domain.FunctionComplexity, int) {
+// filterScopes returns the execution scopes to display. report_unchanged and
+// min_complexity are presentation filters only: summaries and module rollups
+// consume the complete analyzer population.
+func (s *ComplexityServiceImpl) filterScopes(functions []domain.FunctionComplexity, req domain.ComplexityRequest) []domain.FunctionComplexity {
 	var filtered []domain.FunctionComplexity
 	complexityConfig := s.buildComplexityConfig(req)
-	functionsParsed := 0
 
 	for _, function := range functions {
 		if !complexityConfig.ShouldReport(function.Metrics.Complexity) {
 			continue
 		}
-		functionsParsed++
-		// Apply minimum complexity filter
 		if function.Metrics.Complexity < req.MinComplexity {
 			continue
 		}
@@ -367,7 +320,7 @@ func (s *ComplexityServiceImpl) filterScopes(functions []domain.FunctionComplexi
 		filtered = append(filtered, function)
 	}
 
-	return filtered, functionsParsed
+	return filtered
 }
 
 // complexitySummaryCounts carries the labeled counts for generateSummary so

--- a/service/complexity_service_test.go
+++ b/service/complexity_service_test.go
@@ -567,7 +567,7 @@ func TestComplexityService_FilterFunctions(t *testing.T) {
 			MaxComplexity: 0,
 		}
 
-		filtered, _ := service.filterScopes(functions, req)
+		filtered := service.filterScopes(functions, req)
 
 		require.Len(t, filtered, 3)
 		assert.Equal(t, "func2", filtered[0].Name)
@@ -582,7 +582,7 @@ func TestComplexityService_FilterFunctions(t *testing.T) {
 			MaxComplexity: 8, // This should NOT filter out functions
 		}
 
-		filtered, _ := service.filterScopes(functions, req)
+		filtered := service.filterScopes(functions, req)
 
 		// All 4 functions should be returned (MaxComplexity doesn't filter)
 		require.Len(t, filtered, 4)
@@ -682,7 +682,7 @@ func TestComplexityService_GenerateSummary(t *testing.T) {
 		}
 
 		req := domain.ComplexityRequest{MinComplexity: 5}
-		filtered, _ := service.filterScopes(allFunctions, req)
+		filtered := service.filterScopes(allFunctions, req)
 		summary := service.generateSummary(allFunctions, nil, complexitySummaryCounts{
 			filesAnalyzed: 1,
 		})

--- a/service/output_formatter.go
+++ b/service/output_formatter.go
@@ -62,7 +62,7 @@ func (f *OutputFormatterImpl) formatText(response *domain.ComplexityResponse) (s
 
 	// Summary counts describe the complete population used by aggregate metrics.
 	stats := map[string]interface{}{
-		"Total Functions": formatFunctionCoverage(response.Summary.TotalFunctions, response.Summary.FunctionsParsed),
+		"Total Functions": formatFunctionCoverage(len(response.Functions), response.Summary.TotalFunctions),
 		"Class Scopes":    response.Summary.TotalClassScopes,
 		"Files Analyzed":  response.Summary.FilesAnalyzed,
 	}
@@ -370,7 +370,7 @@ func (f *OutputFormatterImpl) formatSummaryText(response *domain.ComplexityRespo
 	var builder strings.Builder
 
 	builder.WriteString("Summary:\n")
-	builder.WriteString(fmt.Sprintf("  Total Functions: %s\n", formatFunctionCoverage(response.Summary.TotalFunctions, response.Summary.FunctionsParsed)))
+	builder.WriteString(fmt.Sprintf("  Total Functions: %s\n", formatFunctionCoverage(len(response.Functions), response.Summary.TotalFunctions)))
 	builder.WriteString(fmt.Sprintf("  Class Scopes: %d\n", response.Summary.TotalClassScopes))
 	if response.Summary.TotalFunctions > 0 {
 		builder.WriteString(fmt.Sprintf("  Average Complexity: %.2f\n", response.Summary.AverageComplexity))
@@ -408,12 +408,11 @@ func (f *OutputFormatterImpl) formatHTML(response *domain.ComplexityResponse) (s
 	return htmlFormatter.FormatComplexityAsHTML(response, projectName)
 }
 
-// formatFunctionCoverage preserves the legacy "reported / parsed" display for
-// externally constructed responses whose counts differ. Service-produced
-// responses use one complete-population count for both values.
-func formatFunctionCoverage(reported, parsed int) string {
-	if parsed > 0 && parsed != reported {
-		return fmt.Sprintf("%d reported / %d parsed", reported, parsed)
+// formatFunctionCoverage shows "reported / parsed" when presentation filters
+// (min_complexity, report_unchanged) hide part of the analyzed population.
+func formatFunctionCoverage(reported, total int) string {
+	if reported != total {
+		return fmt.Sprintf("%d reported / %d parsed", reported, total)
 	}
-	return fmt.Sprintf("%d", reported)
+	return fmt.Sprintf("%d", total)
 }

--- a/service/output_formatter_test.go
+++ b/service/output_formatter_test.go
@@ -814,7 +814,7 @@ func TestOutputFormatter_ErrorHandling(t *testing.T) {
 
 func TestFormatFunctionCoverage(t *testing.T) {
 	assert.Equal(t, "3", formatFunctionCoverage(3, 3))
-	assert.Equal(t, "3", formatFunctionCoverage(3, 0))
+	assert.Equal(t, "0", formatFunctionCoverage(0, 0))
 	assert.Equal(t, "1 reported / 3 parsed", formatFunctionCoverage(1, 3))
 	assert.Equal(t, "0 reported / 5 parsed", formatFunctionCoverage(0, 5))
 }
@@ -822,7 +822,9 @@ func TestFormatFunctionCoverage(t *testing.T) {
 func TestOutputFormatter_FunctionCoverageDisclosure(t *testing.T) {
 	formatter := NewOutputFormatter()
 	response := createTestComplexityResponse()
-	response.Summary.TotalFunctions = 1
+	// Simulate a presentation filter hiding two of three analyzed functions.
+	response.Functions = response.Functions[:1]
+	response.Summary.TotalFunctions = 3
 	response.Summary.FunctionsParsed = 3
 
 	t.Run("text shows reported vs parsed", func(t *testing.T) {
@@ -832,14 +834,14 @@ func TestOutputFormatter_FunctionCoverageDisclosure(t *testing.T) {
 		assert.NotContains(t, output, "Functions Total")
 	})
 
-	t.Run("json exposes functions_parsed distinctly", func(t *testing.T) {
+	t.Run("json keeps functions_parsed equal to total_functions", func(t *testing.T) {
 		output, err := formatter.Format(response, domain.OutputFormatJSON)
 		assert.NoError(t, err)
 
 		var result map[string]interface{}
 		require.NoError(t, json.Unmarshal([]byte(output), &result))
 		summary := result["summary"].(map[string]interface{})
-		assert.Equal(t, float64(1), summary["total_functions"])
+		assert.Equal(t, float64(3), summary["total_functions"])
 		assert.Equal(t, float64(3), summary["functions_parsed"])
 		assert.NotContains(t, summary, "functions_total")
 	})

--- a/service/templates/analyze/report.html
+++ b/service/templates/analyze/report.html
@@ -227,7 +227,7 @@
   <div class="card">
     <div class="card-h"><h2>Complexity</h2></div>
     <div class="strip">
-      <div class="s"><div class="v num">{{if and (gt .Complexity.Summary.FunctionsParsed 0) (ne .Complexity.Summary.FunctionsParsed .Complexity.Summary.TotalFunctions)}}{{.Complexity.Summary.TotalFunctions}} / {{.Complexity.Summary.FunctionsParsed}}{{else}}{{.Complexity.Summary.TotalFunctions}}{{end}}</div><div class="l">{{if and (gt .Complexity.Summary.FunctionsParsed 0) (ne .Complexity.Summary.FunctionsParsed .Complexity.Summary.TotalFunctions)}}reported / parsed{{else}}functions{{end}}</div></div>
+      {{$reported := len .Complexity.Functions}}<div class="s"><div class="v num">{{if ne $reported .Complexity.Summary.TotalFunctions}}{{$reported}} / {{.Complexity.Summary.TotalFunctions}}{{else}}{{.Complexity.Summary.TotalFunctions}}{{end}}</div><div class="l">{{if ne $reported .Complexity.Summary.TotalFunctions}}reported / parsed{{else}}functions{{end}}</div></div>
       <div class="s"><div class="v num">{{printf "%.2f" .Complexity.Summary.AverageComplexity}}</div><div class="l">average CC</div></div>
       <div class="s"><div class="v num">{{.Complexity.Summary.MaxComplexity}}</div><div class="l">max CC</div></div>
       <div class="s"><div class="v num{{if .Complexity.Summary.HighRiskFunctions}} bad{{end}}">{{.Complexity.Summary.HighRiskFunctions}}</div><div class="l">high risk</div></div>

--- a/website/docs/fr/output/schemas.md
+++ b/website/docs/fr/output/schemas.md
@@ -214,7 +214,7 @@ Reflet de `domain.ComplexityResponse`.
 | ---------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
 | `total_functions`                  | integer | Total des portées de module et de fonction analysées.                                                              |
 | `total_class_scopes`               | integer | Total des suites de classe exécutables analysées.                                                                 |
-| `functions_parsed`                 | integer | Compteur de compatibilité égal à la population complète de `total_functions`.                                     |
+| `functions_parsed`                 | integer | Obsolète. Toujours égal à `total_functions` ; conservé pour la compatibilité du schéma et sera supprimé.          |
 | `average_complexity`               | number  | Moyenne arithmétique de `complexity` sur les portées de module et de fonction.                                     |
 | `average_cognitive_complexity`     | number  | Moyenne arithmétique de `cognitive_complexity` sur les portées de module et de fonction.                           |
 | `average_nesting_depth`            | number  | Moyenne arithmétique de `nesting_depth` sur les portées de module et de fonction.                                  |

--- a/website/docs/ja/output/schemas.md
+++ b/website/docs/ja/output/schemas.md
@@ -214,7 +214,7 @@ JSON および YAML 出力は、`domain/analyze.go` で定義された `AnalyzeR
 | ---------------------------------- | ------- | -------------------------------------------------------------------- |
 | `total_functions`                  | integer | 分析されたモジュールおよび関数スコープの合計数。                     |
 | `total_class_scopes`               | integer | 分析された実行可能なクラススイートの合計数。                         |
-| `functions_parsed`                 | integer | `total_functions` の完全な母集団と一致する互換カウント。             |
+| `functions_parsed`                 | integer | 非推奨。常に `total_functions` と同じ値。互換性のために残しており、将来削除されます。 |
 | `average_complexity`               | number  | モジュールおよび関数スコープの `complexity` の算術平均。             |
 | `average_cognitive_complexity`     | number  | モジュールおよび関数スコープの `cognitive_complexity` の算術平均。   |
 | `average_nesting_depth`            | number  | モジュールおよび関数スコープの `nesting_depth` の算術平均。          |

--- a/website/docs/output/schemas.md
+++ b/website/docs/output/schemas.md
@@ -283,7 +283,7 @@ The standalone complexity formatter uses `by_directory` at the report root besid
 | ---------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
 | `total_functions`                  | integer | Total module and function scopes analyzed.                                                                 |
 | `total_class_scopes`               | integer | Total executable class suites analyzed.                                                                    |
-| `functions_parsed`                 | integer | Compatibility count matching the complete `total_functions` population.                                   |
+| `functions_parsed`                 | integer | Deprecated. Always equal to `total_functions`; kept for schema compatibility and will be removed.          |
 | `average_complexity`               | number  | Arithmetic mean of `complexity` across module and function scopes.                                         |
 | `average_cognitive_complexity`     | number  | Arithmetic mean of `cognitive_complexity` across module and function scopes.                               |
 | `average_nesting_depth`            | number  | Arithmetic mean of `nesting_depth` across module and function scopes.                                      |

--- a/website/docs/zh/output/schemas.md
+++ b/website/docs/zh/output/schemas.md
@@ -214,7 +214,7 @@ JSON 和 YAML 输出序列化 `domain/analyze.go` 中定义的 `AnalyzeResponse`
 | ---------------------------------- | ------- | ------------------------------------------------------------ |
 | `total_functions`                  | integer | 分析的模块与函数作用域总数。                                 |
 | `total_class_scopes`               | integer | 分析的可执行类套件总数。                                     |
-| `functions_parsed`                 | integer | 与完整 `total_functions` 总体一致的兼容计数。                |
+| `functions_parsed`                 | integer | 已弃用。始终等于 `total_functions`，仅为兼容性保留，将来会移除。 |
 | `average_complexity`               | number  | 模块与函数作用域 `complexity` 的算术平均值。                  |
 | `average_cognitive_complexity`     | number  | 模块与函数作用域 `cognitive_complexity` 的算术平均值。        |
 | `average_nesting_depth`            | number  | 模块与函数作用域 `nesting_depth` 的算术平均值。               |


### PR DESCRIPTION
Closes #706

- Fail fast in `attachDirectoryComplexity` when `AnalyzedFunctions` is unset instead of silently producing an empty `ByDirectory`
- Restore the "reported / parsed" indicator in text and HTML output by comparing the displayed function list with `TotalFunctions`
- Extract `buildComplexityResponse` shared by `Analyze` and `AnalyzeSnapshot`
- Drop the unused count returned by `filterScopes`
- Keep `FunctionsParsed` for JSON/YAML schema compatibility, documented as deprecated and always equal to `TotalFunctions`

https://claude.ai/code/session_015vcPsxnNU1eswPoodvkbnY