### PR TITLE
fix(parser): accept unparenthesized except lists with three or more types (PEP 758)

### DIFF
--- a/internal/parser/ast_builder.go
+++ b/internal/parser/ast_builder.go
@@ -1930,31 +1930,53 @@ func (b *ASTBuilder) buildExceptHandler(tsNode *sitter.Node) *Node {
 	node := NewNode(NodeExceptHandler)
 	node.Location = b.getLocation(tsNode)
 
+	// An unparenthesized list (`except A, B, C:`, PEP 758) spreads its types
+	// over several children, with the middle ones wrapped in an ERROR node.
+	var types []*Node
 	childCount := int(tsNode.ChildCount())
 	for i := 0; i < childCount; i++ {
 		child := tsNode.Child(i)
-		if child != nil {
-			switch child.Type() {
-			case "as_pattern":
-				// Exception type and optional name
-				if exType := b.getChildByFieldName(child, "type"); exType != nil {
-					node.Value = b.buildNode(exType)
-				}
-				if alias := b.getChildByFieldName(child, "alias"); alias != nil {
-					node.Name = b.getNodeText(alias)
-				}
-			case "block":
-				// Handler body
-				if body := b.buildNode(child); body != nil {
-					node.Body = b.extractBlockBody(body, node)
-				}
-			default:
-				if child.Type() != "except" && child.Type() != ":" {
-					// Exception type without alias
-					node.Value = b.buildNode(child)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "as_pattern":
+			// Exception type and optional name
+			if exType := b.getChildByFieldName(child, "type"); exType != nil {
+				types = append(types, b.buildNode(exType))
+			}
+			if alias := b.getChildByFieldName(child, "alias"); alias != nil {
+				node.Name = b.getNodeText(alias)
+			}
+		case "block":
+			// Handler body
+			if body := b.buildNode(child); body != nil {
+				node.Body = b.extractBlockBody(body, node)
+			}
+		case "except", ":", ",":
+		case "ERROR":
+			errChildCount := int(child.ChildCount())
+			for j := 0; j < errChildCount; j++ {
+				if part := child.Child(j); part != nil && part.IsNamed() {
+					types = append(types, b.buildNode(part))
 				}
 			}
+		default:
+			types = append(types, b.buildNode(child))
 		}
+	}
+
+	switch len(types) {
+	case 0:
+	case 1:
+		node.Value = types[0]
+	default:
+		tuple := NewNode(NodeTuple)
+		tuple.Location = types[0].Location
+		for _, t := range types {
+			tuple.AddChild(t)
+		}
+		node.Value = tuple
 	}
 
 	return node

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -110,7 +110,7 @@ func (p *Parser) FindNodes(node *sitter.Node, nodeType string) []*sitter.Node {
 // still accepts but no Python 3 release compiles (see python3_syntax.go).
 func (p *Parser) CheckSyntax(node *sitter.Node, source []byte) error {
 	return p.WalkTree(node, func(n *sitter.Node) error {
-		if n.IsError() || n.IsMissing() {
+		if n.IsMissing() || (n.IsError() && !isBracketlessExceptListError(n)) {
 			return fmt.Errorf("syntax errors found in source code")
 		}
 		if reason := invalidInPython3(n, source); reason != "" {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -300,11 +300,6 @@ func TestCheckSyntax(t *testing.T) {
 			source:    "if True",
 			hasErrors: true,
 		},
-		{
-			name:      "garbage inside an unparenthesized exception list",
-			source:    "try:\n    pass\nexcept OSError, ), ValueError:\n    pass\n",
-			hasErrors: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -340,6 +335,10 @@ func TestParseRejectsSyntaxInvalidInEveryPython3(t *testing.T) {
 			name:   "exception list bound with as",
 			source: "try:\n    pass\nexcept OSError, TypeError as e:\n    pass\n",
 		},
+		{"doubled comma in exception list", "try:\n    pass\nexcept A,, B:\n    pass\n"},
+		{"missing comma in exception list", "try:\n    pass\nexcept A B:\n    pass\n"},
+		{"missing comma in three-type exception list", "try:\n    pass\nexcept A, B C:\n    pass\n"},
+		{"stray token in exception list", "try:\n    pass\nexcept OSError, ), ValueError:\n    pass\n"},
 		{
 			name:   "three-type exception list bound with as",
 			source: "try:\n    pass\nexcept OSError, TypeError, ValueError as e:\n    pass\n",
@@ -396,6 +395,9 @@ func TestParseAcceptsValidPython3(t *testing.T) {
 			source: "def f(x):\n    try:\n        return x\n    except OSError, TypeError:\n        return None\n",
 		},
 		{"three unparenthesized exception types", "try:\n    pass\nexcept OSError, TypeError, ValueError:\n    pass\n"},
+		{"unparenthesized exception list with trailing comma", "try:\n    pass\nexcept OSError, TypeError,:\n    pass\n"},
+		{"single exception type with trailing comma", "try:\n    pass\nexcept OSError,:\n    pass\n"},
+		{"three unparenthesized exception types with trailing comma", "try:\n    pass\nexcept OSError, TypeError, ValueError,:\n    pass\n"},
 		{"four unparenthesized dotted exception types", "try:\n    pass\nexcept a.E, b.F, c.G, d.H:\n    pass\n"},
 		{"parenthesized exception list", "try:\n    pass\nexcept (OSError, TypeError):\n    pass\n"},
 		{"parenthesized exception list with as", "try:\n    pass\nexcept (OSError, TypeError) as e:\n    pass\n"},

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -300,6 +300,11 @@ func TestCheckSyntax(t *testing.T) {
 			source:    "if True",
 			hasErrors: true,
 		},
+		{
+			name:      "garbage inside an unparenthesized exception list",
+			source:    "try:\n    pass\nexcept OSError, ), ValueError:\n    pass\n",
+			hasErrors: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,6 +339,10 @@ func TestParseRejectsSyntaxInvalidInEveryPython3(t *testing.T) {
 		{
 			name:   "exception list bound with as",
 			source: "try:\n    pass\nexcept OSError, TypeError as e:\n    pass\n",
+		},
+		{
+			name:   "three-type exception list bound with as",
+			source: "try:\n    pass\nexcept OSError, TypeError, ValueError as e:\n    pass\n",
 		},
 		{"raise with argument list", "raise ValueError, 'msg'\n"},
 		{"raise with traceback", "raise ValueError, 'msg', tb\n"},
@@ -386,6 +395,8 @@ func TestParseAcceptsValidPython3(t *testing.T) {
 			name:   "unparenthesized exception list is valid since PEP 758",
 			source: "def f(x):\n    try:\n        return x\n    except OSError, TypeError:\n        return None\n",
 		},
+		{"three unparenthesized exception types", "try:\n    pass\nexcept OSError, TypeError, ValueError:\n    pass\n"},
+		{"four unparenthesized dotted exception types", "try:\n    pass\nexcept a.E, b.F, c.G, d.H:\n    pass\n"},
 		{"parenthesized exception list", "try:\n    pass\nexcept (OSError, TypeError):\n    pass\n"},
 		{"parenthesized exception list with as", "try:\n    pass\nexcept (OSError, TypeError) as e:\n    pass\n"},
 		{"except with as", "try:\n    pass\nexcept OSError as e:\n    pass\n"},
@@ -478,4 +489,51 @@ def func2():
 			return nil
 		})
 	}
+}
+
+// The types of an unparenthesized exception list must all reach the AST, not
+// just the last one, whether the grammar accepts the list or wraps part of it
+// in an ERROR node (three or more types).
+func TestParseBracketlessExceptListTypes(t *testing.T) {
+	parser := New()
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{"two types", "try:\n    pass\nexcept OSError, TypeError:\n    pass\n", []string{"OSError", "TypeError"}},
+		{"three types", "try:\n    pass\nexcept OSError, TypeError, ValueError:\n    pass\n", []string{"OSError", "TypeError", "ValueError"}},
+		{"four dotted types", "try:\n    pass\nexcept a.E, b.F, c.G, d.H:\n    pass\n", []string{"a.E", "b.F", "c.G", "d.H"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parser.Parse(ctx, []byte(tt.source))
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			handler := result.AST.Body[0].Handlers[0]
+			tuple, ok := handler.Value.(*Node)
+			if !ok || tuple.Type != NodeTuple {
+				t.Fatalf("handler.Value = %v, want a Tuple", handler.Value)
+			}
+			var got []string
+			for _, c := range tuple.Children {
+				got = append(got, exprText(c))
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("exception types = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// exprText renders a Name or dotted Attribute node back to source form.
+func exprText(n *Node) string {
+	if n.Type == NodeAttribute {
+		return exprText(n.Value.(*Node)) + "." + n.Name
+	}
+	return n.Name
 }

--- a/internal/parser/python3_syntax.go
+++ b/internal/parser/python3_syntax.go
@@ -95,6 +95,34 @@ func isLegacyOctal(text string) bool {
 	return false
 }
 
+// isBracketlessExceptListError reports whether the ERROR node is the middle of
+// an unparenthesized exception list with three or more types, such as
+// `except A, B, C:`. The tree-sitter grammar only knows the two-item Python 2
+// form, so it wraps every type between the first and the last in an ERROR node
+// holding nothing but expressions and commas. PEP 758 made the list valid, so
+// that shape is accepted; combined with `as` it stays a syntax error, which the
+// enclosing except_clause reports before this node is reached.
+func isBracketlessExceptListError(errNode *sitter.Node) bool {
+	parent := errNode.Parent()
+	if parent == nil || parent.Type() != "except_clause" || firstChildOfType(parent, "as_pattern") != nil {
+		return false
+	}
+	childCount := int(errNode.ChildCount())
+	if childCount == 0 {
+		return false
+	}
+	for i := 0; i < childCount; i++ {
+		child := errNode.Child(i)
+		if child.Type() == "," {
+			continue
+		}
+		if !child.IsNamed() || child.IsError() || child.IsMissing() {
+			return false
+		}
+	}
+	return true
+}
+
 // isParameterPosition reports whether tsNode is a function or lambda parameter
 // list. A defaulted parameter (`def f((a, b)=(1, 2))`) nests the pattern one
 // level deeper, and default_parameter only ever occurs inside such a list.

--- a/internal/parser/python3_syntax.go
+++ b/internal/parser/python3_syntax.go
@@ -39,6 +39,7 @@ func invalidInPython3(tsNode *sitter.Node, source []byte) string {
 		if firstChildOfType(tsNode, ",") != nil && firstChildOfType(tsNode, "as_pattern") != nil {
 			return "an unparenthesized exception list bound with `as` (multiple exception types must be parenthesized when using `as`)"
 		}
+		return invalidExceptHeader(tsNode)
 	case "raise_statement":
 		// `raise E, v` / `raise E, v, tb`. A valid Python 3 raise carries a
 		// single expression, optionally followed by `from`.
@@ -95,32 +96,73 @@ func isLegacyOctal(text string) bool {
 	return false
 }
 
-// isBracketlessExceptListError reports whether the ERROR node is the middle of
-// an unparenthesized exception list with three or more types, such as
+// isBracketlessExceptListError reports whether the ERROR node is part of a
+// well-formed unparenthesized exception list with three or more types, such as
 // `except A, B, C:`. The tree-sitter grammar only knows the two-item Python 2
-// form, so it wraps every type between the first and the last in an ERROR node
-// holding nothing but expressions and commas. PEP 758 made the list valid, so
-// that shape is accepted; combined with `as` it stays a syntax error, which the
-// enclosing except_clause reports before this node is reached.
+// form, so it wraps the extra types (and any trailing comma) in ERROR nodes.
+// PEP 758 made the list valid, so the node is accepted when the whole except
+// header still reads as expressions separated by commas.
 func isBracketlessExceptListError(errNode *sitter.Node) bool {
 	parent := errNode.Parent()
-	if parent == nil || parent.Type() != "except_clause" || firstChildOfType(parent, "as_pattern") != nil {
-		return false
+	return parent != nil && parent.Type() == "except_clause" && invalidExceptHeader(parent) == ""
+}
+
+// invalidExceptHeader reports why the header of the except_clause is not a
+// valid Python 3 exception list, or an empty string when it is. Only clauses
+// the grammar could not parse cleanly are checked; a clean clause is trusted.
+// The tokens between `except` and `:` (with ERROR nodes flattened) must form
+// `expr (',' expr)* [',']` with no `as`, mirroring PEP 758's grammar.
+func invalidExceptHeader(clause *sitter.Node) string {
+	if firstChildOfType(clause, "ERROR") == nil {
+		return ""
 	}
-	childCount := int(errNode.ChildCount())
-	if childCount == 0 {
-		return false
+	if firstChildOfType(clause, "as_pattern") != nil {
+		return "an unparenthesized exception list bound with `as` (multiple exception types must be parenthesized when using `as`)"
 	}
+	const malformed = "a malformed exception list"
+	wantExpr := true
+	count := 0
+	for _, tok := range exceptHeaderTokens(clause) {
+		isComma := tok.Type() == ","
+		if isComma == wantExpr {
+			return malformed
+		}
+		if !isComma {
+			if !tok.IsNamed() || tok.IsError() || tok.IsMissing() {
+				return malformed
+			}
+			count++
+		}
+		wantExpr = isComma
+	}
+	if count == 0 {
+		return malformed
+	}
+	return ""
+}
+
+// exceptHeaderTokens returns the nodes between `except` and `:` of the clause,
+// with the children of ERROR nodes spliced in place of the node itself.
+func exceptHeaderTokens(clause *sitter.Node) []*sitter.Node {
+	var tokens []*sitter.Node
+	childCount := int(clause.ChildCount())
 	for i := 0; i < childCount; i++ {
-		child := errNode.Child(i)
-		if child.Type() == "," {
+		child := clause.Child(i)
+		switch child.Type() {
+		case "except", "except*":
 			continue
-		}
-		if !child.IsNamed() || child.IsError() || child.IsMissing() {
-			return false
+		case ":":
+			return tokens
+		case "ERROR":
+			errChildCount := int(child.ChildCount())
+			for j := 0; j < errChildCount; j++ {
+				tokens = append(tokens, child.Child(j))
+			}
+		default:
+			tokens = append(tokens, child)
 		}
 	}
-	return true
+	return tokens
 }
 
 // isParameterPosition reports whether tsNode is a function or lambda parameter


### PR DESCRIPTION
tree-sitter only knows the two-item `except A, B:` form, so the middle types of `except A, B, C:` land in an ERROR node and the whole file was rejected as a syntax error.

- Accept that specific ERROR shape (expressions and commas only, no `as` in the clause) in `CheckSyntax`
- Collect every type of an unparenthesized list into the handler's Tuple instead of keeping only the last one
- `except A, B, C as e:` and malformed lists are still rejected

Fixes #763