### PR TITLE
ci: publish Linux arm64 wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -19,7 +19,16 @@ jobs:
             goos: linux
             goarch: amd64
             wheel_platform: manylinux_2_17_x86_64
-          
+
+          # Linux ARM64 (Graviton, arm64 containers on Apple Silicon)
+          # Needs a native runner: the tree-sitter bindings require CGO, which
+          # rules out cross-compiling from the amd64 runner.
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+            goos: linux
+            goarch: arm64
+            wheel_platform: manylinux_2_17_aarch64
+
           # Windows builds
           - os: windows-latest
             platform: windows-amd64
@@ -131,7 +140,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         python-version: ['3.8', '3.13']
     
     steps:

--- a/python/scripts/build_all_wheels.sh
+++ b/python/scripts/build_all_wheels.sh
@@ -5,10 +5,13 @@
 
 set -e
 
-# Platform configurations (GOOS, GOARCH, wheel_platform_tag)
+# Platform configurations (GOOS, GOARCH, wheel_platform_tag).
+# Keep this list in sync with the build-wheels matrix in
+# .github/workflows/python-release.yml, which is what actually ships to PyPI.
+# Note that the tree-sitter bindings need CGO, so only the entry matching the
+# host builds here; the release workflow uses one native runner per platform.
 PLATFORMS=(
-    "darwin:amd64:macosx_10_9_x86_64"
-    "darwin:arm64:macosx_11_0_arm64" 
+    "darwin:arm64:macosx_11_0_arm64"
     "linux:amd64:manylinux_2_17_x86_64"
     "linux:arm64:manylinux_2_17_aarch64"
     "windows:amd64:win_amd64"

--- a/website/docs/fr/getting-started/installation.md
+++ b/website/docs/fr/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Prérequis
 
 - Python 3.8–3.13 (lanceur uniquement ; pyscn n'a aucune dépendance d'exécution Python)
-- Wheels PyPI pour Linux x86_64, macOS arm64 (Apple Silicon) et Windows x86_64. Aucun wheel macOS Intel depuis la v1.5.1 : utilisez `brew install pyscn` ou l'installation Go ci-dessous.
+- Wheels PyPI pour Linux x86_64 et arm64, macOS arm64 (Apple Silicon) et Windows x86_64. Aucun wheel macOS Intel depuis la v1.5.1 : utilisez `brew install pyscn` ou l'installation Go ci-dessous.
 
 ## Installation
 

--- a/website/docs/fr/integrations/python-packaging.md
+++ b/website/docs/fr/integrations/python-packaging.md
@@ -17,7 +17,7 @@ CI : `uvx pyscn@latest check .`. Développement local : `uv tool install pyscn` 
 
 | OS | Architectures |
 | --- | --- |
-| Linux | x86_64 |
+| Linux | x86_64, arm64 |
 | macOS | arm64 (Apple Silicon). Aucun wheel Intel depuis la v1.5.1 : utilisez `brew install pyscn` ou `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest`. |
 | Windows | x86_64 |
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - Python 3.8–3.13 (launcher only; pyscn has no Python runtime dependencies)
-- Linux x86_64, macOS arm64 (Apple Silicon), or Windows x86_64 for the PyPI wheels. macOS Intel has had no wheel since v1.5.1: use `brew install pyscn` or the Go install below.
+- Linux x86_64 and arm64, macOS arm64 (Apple Silicon), or Windows x86_64 for the PyPI wheels. macOS Intel has had no wheel since v1.5.1: use `brew install pyscn` or the Go install below.
 
 ## Install
 

--- a/website/docs/integrations/python-packaging.md
+++ b/website/docs/integrations/python-packaging.md
@@ -17,7 +17,7 @@ CI: `uvx pyscn@latest check .`. Local dev: `uv tool install pyscn` or `pipx inst
 
 | OS | Architectures |
 | --- | --- |
-| Linux | x86_64 |
+| Linux | x86_64, arm64 |
 | macOS | arm64 (Apple Silicon). No Intel wheel since v1.5.1: use `brew install pyscn` or `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest`. |
 | Windows | x86_64 |
 

--- a/website/docs/ja/getting-started/installation.md
+++ b/website/docs/ja/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## 動作要件
 
 - Python 3.8〜3.13（ランチャーのみ使用。pyscn 自体は Python ランタイムに依存しません）
-- PyPI wheel は Linux x86_64、macOS arm64（Apple Silicon）、Windows x86_64 向け。macOS Intel には v1.5.1 以降 wheel がありません。`brew install pyscn` または下記の Go install を使用してください。
+- PyPI wheel は Linux x86_64 / arm64、macOS arm64（Apple Silicon）、Windows x86_64 向け。macOS Intel には v1.5.1 以降 wheel がありません。`brew install pyscn` または下記の Go install を使用してください。
 
 ## インストール方法
 

--- a/website/docs/ja/integrations/python-packaging.md
+++ b/website/docs/ja/integrations/python-packaging.md
@@ -17,7 +17,7 @@ CI: `uvx pyscn@latest check .`。ローカル開発: `uv tool install pyscn` ま
 
 | OS | アーキテクチャ |
 | --- | --- |
-| Linux | x86_64 |
+| Linux | x86_64、arm64 |
 | macOS | arm64（Apple Silicon）。v1.5.1 以降 Intel 向け wheel はありません。`brew install pyscn` または `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest` を使用してください。 |
 | Windows | x86_64 |
 

--- a/website/docs/zh/getting-started/installation.md
+++ b/website/docs/zh/getting-started/installation.md
@@ -3,7 +3,7 @@
 ## 系统要求
 
 - Python 3.8-3.13（仅用于启动器；pyscn 无 Python 运行时依赖）
-- PyPI wheel 面向 Linux x86_64、macOS arm64（Apple Silicon）和 Windows x86_64。macOS Intel 自 v1.5.1 起没有 wheel：请使用 `brew install pyscn` 或下方的 Go 安装方式。
+- PyPI wheel 面向 Linux x86_64 和 arm64、macOS arm64（Apple Silicon）和 Windows x86_64。macOS Intel 自 v1.5.1 起没有 wheel：请使用 `brew install pyscn` 或下方的 Go 安装方式。
 
 ## 安装方式
 

--- a/website/docs/zh/integrations/python-packaging.md
+++ b/website/docs/zh/integrations/python-packaging.md
@@ -17,7 +17,7 @@ CI：`uvx pyscn@latest check .`。本地开发：`uv tool install pyscn` 或 `pi
 
 | 操作系统 | 架构 |
 | --- | --- |
-| Linux | x86_64 |
+| Linux | x86_64、arm64 |
 | macOS | arm64（Apple Silicon）。自 v1.5.1 起不再提供 Intel wheel：请使用 `brew install pyscn` 或 `go install github.com/ludo-technologies/pyscn/cmd/pyscn@latest`。 |
 | Windows | x86_64 |
 


### PR DESCRIPTION
PyPI currently has only 3 wheels (`manylinux_2_17_x86_64`, `win_amd64`, `macosx_11_0_arm64`). Linux arm64 was never in the release matrix, so `pip install pyscn` / `uvx pyscn` fails on Graviton, arm64 GitHub runners, and arm64 containers on Apple Silicon. There is no sdist, so there is no fallback.

- Add `ubuntu-24.04-arm` to `build-wheels` and `test-wheels`. A native runner is needed because go-tree-sitter requires CGO; `build_platform_wheel.sh` already matches on `*linux*` and needs no change.
- Drop `darwin:amd64` from `build_all_wheels.sh`, which still listed a platform the release workflow stopped building in d1d7987.
- Update the platform tables in the docs (en/ja/zh/fr).

The docs list arm64 as supported before the next release actually publishes it. Related: #756 needs `pip install pyscn` to work on the user's platform.

Known and out of scope: wheels are built on ubuntu-24.04 (glibc 2.39) but tagged `manylinux_2_17_*`. That is already true for the amd64 wheel; filing separately.

https://claude.ai/code/session_01UoUXYp7HGDvgUncZBipqkv