### PR TITLE
fix: tag Linux wheels as manylinux_2_34

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -18,7 +18,7 @@ jobs:
             platform: linux-amd64
             goos: linux
             goarch: amd64
-            wheel_platform: manylinux_2_17_x86_64
+            wheel_platform: manylinux_2_34_x86_64
 
           # Linux ARM64 (Graviton, arm64 containers on Apple Silicon)
           # Needs a native runner: the tree-sitter bindings require CGO, which
@@ -27,7 +27,7 @@ jobs:
             platform: linux-arm64
             goos: linux
             goarch: arm64
-            wheel_platform: manylinux_2_17_aarch64
+            wheel_platform: manylinux_2_34_aarch64
 
           # Windows builds
           - os: windows-latest

--- a/python/scripts/build_all_wheels.sh
+++ b/python/scripts/build_all_wheels.sh
@@ -12,8 +12,8 @@ set -e
 # host builds here; the release workflow uses one native runner per platform.
 PLATFORMS=(
     "darwin:arm64:macosx_11_0_arm64"
-    "linux:amd64:manylinux_2_17_x86_64"
-    "linux:arm64:manylinux_2_17_aarch64"
+    "linux:amd64:manylinux_2_34_x86_64"
+    "linux:arm64:manylinux_2_34_aarch64"
     "windows:amd64:win_amd64"
 )
 

--- a/python/scripts/create_wheel.sh
+++ b/python/scripts/create_wheel.sh
@@ -136,8 +136,8 @@ detect_platform() {
             ;;
         linux)
             case "$arch" in
-                amd64) echo "manylinux_2_17_x86_64" ;;
-                arm64) echo "manylinux_2_17_aarch64" ;;
+                amd64) echo "manylinux_2_34_x86_64" ;;
+                arm64) echo "manylinux_2_34_aarch64" ;;
                 *) echo "unsupported"; exit 1 ;;
             esac
             ;;

--- a/website/docs/fr/integrations/python-packaging.md
+++ b/website/docs/fr/integrations/python-packaging.md
@@ -55,7 +55,7 @@ ENTRYPOINT ["pyscn"]
 ## Contenu du wheel
 
 ```
-pyscn-0.2.0-py3-none-manylinux_2_17_x86_64.whl
+pyscn-0.2.0-py3-none-manylinux_2_34_x86_64.whl
 ├── pyscn/
 │   ├── __init__.py
 │   ├── __main__.py        # CLI launcher

--- a/website/docs/integrations/python-packaging.md
+++ b/website/docs/integrations/python-packaging.md
@@ -55,7 +55,7 @@ ENTRYPOINT ["pyscn"]
 ## Wheel contents
 
 ```
-pyscn-0.2.0-py3-none-manylinux_2_17_x86_64.whl
+pyscn-0.2.0-py3-none-manylinux_2_34_x86_64.whl
 ├── pyscn/
 │   ├── __init__.py
 │   ├── __main__.py        # CLI launcher

--- a/website/docs/ja/integrations/python-packaging.md
+++ b/website/docs/ja/integrations/python-packaging.md
@@ -55,7 +55,7 @@ ENTRYPOINT ["pyscn"]
 ## wheel の内容
 
 ```
-pyscn-0.2.0-py3-none-manylinux_2_17_x86_64.whl
+pyscn-0.2.0-py3-none-manylinux_2_34_x86_64.whl
 ├── pyscn/
 │   ├── __init__.py
 │   ├── __main__.py        # CLI launcher

--- a/website/docs/zh/integrations/python-packaging.md
+++ b/website/docs/zh/integrations/python-packaging.md
@@ -55,7 +55,7 @@ ENTRYPOINT ["pyscn"]
 ## Wheel 内容
 
 ```
-pyscn-0.2.0-py3-none-manylinux_2_17_x86_64.whl
+pyscn-0.2.0-py3-none-manylinux_2_34_x86_64.whl
 ├── pyscn/
 │   ├── __init__.py
 │   ├── __main__.py        # CLI launcher


### PR DESCRIPTION
Linux wheels were tagged `manylinux_2_17` but the binary requires glibc 2.34 (built on ubuntu-latest with CGO). pip installed them on older distros and `pyscn` failed at runtime with `GLIBC_2.34 not found`.

Change the tag to `manylinux_2_34` in the build scripts, release workflow, and docs so pip refuses the wheel on unsupported glibc instead.

Closes #760

https://claude.ai/code/session_01Uqhshn7EzThTHmo4RP1mfz