### PR TITLE
feat: add --output flag to analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Run comprehensive analysis with HTML report
 ```bash
 pyscn analyze .                              # All analyses with HTML report
 pyscn analyze --json .                       # Generate JSON report
+pyscn analyze --json --output - . | jq       # JSON report on stdout
 pyscn analyze --select complexity .          # Only complexity analysis
 pyscn analyze --select deps .                # Only dependency analysis
 pyscn analyze --select complexity,deps,deadcode . # Multiple analyses

--- a/cmd/pyscn/analyze.go
+++ b/cmd/pyscn/analyze.go
@@ -26,6 +26,7 @@ type AnalyzeCommand struct {
 	yaml   bool
 	text   bool
 	noOpen bool
+	output string // report path; "-" writes to stdout, "" picks a timestamped file
 
 	// Configuration
 	configFile string
@@ -116,6 +117,9 @@ Examples:
   # Analyze specific files with JSON output
   pyscn analyze --json src/myfile.py
 
+  # Write the JSON report to stdout instead of .pyscn/reports/
+  pyscn analyze --json --output - . | jq '.summary.health_score'
+
   # Skip clone detection, focus on complexity, dead code, and dependencies
   pyscn analyze --skip-clones src/
 
@@ -136,6 +140,7 @@ Examples:
 	cmd.Flags().BoolVar(&c.yaml, "yaml", false, "Generate YAML report file")
 	cmd.Flags().BoolVar(&c.text, "text", false, "Generate plain-text report file")
 	cmd.Flags().BoolVar(&c.noOpen, "no-open", false, "Don't auto-open HTML in browser")
+	cmd.Flags().StringVarP(&c.output, "output", "o", "", "Report path instead of a timestamped file in .pyscn/reports/ (\"-\" for stdout)")
 	cmd.Flags().StringVarP(&c.configFile, "config", "c", "", "Configuration file path")
 
 	// Analysis selection flags
@@ -433,35 +438,47 @@ func (c *AnalyzeCommand) generateOutput(cmd *cobra.Command, response *domain.Ana
 		return err
 	}
 
-	// Generate filename with timestamp
-	targetPath := getTargetPathFromArgs(args)
-	filename, err := generateOutputFilePath("analyze", extension, targetPath)
-	if err != nil {
-		return fmt.Errorf("failed to generate output path: %w", err)
-	}
-
 	// Add version to response
 	response.Version = version.Version
 
 	// Create formatter
 	formatter := service.NewAnalyzeFormatter()
 
-	// Create output file
-	file, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("failed to create output file %s: %w", filename, err)
+	// Resolve the destination: stdout, an explicit path, or a timestamped
+	// file under the reports directory. Only the last one touches .pyscn/reports/.
+	var out io.Writer
+	filename := c.output
+	if filename == "-" {
+		out = cmd.OutOrStdout()
+	} else {
+		if filename == "" {
+			filename, err = generateOutputFilePath("analyze", extension, getTargetPathFromArgs(args))
+			if err != nil {
+				return fmt.Errorf("failed to generate output path: %w", err)
+			}
+		}
+		file, createErr := os.Create(filename)
+		if createErr != nil {
+			return fmt.Errorf("failed to create output file %s: %w", filename, createErr)
+		}
+		defer file.Close()
+		out = file
 	}
-	defer file.Close()
 
 	// Write standalone community JSON when only communities were selected.
 	formatType := domain.OutputFormat(format)
 	if c.shouldWriteStandaloneCommunityJSON(response) {
 		communityFormatter := service.NewCommunityFormatter()
-		if err := communityFormatter.Write(response.Communities, formatType, file); err != nil {
+		if err := communityFormatter.Write(response.Communities, formatType, out); err != nil {
 			return fmt.Errorf("failed to write community analysis report: %w", err)
 		}
-	} else if err := formatter.Write(response, formatType, file); err != nil {
+	} else if err := formatter.Write(response, formatType, out); err != nil {
 		return fmt.Errorf("failed to write unified report: %w", err)
+	}
+
+	// Nothing to open or point at when the report went to stdout
+	if filename == "-" {
+		return nil
 	}
 
 	// Get absolute path for display

--- a/cmd/pyscn/new_commands_test.go
+++ b/cmd/pyscn/new_commands_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +65,61 @@ func TestAnalyzeCommandTextOutputFormat(t *testing.T) {
 	if _, _, err := analyzeCmd.determineOutputFormat(); err == nil {
 		t.Fatal("expected --text and --json to conflict")
 	}
+}
+
+func TestAnalyzeCommandOutputFlag(t *testing.T) {
+	fixture, err := filepath.Abs(filepath.Join("..", "..", "testdata", "python", "simple"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Run from an empty directory so anything that lands in .pyscn/reports/ is ours.
+	t.Chdir(t.TempDir())
+
+	run := func(output string) []byte {
+		t.Helper()
+		var stdout bytes.Buffer
+		cmd := NewAnalyzeCmd()
+		cmd.SetOut(&stdout)
+		cmd.SetErr(io.Discard)
+		cmd.SetArgs([]string{"--json", "--select", "complexity", "--output", output, fixture})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("analyze --output %s: %v", output, err)
+		}
+		return stdout.Bytes()
+	}
+	assertReport := func(data []byte) {
+		t.Helper()
+		var report struct {
+			Summary struct {
+				Grade string `json:"grade"`
+			} `json:"summary"`
+		}
+		if err := json.Unmarshal(data, &report); err != nil || report.Summary.Grade == "" {
+			t.Fatalf("expected a JSON analyze report, got err=%v data=%.80q", err, data)
+		}
+	}
+	assertNoReportsDir := func() {
+		t.Helper()
+		if _, err := os.Stat(".pyscn"); !os.IsNotExist(err) {
+			t.Fatalf("--output must not create .pyscn/reports/, stat: %v", err)
+		}
+	}
+
+	// "-" streams the report to stdout.
+	assertReport(run("-"))
+	assertNoReportsDir()
+
+	// Any other value is used as the report path, with nothing on stdout.
+	path := filepath.Join(t.TempDir(), "report.json")
+	if out := run(path); len(out) != 0 {
+		t.Fatalf("expected empty stdout, got %.80q", out)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertReport(data)
+	assertNoReportsDir()
 }
 
 // TestCheckCommandInterface tests the check command interface

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -39,8 +39,9 @@ Only one of these may be set per invocation. If none is set, HTML is generated.
 | `--csv`     | Generate CSV summary, module-quality, community, and directory-complexity rollups (no per-finding detail). |
 | `--text`    | Generate a human-readable plain-text report. |
 | `--no-open` | Do not open the HTML report in a browser. |
+| `-o, --output <path>` | Write the report to `<path>` instead of `.pyscn/reports/`. `-` writes it to stdout. |
 
-Output files land in `.pyscn/reports/` by default, named `analyze_YYYYMMDD_HHMMSS.{ext}`. Configure the directory with `[output] directory = "..."`.
+Output files land in `.pyscn/reports/` by default, named `analyze_YYYYMMDD_HHMMSS.{ext}`. Configure the directory with `[output] directory = "..."`, or bypass it for one run with `--output`.
 
 ### Analysis selection
 
@@ -90,6 +91,9 @@ pyscn analyze .
 
 # JSON for pipelines
 pyscn analyze --json src/
+
+# JSON on stdout, nothing written to .pyscn/reports/
+pyscn analyze --json --output - src/ | jq '.summary.health_score'
 
 # Skip the slowest analyzer
 pyscn analyze --skip-clones src/

--- a/website/docs/integrations/ci-cd.md
+++ b/website/docs/integrations/ci-cd.md
@@ -189,17 +189,15 @@ pyscn check --config packages/tooling/.pyscn.toml packages/tooling
 
 ## PR comment from JSON
 
-`pyscn analyze --json` writes to a timestamped file in `.pyscn/reports/`, not stdout. Pick up the generated file:
+`pyscn analyze --json --output -` writes the report to stdout instead of a timestamped file in `.pyscn/reports/`, so it can be piped straight into `jq`:
 
 ```bash
-pyscn analyze --json --no-open .
-report=$(ls -t .pyscn/reports/analyze_*.json | head -1)
-jq -r '
+pyscn analyze --json --output - . | jq -r '
   "## pyscn report\n" +
   "- **Health Score:** " + (.summary.health_score | tostring) + " / 100 (" + .summary.grade + ")\n" +
   "- Complexity: " + (.summary.complexity_score | tostring) + "\n" +
   "- Dead code: " + (.summary.dead_code_score | tostring) + "\n"
-' "$report" > comment.md
+' > comment.md
 
 gh pr comment $PR_NUMBER --body-file comment.md
 ```


### PR DESCRIPTION
## Summary
`pyscn analyze --json` always writes to `.pyscn/reports/analyze_<timestamp>.json`, so a script that wants the result has to snapshot the reports directory before and after the run to find the new file. This adds `-o, --output <path>` to `analyze`: `-` streams the report to stdout, any other value is used as the report path. In both cases nothing is written to `.pyscn/reports/`.

```bash
pyscn analyze --json --output - . | jq '.summary.health_score'
```

The summary, progress bars, and badge snippet already go to stderr, so stdout carries only the report. The default behaviour without `--output` is unchanged.

## Type of Change
- [x] New feature (non-breaking change)

## Related Issues
Closes #743

## Changes
- `cmd/pyscn/analyze.go`: add the `--output` flag; `generateOutput` now resolves the destination once (stdout, explicit path, or the timestamped reports file) and skips the path message / browser open when writing to stdout
- `cmd/pyscn/new_commands_test.go`: `TestAnalyzeCommandOutputFlag` runs the command with `-` and with an explicit path from an empty working directory, checks that a JSON report lands where expected, and that `.pyscn/` is never created
- Docs: flag table and example in `website/docs/cli/analyze.md`, the "PR comment from JSON" recipe in `website/docs/integrations/ci-cd.md` (no more `ls -t .pyscn/reports/...`), and one line in the README quick reference

## Testing
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Added tests for new functionality (if applicable)
- [x] Manual testing completed (if applicable)

Manual check on `testdata/python/simple`:

```
$ pyscn analyze --json --output - testdata/python/simple 2>/dev/null | jq -c '{hs: .summary.health_score, grade: .summary.grade}'
{"hs":86,"grade":"B"}
$ ls .pyscn
ls: .pyscn: No such file or directory
```

## Documentation
- [x] Updated godoc comments
- [x] Updated README or other docs (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
