### PR TITLE
fix(report): add LCOM4 to analyze text and CSV reports

### DIFF
--- a/service/analyze_formatter.go
+++ b/service/analyze_formatter.go
@@ -128,6 +128,15 @@ func (f *AnalyzeFormatter) writeText(response *domain.AnalyzeResponse, writer io
 		fmt.Fprint(writer, utils.FormatSectionSeparator())
 	}
 
+	if response.Summary.LCOMEnabled {
+		fmt.Fprint(writer, utils.FormatSectionHeader("COHESION ANALYSIS"))
+		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Classes Analyzed", response.Summary.LCOMClasses))
+		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "High LCOM Classes", response.Summary.HighLCOMClasses))
+		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Medium LCOM Classes", response.Summary.MediumLCOMClasses))
+		fmt.Fprint(writer, utils.FormatLabelWithIndent(SectionPadding, "Average LCOM4", fmt.Sprintf("%.1f", response.Summary.AverageLCOM)))
+		fmt.Fprint(writer, utils.FormatSectionSeparator())
+	}
+
 	if len(response.ModuleQuality) > 0 {
 		fmt.Fprint(writer, utils.FormatSectionHeader("MODULE QUALITY HOTSPOTS"))
 		for index, module := range response.ModuleQuality {
@@ -176,7 +185,7 @@ func (f *AnalyzeFormatter) writeCSV(response *domain.AnalyzeResponse, writer io.
 	if response.Complexity != nil {
 		directories = response.Complexity.ByDirectory
 	}
-	rowCapacity := 17 + len(response.Diagnostics) + len(response.Failures) + (12 * len(response.ModuleQuality))
+	rowCapacity := 20 + len(response.Diagnostics) + len(response.Failures) + (12 * len(response.ModuleQuality))
 	if response.Complexity != nil {
 		rowCapacity += 1 + (7 * len(directories))
 	}
@@ -203,6 +212,9 @@ func (f *AnalyzeFormatter) writeCSV(response *domain.AnalyzeResponse, writer io.
 		[]string{"Total Classes Analyzed", fmt.Sprint(response.Summary.CBOClasses)},
 		[]string{"High Coupling (CBO) Classes", fmt.Sprint(response.Summary.HighCouplingClasses)},
 		[]string{"Average CBO", fmt.Sprintf("%.2f", response.Summary.AverageCoupling)},
+		[]string{"LCOM Classes Analyzed", fmt.Sprint(response.Summary.LCOMClasses)},
+		[]string{"High Cohesion Risk (LCOM4) Classes", fmt.Sprint(response.Summary.HighLCOMClasses)},
+		[]string{"Average LCOM4", fmt.Sprintf("%.2f", response.Summary.AverageLCOM)},
 		[]string{"Module Quality Count", fmt.Sprint(len(response.ModuleQuality))},
 	)
 	for _, diagnostic := range response.Diagnostics {

--- a/service/analyze_formatter_test.go
+++ b/service/analyze_formatter_test.go
@@ -45,6 +45,11 @@ func createTestAnalyzeResponse() *domain.AnalyzeResponse {
 			DeadCodeEnabled:       true,
 			CloneEnabled:          true,
 			CBOEnabled:            true,
+			LCOMEnabled:           true,
+			LCOMClasses:           8,
+			HighLCOMClasses:       1,
+			MediumLCOMClasses:     2,
+			AverageLCOM:           2.5,
 		},
 		Complexity: &domain.ComplexityResponse{
 			Functions: []domain.FunctionComplexity{
@@ -82,6 +87,14 @@ func createTestAnalyzeResponse() *domain.AnalyzeResponse {
 				HighRiskClasses:   1,
 				MediumRiskClasses: 2,
 				AverageCBO:        3.2,
+			},
+		},
+		LCOM: &domain.LCOMResponse{
+			Summary: domain.LCOMSummary{
+				TotalClasses:      8,
+				HighRiskClasses:   1,
+				MediumRiskClasses: 2,
+				AverageLCOM:       2.5,
 			},
 		},
 	}
@@ -162,6 +175,7 @@ func TestAnalyzeFormatter_Write_Text(t *testing.T) {
 				"DEAD CODE DETECTION",
 				"CLONE DETECTION",
 				"DEPENDENCY ANALYSIS",
+				"COHESION ANALYSIS",
 			},
 		},
 		{
@@ -175,6 +189,7 @@ func TestAnalyzeFormatter_Write_Text(t *testing.T) {
 			notExpected: []string{
 				"COMPLEXITY ANALYSIS",
 				"DEAD CODE DETECTION",
+				"COHESION ANALYSIS",
 			},
 		},
 	}
@@ -543,6 +558,8 @@ func TestAnalyzeFormatter_Write_CSV(t *testing.T) {
 	assert.Contains(t, output, "Grade,B")
 	assert.Contains(t, output, "Total Files,10")
 	assert.Contains(t, output, "Analyzed Files,10")
+	assert.Contains(t, output, "High Cohesion Risk (LCOM4) Classes,1")
+	assert.Contains(t, output, "Average LCOM4,2.50")
 }
 
 func TestAnalyzeFormatter_Write_CSVIncludesModuleQuality(t *testing.T) {


### PR DESCRIPTION
## Summary

The two headline bugs in #698 do not reproduce on `main` (v1.30.0). Verified with the issue's own `sample.py`:

- `pyscn analyze --json` emits a `lcom` object (`lcom4: 2` for the repro class), `summary.lcom_*` fields and `cohesion_score`; the terminal summary prints a `Cohesion (LCOM)` line; `--select lcom` works. YAML and HTML also carry LCOM.
- `--select totally-bogus-name` fails with `invalid --select flag: ...` and a non-zero exit (validation added in v1.19.3).

The remaining gap versus CBO was that the `--text` and `--csv` reports had no LCOM rows. This PR adds them:

- text: a `COHESION ANALYSIS` section (classes analyzed, high/medium LCOM classes, average LCOM4)
- CSV: `LCOM Classes Analyzed`, `High Cohesion Risk (LCOM4) Classes`, `Average LCOM4`

Closes #698

## Not addressed

- `analyze --select <bad>` exits 1, while `check` maps the same error to exit 2.
- MCP `analyze_project` applies the selection with no validation, so an unknown name there still disables every analysis.
- #678 (`InstanceVariables` over-count) stays open.

https://claude.ai/code/session_01F5eUGdA3WoqV4ERKpVWseB
