### PR TITLE
docs: clarify Polyscan install CTA

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -183,14 +183,9 @@ directory = "reports"
 
 > ⚙️ Exécutez `pyscn init` pour générer un fichier de configuration complet avec toutes les options disponibles
 
-## Pyscn Bot (GitHub App)
+## Une GitHub App est également disponible
 
-[Pyscn Bot](https://github.com/marketplace/pyscn-bot) surveille automatiquement la qualité de votre code Python.
-
-### Fonctionnalités
-
-- **Revue de code sur les PR** - Revue automatique sur chaque pull request
-- **Audit hebdomadaire du code** - Analyse l'ensemble du dépôt et crée des issues pour les problèmes architecturaux
+[Installez Polyscan sur GitHub](https://codescan.dev/pyscn-bot) — recevez chaque semaine le score de santé de votre code dans une issue GitHub. Gratuit pour tous les dépôts.
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -183,14 +183,9 @@ directory = "reports"
 
 > ⚙️ `pyscn init` を実行すると、利用可能なすべてのオプションを含む完全な設定ファイルが生成されます
 
-## Pyscn Bot（GitHub App）
+## 毎週 CLI を実行したくないですか？
 
-[Pyscn Bot](https://github.com/marketplace/pyscn-bot) は Python コード品質を自動的に監視します。
-
-### 機能
-
-- **PR コードレビュー** - すべてのプルリクエストで自動コードレビュー
-- **週次コード監査** - リポジトリ全体をスキャンし、アーキテクチャ上の問題を Issue として作成
+[GitHub に Polyscan をインストール](https://codescan.dev/pyscn-bot) — 毎週のヘルススコアを GitHub Issue として作成します。すべてのリポジトリで無料です。
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -183,9 +183,9 @@ directory = "reports"
 
 > ⚙️ `pyscn init` を実行すると、利用可能なすべてのオプションを含む完全な設定ファイルが生成されます
 
-## 毎週 CLI を実行したくないですか？
+## GitHub App もあります
 
-[GitHub に Polyscan をインストール](https://codescan.dev/pyscn-bot) — 毎週のヘルススコアを GitHub Issue として作成します。すべてのリポジトリで無料です。
+[GitHub に Polyscan をインストール](https://codescan.dev/pyscn-bot) — 毎週、コードベースのヘルススコアを GitHub Issue でお知らせします。すべてのリポジトリで無料です。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -184,14 +184,9 @@ directory = "reports"
 
 > ⚙️ Run `pyscn init` to generate a full configuration file with all available options
 
-## Polyscan App (GitHub App)
+## Don't want to run the CLI every week?
 
-[Pyscn Bot](https://codescan.dev/ja/pyscn-bot) monitors your Python code quality automatically.
-
-### Features
-
-- **PR Code Review** - Automatic code review on every pull request
-- **Weekly Code Audit** - Scans your entire repository and creates issues for architectural problems
+[Install Polyscan on GitHub](https://codescan.dev/pyscn-bot) — it files a weekly health score as a GitHub Issue. Free for every repository.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,14 +183,9 @@ directory = "reports"
 
 > ⚙️ 运行 `pyscn init` 可生成包含所有可用选项的完整配置文件
 
-## Pyscn Bot（GitHub App）
+## 也可使用 GitHub App
 
-[Pyscn Bot](https://github.com/marketplace/pyscn-bot) 自动监控 Python 代码质量。
-
-### 功能
-
-- **PR 代码审查** - 在每个 Pull Request 上自动进行代码审查
-- **每周代码审计** - 扫描整个仓库并为架构问题创建 Issue
+[在 GitHub 上安装 Polyscan](https://codescan.dev/pyscn-bot) — 每周通过 GitHub Issue 报告代码库健康评分。所有仓库均可免费使用。
 
 ---
 


### PR DESCRIPTION
Unifies the Polyscan name and landing-page URL across the English, Japanese, Simplified Chinese, and French READMEs. Replaces duplicated feature lists with a direct CTA for free weekly GitHub Issue health scores.