### PR TITLE
docs: replace vibe coders tagline with AI coding wording

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -10,9 +10,9 @@
   <img alt="pyscn" src="assets/logo-light.svg" width="320">
 </picture>
 
-**Un analyseur de qualité de code pour les vibe coders Python.**
+**Analyse de la qualité du code Python à l'ère du codage par IA.**
 
-Vous développez avec Cursor, Claude ou ChatGPT ? pyscn effectue une analyse structurelle pour maintenir la maintenabilité de votre codebase.
+Vous développez avec Cursor, Claude ou ChatGPT ? pyscn garde le code généré par IA maintenable grâce à une analyse structurelle.
 
 [![Article](https://img.shields.io/badge/dev.to-Article-0A0A0A?style=flat-square&logo=dev.to)](https://dev.to/daisukeyoda/pyscn-the-code-quality-analyzer-for-vibe-coders-18hk)
 [![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi)](https://pypi.org/project/pyscn/)

--- a/README.ja.md
+++ b/README.ja.md
@@ -10,9 +10,9 @@
   <img alt="pyscn" src="assets/logo-light.svg" width="320">
 </picture>
 
-**Python のバイブコーダー向けコード品質アナライザー。**
+**AI コーディング時代の Python コード品質解析。**
 
-Cursor、Claude、ChatGPT で開発していますか？pyscn は構造解析により、コードベースの保守性を保ちます。
+Cursor、Claude、ChatGPT で開発していますか？pyscn は構造解析により、AI が生成したコードの保守性を保ちます。
 
 [![Article](https://img.shields.io/badge/dev.to-Article-0A0A0A?style=flat-square&logo=dev.to)](https://dev.to/daisukeyoda/pyscn-the-code-quality-analyzer-for-vibe-coders-18hk)
 [![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi)](https://pypi.org/project/pyscn/)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
   <img alt="pyscn" src="assets/logo-light.svg" width="320">
 </picture>
 
-**A code quality analyzer for Python vibe coders.**
+**Code quality analysis for Python in the age of AI coding.**
 
-Building with Cursor, Claude, or ChatGPT? pyscn performs structural analysis to keep your codebase maintainable.
+Building with Cursor, Claude, or ChatGPT? pyscn keeps AI-generated code maintainable with structural analysis.
 
 [![Article](https://img.shields.io/badge/dev.to-Article-0A0A0A?style=flat-square&logo=dev.to)](https://dev.to/daisukeyoda/pyscn-the-code-quality-analyzer-for-vibe-coders-18hk)
 [![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi)](https://pypi.org/project/pyscn/)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,9 +10,9 @@
   <img alt="pyscn" src="assets/logo-light.svg" width="320">
 </picture>
 
-**面向 Python 氛围编程者的代码质量分析工具。**
+**AI 编程时代的 Python 代码质量分析。**
 
-使用 Cursor、Claude 或 ChatGPT 开发？pyscn 通过结构化分析帮助保持代码库的可维护性。
+使用 Cursor、Claude 或 ChatGPT 开发？pyscn 通过结构化分析保持 AI 生成代码的可维护性。
 
 [![Article](https://img.shields.io/badge/dev.to-Article-0A0A0A?style=flat-square&logo=dev.to)](https://dev.to/daisukeyoda/pyscn-the-code-quality-analyzer-for-vibe-coders-18hk)
 [![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi)](https://pypi.org/project/pyscn/)


### PR DESCRIPTION
Replace the "for vibe coders" tagline in all four READMEs with wording centered on AI-assisted coding. The dev.to article badge keeps its existing URL.

https://claude.ai/code/session_01UoUXYp7HGDvgUncZBipqkv