### PR TITLE
fix(config): keep system analysis LoadDefaultConfig free of discovery

### DIFF
--- a/service/system_analysis_config_loader.go
+++ b/service/system_analysis_config_loader.go
@@ -90,10 +90,10 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) pyscnConfigToSystemAnalysisRequ
 	return request
 }
 
-// LoadDefaultConfig returns built-in defaults and discovers project config when
-// a target path is available.
+// LoadDefaultConfig returns the built-in defaults. System analysis config is
+// resolved by the caller, so there is nothing to discover from targetPath.
 func (cl *SystemAnalysisConfigurationLoaderImpl) LoadDefaultConfig(targetPath string) *domain.SystemAnalysisRequest {
-	defaults := &domain.SystemAnalysisRequest{
+	return &domain.SystemAnalysisRequest{
 		OutputFormat:                    domain.OutputFormatText,
 		AnalyzeDependencies:             domain.BoolPtr(true),
 		AnalyzeArchitecture:             domain.BoolPtr(true),
@@ -112,16 +112,6 @@ func (cl *SystemAnalysisConfigurationLoaderImpl) LoadDefaultConfig(targetPath st
 		IncludePatterns:                 domain.DefaultPythonModuleIncludePatterns(),
 		ExcludePatterns:                 domain.DefaultAnalysisExcludePatterns(),
 	}
-	if targetPath == "" {
-		return defaults
-	}
-	tomlLoader := config.NewTomlConfigLoader()
-	if configPath, err := tomlLoader.ResolveConfigPath("", targetPath); err == nil && configPath != "" {
-		if cfg, err := tomlLoader.LoadConfig(configPath); err == nil {
-			return cl.pyscnConfigToSystemAnalysisRequest(cfg)
-		}
-	}
-	return defaults
 }
 
 // MergeConfig merges CLI flags with configuration file

--- a/service/system_analysis_config_loader_test.go
+++ b/service/system_analysis_config_loader_test.go
@@ -47,26 +47,6 @@ func TestSystemAnalysisConfigurationLoaderLoadsConfiguredProjectRoot(t *testing.
 	}
 }
 
-func TestSystemAnalysisConfigurationLoaderDiscoversProjectRootFromTargetPath(t *testing.T) {
-	root := t.TempDir()
-	targetDir := filepath.Join(root, "src")
-	targetPath := filepath.Join(targetDir, "consumer.py")
-	if err := os.MkdirAll(targetDir, 0o755); err != nil {
-		t.Fatalf("failed to create target directory: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".pyscn.toml"), []byte("project_root = \"src\"\n"), 0o644); err != nil {
-		t.Fatalf("failed to write config: %v", err)
-	}
-	if err := os.WriteFile(targetPath, []byte("value = 1\n"), 0o644); err != nil {
-		t.Fatalf("failed to write target: %v", err)
-	}
-
-	request := NewSystemAnalysisConfigurationLoader().LoadDefaultConfig(targetPath)
-	if request.ProjectRoot != targetDir {
-		t.Errorf("expected project root %q, got %q", targetDir, request.ProjectRoot)
-	}
-}
-
 // TestSystemAnalysisConfigurationLoader_MergeConfigZeroValueKeepsBase verifies
 // that a zero-valued override ("no CLI flags set") preserves all base values.
 func TestSystemAnalysisConfigurationLoader_MergeConfigZeroValueKeepsBase(t *testing.T) {


### PR DESCRIPTION
Follow-up to #740. `LoadDefaultConfig` gained config discovery from the target path, but `analyze` always resolves `ConfigPath` before building the system request, so the branch is never reached. It also reverses f818f22, where system analysis config is resolved by the caller only. Removes the discovery and its test.

https://claude.ai/code/session_01UoUXYp7HGDvgUncZBipqkv