### PR TITLE
fix: report unclamped code duplication percentage

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -988,7 +988,9 @@ func (uc *AnalyzeUseCase) calculateSummary(summary *domain.AnalyzeSummary, respo
 		totalClones := response.Clone.Statistics.TotalClones
 
 		if totalFragments > 0 && totalClones > 0 {
-			summary.CodeDuplication = math.Min(domain.DuplicationThresholdHigh, float64(totalClones)/float64(totalFragments)*100)
+			// Store the true ratio; DuplicationPenalty saturates at
+			// DuplicationThresholdHigh on its own, so no clamp is needed here.
+			summary.CodeDuplication = float64(totalClones) / float64(totalFragments) * 100
 		}
 	}
 

--- a/app/analyze_usecase_test.go
+++ b/app/analyze_usecase_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1190,5 +1191,35 @@ func TestBuildComplexityTaskRequest_UsesExecutionConfigBooleans(t *testing.T) {
 	}
 	if req.ShowDetails == nil || !*req.ShowDetails {
 		t.Error("ShowDetails: expected explicit true from execution config")
+	}
+}
+
+func TestCalculateSummaryDuplicationPercentageNotClamped(t *testing.T) {
+	// Regression for #724: CodeDuplication must carry the true fragment-clone
+	// ratio even above the 30% scoring saturation point, instead of being
+	// clamped to DuplicationThresholdHigh before storage.
+	summary := &domain.AnalyzeSummary{}
+	response := &domain.AnalyzeResponse{
+		Clone: &domain.CloneResponse{
+			Statistics: &domain.CloneStatistics{
+				TotalFragments: 61,
+				TotalClones:    32,
+			},
+		},
+	}
+
+	(&AnalyzeUseCase{}).calculateSummary(summary, response)
+
+	want := 32.0 / 61.0 * 100 // 52.46%, above the old 30.0 cap
+	if math.Abs(summary.CodeDuplication-want) > 1e-9 {
+		t.Errorf("CodeDuplication = %f, want %f (unclamped ratio)", summary.CodeDuplication, want)
+	}
+	if summary.Grade == "N/A" {
+		t.Fatal("health score calculation failed for a valid summary")
+	}
+	// Scoring is unchanged: DuplicationPenalty saturates at 30%, so any ratio
+	// at or above it yields the same (zero) duplication score.
+	if summary.DuplicationScore != 0 {
+		t.Errorf("DuplicationScore = %d, want 0 (penalty saturated at 30%%)", summary.DuplicationScore)
 	}
 }

--- a/website/docs/fr/output/health-score.md
+++ b/website/docs/fr/output/health-score.md
@@ -120,7 +120,7 @@ Source : `domain/analyze.go:283-296`. Facteur de normalisation dérivé dans `Ca
 
 ### Duplication
 
-**Entrées.** `CodeDuplication` (float64). Ce champ est le ratio de fragments : le pourcentage de tous les fragments de code extraits qui participent à une paire ou un groupe de clones, plafonné à 30 par le calcul en amont.
+**Entrées.** `CodeDuplication` (float64). Ce champ est le ratio de fragments : le pourcentage de tous les fragments de code extraits qui participent à une paire ou un groupe de clones. La valeur n'est pas plafonnée ; la formule de pénalité ci-dessous sature d'elle-même à `DuplicationThresholdHigh`.
 
 **Formule.**
 
@@ -142,7 +142,7 @@ else:
 **Calcul en amont.** `CodeDuplication` est calculé dans `app/analyze_usecase.go` :
 
 ```
-CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
+CodeDuplication = TotalClones / TotalFragments * 100
 ```
 
 Où `TotalClones` est le nombre de fragments uniques participant à au moins une paire ou un groupe de clones, et `TotalFragments` est le nombre total de fragments de code extraits (`domain/clone.go:128-131`).

--- a/website/docs/ja/output/health-score.md
+++ b/website/docs/ja/output/health-score.md
@@ -120,7 +120,7 @@ else:
 
 ### 重複
 
-**入力.** `CodeDuplication` (float64)。このフィールドはフラグメント比率で、抽出されたコードフラグメントのうちクローンペアまたはグループに含まれるユニークなフラグメントの割合を表します。上流の計算で 30 に上限が設定されています。
+**入力.** `CodeDuplication` (float64)。このフィールドはフラグメント比率で、抽出されたコードフラグメントのうちクローンペアまたはグループに含まれるユニークなフラグメントの割合を表します。この値にクランプはなく、下記のペナルティ計算式自体が `DuplicationThresholdHigh` で飽和します。
 
 **計算式.**
 
@@ -142,7 +142,7 @@ else:
 **上流の計算.** `CodeDuplication` 自体は `app/analyze_usecase.go` で計算されます:
 
 ```
-CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
+CodeDuplication = TotalClones / TotalFragments * 100
 ```
 
 ここで `TotalClones` はクローンペアまたはグループに含まれるユニークなフラグメント数、`TotalFragments` は抽出されたコードフラグメントの総数です（`domain/clone.go:128-131`）。

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -120,7 +120,7 @@ Source: `domain/analyze.go:283-296`. Normalization factor derived in `CalculateH
 
 ### Duplication
 
-**Inputs.** `CodeDuplication` (float64). This field is the fragment ratio: the percentage of all extracted code fragments that participate in clone pairs or groups, capped at 30 by the upstream calculation.
+**Inputs.** `CodeDuplication` (float64). This field is the fragment ratio: the percentage of all extracted code fragments that participate in clone pairs or groups. The value is not clamped; the penalty formula below saturates on its own at `DuplicationThresholdHigh`.
 
 **Formula.**
 
@@ -142,7 +142,7 @@ else:
 **Upstream computation.** `CodeDuplication` itself is computed in `app/analyze_usecase.go`:
 
 ```
-CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
+CodeDuplication = TotalClones / TotalFragments * 100
 ```
 
 Where `TotalClones` is the number of unique fragments that participate in at least one clone pair or group, and `TotalFragments` is the total number of extracted code fragments (`domain/clone.go:128-131`).

--- a/website/docs/zh/output/health-score.md
+++ b/website/docs/zh/output/health-score.md
@@ -120,7 +120,7 @@ else:
 
 ### 代码重复
 
-**输入。** `CodeDuplication`（float64）。此字段是片段比率：所有提取出的代码片段中，参与克隆对或克隆组的唯一片段所占百分比，上游计算限制为 30。
+**输入。** `CodeDuplication`（float64）。此字段是片段比率：所有提取出的代码片段中，参与克隆对或克隆组的唯一片段所占百分比。该值不做截断；下方的惩罚公式自身会在 `DuplicationThresholdHigh` 处饱和。
 
 **公式。**
 
@@ -142,7 +142,7 @@ else:
 **上游计算。** `CodeDuplication` 本身在 `app/analyze_usecase.go` 中计算：
 
 ```
-CodeDuplication = min(DuplicationThresholdHigh, TotalClones / TotalFragments * 100)
+CodeDuplication = TotalClones / TotalFragments * 100
 ```
 
 其中 `TotalClones` 是至少参与一个克隆对或克隆组的唯一片段数量，`TotalFragments` 是提取出的代码片段总数（`domain/clone.go:128-131`）。


### PR DESCRIPTION
## Summary
`code_duplication_percentage` was clamped to `DuplicationThresholdHigh` (30.0) before being stored in the summary, so any project whose true fragment-clone ratio exceeds 30% reported exactly `30.0` across JSON, terminal, HTML, and CSV output. The clamp is redundant for scoring: `DuplicationPenalty` in polyscan/core already saturates at the same threshold, so `DuplicationPenalty(30.0) == DuplicationPenalty(52.5) == 20`. Removing the pre-storage clamp changes no score — only the reported percentage becomes accurate.

## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
Fixes #724

## Changes
- Drop the `math.Min(domain.DuplicationThresholdHigh, ...)` clamp in `calculateSummary` (`app/analyze_usecase.go`) and store the true `totalClones/totalFragments` ratio
- Add a regression test asserting the summary carries an above-30% ratio unclamped while `DuplicationScore` stays at its saturated value (no score change)

## Testing
- [x] `go test ./app/ ./domain/ ./service/ ./cmd/...` passes locally
- [x] `gofmt` / `go vet` clean on touched packages
- [x] Added tests for new functionality (the new test fails against the old clamped code and passes with the fix)
- [ ] Full `make test` / `make lint` not run (only `app` touched; its tests and dependent packages pass)

## Documentation
- [x] Updated the inline comment at the changed line
- [ ] No README/doc changes needed (reporting-only fix, no interface change)

## Additional Context
`TotalClones` counts distinct fragments involved in clones (`len(seenFragments)` in `internal/analyzer/clone_detector.go`), so the ratio is bounded by 100 and the existing `0-100` validation in `domain/analyze.go` still holds. No consumer of `CodeDuplication` assumes a `<= 30` bound; the HTML per-type bars use separately normalized percentages.

Written with the assistance of Claude Code.
