### PR TITLE
fix: surface project root import diagnostics

### DIFF
--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -46,8 +46,9 @@ type AnalyzeUseCaseConfig struct {
 	// Clone detection options
 	EnableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
-	ConfigFile string
-	Verbose    bool
+	ConfigFile  string
+	ProjectRoot string
+	Verbose     bool
 }
 
 // AnalyzeRequestOverrides contains request-scoped values that take precedence
@@ -497,9 +498,13 @@ func (uc *AnalyzeUseCase) executeProject(ctx context.Context, useCaseCfg Analyze
 	// timings recorded by previous runs on this project (if any)
 	estimatedSeconds := uc.estimateTaskSeconds(len(allFiles), useCaseCfg, executionCfg)
 
+	projectRoot := useCaseCfg.ProjectRoot
+	if projectRoot == "" {
+		projectRoot = service.FindProjectRoot(paths)
+	}
 	snapshot := service.BuildAnalysisProjectSnapshot(ctx, analysisFiles, moduleFiles, service.ProjectSnapshotOptions{
 		IncludeRawMetrics: uc.complexityUseCase != nil && !useCaseCfg.SkipComplexity,
-		ProjectRoot:       service.FindProjectRoot(paths),
+		ProjectRoot:       projectRoot,
 	})
 
 	var moduleGraph *service.ProjectModuleGraph
@@ -751,7 +756,8 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 					return nil, fmt.Errorf("prepare system analysis graph: %w", err)
 				}
 				request := domain.SystemAnalysisRequest{
-					Paths:                files,
+					Paths:                append([]string(nil), sourcePaths...),
+					ProjectRoot:          config.ProjectRoot,
 					Recursive:            domain.BoolPtr(executionCfg.Recursive),
 					IncludePatterns:      []string{},
 					ExcludePatterns:      []string{},

--- a/app/analyze_usecase.go
+++ b/app/analyze_usecase.go
@@ -46,9 +46,8 @@ type AnalyzeUseCaseConfig struct {
 	// Clone detection options
 	EnableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
-	ConfigFile  string
-	ProjectRoot string
-	Verbose     bool
+	ConfigFile string
+	Verbose    bool
 }
 
 // AnalyzeRequestOverrides contains request-scoped values that take precedence
@@ -498,7 +497,7 @@ func (uc *AnalyzeUseCase) executeProject(ctx context.Context, useCaseCfg Analyze
 	// timings recorded by previous runs on this project (if any)
 	estimatedSeconds := uc.estimateTaskSeconds(len(allFiles), useCaseCfg, executionCfg)
 
-	projectRoot := useCaseCfg.ProjectRoot
+	projectRoot := executionCfg.ProjectRoot
 	if projectRoot == "" {
 		projectRoot = service.FindProjectRoot(paths)
 	}
@@ -757,7 +756,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 				}
 				request := domain.SystemAnalysisRequest{
 					Paths:                append([]string(nil), sourcePaths...),
-					ProjectRoot:          config.ProjectRoot,
+					ProjectRoot:          executionCfg.ProjectRoot,
 					Recursive:            domain.BoolPtr(executionCfg.Recursive),
 					IncludePatterns:      []string{},
 					ExcludePatterns:      []string{},
@@ -798,6 +797,7 @@ func (uc *AnalyzeUseCase) createAnalysisTasks(config AnalyzeUseCaseConfig, sourc
 					OutputFormat:      domain.OutputFormatJSON,
 					OutputWriter:      io.Discard,
 					ConfigPath:        config.ConfigFile,
+					ProjectRoot:       executionCfg.ProjectRoot,
 					IncludeStdLib:     domain.BoolPtr(executionCfg.ModuleGraph.IncludeStdLib),
 					IncludeThirdParty: domain.BoolPtr(executionCfg.ModuleGraph.IncludeThirdParty),
 					FollowRelative:    domain.BoolPtr(executionCfg.ModuleGraph.FollowRelative),

--- a/app/system_analysis_usecase.go
+++ b/app/system_analysis_usecase.go
@@ -435,6 +435,9 @@ func (n *noOpSystemAnalysisConfigLoader) MergeConfig(base *domain.SystemAnalysis
 	if override.ConfigPath != "" {
 		merged.ConfigPath = override.ConfigPath
 	}
+	if override.ProjectRoot != "" {
+		merged.ProjectRoot = override.ProjectRoot
+	}
 
 	// NoOpen is a caller-only execution flag, not a persisted configuration.
 	merged.NoOpen = override.NoOpen

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -60,8 +60,9 @@ type AnalyzeCommand struct {
 	enableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
 	// System analysis options
-	detectCycles bool // Detect circular dependencies
-	validateArch bool // Validate architecture rules
+	detectCycles bool   // Detect circular dependencies
+	validateArch bool   // Validate architecture rules
+	projectRoot  string // Explicit project root for import resolution
 }
 
 // NewAnalyzeCommand creates a new analyze command
@@ -123,7 +124,10 @@ Examples:
   pyscn analyze --min-complexity 10 --min-severity critical --min-cbo 5 src/
 
   # Skip dependency analysis
-  pyscn analyze --skip-cbo src/`,
+  pyscn analyze --skip-cbo src/
+
+  # Analyze a subdirectory with an explicit import-resolution root
+  pyscn analyze --project-root . src/`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: c.runAnalyze,
 	}
@@ -136,6 +140,7 @@ Examples:
 	cmd.Flags().BoolVar(&c.text, "text", false, "Generate plain-text report file")
 	cmd.Flags().BoolVar(&c.noOpen, "no-open", false, "Don't auto-open HTML in browser")
 	cmd.Flags().StringVarP(&c.configFile, "config", "c", "", "Configuration file path")
+	cmd.Flags().StringVar(&c.projectRoot, "project-root", "", "Project root used for module import resolution (overrides inference)")
 
 	// Analysis selection flags
 	cmd.Flags().BoolVar(&c.skipComplexity, "skip-complexity", false, "Skip complexity analysis")
@@ -182,6 +187,20 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("invalid --min-severity value %q (expected: critical, warning, info)", c.minSeverity)
 	}
+	if c.projectRoot != "" {
+		absoluteRoot, err := filepath.Abs(c.projectRoot)
+		if err != nil {
+			return fmt.Errorf("invalid --project-root %q: %w", c.projectRoot, err)
+		}
+		info, err := os.Stat(absoluteRoot)
+		if err != nil {
+			return fmt.Errorf("invalid --project-root %q: %w", c.projectRoot, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("invalid --project-root %q: path is not a directory", c.projectRoot)
+		}
+		c.projectRoot = absoluteRoot
+	}
 
 	// Create use case configuration
 	config := c.createUseCaseConfig()
@@ -226,6 +245,7 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 	config := app.AnalyzeUseCaseConfig{
 		ConfigFile:              c.configFile,
+		ProjectRoot:             c.projectRoot,
 		Verbose:                 c.verbose,
 		MinComplexity:           c.minComplexity,
 		CloneSimilarity:         c.cloneSimilarity,
@@ -508,6 +528,11 @@ func getScoreIcon(score int) string {
 // printSummary prints a summary of the analysis results
 func (c *AnalyzeCommand) printSummary(cmd *cobra.Command, response *domain.AnalyzeResponse) {
 	fmt.Fprintf(cmd.ErrOrStderr(), "\n📊 Analysis Summary:\n")
+	if response.System != nil && len(response.System.Warnings) > 0 {
+		for _, warning := range response.System.Warnings {
+			fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  %s\n", warning)
+		}
+	}
 	fmt.Fprintf(cmd.ErrOrStderr(), "Health Score: %d/100 (Grade: %s)\n", response.Summary.HealthScore, response.Summary.Grade)
 	// Restate the shortfall next to the score. The per-file warnings are
 	// printed before the analysis runs and scroll away, which is how an

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -60,9 +60,8 @@ type AnalyzeCommand struct {
 	enableDFA bool // Enable Data Flow Analysis for enhanced Type-4 detection
 
 	// System analysis options
-	detectCycles bool   // Detect circular dependencies
-	validateArch bool   // Validate architecture rules
-	projectRoot  string // Explicit project root for import resolution
+	detectCycles bool // Detect circular dependencies
+	validateArch bool // Validate architecture rules
 }
 
 // NewAnalyzeCommand creates a new analyze command
@@ -124,10 +123,8 @@ Examples:
   pyscn analyze --min-complexity 10 --min-severity critical --min-cbo 5 src/
 
   # Skip dependency analysis
-  pyscn analyze --skip-cbo src/
+  pyscn analyze --skip-cbo src/`,
 
-  # Analyze a subdirectory with an explicit import-resolution root
-  pyscn analyze --project-root . src/`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: c.runAnalyze,
 	}
@@ -140,7 +137,6 @@ Examples:
 	cmd.Flags().BoolVar(&c.text, "text", false, "Generate plain-text report file")
 	cmd.Flags().BoolVar(&c.noOpen, "no-open", false, "Don't auto-open HTML in browser")
 	cmd.Flags().StringVarP(&c.configFile, "config", "c", "", "Configuration file path")
-	cmd.Flags().StringVar(&c.projectRoot, "project-root", "", "Project root used for module import resolution (overrides inference)")
 
 	// Analysis selection flags
 	cmd.Flags().BoolVar(&c.skipComplexity, "skip-complexity", false, "Skip complexity analysis")
@@ -187,21 +183,6 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("invalid --min-severity value %q (expected: critical, warning, info)", c.minSeverity)
 	}
-	if c.projectRoot != "" {
-		absoluteRoot, err := filepath.Abs(c.projectRoot)
-		if err != nil {
-			return fmt.Errorf("invalid --project-root %q: %w", c.projectRoot, err)
-		}
-		info, err := os.Stat(absoluteRoot)
-		if err != nil {
-			return fmt.Errorf("invalid --project-root %q: %w", c.projectRoot, err)
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("invalid --project-root %q: path is not a directory", c.projectRoot)
-		}
-		c.projectRoot = absoluteRoot
-	}
-
 	// Create use case configuration
 	config := c.createUseCaseConfig()
 
@@ -245,7 +226,6 @@ func (c *AnalyzeCommand) runAnalyze(cmd *cobra.Command, args []string) error {
 func (c *AnalyzeCommand) createUseCaseConfig() app.AnalyzeUseCaseConfig {
 	config := app.AnalyzeUseCaseConfig{
 		ConfigFile:              c.configFile,
-		ProjectRoot:             c.projectRoot,
 		Verbose:                 c.verbose,
 		MinComplexity:           c.minComplexity,
 		CloneSimilarity:         c.cloneSimilarity,

--- a/cmd/pyscn/analyze_project_root_test.go
+++ b/cmd/pyscn/analyze_project_root_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ludo-technologies/pyscn/domain"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyzeCommandSupportsExplicitProjectRoot(t *testing.T) {
+	command := NewAnalyzeCommand()
+	flag := command.CreateCobraCommand().Flags().Lookup("project-root")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+
+	command.projectRoot = "project"
+	assert.Equal(t, "project", command.createUseCaseConfig().ProjectRoot)
+}
+
+func TestAnalyzeSummaryPrintsSystemWarnings(t *testing.T) {
+	command := NewAnalyzeCommand()
+	root := &cobra.Command{}
+	var output bytes.Buffer
+	root.SetErr(&output)
+	command.printSummary(root, &domain.AnalyzeResponse{
+		System: &domain.SystemAnalysisResponse{Warnings: []string{"inferred project root differs from analyzed directory"}},
+	})
+	assert.Contains(t, output.String(), "inferred project root differs from analyzed directory")
+}

--- a/cmd/pyscn/analyze_project_root_test.go
+++ b/cmd/pyscn/analyze_project_root_test.go
@@ -7,17 +7,12 @@ import (
 	"github.com/ludo-technologies/pyscn/domain"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestAnalyzeCommandSupportsExplicitProjectRoot(t *testing.T) {
+func TestAnalyzeCommandDoesNotExposeProjectRootFlag(t *testing.T) {
 	command := NewAnalyzeCommand()
 	flag := command.CreateCobraCommand().Flags().Lookup("project-root")
-	require.NotNil(t, flag)
-	assert.Equal(t, "", flag.DefValue)
-
-	command.projectRoot = "project"
-	assert.Equal(t, "project", command.createUseCaseConfig().ProjectRoot)
+	assert.Nil(t, flag)
 }
 
 func TestAnalyzeSummaryPrintsSystemWarnings(t *testing.T) {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -134,6 +134,8 @@ Supported configuration file names (in priority order):
 
 ```toml
 # .pyscn.toml or [tool.pyscn] section in pyproject.toml
+project_root = "src"  # Optional; relative to this configuration file
+
 [output]
 directory = "reports"  # Output directory for generated reports
 

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -13,6 +13,16 @@ Dependency analysis examines the `import` relationships between Python modules i
 
 Understanding these relationships is critical for maintaining a healthy codebase. Excessive coupling, deep dependency chains, and circular imports all increase the cost of change and the risk of introducing bugs.
 
+### Project-root diagnostics
+
+The `analyze` command accepts `--project-root` when the analyzed path is a
+subdirectory or when automatic marker-based inference is ambiguous. The
+explicit root is used for module naming and import resolution. System-analysis
+reports include `resolved_imports` and `unresolved_imports` counts for internal
+imports. A visible warning is emitted when the inferred root differs from the
+analyzed directory, or when at least half of the detected internal imports are
+unresolved.
+
 ## Module Dependency Graph Construction
 
 ### Data Model

--- a/docs/algorithms/dependency.md
+++ b/docs/algorithms/dependency.md
@@ -15,13 +15,20 @@ Understanding these relationships is critical for maintaining a healthy codebase
 
 ### Project-root diagnostics
 
-The `analyze` command accepts `--project-root` when the analyzed path is a
-subdirectory or when automatic marker-based inference is ambiguous. The
-explicit root is used for module naming and import resolution. System-analysis
+The project root is taken from the directory containing the discovered
+`.pyscn.toml` or `pyproject.toml` file. An optional top-level `project_root`
+setting can select a path relative to that configuration file, for example:
+
+```toml
+project_root = "src"
+```
+
+This setting is shared by every command that builds a module graph. Without a
+configuration file, pyscn falls back to marker-based inference. System-analysis
 reports include `resolved_imports` and `unresolved_imports` counts for internal
 imports. A visible warning is emitted when the inferred root differs from the
-analyzed directory, or when at least half of the detected internal imports are
-unresolved.
+current working directory, or when at least half of the detected internal
+imports are unresolved.
 
 ## Module Dependency Graph Construction
 

--- a/domain/analyze.go
+++ b/domain/analyze.go
@@ -17,7 +17,8 @@ type AnalyzeOutputFormatter interface {
 // AnalyzeExecutionConfig contains the resolved configuration that AnalyzeUseCase
 // needs after config file discovery and loading.
 type AnalyzeExecutionConfig struct {
-	ConfigPath string
+	ConfigPath  string
+	ProjectRoot string
 
 	IncludePatterns []string
 	ExcludePatterns []string

--- a/domain/community.go
+++ b/domain/community.go
@@ -26,6 +26,7 @@ type CommunityAnalysisRequest struct {
 
 	// Configuration
 	ConfigPath      string
+	ProjectRoot     string
 	Recursive       *bool
 	IncludePatterns []string
 	ExcludePatterns []string

--- a/domain/system_analysis.go
+++ b/domain/system_analysis.go
@@ -12,6 +12,9 @@ type SystemAnalysisRequest struct {
 	// Input files or directories to analyze
 	Paths []string
 
+	// ProjectRoot overrides automatic project-root inference when set.
+	ProjectRoot string
+
 	// Output configuration
 	OutputFormat OutputFormat
 	OutputWriter io.Writer
@@ -80,6 +83,8 @@ type SystemAnalysisSummary struct {
 	TotalPackages     int    `json:"total_packages" yaml:"total_packages"`         // Total number of packages
 	TotalDependencies int    `json:"total_dependencies" yaml:"total_dependencies"` // Total dependency relationships
 	ProjectRoot       string `json:"project_root" yaml:"project_root"`             // Project root directory
+	ResolvedImports   int    `json:"resolved_imports" yaml:"resolved_imports"`     // Internal imports resolved to analyzed modules
+	UnresolvedImports int    `json:"unresolved_imports" yaml:"unresolved_imports"` // Internal imports that could not be resolved
 
 	// Quality scores (0-100, higher is better)
 	OverallQualityScore  float64 `json:"overall_quality_score" yaml:"overall_quality_score"` // Composite quality score
@@ -106,6 +111,8 @@ type DependencyAnalysisResult struct {
 	// Dependency graph information
 	TotalModules      int      `json:"total_modules" yaml:"total_modules"`           // Total number of modules
 	TotalDependencies int      `json:"total_dependencies" yaml:"total_dependencies"` // Total number of dependencies
+	ResolvedImports   int      `json:"resolved_imports" yaml:"resolved_imports"`     // Internal imports resolved to analyzed modules
+	UnresolvedImports int      `json:"unresolved_imports" yaml:"unresolved_imports"` // Internal imports that could not be resolved
 	RootModules       []string `json:"root_modules" yaml:"root_modules"`             // Modules with no dependencies
 	LeafModules       []string `json:"leaf_modules" yaml:"leaf_modules"`             // Modules with no dependents
 

--- a/integration/architecture_integration_test.go
+++ b/integration/architecture_integration_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/app"
@@ -31,9 +32,12 @@ func analyzeArchitecture(t *testing.T, dir string) *domain.ArchitectureAnalysisR
 	t.Helper()
 	uc := newArchitectureUseCase()
 	var buf bytes.Buffer
+	projectRoot, err := filepath.Abs(dir)
+	require.NoError(t, err)
 	result, err := uc.AnalyzeArchitectureOnly(context.Background(), domain.SystemAnalysisRequest{
 		Paths:        []string{dir},
 		ConfigPath:   dir,
+		ProjectRoot:  projectRoot,
 		OutputFormat: domain.OutputFormatJSON,
 		OutputWriter: &buf,
 	})

--- a/integration/community_integration_test.go
+++ b/integration/community_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/app"
@@ -49,6 +50,7 @@ func analyzeCommunityFixture(t *testing.T, fixtureDir string) *domain.CommunityA
 	result, err := uc.AnalyzeAndReturn(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            []string{absDir},
 		SourcePaths:      []string{absDir},
+		ProjectRoot:      absDir,
 		OutputWriter:     ioDiscard{},
 		OutputFormat:     domain.OutputFormatJSON,
 		Recursive:        domain.BoolPtr(true),
@@ -214,6 +216,7 @@ func TestCommunity_DeterministicRepeatedRuns(t *testing.T) {
 	req := domain.CommunityAnalysisRequest{
 		Paths:            []string{absDir},
 		SourcePaths:      []string{absDir},
+		ProjectRoot:      absDir,
 		OutputWriter:     ioDiscard{},
 		OutputFormat:     domain.OutputFormatJSON,
 		Recursive:        domain.BoolPtr(true),
@@ -259,6 +262,7 @@ func TestCommunity_AnalyzeUseCase_SelectCommunities(t *testing.T) {
 		SkipSystem:         true,
 		SkipCommunities:    false,
 		SelectAnalysesUsed: true,
+		ConfigFile:         communityFixtureConfig(t, absDir),
 	}, []string{absDir})
 	require.NoError(t, err)
 	require.NotNil(t, response)
@@ -291,6 +295,14 @@ func TestCommunity_AnalyzeUseCase_SelectCommunities(t *testing.T) {
 	require.NoError(t, err)
 
 	assertCommunityJSONEqual(t, expected, buf.Bytes())
+}
+
+func communityFixtureConfig(t *testing.T, projectRoot string) string {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), ".pyscn.toml")
+	content := []byte("project_root = " + strconv.Quote(projectRoot) + "\n")
+	require.NoError(t, os.WriteFile(configPath, content, 0o644))
+	return configPath
 }
 
 func communityIDs(result *domain.CommunityAnalysisResult) []string {

--- a/internal/analyzer/dependency_graph.go
+++ b/internal/analyzer/dependency_graph.go
@@ -94,11 +94,16 @@ type DependencyGraph struct {
 	Edges []*DependencyEdge      // All dependency relationships
 
 	// Graph metadata
-	TotalModules int      // Total number of modules
-	TotalEdges   int      // Total number of dependencies
-	RootModules  []string // Modules with no dependencies
-	LeafModules  []string // Modules with no dependents
-	ProjectRoot  string   // Project root directory
+	TotalModules int // Total number of modules
+	TotalEdges   int // Total number of dependencies
+	// ResolvedImports and UnresolvedImports count internal import statements,
+	// excluding standard-library and third-party imports that are not part of
+	// the analyzed graph.
+	ResolvedImports   int
+	UnresolvedImports int
+	RootModules       []string // Modules with no dependencies
+	LeafModules       []string // Modules with no dependents
+	ProjectRoot       string   // Project root directory
 
 	// Analysis results
 	CyclicGroups  [][]string                // Strongly connected components (cycles)
@@ -572,6 +577,8 @@ func (g *DependencyGraph) Clone() *DependencyGraph {
 
 	clone.TotalModules = g.TotalModules
 	clone.TotalEdges = g.TotalEdges
+	clone.ResolvedImports = g.ResolvedImports
+	clone.UnresolvedImports = g.UnresolvedImports
 	clone.RootModules = append([]string(nil), g.RootModules...)
 	clone.LeafModules = append([]string(nil), g.LeafModules...)
 	clone.CyclicGroups = make([][]string, len(g.CyclicGroups))

--- a/internal/analyzer/module_analyzer.go
+++ b/internal/analyzer/module_analyzer.go
@@ -372,6 +372,7 @@ func (ma *ModuleAnalyzer) analyzeParsedModuleDependencies(graph *DependencyGraph
 		// circular-dependency detection. See issue #460.
 
 		targetModule := ma.resolveImport(graph, imp, parsedModule.path, capturedOnly)
+		ma.recordImportResolution(graph, imp, parsedModule.path, targetModule)
 		if targetModule == "" {
 			continue
 		}
@@ -388,6 +389,81 @@ func (ma *ModuleAnalyzer) analyzeParsedModuleDependencies(graph *DependencyGraph
 	}
 
 	return nil
+}
+
+// recordImportResolution tracks internal imports separately from imports that
+// are intentionally outside the analyzed project (stdlib and third-party
+// dependencies). This keeps the diagnostic ratio useful when third-party
+// fallback is enabled.
+func (ma *ModuleAnalyzer) recordImportResolution(graph *DependencyGraph, imp *ImportInfo, fromFile, targetModule string) {
+	if graph == nil || imp == nil {
+		return
+	}
+	moduleName := ma.moduleNameFromImport(imp)
+	if moduleName == "" || (!imp.IsRelative && ma.isStandardLibrary(moduleName)) {
+		return
+	}
+
+	if ma.isLikelyInternalImport(graph, imp, fromFile, targetModule) {
+		if targetModule != "" && ma.importTargetsAnalyzedModule(graph, imp, targetModule) {
+			graph.ResolvedImports++
+			return
+		}
+		graph.UnresolvedImports++
+	}
+}
+
+func (ma *ModuleAnalyzer) importTargetsAnalyzedModule(graph *DependencyGraph, imp *ImportInfo, targetModule string) bool {
+	if graph == nil || targetModule == "" {
+		return false
+	}
+	for _, target := range ma.importDependencyTargets(graph, imp, targetModule) {
+		if graph.GetModule(target) != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (ma *ModuleAnalyzer) isLikelyInternalImport(graph *DependencyGraph, imp *ImportInfo, fromFile, targetModule string) bool {
+	if imp.IsRelative {
+		return true
+	}
+	moduleName := ma.moduleNameFromImport(imp)
+	if moduleName == "" || ma.isStandardLibrary(moduleName) {
+		return false
+	}
+	if ma.importTargetsAnalyzedModule(graph, imp, targetModule) || ma.hasProjectImport(moduleName, fromFile) {
+		return true
+	}
+
+	// A missing module under a namespace already represented in the graph is
+	// likely an internal import. This catches the common wrong-root case where
+	// the resolver gives the captured files a different qualified name.
+	namespace := moduleName
+	if dot := strings.IndexByte(namespace, '.'); dot >= 0 {
+		namespace = namespace[:dot]
+	}
+	for name := range graph.Nodes {
+		if name == namespace || strings.HasPrefix(name, namespace+".") {
+			return true
+		}
+	}
+	return false
+}
+
+func (ma *ModuleAnalyzer) hasProjectImport(moduleName, fromFile string) bool {
+	searchPaths := append([]string{
+		filepath.Dir(fromFile),
+		filepath.Dir(filepath.Dir(fromFile)),
+	}, ma.moduleRoots...)
+	for _, searchPath := range searchPaths {
+		modulePath := filepath.Join(searchPath, strings.ReplaceAll(moduleName, ".", string(filepath.Separator)))
+		if ma.resolveModuleFile(modulePath) != "" || ma.resolvePackageInit(modulePath) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (ma *ModuleAnalyzer) dependencyEdgeType(imp *ImportInfo) DependencyEdgeType {

--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -18,6 +18,7 @@ type ToolConfig struct {
 
 // PyprojectPyscnSection represents the [tool.pyscn] section in pyproject.toml
 type PyprojectPyscnSection struct {
+	ProjectRoot    string                   `toml:"project_root"`
 	Complexity     ComplexityTomlConfig     `toml:"complexity"`
 	DeadCode       DeadCodeTomlConfig       `toml:"dead_code"`
 	Output         OutputTomlConfig         `toml:"output"`
@@ -47,7 +48,12 @@ func LoadPyprojectConfig(startDir string) (*PyscnConfig, error) {
 		return nil, err
 	}
 
-	return loadPyprojectConfigData(data)
+	config, err := loadPyprojectConfigData(data)
+	if err != nil {
+		return nil, err
+	}
+	applyConfigProjectRoot(config, configPath)
+	return config, nil
 }
 
 // LoadPyprojectConfigFromFile loads configuration from a specific pyproject.toml file path.
@@ -57,7 +63,12 @@ func LoadPyprojectConfigFromFile(filePath string) (*PyscnConfig, error) {
 		return nil, err
 	}
 
-	return loadPyprojectConfigData(data)
+	config, err := loadPyprojectConfigData(data)
+	if err != nil {
+		return nil, err
+	}
+	applyConfigProjectRoot(config, filePath)
+	return config, nil
 }
 
 func loadPyprojectConfigData(data []byte) (*PyscnConfig, error) {
@@ -69,6 +80,7 @@ func loadPyprojectConfigData(data []byte) (*PyscnConfig, error) {
 
 	// Merge with defaults using shared merge logic
 	config := DefaultPyscnConfig()
+	config.ProjectRoot = pyproject.Tool.Pyscn.ProjectRoot
 	mergeComplexitySection(config, &pyproject.Tool.Pyscn.Complexity)
 	mergeDeadCodeSection(config, &pyproject.Tool.Pyscn.DeadCode)
 	mergeOutputSection(config, &pyproject.Tool.Pyscn.Output)

--- a/internal/config/pyscn_config.go
+++ b/internal/config/pyscn_config.go
@@ -10,6 +10,10 @@ import (
 // PyscnConfig represents the universal pyscn configuration from TOML files
 // This holds all configuration sections that can be loaded from .pyscn.toml or pyproject.toml
 type PyscnConfig struct {
+	// ProjectRoot is the effective absolute project root resolved from the
+	// configuration file location and its optional project_root value.
+	ProjectRoot string `mapstructure:"project_root" yaml:"project_root" json:"project_root"`
+
 	// Clone Analysis Configuration
 	Analysis CloneAnalysisConfig `mapstructure:"analysis" yaml:"analysis" json:"analysis"`
 

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -20,6 +20,8 @@ const (
 
 // PyscnTomlConfig represents the structure of .pyscn.toml
 type PyscnTomlConfig struct {
+	// ProjectRoot is resolved relative to the directory containing the config file.
+	ProjectRoot    string                   `toml:"project_root"`
 	Complexity     ComplexityTomlConfig     `toml:"complexity"`      // [complexity] section
 	DeadCode       DeadCodeTomlConfig       `toml:"dead_code"`       // [dead_code] section
 	Output         OutputTomlConfig         `toml:"output"`          // [output] section
@@ -341,6 +343,7 @@ func (l *TomlConfigLoader) loadFromFile(filePath string) (*PyscnConfig, error) {
 
 	defaults := DefaultPyscnConfig()
 	l.mergePyscnTomlConfigs(defaults, &parsed)
+	applyConfigProjectRoot(defaults, filePath)
 	return defaults, nil
 }
 
@@ -376,6 +379,7 @@ func (l *TomlConfigLoader) loadFromPyscnToml(startDir string) (*PyscnConfig, err
 	// Merge with defaults
 	defaults := DefaultPyscnConfig()
 	l.mergePyscnTomlConfigs(defaults, &config)
+	applyConfigProjectRoot(defaults, configPath)
 
 	return defaults, nil
 }
@@ -520,9 +524,36 @@ func normalizeSearchDir(path string) (string, error) {
 	return absPath, nil
 }
 
+// applyConfigProjectRoot resolves the configured project root against the
+// directory containing the config file. A config file without an explicit
+// project_root uses its own directory as the project root.
+func applyConfigProjectRoot(cfg *PyscnConfig, configPath string) {
+	if cfg == nil || configPath == "" {
+		return
+	}
+
+	configDir, err := filepath.Abs(filepath.Dir(configPath))
+	if err != nil {
+		return
+	}
+	if cfg.ProjectRoot == "" {
+		cfg.ProjectRoot = configDir
+		return
+	}
+	if filepath.IsAbs(cfg.ProjectRoot) {
+		cfg.ProjectRoot = filepath.Clean(cfg.ProjectRoot)
+		return
+	}
+	cfg.ProjectRoot = filepath.Join(configDir, cfg.ProjectRoot)
+}
+
 // mergePyscnTomlConfigs merges .pyscn.toml config into defaults
 // using pointer booleans to detect unset values
 func (l *TomlConfigLoader) mergePyscnTomlConfigs(defaults *PyscnConfig, pyscnToml *PyscnTomlConfig) {
+	if pyscnToml.ProjectRoot != "" {
+		defaults.ProjectRoot = pyscnToml.ProjectRoot
+	}
+
 	// Merge from [complexity] section using shared merge logic
 	mergeComplexitySection(defaults, &pyscnToml.Complexity)
 

--- a/internal/config/toml_loader_test.go
+++ b/internal/config/toml_loader_test.go
@@ -55,6 +55,47 @@ func TestLoadComplexityFromPyscnToml(t *testing.T) {
 	}
 }
 
+func TestTomlConfigLoaderResolvesProjectRootFromConfig(t *testing.T) {
+	configDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configDir, ".pyscn.toml"), []byte("project_root = \"src\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := NewTomlConfigLoader().LoadConfig(configDir)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	want, err := filepath.Abs(filepath.Join(configDir, "src"))
+	if err != nil {
+		t.Fatalf("failed to resolve expected root: %v", err)
+	}
+	if cfg.ProjectRoot != want {
+		t.Fatalf("expected project root %q, got %q", want, cfg.ProjectRoot)
+	}
+}
+
+func TestPyprojectConfigDefaultsProjectRootToConfigDirectory(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "pyproject.toml")
+	if err := os.WriteFile(configPath, []byte("[tool.pyscn]\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadPyprojectConfig(configDir)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	want, err := filepath.Abs(configDir)
+	if err != nil {
+		t.Fatalf("failed to resolve expected root: %v", err)
+	}
+	if cfg.ProjectRoot != want {
+		t.Fatalf("expected project root %q, got %q", want, cfg.ProjectRoot)
+	}
+}
+
 func TestLoadComplexityFromPyscnTomlPartial(t *testing.T) {
 	// Create temporary directory
 	tempDir := t.TempDir()

--- a/service/analyze_config_loader.go
+++ b/service/analyze_config_loader.go
@@ -31,9 +31,13 @@ func (l *AnalyzeConfigurationLoaderImpl) LoadAnalyzeExecutionConfig(configPath s
 		return defaultAnalyzeExecutionConfig(), nil
 	}
 
-	cfg, err := config.LoadConfig(resolvedConfigPath)
+	pyscnCfg, err := tomlLoader.LoadConfig(resolvedConfigPath)
 	if err != nil {
 		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("failed to load configuration: %w", err)
+	}
+	cfg := config.PyscnConfigToConfig(pyscnCfg)
+	if err := cfg.Validate(); err != nil {
+		return domain.AnalyzeExecutionConfig{}, fmt.Errorf("invalid configuration: %w", err)
 	}
 
 	overrides, err := loadAnalyzeEnabledOverrides(resolvedConfigPath)
@@ -43,6 +47,7 @@ func (l *AnalyzeConfigurationLoaderImpl) LoadAnalyzeExecutionConfig(configPath s
 
 	executionCfg := analyzeExecutionConfigFromConfig(cfg, overrides)
 	executionCfg.ConfigPath = resolvedConfigPath
+	executionCfg.ProjectRoot = pyscnCfg.ProjectRoot
 
 	return executionCfg, nil
 }

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -113,6 +113,9 @@ lsh_auto_threshold = 123
 		if cfg.ConfigPath != configPath {
 			t.Errorf("expected config path %q, got %q", configPath, cfg.ConfigPath)
 		}
+		if cfg.ProjectRoot != projectDir {
+			t.Errorf("expected project root %q, got %q", projectDir, cfg.ProjectRoot)
+		}
 		if cfg.Recursive {
 			t.Error("expected recursive false")
 		}

--- a/service/community_analysis_service.go
+++ b/service/community_analysis_service.go
@@ -132,7 +132,10 @@ func (s *CommunityAnalysisServiceImpl) buildDependencyGraph(ctx context.Context,
 	if len(rootPaths) == 0 {
 		rootPaths = req.Paths
 	}
-	projectRoot := FindProjectRoot(rootPaths)
+	projectRoot := req.ProjectRoot
+	if projectRoot == "" {
+		projectRoot = FindProjectRoot(rootPaths)
+	}
 	options := &analyzer.ModuleAnalysisOptions{
 		ProjectRoot:       projectRoot,
 		IncludeStdLib:     req.IncludeStdLib,

--- a/service/community_analysis_service_test.go
+++ b/service/community_analysis_service_test.go
@@ -24,6 +24,7 @@ func TestCommunityAnalysisService_Analyze_FixtureProject(t *testing.T) {
 	service := NewCommunityAnalysisService()
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:        files,
+		ProjectRoot:  fixtureRoot,
 		OutputFormat: domain.OutputFormatJSON,
 	})
 	require.NoError(t, err)
@@ -48,6 +49,7 @@ func TestCommunityAnalysisService_Analyze_MinimalSingleModule(t *testing.T) {
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:       files,
 		SourcePaths: []string{fixtureRoot},
+		ProjectRoot: fixtureRoot,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -103,6 +105,7 @@ func TestCommunityAnalysisService_Analyze_IsolatedModulesNoEdges(t *testing.T) {
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:       files,
 		SourcePaths: []string{fixtureRoot},
+		ProjectRoot: fixtureRoot,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -124,6 +127,7 @@ func TestCommunityAnalysisService_Analyze_PackageMismatch_BridgeFixture(t *testi
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -152,6 +156,7 @@ func TestCommunityAnalysisService_Analyze_PackageMismatch_SeparatedFixture(t *te
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -174,6 +179,7 @@ func TestCommunityAnalysisService_Analyze_PackageMismatch_MixedFixture(t *testin
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -204,6 +210,7 @@ func analyzeCommunityFixtureForRisk(t *testing.T, fixture string) *domain.Commun
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -242,6 +249,7 @@ func TestCommunityAnalysisService_RiskScore_IndependentOfBridgeReporting(t *test
 	base := domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	}
 
@@ -276,6 +284,7 @@ func TestCommunityAnalysisService_Analyze_Deterministic(t *testing.T) {
 	req := domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	}
 	service := NewCommunityAnalysisService()
@@ -309,6 +318,7 @@ func TestCommunityAnalysisService_Analyze_LayerMismatch_BridgeFixture(t *testing
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -331,6 +341,7 @@ func TestCommunityAnalysisService_Analyze_LayerMismatch_AlignedFixture(t *testin
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -353,6 +364,7 @@ func TestCommunityAnalysisService_Analyze_LayerMismatch_MixedFixture(t *testing.
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)
@@ -385,6 +397,7 @@ func TestCommunityAnalysisService_Analyze_LayerMismatch_OmittedWithoutArchitectu
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)

--- a/service/community_config_loader.go
+++ b/service/community_config_loader.go
@@ -59,6 +59,7 @@ func (cl *CommunityConfigurationLoaderImpl) MergeConfig(base *domain.CommunityAn
 	merged.NoOpen = override.NoOpen
 
 	merged.ConfigPath = config.Merge(merged.ConfigPath, override.ConfigPath)
+	merged.ProjectRoot = config.Merge(merged.ProjectRoot, override.ProjectRoot)
 	merged.Recursive = config.MergePtr(merged.Recursive, override.Recursive)
 	merged.IncludePatterns = config.MergeSlice(merged.IncludePatterns, override.IncludePatterns)
 	merged.ExcludePatterns = config.MergeSlice(merged.ExcludePatterns, override.ExcludePatterns)
@@ -85,6 +86,7 @@ func (cl *CommunityConfigurationLoaderImpl) configToRequest(pyscnCfg *config.Pys
 	}
 
 	req := domain.DefaultCommunityAnalysisRequest()
+	req.ProjectRoot = pyscnCfg.ProjectRoot
 	req.Algorithm = pyscnCfg.CommunitiesAlgorithm
 	req.Scope = pyscnCfg.CommunitiesScope
 	req.MinCommunitySize = pyscnCfg.CommunitiesMinCommunitySize

--- a/service/community_config_loader_test.go
+++ b/service/community_config_loader_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestCommunityConfigurationLoader_LoadConfig(t *testing.T) {
 	tempDir := t.TempDir()
-	configContent := `[communities]
+	configContent := `project_root = "src"
+
+[communities]
 enabled = true
 algorithm = "leiden"
 scope = "module"
@@ -47,6 +49,10 @@ resolution = 1.25
 	}
 	if req.Resolution != 1.25 {
 		t.Errorf("expected resolution 1.25, got %f", req.Resolution)
+	}
+	wantRoot := filepath.Join(tempDir, "src")
+	if req.ProjectRoot != wantRoot {
+		t.Errorf("expected project root %q, got %q", wantRoot, req.ProjectRoot)
 	}
 }
 

--- a/service/community_formatter_test.go
+++ b/service/community_formatter_test.go
@@ -399,6 +399,7 @@ func analyzeCommunityBridgeFixture(t *testing.T) *domain.CommunityAnalysisResult
 	result, err := service.Analyze(context.Background(), domain.CommunityAnalysisRequest{
 		Paths:            files,
 		SourcePaths:      []string{fixtureRoot},
+		ProjectRoot:      fixtureRoot,
 		MinCommunitySize: 2,
 	})
 	require.NoError(t, err)

--- a/service/project_root.go
+++ b/service/project_root.go
@@ -4,14 +4,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ludo-technologies/pyscn/internal/config"
 )
 
 // FindProjectRoot locates the project root from the given paths by finding their
-// common parent and walking upward for standard Python project markers.
+// discovered config file first, then falling back to the common parent and
+// standard Python project markers.
 func FindProjectRoot(paths []string) string {
 	if len(paths) == 0 {
 		cwd, _ := os.Getwd()
 		return cwd
+	}
+
+	if configuredRoot := configuredProjectRoot(paths); configuredRoot != "" {
+		return configuredRoot
 	}
 
 	absPaths := make([]string, 0, len(paths))
@@ -65,6 +72,57 @@ func FindProjectRoot(paths []string) string {
 	}
 
 	return commonParent
+}
+
+func configuredProjectRoot(paths []string) string {
+	searchPath := commonAnalysisParent(paths)
+	if searchPath == "" {
+		searchPath = "."
+	}
+
+	loader := config.NewTomlConfigLoader()
+	configPath := loader.FindConfigFileFromPath(searchPath)
+	if configPath == "" {
+		return ""
+	}
+
+	cfg, err := loader.LoadConfig(configPath)
+	if err != nil {
+		return ""
+	}
+	return cfg.ProjectRoot
+}
+
+func commonAnalysisParent(paths []string) string {
+	var absPaths []string
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		absolute, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		if info, err := os.Stat(absolute); err == nil && !info.IsDir() {
+			absolute = filepath.Dir(absolute)
+		}
+		absPaths = append(absPaths, absolute)
+	}
+	if len(absPaths) == 0 {
+		return ""
+	}
+
+	common := absPaths[0]
+	for _, path := range absPaths[1:] {
+		for !pathWithinDirectory(path, common) {
+			parent := filepath.Dir(common)
+			if parent == common {
+				break
+			}
+			common = parent
+		}
+	}
+	return common
 }
 
 func pathWithinDirectory(path, root string) bool {

--- a/service/project_root_test.go
+++ b/service/project_root_test.go
@@ -53,3 +53,18 @@ func TestFindProjectRoot_UsesPathComponentBoundaries(t *testing.T) {
 	got := FindProjectRoot([]string{pkg, pkgExtra})
 	assert.Equal(t, root, got)
 }
+
+func TestFindProjectRoot_UsesConfiguredProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".pyscn.toml"), []byte("project_root = \"src\"\n"), 0o644))
+	file := filepath.Join(root, "package", "module.py")
+	require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
+	require.NoError(t, os.WriteFile(file, []byte("pass\n"), 0o644))
+
+	got := FindProjectRoot([]string{file})
+	want, err := filepath.Abs(srcDir)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}

--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -133,6 +133,7 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) MergeConfig(base *domain.System
 	}
 	merged.OutputPath = config.Merge(merged.OutputPath, override.OutputPath)
 	merged.ConfigPath = config.Merge(merged.ConfigPath, override.ConfigPath)
+	merged.ProjectRoot = config.Merge(merged.ProjectRoot, override.ProjectRoot)
 
 	// Boolean flags - CLI always takes precedence for explicit settings
 	merged.NoOpen = override.NoOpen

--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -74,6 +74,7 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) pyscnConfigToSystemAnalysisRequ
 	if rules := ArchitectureRulesFromPyscnConfig(cfg); rules != nil {
 		request.ArchitectureRules = rules
 	}
+	request.ProjectRoot = cfg.ProjectRoot
 
 	// Analysis settings (include/exclude patterns)
 	if cfg.HasExplicitAnalysisIncludePatterns() {
@@ -89,10 +90,10 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) pyscnConfigToSystemAnalysisRequ
 	return request
 }
 
-// LoadDefaultConfig returns the built-in defaults. System analysis config is
-// resolved by the caller, so there is nothing to discover from targetPath.
+// LoadDefaultConfig returns built-in defaults and discovers project config when
+// a target path is available.
 func (cl *SystemAnalysisConfigurationLoaderImpl) LoadDefaultConfig(targetPath string) *domain.SystemAnalysisRequest {
-	return &domain.SystemAnalysisRequest{
+	defaults := &domain.SystemAnalysisRequest{
 		OutputFormat:                    domain.OutputFormatText,
 		AnalyzeDependencies:             domain.BoolPtr(true),
 		AnalyzeArchitecture:             domain.BoolPtr(true),
@@ -111,6 +112,16 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) LoadDefaultConfig(targetPath st
 		IncludePatterns:                 domain.DefaultPythonModuleIncludePatterns(),
 		ExcludePatterns:                 domain.DefaultAnalysisExcludePatterns(),
 	}
+	if targetPath == "" {
+		return defaults
+	}
+	tomlLoader := config.NewTomlConfigLoader()
+	if configPath, err := tomlLoader.ResolveConfigPath("", targetPath); err == nil && configPath != "" {
+		if cfg, err := tomlLoader.LoadConfig(configPath); err == nil {
+			return cl.pyscnConfigToSystemAnalysisRequest(cfg)
+		}
+	}
+	return defaults
 }
 
 // MergeConfig merges CLI flags with configuration file

--- a/service/system_analysis_config_loader_test.go
+++ b/service/system_analysis_config_loader_test.go
@@ -55,3 +55,14 @@ func TestSystemAnalysisConfigurationLoader_MergeConfigZeroValueKeepsBase(t *test
 		t.Errorf("expected include_stdlib true preserved, got %v", merged.IncludeStdLib)
 	}
 }
+
+func TestSystemAnalysisConfigurationLoader_MergesExplicitProjectRoot(t *testing.T) {
+	loader := NewSystemAnalysisConfigurationLoader()
+	base := loader.LoadDefaultConfig("")
+	base.ProjectRoot = "inferred"
+
+	merged := loader.MergeConfig(base, &domain.SystemAnalysisRequest{ProjectRoot: "explicit"})
+	if merged.ProjectRoot != "explicit" {
+		t.Fatalf("expected explicit project root to override base, got %q", merged.ProjectRoot)
+	}
+}

--- a/service/system_analysis_config_loader_test.go
+++ b/service/system_analysis_config_loader_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ludo-technologies/pyscn/domain"
@@ -24,6 +26,44 @@ func TestSystemAnalysisConfigurationLoader_MergeConfigOverrideEqualsDefault(t *t
 
 	if merged.OutputFormat != domain.OutputFormatText {
 		t.Errorf("expected output format %q to override base, got %q", domain.OutputFormatText, merged.OutputFormat)
+	}
+}
+
+func TestSystemAnalysisConfigurationLoaderLoadsConfiguredProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte("project_root = \"src\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	request, err := NewSystemAnalysisConfigurationLoader().LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	want := filepath.Join(root, "src")
+	if request.ProjectRoot != want {
+		t.Fatalf("expected project root %q, got %q", want, request.ProjectRoot)
+	}
+}
+
+func TestSystemAnalysisConfigurationLoaderDiscoversProjectRootFromTargetPath(t *testing.T) {
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "src")
+	targetPath := filepath.Join(targetDir, "consumer.py")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		t.Fatalf("failed to create target directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".pyscn.toml"), []byte("project_root = \"src\"\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("value = 1\n"), 0o644); err != nil {
+		t.Fatalf("failed to write target: %v", err)
+	}
+
+	request := NewSystemAnalysisConfigurationLoader().LoadDefaultConfig(targetPath)
+	if request.ProjectRoot != targetDir {
+		t.Errorf("expected project root %q, got %q", targetDir, request.ProjectRoot)
 	}
 }
 

--- a/service/system_analysis_formatter.go
+++ b/service/system_analysis_formatter.go
@@ -101,6 +101,8 @@ func (f *SystemAnalysisFormatterImpl) writeDependenciesSection(builder *strings.
 	stats := map[string]interface{}{
 		"Total Modules":      deps.TotalModules,
 		"Total Dependencies": deps.TotalDependencies,
+		"Resolved Imports":   deps.ResolvedImports,
+		"Unresolved Imports": deps.UnresolvedImports,
 		"Root Modules":       len(deps.RootModules),
 		"Leaf Modules":       len(deps.LeafModules),
 		"Max Depth":          deps.MaxDepth,
@@ -262,6 +264,8 @@ func (f *SystemAnalysisFormatterImpl) formatCSV(response *domain.SystemAnalysisR
 		// Dependency metrics
 		_ = writer.Write([]string{"Dependencies", "Total Modules", strconv.Itoa(response.DependencyAnalysis.TotalModules)})
 		_ = writer.Write([]string{"Dependencies", "Total Dependencies", strconv.Itoa(response.DependencyAnalysis.TotalDependencies)})
+		_ = writer.Write([]string{"Dependencies", "Resolved Imports", strconv.Itoa(response.DependencyAnalysis.ResolvedImports)})
+		_ = writer.Write([]string{"Dependencies", "Unresolved Imports", strconv.Itoa(response.DependencyAnalysis.UnresolvedImports)})
 		_ = writer.Write([]string{"Dependencies", "Root Modules", strconv.Itoa(len(response.DependencyAnalysis.RootModules))})
 		_ = writer.Write([]string{"Dependencies", "Leaf Modules", strconv.Itoa(len(response.DependencyAnalysis.LeafModules))})
 		_ = writer.Write([]string{"Dependencies", "Max Depth", strconv.Itoa(response.DependencyAnalysis.MaxDepth)})
@@ -478,6 +482,8 @@ func (f *SystemAnalysisFormatterImpl) writeHTMLDependenciesContent(builder *stri
 	builder.WriteString(`<div class="metric-grid">`)
 	builder.WriteString(GenerateMetricCard(strconv.Itoa(deps.TotalModules), "Total Modules"))
 	builder.WriteString(GenerateMetricCard(strconv.Itoa(deps.TotalDependencies), "Total Dependencies"))
+	builder.WriteString(GenerateMetricCard(strconv.Itoa(deps.ResolvedImports), "Resolved Imports"))
+	builder.WriteString(GenerateMetricCard(strconv.Itoa(deps.UnresolvedImports), "Unresolved Imports"))
 	builder.WriteString(GenerateMetricCard(strconv.Itoa(deps.MaxDepth), "Max Dependency Depth"))
 
 	if deps.CircularDependencies != nil {

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -111,12 +114,78 @@ func (s *SystemAnalysisServiceImpl) analyzeGraph(ctx context.Context, graph *ana
 		GeneratedAt:          time.Now(),
 		Duration:             time.Since(startTime).Milliseconds(),
 		Version:              version.Version,
-		Warnings:             warnings,
+		Warnings:             append(warnings, systemAnalysisWarnings(graph, req)...),
 		Errors:               analysisIssueMessages(issues),
 		Failures:             analyzerFailures(domain.AnalysisKindSystem, issues),
 	}
 
 	return response, nil
+}
+
+func systemAnalysisWarnings(graph *analyzer.DependencyGraph, req domain.SystemAnalysisRequest) []string {
+	if graph == nil {
+		return nil
+	}
+	warnings := make([]string, 0, 2)
+	if req.ProjectRoot == "" {
+		scopeRoot := analysisScopeRoot(req.Paths)
+		if scopeRoot != "" && !sameAnalysisPath(scopeRoot, graph.ProjectRoot) {
+			warnings = append(warnings, fmt.Sprintf("inferred project root %q differs from analyzed directory %q; use --project-root to make the analysis root explicit", graph.ProjectRoot, scopeRoot))
+		}
+	}
+	totalImports := graph.ResolvedImports + graph.UnresolvedImports
+	if totalImports > 0 && graph.UnresolvedImports*2 >= totalImports {
+		warnings = append(warnings, fmt.Sprintf("%d of %d internal imports remain unresolved; verify the project root or pass --project-root", graph.UnresolvedImports, totalImports))
+	}
+	return warnings
+}
+
+func analysisScopeRoot(paths []string) string {
+	if len(paths) == 0 {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return ""
+		}
+		return cwd
+	}
+
+	var roots []string
+	for _, path := range paths {
+		absolute, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		if info, err := os.Stat(absolute); err == nil && !info.IsDir() {
+			absolute = filepath.Dir(absolute)
+		}
+		roots = append(roots, absolute)
+	}
+	if len(roots) == 0 {
+		return ""
+	}
+	common := roots[0]
+	for _, root := range roots[1:] {
+		for !pathWithinDirectory(root, common) {
+			parent := filepath.Dir(common)
+			if parent == common {
+				break
+			}
+			common = parent
+		}
+	}
+	return common
+}
+
+func sameAnalysisPath(left, right string) bool {
+	leftAbs, leftErr := filepath.Abs(left)
+	rightAbs, rightErr := filepath.Abs(right)
+	if leftErr != nil || rightErr != nil {
+		return filepath.Clean(left) == filepath.Clean(right)
+	}
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(filepath.Clean(leftAbs), filepath.Clean(rightAbs))
+	}
+	return filepath.Clean(leftAbs) == filepath.Clean(rightAbs)
 }
 
 func (s *SystemAnalysisServiceImpl) buildSystemAnalysisSummary(
@@ -130,6 +199,8 @@ func (s *SystemAnalysisServiceImpl) buildSystemAnalysisSummary(
 		summary.ProjectRoot = graph.ProjectRoot
 		summary.TotalModules = graph.TotalModules
 		summary.TotalDependencies = graph.TotalEdges
+		summary.ResolvedImports = graph.ResolvedImports
+		summary.UnresolvedImports = graph.UnresolvedImports
 		summary.TotalPackages = len(graph.GetPackages())
 	}
 
@@ -138,6 +209,8 @@ func (s *SystemAnalysisServiceImpl) buildSystemAnalysisSummary(
 	if dependencyResult != nil {
 		summary.TotalModules = dependencyResult.TotalModules
 		summary.TotalDependencies = dependencyResult.TotalDependencies
+		summary.ResolvedImports = dependencyResult.ResolvedImports
+		summary.UnresolvedImports = dependencyResult.UnresolvedImports
 		if packageCount := countSystemAnalysisPackages(dependencyResult.ModuleMetrics); packageCount > 0 {
 			summary.TotalPackages = packageCount
 		}
@@ -387,6 +460,8 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 		return &domain.DependencyAnalysisResult{
 			TotalModules:      0,
 			TotalDependencies: 0,
+			ResolvedImports:   graph.ResolvedImports,
+			UnresolvedImports: graph.UnresolvedImports,
 			RootModules:       []string{},
 			LeafModules:       []string{},
 			MaxDepth:          0,
@@ -437,6 +512,8 @@ func (s *SystemAnalysisServiceImpl) buildDependencyAnalysisResult(ctx context.Co
 	result := &domain.DependencyAnalysisResult{
 		TotalModules:         graph.TotalModules,
 		TotalDependencies:    graph.TotalEdges,
+		ResolvedImports:      graph.ResolvedImports,
+		UnresolvedImports:    graph.UnresolvedImports,
 		RootModules:          graph.GetRootModules(),
 		LeafModules:          graph.GetLeafModules(),
 		ModuleMetrics:        moduleMetrics,
@@ -573,7 +650,10 @@ func (s *SystemAnalysisServiceImpl) buildDependencyGraph(ctx context.Context, re
 		return nil, fmt.Errorf("module graph cancelled: %w", err)
 	}
 
-	projectRoot := FindProjectRoot(req.Paths)
+	projectRoot := req.ProjectRoot
+	if projectRoot == "" {
+		projectRoot = FindProjectRoot(req.Paths)
+	}
 	options := &analyzer.ModuleAnalysisOptions{
 		ProjectRoot:       projectRoot,
 		IncludeStdLib:     req.IncludeStdLib,

--- a/service/system_analysis_service.go
+++ b/service/system_analysis_service.go
@@ -128,52 +128,15 @@ func systemAnalysisWarnings(graph *analyzer.DependencyGraph, req domain.SystemAn
 	}
 	warnings := make([]string, 0, 2)
 	if req.ProjectRoot == "" {
-		scopeRoot := analysisScopeRoot(req.Paths)
-		if scopeRoot != "" && !sameAnalysisPath(scopeRoot, graph.ProjectRoot) {
-			warnings = append(warnings, fmt.Sprintf("inferred project root %q differs from analyzed directory %q; use --project-root to make the analysis root explicit", graph.ProjectRoot, scopeRoot))
+		if cwd, err := os.Getwd(); err == nil && !sameAnalysisPath(cwd, graph.ProjectRoot) {
+			warnings = append(warnings, fmt.Sprintf("inferred project root %q differs from current working directory %q; set project_root in the configuration to make the analysis root explicit", graph.ProjectRoot, cwd))
 		}
 	}
 	totalImports := graph.ResolvedImports + graph.UnresolvedImports
 	if totalImports > 0 && graph.UnresolvedImports*2 >= totalImports {
-		warnings = append(warnings, fmt.Sprintf("%d of %d internal imports remain unresolved; verify the project root or pass --project-root", graph.UnresolvedImports, totalImports))
+		warnings = append(warnings, fmt.Sprintf("%d of %d internal imports remain unresolved; verify the project root or set project_root in the configuration", graph.UnresolvedImports, totalImports))
 	}
 	return warnings
-}
-
-func analysisScopeRoot(paths []string) string {
-	if len(paths) == 0 {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return ""
-		}
-		return cwd
-	}
-
-	var roots []string
-	for _, path := range paths {
-		absolute, err := filepath.Abs(path)
-		if err != nil {
-			continue
-		}
-		if info, err := os.Stat(absolute); err == nil && !info.IsDir() {
-			absolute = filepath.Dir(absolute)
-		}
-		roots = append(roots, absolute)
-	}
-	if len(roots) == 0 {
-		return ""
-	}
-	common := roots[0]
-	for _, root := range roots[1:] {
-		for !pathWithinDirectory(root, common) {
-			parent := filepath.Dir(common)
-			if parent == common {
-				break
-			}
-			common = parent
-		}
-	}
-	return common
 }
 
 func sameAnalysisPath(left, right string) bool {

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -157,6 +157,38 @@ class Dependency:
 	assert.InDelta(t, 0.0, response.ModuleMetrics[balancedService].Distance, 0.01)
 }
 
+func TestSystemAnalysisReportsImportResolutionDiagnosticsAndRootWarnings(t *testing.T) {
+	dir := t.TempDir()
+	consumer := filepath.Join(dir, "pkg", "consumer.py")
+	provider := filepath.Join(dir, "pkg", "provider.py")
+	require.NoError(t, os.MkdirAll(filepath.Dir(consumer), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[project]\nname = \"root-diagnostics\"\n"), 0o644))
+	require.NoError(t, os.WriteFile(consumer, []byte("from . import provider\nimport pkg.missing\n"), 0o644))
+	require.NoError(t, os.WriteFile(provider, []byte("value = 1\n"), 0o644))
+
+	service := NewSystemAnalysisService()
+	response, err := service.Analyze(context.Background(), domain.SystemAnalysisRequest{
+		Paths:             []string{consumer, provider},
+		IncludeThirdParty: domain.BoolPtr(false),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, response.DependencyAnalysis)
+	assert.Equal(t, 1, response.DependencyAnalysis.ResolvedImports)
+	assert.Equal(t, 1, response.DependencyAnalysis.UnresolvedImports)
+	assert.Equal(t, 1, response.Summary.ResolvedImports)
+	assert.Equal(t, 1, response.Summary.UnresolvedImports)
+	assert.Contains(t, strings.Join(response.Warnings, "\n"), "unresolved")
+	assert.Contains(t, strings.Join(response.Warnings, "\n"), "project root")
+
+	response, err = service.Analyze(context.Background(), domain.SystemAnalysisRequest{
+		Paths:             []string{consumer, provider},
+		ProjectRoot:       dir,
+		IncludeThirdParty: domain.BoolPtr(false),
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, strings.Join(response.Warnings, "\n"), "inferred project root")
+}
+
 func TestAnalyzeBuildsEquivalentDependencyAndArchitectureResults(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]string{

--- a/service/system_analysis_service_test.go
+++ b/service/system_analysis_service_test.go
@@ -189,6 +189,25 @@ func TestSystemAnalysisReportsImportResolutionDiagnosticsAndRootWarnings(t *test
 	assert.NotContains(t, strings.Join(response.Warnings, "\n"), "inferred project root")
 }
 
+func TestSystemAnalysisRootWarningComparesAgainstWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	srcDir := filepath.Join(root, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pyproject.toml"), []byte("[tool.pyscn]\n"), 0o644))
+	consumer := filepath.Join(srcDir, "consumer.py")
+	provider := filepath.Join(srcDir, "provider.py")
+	require.NoError(t, os.WriteFile(consumer, []byte("from . import provider\n"), 0o644))
+	require.NoError(t, os.WriteFile(provider, []byte("value = 1\n"), 0o644))
+
+	t.Chdir(root)
+	response, err := NewSystemAnalysisService().Analyze(context.Background(), domain.SystemAnalysisRequest{
+		Paths:             []string{filepath.Join("src", "consumer.py"), filepath.Join("src", "provider.py")},
+		IncludeThirdParty: domain.BoolPtr(false),
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, strings.Join(response.Warnings, "\n"), "inferred project root")
+}
+
 func TestAnalyzeBuildsEquivalentDependencyAndArchitectureResults(t *testing.T) {
 	dir := t.TempDir()
 	files := map[string]string{


### PR DESCRIPTION
## Summary / Problem

When pyscn analyzes a subdirectory, marker-based project-root inference can assign modules the wrong qualified names. That silently drops internal dependency edges and can make dependency-derived scores look healthier than the analyzed project really is.

## Changes

- Prefer the discovered `.pyscn.toml` or `pyproject.toml [tool.pyscn]` directory as the project root.
- Add an optional top-level `project_root` configuration key, resolved relative to the configuration file, for projects whose import root differs from the configuration directory.
- Propagate the resolved root through `analyze`, system analysis, and community analysis; remove the `--project-root` CLI flag.
- Compare root diagnostics with the current working directory and direct users to the configuration key when an explicit root is needed.
- Track resolved and unresolved internal import statements in dependency analysis results and summaries.
- Include the import-resolution counts in text, CSV, HTML, JSON, and YAML reports.
- Add regression coverage for configuration discovery, root propagation, diagnostics, resolution counts, warnings, and CLI output; document the configuration behavior.

## Tests

- `go mod verify`
- `go test ./...`
- `go test -race ./service ./cmd/pyscn`
- `go vet ./...`
- `go build ./cmd/pyscn`

All listed checks passed in a Linux Go 1.26.8 container. The repository CI matrix uses Go 1.22 and 1.23 for tests, Go 1.23 for the build, and Go 1.25 with golangci-lint; the golangci-lint action and those exact toolchain versions were not available locally.

## Compatibility / Known limitations

The new configuration key is optional. Without a discovered pyscn configuration file, automatic marker-based project-root inference remains the fallback. `project_root` paths are resolved relative to the configuration file, and the new report fields are additive. Internal import diagnostics exclude standard-library and third-party imports that are outside the analyzed graph.

## Issue link

Fixes #738

https://github.com/ludo-technologies/pyscn/issues/738
