### PR TITLE
fix: stop counting elif arms as extra nesting levels

### DIFF
--- a/internal/analyzer/complexity_test.go
+++ b/internal/analyzer/complexity_test.go
@@ -365,8 +365,9 @@ class Config:
 	if classResult.IfStatements != 2 || classResult.LoopStatements != 1 {
 		t.Fatalf("class statement metrics = if:%d loop:%d, want 2/1", classResult.IfStatements, classResult.LoopStatements)
 	}
-	if classResult.NestingDepth != 2 {
-		t.Fatalf("class nesting depth = %d, want 2", classResult.NestingDepth)
+	// The if/elif/else chain is flat, so the deepest nesting is 1 (issue #728).
+	if classResult.NestingDepth != 1 {
+		t.Fatalf("class nesting depth = %d, want 1", classResult.NestingDepth)
 	}
 }
 

--- a/internal/analyzer/nesting_depth.go
+++ b/internal/analyzer/nesting_depth.go
@@ -115,12 +115,14 @@ func isNestingNode(node *parser.Node) bool {
 	}
 
 	switch node.Type {
-	case parser.NodeIf, parser.NodeFor, parser.NodeAsyncFor, parser.NodeWhile, parser.NodeWith, parser.NodeAsyncWith, parser.NodeTry, parser.NodeExceptHandler, parser.NodeMatch, parser.NodeMatchCase, parser.NodeElifClause,
+	case parser.NodeIf, parser.NodeFor, parser.NodeAsyncFor, parser.NodeWhile, parser.NodeWith, parser.NodeAsyncWith, parser.NodeTry, parser.NodeExceptHandler, parser.NodeMatch, parser.NodeMatchCase,
 		parser.NodeLambda, parser.NodeListComp, parser.NodeSetComp, parser.NodeDictComp, parser.NodeGeneratorExp:
 		// These nodes increase nesting depth
 		return true
-	case parser.NodeElseClause:
-		// else doesn't add nesting, it's at same level
+	case parser.NodeElifClause, parser.NodeElseClause:
+		// elif/else arms don't add nesting; they're at the same level as the
+		// parent if. The AST builder chains elif arms through Orelse, so
+		// counting them would inflate depth by one per arm (issue #728).
 		return false
 	default:
 		return false

--- a/internal/analyzer/nesting_depth_test.go
+++ b/internal/analyzer/nesting_depth_test.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/internal/parser"
@@ -414,6 +415,51 @@ func TestCalculateMaxNestingDepth_StopsAtNestedScopes(t *testing.T) {
 	}
 }
 
+// Regression test for issue #728: a flat if/elif chain must not count each
+// elif arm as one more nesting level. The AST builder chains elif arms through
+// Orelse, so the arms are structurally nested even though the source is flat.
+func TestCalculateMaxNestingDepth_ElifChainStaysFlat(t *testing.T) {
+	source := `def dispatch(kind):
+    if kind == "a":
+        return 1
+    elif kind == "b":
+        return 2
+    elif kind == "c":
+        return 3
+    elif kind == "d":
+        return 4
+    elif kind == "e":
+        if kind:
+            return 5
+    else:
+        return 6
+    raise NotImplementedError
+`
+
+	p := parser.New()
+	parseResult, err := p.Parse(context.Background(), []byte(source))
+	if err != nil {
+		t.Fatalf("Failed to parse source: %v", err)
+	}
+
+	var funcNode *parser.Node
+	for _, stmt := range parseResult.AST.Body {
+		if stmt.Type == parser.NodeFunctionDef && stmt.Name == "dispatch" {
+			funcNode = stmt
+		}
+	}
+	if funcNode == nil {
+		t.Fatal("Function 'dispatch' not found in parsed AST")
+	}
+
+	result := CalculateMaxNestingDepth(funcNode)
+
+	// The only real nesting is the if inside the last elif arm (depth 2).
+	if result.MaxDepth != 2 {
+		t.Errorf("Expected max depth 2 for flat elif chain with one nested if, got %d", result.MaxDepth)
+	}
+}
+
 func TestIsNestingNode(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -436,6 +482,7 @@ func TestIsNestingNode(t *testing.T) {
 		{"Pass statement", parser.NodePass, false},
 		{"Assign statement", parser.NodeAssign, false},
 		{"Else clause", parser.NodeElseClause, false},
+		{"Elif clause", parser.NodeElifClause, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
`nesting_depth` counted every `elif` arm of a flat `if/elif/...` chain as one more nesting level, because the AST builder chains elif arms through `Orelse` and `isNestingNode` treated `NodeElifClause` as a nesting construct. A flat dispatch chain with one real inner `if` was reported with `nesting_depth` = arm count + 1, which promoted `risk_level` to `high` via the nesting threshold.

This treats `NodeElifClause` like `NodeElseClause` — same level as the parent `if` — so only real nesting counts.

## Type of Change
- [x] Bug fix (non-breaking change)

## Related Issues
Fixes #728

## Changes
- `internal/analyzer/nesting_depth.go`: move `NodeElifClause` from the nesting case to the same-level case in `isNestingNode`
- `internal/analyzer/nesting_depth_test.go`: regression test parsing the issue's repro (flat 5-arm elif chain with one nested `if` now reports depth 2), plus an `ElifClause` entry in `TestIsNestingNode`
- `internal/analyzer/complexity_test.go`: `TestCalculateComplexity_ClassSuiteOwnsControlFlow` expected depth 2 for a flat class-body `if/elif/else` — that expectation encoded the bug; updated to 1

## Testing
- [x] `go test ./...` passes locally
- [x] `gofmt` / `go vet` clean on the touched package (local golangci-lint is v1 and can't read the repo's v2 config)
- [x] Added tests for new functionality (if applicable)
- [x] Manual testing completed: built the binary and ran `analyze --json` on the issue repro — `dispatch` now reports `nesting_depth: 2`, `risk_level: low` (was 7/high)
