### PR TITLE
docs: use the pre-commit hook mirror

### DIFF
--- a/website/docs/fr/integrations/ci-cd.md
+++ b/website/docs/fr/integrations/ci-cd.md
@@ -78,27 +78,28 @@ Avec `pip` plutôt qu'uvx :
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: local
+  - repo: https://github.com/ludo-technologies/pyscn-pre-commit
+    rev: v1.31.1
     hooks:
       - id: pyscn
-        name: pyscn check
-        entry: pyscn check
-        language: python
-        additional_dependencies: [pyscn]
-        pass_filenames: false
-        files: '\.py$'
+```
+
+Le hook exécute `pyscn check` sur l'ensemble du projet, et est ignoré sur les commits qui ne touchent aucun fichier Python. Ajoutez des options avec `args` :
+
+```yaml
+      - id: pyscn
+        args: [--select, complexity, --max-complexity, "15"]
 ```
 
 Limiter aux fichiers indexés :
 
 ```yaml
       - id: pyscn
-        name: pyscn check (staged)
-        entry: bash -c 'pyscn check --quiet "$@"' --
-        language: python
-        additional_dependencies: [pyscn]
-        files: '\.py$'
+        pass_filenames: true
+        args: [--quiet]
 ```
+
+`rev` suit les versions de pyscn et `pre-commit autoupdate` le met à jour. Le hook fonctionne également avec [prek](https://github.com/j178/prek).
 
 ## GitLab CI
 

--- a/website/docs/integrations/ci-cd.md
+++ b/website/docs/integrations/ci-cd.md
@@ -78,27 +78,28 @@ With `pip` instead of uvx:
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: local
+  - repo: https://github.com/ludo-technologies/pyscn-pre-commit
+    rev: v1.31.1
     hooks:
       - id: pyscn
-        name: pyscn check
-        entry: pyscn check
-        language: python
-        additional_dependencies: [pyscn]
-        pass_filenames: false
-        files: '\.py$'
+```
+
+The hook runs `pyscn check` over the whole project, and is skipped entirely on commits that touch no Python files. Add flags with `args`:
+
+```yaml
+      - id: pyscn
+        args: [--select, complexity, --max-complexity, "15"]
 ```
 
 Scope to staged files:
 
 ```yaml
       - id: pyscn
-        name: pyscn check (staged)
-        entry: bash -c 'pyscn check --quiet "$@"' --
-        language: python
-        additional_dependencies: [pyscn]
-        files: '\.py$'
+        pass_filenames: true
+        args: [--quiet]
 ```
+
+`rev` tracks pyscn releases and `pre-commit autoupdate` moves it. The hook also works with [prek](https://github.com/j178/prek).
 
 ## GitLab CI
 

--- a/website/docs/ja/integrations/ci-cd.md
+++ b/website/docs/ja/integrations/ci-cd.md
@@ -78,27 +78,28 @@ uvx の代わりに `pip` を使用:
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: local
+  - repo: https://github.com/ludo-technologies/pyscn-pre-commit
+    rev: v1.31.1
     hooks:
       - id: pyscn
-        name: pyscn check
-        entry: pyscn check
-        language: python
-        additional_dependencies: [pyscn]
-        pass_filenames: false
-        files: '\.py$'
+```
+
+このフックはプロジェクト全体に対して `pyscn check` を実行します。Python ファイルを含まないコミットではスキップされます。フラグは `args` で渡します:
+
+```yaml
+      - id: pyscn
+        args: [--select, complexity, --max-complexity, "15"]
 ```
 
 ステージされたファイルに限定:
 
 ```yaml
       - id: pyscn
-        name: pyscn check (staged)
-        entry: bash -c 'pyscn check --quiet "$@"' --
-        language: python
-        additional_dependencies: [pyscn]
-        files: '\.py$'
+        pass_filenames: true
+        args: [--quiet]
 ```
+
+`rev` は pyscn のリリースに追随します。更新は `pre-commit autoupdate` で行えます。[prek](https://github.com/j178/prek) でも同じ設定が使えます。
 
 ## GitLab CI
 

--- a/website/docs/zh/integrations/ci-cd.md
+++ b/website/docs/zh/integrations/ci-cd.md
@@ -78,27 +78,28 @@ on:
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: local
+  - repo: https://github.com/ludo-technologies/pyscn-pre-commit
+    rev: v1.31.1
     hooks:
       - id: pyscn
-        name: pyscn check
-        entry: pyscn check
-        language: python
-        additional_dependencies: [pyscn]
-        pass_filenames: false
-        files: '\.py$'
+```
+
+该钩子对整个项目运行 `pyscn check`；如果提交不涉及 Python 文件则会被跳过。可通过 `args` 传递参数：
+
+```yaml
+      - id: pyscn
+        args: [--select, complexity, --max-complexity, "15"]
 ```
 
 限定为暂存文件：
 
 ```yaml
       - id: pyscn
-        name: pyscn check (staged)
-        entry: bash -c 'pyscn check --quiet "$@"' --
-        language: python
-        additional_dependencies: [pyscn]
-        files: '\.py$'
+        pass_filenames: true
+        args: [--quiet]
 ```
+
+`rev` 跟随 pyscn 的发布，可用 `pre-commit autoupdate` 更新。该钩子同样适用于 [prek](https://github.com/j178/prek)。
 
 ## GitLab CI
 


### PR DESCRIPTION
Closes #756.

`ludo-technologies/pyscn-pre-commit` is live and tagged `v1.31.1`. It is a thin mirror holding only `.pre-commit-hooks.yaml`, a `pyscn==<version>` dependency pin, and a `mirror.py` on a 4-hourly cron that follows PyPI. pre-commit cannot install a `language: python` hook from this repository directly, because the Go binary lives in the PyPI wheel and is not in git.

Docs updated in en/ja/zh/fr:

- `repo: local` block replaced with the 3-line mirror reference.
- Staged-files variant drops the `bash -c 'pyscn check --quiet "$@"' --` wrapper; overriding `pass_filenames: true` in the config does the same thing.
- Added an `args` example and a note that `pre-commit autoupdate` moves `rev`.

Verified against the published repo and tag: clean tree passes, a complexity-13 function fails, a Markdown-only commit is skipped, `git commit` is actually blocked, `args` reach pyscn, `pass_filenames: true` narrows the analysis to the given files, and `autoupdate` resolves v1.30.0 to v1.31.1.

https://claude.ai/code/session_01UoUXYp7HGDvgUncZBipqkv