### PR TITLE
fix(config): stop treating an explicit config file's directory as the project root

### DIFF
--- a/internal/config/pyproject_loader.go
+++ b/internal/config/pyproject_loader.go
@@ -67,7 +67,7 @@ func LoadPyprojectConfigFromFile(filePath string) (*PyscnConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	applyConfigProjectRoot(config, filePath)
+	resolveConfigProjectRoot(config, filePath)
 	return config, nil
 }
 

--- a/internal/config/toml_loader.go
+++ b/internal/config/toml_loader.go
@@ -343,7 +343,7 @@ func (l *TomlConfigLoader) loadFromFile(filePath string) (*PyscnConfig, error) {
 
 	defaults := DefaultPyscnConfig()
 	l.mergePyscnTomlConfigs(defaults, &parsed)
-	applyConfigProjectRoot(defaults, filePath)
+	resolveConfigProjectRoot(defaults, filePath)
 	return defaults, nil
 }
 
@@ -525,23 +525,33 @@ func normalizeSearchDir(path string) (string, error) {
 }
 
 // applyConfigProjectRoot resolves the configured project root against the
-// directory containing the config file. A config file without an explicit
-// project_root uses its own directory as the project root.
+// directory containing the config file. A discovered config file without an
+// explicit project_root uses its own directory as the project root.
 func applyConfigProjectRoot(cfg *PyscnConfig, configPath string) {
-	if cfg == nil || configPath == "" {
+	resolveConfigProjectRoot(cfg, configPath)
+	if cfg == nil || cfg.ProjectRoot != "" {
 		return
 	}
-
-	configDir, err := filepath.Abs(filepath.Dir(configPath))
-	if err != nil {
-		return
-	}
-	if cfg.ProjectRoot == "" {
+	if configDir, err := filepath.Abs(filepath.Dir(configPath)); err == nil {
 		cfg.ProjectRoot = configDir
+	}
+}
+
+// resolveConfigProjectRoot resolves an explicit relative project_root against
+// the directory containing the config file and leaves an unset project_root
+// empty. An explicitly passed config file may live outside the analyzed tree
+// (a shared config under /etc, say), so its directory says nothing about the
+// project root; callers fall back to discovery from the analyzed paths.
+func resolveConfigProjectRoot(cfg *PyscnConfig, configPath string) {
+	if cfg == nil || configPath == "" || cfg.ProjectRoot == "" {
 		return
 	}
 	if filepath.IsAbs(cfg.ProjectRoot) {
 		cfg.ProjectRoot = filepath.Clean(cfg.ProjectRoot)
+		return
+	}
+	configDir, err := filepath.Abs(filepath.Dir(configPath))
+	if err != nil {
 		return
 	}
 	cfg.ProjectRoot = filepath.Join(configDir, cfg.ProjectRoot)

--- a/internal/config/toml_loader_test.go
+++ b/internal/config/toml_loader_test.go
@@ -659,3 +659,19 @@ style = "hexagonal"
 		t.Errorf("Expected architecture style 'hexagonal', got %q", cfg.ArchitectureStyle)
 	}
 }
+
+func TestTomlConfigLoaderExplicitFileWithoutProjectRootLeavesItEmpty(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte("[output]\nmin_complexity = 15\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := NewTomlConfigLoader().LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.ProjectRoot != "" {
+		t.Fatalf("expected empty project root for an explicit config file, got %q", cfg.ProjectRoot)
+	}
+}

--- a/internal/config/toml_loader_test.go
+++ b/internal/config/toml_loader_test.go
@@ -675,3 +675,19 @@ func TestTomlConfigLoaderExplicitFileWithoutProjectRootLeavesItEmpty(t *testing.
 		t.Fatalf("expected empty project root for an explicit config file, got %q", cfg.ProjectRoot)
 	}
 }
+
+func TestTomlConfigLoaderExplicitPyprojectWithoutProjectRootLeavesItEmpty(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "pyproject.toml")
+	if err := os.WriteFile(configPath, []byte("[tool.pyscn.output]\nmin_complexity = 15\n"), 0o644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := NewTomlConfigLoader().LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.ProjectRoot != "" {
+		t.Fatalf("expected empty project root for an explicit pyproject.toml, got %q", cfg.ProjectRoot)
+	}
+}

--- a/service/analyze_config_loader_test.go
+++ b/service/analyze_config_loader_test.go
@@ -113,8 +113,10 @@ lsh_auto_threshold = 123
 		if cfg.ConfigPath != configPath {
 			t.Errorf("expected config path %q, got %q", configPath, cfg.ConfigPath)
 		}
-		if cfg.ProjectRoot != projectDir {
-			t.Errorf("expected project root %q, got %q", projectDir, cfg.ProjectRoot)
+		// No explicit project_root: the use case discovers the root from the
+		// analyzed paths, which lands on the config directory.
+		if cfg.ProjectRoot != "" {
+			t.Errorf("expected project root left for discovery, got %q", cfg.ProjectRoot)
 		}
 		if cfg.Recursive {
 			t.Error("expected recursive false")
@@ -248,4 +250,21 @@ enabled = false
 			t.Error("expected architecture analysis to remain enabled")
 		}
 	})
+}
+
+func TestAnalyzeConfigurationLoader_ExplicitConfigOutsideTargetLeavesProjectRootForDiscovery(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, ".pyscn.toml")
+	if err := os.WriteFile(configPath, []byte("[output]\nmin_complexity = 15\n"), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+	targetDir := t.TempDir()
+
+	cfg, err := NewAnalyzeConfigurationLoader().LoadAnalyzeExecutionConfig(configPath, targetDir)
+	if err != nil {
+		t.Fatalf("LoadAnalyzeExecutionConfig returned error: %v", err)
+	}
+	if cfg.ProjectRoot != "" {
+		t.Fatalf("config directory %q must not become the project root of %q", configDir, targetDir)
+	}
 }

--- a/service/project_root.go
+++ b/service/project_root.go
@@ -80,26 +80,13 @@ func configuredProjectRoot(paths []string) string {
 		searchPath = "."
 	}
 
-	loader := config.NewTomlConfigLoader()
-	configPath := loader.FindConfigFileFromPath(searchPath)
-	if configPath == "" {
-		return ""
-	}
-
-	cfg, err := loader.LoadConfig(configPath)
+	// Loading by directory takes the discovery path, so a config file without
+	// an explicit project_root resolves to its own directory.
+	cfg, err := config.NewTomlConfigLoader().LoadConfig(searchPath)
 	if err != nil {
 		return ""
 	}
-	if cfg.ProjectRoot != "" {
-		return cfg.ProjectRoot
-	}
-	// A discovered config file without an explicit project_root marks its own
-	// directory as the project root.
-	configDir, err := filepath.Abs(filepath.Dir(configPath))
-	if err != nil {
-		return ""
-	}
-	return configDir
+	return cfg.ProjectRoot
 }
 
 func commonAnalysisParent(paths []string) string {

--- a/service/project_root.go
+++ b/service/project_root.go
@@ -90,7 +90,16 @@ func configuredProjectRoot(paths []string) string {
 	if err != nil {
 		return ""
 	}
-	return cfg.ProjectRoot
+	if cfg.ProjectRoot != "" {
+		return cfg.ProjectRoot
+	}
+	// A discovered config file without an explicit project_root marks its own
+	// directory as the project root.
+	configDir, err := filepath.Abs(filepath.Dir(configPath))
+	if err != nil {
+		return ""
+	}
+	return configDir
 }
 
 func commonAnalysisParent(paths []string) string {

--- a/service/project_root_test.go
+++ b/service/project_root_test.go
@@ -68,3 +68,16 @@ func TestFindProjectRoot_UsesConfiguredProjectRoot(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
+
+func TestFindProjectRoot_DiscoveredConfigWithoutProjectRootUsesConfigDirectory(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".pyscn.toml"), []byte("[output]\nmin_complexity = 15\n"), 0o644))
+	file := filepath.Join(root, "package", "module.py")
+	require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
+	require.NoError(t, os.WriteFile(file, []byte("pass\n"), 0o644))
+
+	got := FindProjectRoot([]string{file})
+	want, err := filepath.Abs(root)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
Since e9e2d98 (1.30.2) a config file without `project_root` uses its own directory as the project root. For a config passed via `--config` that lives outside the analyzed tree (e.g. `/etc/pyscn/.pyscn.toml` in pyscn-bot) this is the wrong root: module names become path-derived and `system.dependency_analysis` reports 0 dependencies and 0 cycles. 1.30.1 was fine.

- An explicitly loaded config only resolves an explicit relative `project_root`; when unset it stays empty and callers discover the root from the analyzed paths.
- A discovered config keeps defaulting to its own directory, now inside `FindProjectRoot`.
- Regression tests for both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VArrPfQKscytmv91xX8yT