### PR TITLE
fix(lcom): skip Protocol/Enum classes and exclude stub methods from LCOM4

### DIFF
--- a/internal/analyzer/lcom.go
+++ b/internal/analyzer/lcom.go
@@ -21,7 +21,7 @@ type LCOMResult struct {
 
 	// Method statistics
 	TotalMethods    int // All methods found in class
-	ExcludedMethods int // @staticmethod/@classmethod/@abstractmethod and constructors excluded
+	ExcludedMethods int // @staticmethod/@classmethod/@abstractmethod, constructors, implicit classmethods and empty-bodied methods excluded
 
 	// Instance variable count
 	InstanceVariables int // Distinct self.xxx variables
@@ -74,6 +74,12 @@ func (a *LCOMAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*LCO
 
 	var results []*LCOMResult
 	for _, classNode := range classes {
+		// Protocols and enums carry no instance state to be cohesive about:
+		// a Protocol only declares signatures and an Enum only declares
+		// members, so every method would land in its own component.
+		if isStructuralClass(classNode) {
+			continue
+		}
 		result, err := a.analyzeClass(classNode, filePath, ctypesFields[classNode])
 		if err != nil {
 			continue
@@ -199,6 +205,13 @@ func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node, declaredFields map
 		// in the graph unions all the responsibility clusters they set up and
 		// collapses LCOM4 to 1 for almost any class. Keep their variables for
 		// the InstanceVariables count, but keep the method out of the graph.
+		// Dunder hooks that Python treats as classmethods without a decorator,
+		// and bodies with no statements to access state through.
+		if isImplicitClassMethod(node.Name) || isEmptyBody(node.Body) {
+			excluded++
+			continue
+		}
+
 		if isConstructor(node.Name) {
 			excluded++
 			ctorVars := make(map[string]bool)
@@ -250,6 +263,90 @@ func (a *LCOMAnalyzer) collectMethods(classNode *parser.Node, declaredFields map
 		excludedVars: excludedVars,
 		excluded:     excluded,
 	}
+}
+
+// isImplicitClassMethod reports whether a dunder method is implicitly a
+// classmethod. These receive `cls`, so they can never touch instance state.
+func isImplicitClassMethod(name string) bool {
+	return name == "__init_subclass__" || name == "__class_getitem__"
+}
+
+// isEmptyBody reports whether a method body only declares the method without
+// implementing it: a docstring, `...`, `pass`, or `raise NotImplementedError`
+// in any combination. Such stubs (Protocol members, ABC-style interfaces,
+// subclass hooks) cannot access instance state, so counting them would only
+// inflate LCOM4.
+func isEmptyBody(body []*parser.Node) bool {
+	for _, stmt := range body {
+		if stmt == nil {
+			continue
+		}
+		switch stmt.Type {
+		case parser.NodePass, parser.NodeConstant, parser.NodeEllipsis:
+			continue
+		case parser.NodeRaise:
+			if raisesNotImplemented(stmt) {
+				continue
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func raisesNotImplemented(raiseNode *parser.Node) bool {
+	exc := nodeValue(raiseNode)
+	if exc == nil {
+		return false
+	}
+	if exc.Type == parser.NodeCall {
+		exc = nodeValue(exc)
+	}
+	return exc != nil && exc.Type == parser.NodeName && exc.Name == "NotImplementedError"
+}
+
+// structuralBases are base classes whose subclasses hold no instance state
+// for methods to share, making LCOM4 meaningless for them.
+var structuralBases = map[string]bool{
+	"Protocol": true,
+	"Enum":     true,
+	"IntEnum":  true,
+	"StrEnum":  true,
+	"Flag":     true,
+	"IntFlag":  true,
+	"ReprEnum": true,
+}
+
+// isStructuralClass reports whether a class derives from typing.Protocol or
+// an enum.Enum variant, resolving `typing.Protocol`, `Protocol[T]` and
+// `typing.Protocol[T]` forms alike.
+func isStructuralClass(classNode *parser.Node) bool {
+	for _, base := range classNode.Bases {
+		if structuralBases[baseClassName(base)] {
+			return true
+		}
+	}
+	return false
+}
+
+// baseClassName returns the unqualified name of a base class expression.
+func baseClassName(base *parser.Node) string {
+	if base == nil {
+		return ""
+	}
+	if base.Type == parser.NodeSubscript {
+		base = nodeValue(base)
+		if base == nil {
+			return ""
+		}
+	}
+	switch base.Type {
+	case parser.NodeName, parser.NodeAttribute:
+		return base.Name
+	}
+	return ""
 }
 
 // isConstructor reports whether a method builds the instance rather than using

--- a/internal/analyzer/lcom.go
+++ b/internal/analyzer/lcom.go
@@ -71,13 +71,14 @@ func (a *LCOMAnalyzer) AnalyzeClasses(ast *parser.Node, filePath string) ([]*LCO
 	// Collect all class definitions
 	classes := a.collectClasses(ast)
 	ctypesFields := a.collectCtypesFields(ast, classes)
+	imports := collectImportBindings(ast)
 
 	var results []*LCOMResult
 	for _, classNode := range classes {
 		// Protocols and enums carry no instance state to be cohesive about:
 		// a Protocol only declares signatures and an Enum only declares
 		// members, so every method would land in its own component.
-		if isStructuralClass(classNode) {
+		if imports.isStructuralClass(classNode) {
 			continue
 		}
 		result, err := a.analyzeClass(classNode, filePath, ctypesFields[classNode])
@@ -296,6 +297,10 @@ func isEmptyBody(body []*parser.Node) bool {
 	return true
 }
 
+// raisesNotImplemented reports whether a raise statement is a bare
+// `raise NotImplementedError` or `raise NotImplementedError(...)` that never
+// touches self. Arguments or a `from` cause that read instance state (or call
+// sibling methods) make the method a real participant in the cohesion graph.
 func raisesNotImplemented(raiseNode *parser.Node) bool {
 	exc := nodeValue(raiseNode)
 	if exc == nil {
@@ -304,35 +309,102 @@ func raisesNotImplemented(raiseNode *parser.Node) bool {
 	if exc.Type == parser.NodeCall {
 		exc = nodeValue(exc)
 	}
-	return exc != nil && exc.Type == parser.NodeName && exc.Name == "NotImplementedError"
+	if exc == nil || exc.Type != parser.NodeName || exc.Name != "NotImplementedError" {
+		return false
+	}
+	return !mentionsSelf(raiseNode)
 }
 
-// structuralBases are base classes whose subclasses hold no instance state
-// for methods to share, making LCOM4 meaningless for them.
+func mentionsSelf(node *parser.Node) bool {
+	found := false
+	node.WalkDeep(func(n *parser.Node) bool {
+		if n.Type == parser.NodeName && n.Name == "self" {
+			found = true
+		}
+		return !found
+	})
+	return found
+}
+
+// structuralBases are the fully qualified base classes whose subclasses hold
+// no instance state for methods to share, making LCOM4 meaningless for them.
 var structuralBases = map[string]bool{
-	"Protocol": true,
-	"Enum":     true,
-	"IntEnum":  true,
-	"StrEnum":  true,
-	"Flag":     true,
-	"IntFlag":  true,
-	"ReprEnum": true,
+	"typing.Protocol":            true,
+	"typing_extensions.Protocol": true,
+	"enum.Enum":                  true,
+	"enum.IntEnum":               true,
+	"enum.StrEnum":               true,
+	"enum.Flag":                  true,
+	"enum.IntFlag":               true,
+	"enum.ReprEnum":              true,
+}
+
+// importBindings maps the names an import statement binds in the module to
+// the fully qualified name they refer to, so that a base class can be
+// resolved to its origin rather than matched on its bare name (a Twisted
+// `protocol.Protocol` must not be mistaken for `typing.Protocol`).
+type importBindings struct {
+	names     map[string]string // bound name -> qualified name ("Protocol" -> "typing.Protocol", "t" -> "typing")
+	wildcards []string          // modules imported via `from m import *`
+}
+
+func collectImportBindings(ast *parser.Node) importBindings {
+	imports := importBindings{names: make(map[string]string)}
+	ast.WalkDeep(func(node *parser.Node) bool {
+		switch node.Type {
+		case parser.NodeImport, parser.NodeImportFrom:
+		default:
+			return true
+		}
+		prefix := ""
+		if node.Type == parser.NodeImportFrom {
+			if node.Level > 0 {
+				return true
+			}
+			prefix = node.Module + "."
+		}
+		aliased := make(map[string]bool)
+		for _, child := range node.Children {
+			if child == nil || child.Type != parser.NodeAlias {
+				continue
+			}
+			if alias, ok := child.Value.(string); ok && alias != "" {
+				aliased[child.Name] = true
+				imports.names[alias] = prefix + child.Name
+			}
+		}
+		for _, name := range node.Names {
+			if aliased[name] {
+				continue
+			}
+			if name == "*" {
+				imports.wildcards = append(imports.wildcards, node.Module)
+				continue
+			}
+			// `import a.b` binds `a` to package `a`; `from m import x` binds `x`.
+			bound := importBindingName(name)
+			imports.names[bound] = prefix + bound
+		}
+		return true
+	})
+	return imports
 }
 
 // isStructuralClass reports whether a class derives from typing.Protocol or
-// an enum.Enum variant, resolving `typing.Protocol`, `Protocol[T]` and
-// `typing.Protocol[T]` forms alike.
-func isStructuralClass(classNode *parser.Node) bool {
+// an enum.Enum variant, resolving aliases, `typing.Protocol`, `Protocol[T]`
+// and `typing.Protocol[T]` forms alike.
+func (imports importBindings) isStructuralClass(classNode *parser.Node) bool {
 	for _, base := range classNode.Bases {
-		if structuralBases[baseClassName(base)] {
+		if structuralBases[imports.resolveBase(base)] {
 			return true
 		}
 	}
 	return false
 }
 
-// baseClassName returns the unqualified name of a base class expression.
-func baseClassName(base *parser.Node) string {
+// resolveBase returns the fully qualified name a base class expression refers
+// to, or "" when it cannot be traced back to an import.
+func (imports importBindings) resolveBase(base *parser.Node) string {
 	if base == nil {
 		return ""
 	}
@@ -343,8 +415,21 @@ func baseClassName(base *parser.Node) string {
 		}
 	}
 	switch base.Type {
-	case parser.NodeName, parser.NodeAttribute:
-		return base.Name
+	case parser.NodeName:
+		if qualified, ok := imports.names[base.Name]; ok {
+			return qualified
+		}
+		for _, module := range imports.wildcards {
+			if structuralBases[module+"."+base.Name] {
+				return module + "." + base.Name
+			}
+		}
+	case parser.NodeAttribute:
+		if module := nodeValue(base); module != nil && module.Type == parser.NodeName {
+			if qualified, ok := imports.names[module.Name]; ok {
+				return qualified + "." + base.Name
+			}
+		}
 	}
 	return ""
 }

--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -207,6 +207,61 @@ class Impl:
 			expectedRisk:  map[string]string{"Impl": "low"},
 		},
 		{
+			name: "aliased and wildcard Protocol imports are skipped",
+			pythonCode: `
+from typing import Protocol as P
+import typing_extensions as te
+from enum import *
+
+class A(P):
+    def a(self): return 1
+    def b(self): return 2
+    def c(self): return 3
+
+class B(te.Protocol):
+    def a(self): return 1
+    def b(self): return 2
+    def c(self): return 3
+
+class C(IntEnum):
+    X = 1
+    def a(self): return 1
+    def b(self): return 2
+    def c(self): return 3
+`,
+			expectedCount: 0,
+		},
+		{
+			name: "same-named classes from other modules are still analyzed",
+			pythonCode: `
+from twisted.internet import protocol
+from mylib import Enum
+
+class Handler(protocol.Protocol):
+    def dataReceived(self, data):
+        self.buffer += data
+
+    def connectionMade(self):
+        self.transport.write(self.banner)
+
+    def timeout(self):
+        return self.deadline
+
+class Custom(Enum):
+    def a(self): return self.x
+    def b(self): return self.y
+    def c(self): return self.z
+
+class Local(Protocol):
+    def a(self): return self.x
+    def b(self): return self.y
+    def c(self): return self.z
+`,
+			expectedCount: 3,
+			expectedLCOM:  map[string]int{"Handler": 3, "Custom": 3, "Local": 3},
+			expectedRisk:  map[string]string{"Handler": "medium", "Custom": "medium", "Local": "medium"},
+		},
+		{
 			name: "enum classes are skipped",
 			pythonCode: `
 from enum import Enum, IntEnum
@@ -263,6 +318,27 @@ class Hooks:
 			expectedLCOM:     map[string]int{"Hooks": 1},
 			expectedRisk:     map[string]string{"Hooks": "low"},
 			expectedExcluded: map[string]int{"Hooks": 5},
+		},
+		{
+			name: "NotImplementedError that reads self is not an empty body",
+			pythonCode: `
+class Partial:
+    def unsupported(self):
+        raise NotImplementedError(self.description)
+
+    def chained(self):
+        raise NotImplementedError from self.cause
+
+    def run(self):
+        return self.state
+
+    def reset(self):
+        self.state = None
+`,
+			expectedCount:    1,
+			expectedLCOM:     map[string]int{"Partial": 3},
+			expectedRisk:     map[string]string{"Partial": "medium"},
+			expectedExcluded: map[string]int{"Partial": 0},
 		},
 		{
 			name: "raising other exceptions is not an empty body",

--- a/internal/analyzer/lcom_test.go
+++ b/internal/analyzer/lcom_test.go
@@ -177,6 +177,133 @@ class MyProvider:
 			expectedExcluded: map[string]int{"MyProvider": 1},
 		},
 		{
+			name: "protocol classes are skipped",
+			pythonCode: `
+from typing import Protocol
+import typing
+
+class BatchCommand(Protocol):
+    def setup(self) -> None:
+        """Set up the command."""
+
+    def execute(self, path) -> None: ...
+
+    def finalize(self) -> None: ...
+
+class Generic(typing.Protocol[T]):
+    def a(self): ...
+    def b(self): ...
+    def c(self): ...
+
+class Impl:
+    def setup(self):
+        self.ready = True
+
+    def unrelated(self):
+        return self.other
+`,
+			expectedCount: 1,
+			expectedLCOM:  map[string]int{"Impl": 2},
+			expectedRisk:  map[string]string{"Impl": "low"},
+		},
+		{
+			name: "enum classes are skipped",
+			pythonCode: `
+from enum import Enum, IntEnum
+import enum
+
+class Color(Enum):
+    RED = 1
+    BLUE = 2
+
+    def is_warm(self):
+        return self is Color.RED
+
+    def label(self):
+        return self.name.lower()
+
+    def code(self):
+        return self.value
+
+class Level(enum.IntEnum):
+    LOW = 1
+
+    def a(self): return 1
+    def b(self): return 2
+    def c(self): return 3
+`,
+			expectedCount: 0,
+		},
+		{
+			name: "empty-bodied methods excluded from LCOM4 grouping",
+			pythonCode: `
+class Hooks:
+    def on_start(self):
+        """Called before processing."""
+
+    def on_stop(self):
+        pass
+
+    def on_error(self, exc): ...
+
+    def render(self):
+        raise NotImplementedError
+
+    def validate(self):
+        """Validate."""
+        raise NotImplementedError("subclass must implement")
+
+    def run(self):
+        return self.state
+
+    def reset(self):
+        self.state = None
+`,
+			expectedCount:    1,
+			expectedLCOM:     map[string]int{"Hooks": 1},
+			expectedRisk:     map[string]string{"Hooks": "low"},
+			expectedExcluded: map[string]int{"Hooks": 5},
+		},
+		{
+			name: "raising other exceptions is not an empty body",
+			pythonCode: `
+class Guard:
+    def check(self):
+        raise ValueError("bad")
+
+    def run(self):
+        return self.state
+
+    def reset(self):
+        self.state = None
+`,
+			expectedCount:    1,
+			expectedLCOM:     map[string]int{"Guard": 2},
+			expectedRisk:     map[string]string{"Guard": "low"},
+			expectedExcluded: map[string]int{"Guard": 0},
+		},
+		{
+			name: "implicit classmethods excluded from LCOM4 grouping",
+			pythonCode: `
+class Registry:
+    def __init_subclass__(cls, **kwargs):
+        cls.registry.append(cls)
+
+    def __class_getitem__(cls, item):
+        return cls
+
+    def run(self):
+        return self.state
+
+    def reset(self):
+        self.state = None
+`,
+			expectedCount:    1,
+			expectedLCOM:     map[string]int{"Registry": 1},
+			expectedRisk:     map[string]string{"Registry": "low"},
+			expectedExcluded: map[string]int{"Registry": 2},
+		},
+		{
 			name: "class with property included",
 			pythonCode: `
 class ClassWithProperty:

--- a/internal/parser/ast.go
+++ b/internal/parser/ast.go
@@ -62,6 +62,7 @@ const (
 	NodeFormattedValue NodeType = "FormattedValue"
 	NodeJoinedStr      NodeType = "JoinedStr"
 	NodeConstant       NodeType = "Constant"
+	NodeEllipsis       NodeType = "ellipsis" // tree-sitter's type for a bare `...` statement
 	NodeAttribute      NodeType = "Attribute"
 	NodeSubscript      NodeType = "Subscript"
 	NodeStarred        NodeType = "Starred"


### PR DESCRIPTION
Closes #764

Protocol and Enum subclasses have no instance state to share, so every method became its own LCOM4 component and the class was flagged as low cohesion.

- Skip classes deriving from `Protocol` or an `Enum` variant (`typing.Protocol`, `Protocol[T]` forms included)
- Exclude empty-bodied methods (docstring / `...` / `pass` / `raise NotImplementedError`) from the LCOM4 graph, counted in `excluded_methods`
- Exclude the implicit classmethods `__init_subclass__` and `__class_getitem__`
- Add `NodeEllipsis` so a bare `...` statement is addressable in the AST


