### PR TITLE
fix: record dependency kind for imported names in CBO breakdown

### DIFF
--- a/internal/analyzer/cbo.go
+++ b/internal/analyzer/cbo.go
@@ -1062,9 +1062,13 @@ func (a *CBOAnalyzer) addDependency(dependencies *cboDependencies, className str
 
 	dependencies.all[className] = true
 
+	// A dependency reached through an imported name is recorded in the imports
+	// bucket for its provenance AND in the bucket for its usage kind below.
+	// Previously the import check returned early, which made the four kind
+	// counters unreachable for cross-module coupling (see #692). Buckets may
+	// therefore overlap and do not sum to CouplingCount.
 	if a.isImportedDependency(className) {
 		dependencies.imports[className] = true
-		return
 	}
 
 	switch kind {

--- a/internal/analyzer/cbo_test.go
+++ b/internal/analyzer/cbo_test.go
@@ -1781,6 +1781,47 @@ class TOKENS:
 	assert.Contains(t, tokens.DependentClasses, "ast.Attribute")
 }
 
+func TestCBOAnalyzer_ImportedDependenciesKeepKindBreakdown(t *testing.T) {
+	// A dependency reached through an imported name must be counted under its
+	// actual usage kind (inheritance, type hint, instantiation, ...) as well
+	// as in the imports bucket. Before #692 the import check returned early
+	// and the kind was dropped, so the four kind counters were always zero
+	// for cross-module coupling.
+	pythonCode := `
+from base import Base, Helper
+
+class Child(Base):
+    def __init__(self) -> None:
+        self.helper = Helper()
+
+    def make(self) -> Helper:
+        return Helper()
+`
+
+	ast, err := parseCode(pythonCode)
+	require.NoError(t, err)
+
+	results, err := NewCBOAnalyzer(DefaultCBOOptions()).AnalyzeClasses(ast, "test.py")
+	require.NoError(t, err)
+
+	resultMap := make(map[string]*CBOResult)
+	for _, result := range results {
+		resultMap[result.ClassName] = result
+	}
+
+	child := resultMap["Child"]
+	require.NotNil(t, child)
+	assert.Equal(t, 2, child.CouplingCount)
+	assert.ElementsMatch(t, []string{"Base", "Helper"}, child.DependentClasses)
+	assert.Equal(t, 1, child.InheritanceDependencies, "Base is inherited")
+	assert.Equal(t, 1, child.TypeHintDependencies, "Helper is a return annotation")
+	assert.Equal(t, 1, child.InstantiationDependencies, "Helper is instantiated")
+	// Both dependencies arrive via the import, so the imports bucket keeps
+	// recording their provenance. Buckets overlap by design and do not sum
+	// to CouplingCount.
+	assert.Equal(t, 2, child.ImportDependencies)
+}
+
 func parseCode(code string) (*parser.Node, error) {
 	p := parser.New()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

`addDependency` returned early when the dependency name was imported, so the dependency landed in the `imports` bucket and its actual `kind` was discarded. Since cross-module coupling in Python essentially always arrives via an import (and same-file top-level peers are dropped as internal per #637), `InheritanceDependencies`, `TypeHintDependencies`, `InstantiationDependencies`, and `AttributeAccessDependencies` were effectively always `0`, contradicting `BaseClasses` in the same record.

## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
Fixes #692

## Changes
- `internal/analyzer/cbo.go`: drop the early return — an imported dependency is now recorded in both the `imports` bucket (provenance) and its usage-kind bucket. This is the first option from the design question in #692: buckets may overlap and do not sum to `CouplingCount`. The alternative (kind wins over the import check) would leave `ImportDependencies` permanently zero instead, since no call site passes `dependencyKindImport` — so overlapping buckets is the only variant that keeps all five counters meaningful.
- `internal/analyzer/cbo_test.go`: regression test with the repro from the issue (`Child(Base)` inheriting, instantiating, and annotating imported names). Fails on `main`, passes with the fix.

The existing zero assertions in `cbo_test.go` all cover classes with `CouplingCount == 0`, so none needed changes.

On the issue's repro, `pyscn analyze --json --select cbo` now reports for `Child`: `inheritance_dependencies: 1, type_hint_dependencies: 1, instantiation_dependencies: 1, import_dependencies: 2, coupling_count: 2`.

## Testing
- [x] `make test` passes locally (`go test ./...`)
- [x] `make lint` passes locally (`go vet` + gofmt clean; local golangci-lint is v1 and can't read the repo's v2 config)
- [x] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)

## Documentation
- [x] Updated godoc comments
