### PR TITLE
fix(deadcode): don't report the bare yield that keeps a function a generator

### DIFF
--- a/internal/analyzer/complexity.go
+++ b/internal/analyzer/complexity.go
@@ -93,7 +93,7 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 
 	// Primary method: count decision points + 1
 	// This is more reliable for CFGs with entry/exit nodes
-	sourceNode := complexitySourceNode(cfg)
+	sourceNode := cfgSourceNode(cfg)
 	astMetrics, hasASTMetrics := calculateASTComplexityMetrics(sourceNode)
 	reportedMetrics := resolveCoreComplexityMetrics(coreResult, conditionalDecisions, astMetrics, hasASTMetrics)
 	decisionPoints := countCoreDecisionPoints(conditionalDecisions, reportedMetrics, hasASTMetrics)
@@ -105,7 +105,7 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 	}
 
 	// Calculate nesting depth and location from the original AST node if available.
-	// The same node feeds CalculateCognitiveComplexity above via complexitySourceNode.
+	// The same node feeds CalculateCognitiveComplexity above via cfgSourceNode.
 	nestingDepth := 0
 	startLine := 0
 	startCol := 0
@@ -217,13 +217,6 @@ type astComplexityMetrics struct {
 	ExceptionHandlers   int
 	MatchStatements     int
 	SwitchCases         int
-}
-
-func complexitySourceNode(cfg *CFG) *parser.Node {
-	if cfg == nil || cfg.FunctionNode == nil {
-		return nil
-	}
-	return mustPythonNode(cfg.FunctionNode)
 }
 
 func calculateASTComplexityMetrics(root *parser.Node) (astComplexityMetrics, bool) {

--- a/internal/analyzer/dead_code.go
+++ b/internal/analyzer/dead_code.go
@@ -667,27 +667,85 @@ func isGeneratorMarkerBlock(block *BasicBlock) bool {
 	return !ok || value == nil
 }
 
-// countScopeYields counts the yield expressions owned by one execution scope.
-// Nested function and class suites are their own scopes, so their yields do not
-// make the enclosing function a generator and are not counted.
+// countScopeYields counts the yield expressions owned by one execution scope,
+// i.e. the yields that decide whether that scope is a generator.
+//
+// A nested def/lambda/class suite is its own scope and is not counted, but the
+// header Python evaluates at definition time — decorators, parameter defaults
+// and annotations, class bases — runs in the enclosing scope, so `def inner(x=(yield 1))`
+// makes the *enclosing* function a generator. By the same rule the root's own
+// header belongs to whatever scope defines the root, not to the root itself.
 func countScopeYields(root *parser.Node) int {
 	if root == nil {
 		return 0
 	}
+
 	count := 0
-	root.Walk(func(node *parser.Node) bool {
-		if node != root {
-			switch node.Type {
-			case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef, parser.NodeClassDef, parser.NodeLambda:
-				return false
-			}
+	var visit, visitChild func(node *parser.Node)
+
+	visit = func(node *parser.Node) {
+		if node == nil {
+			return
 		}
 		if node.Type == parser.NodeYield || node.Type == parser.NodeYieldFrom {
 			count++
 		}
-		return true
-	})
+		for _, child := range parser.OrderedChildren(node, nil) {
+			visitChild(child)
+		}
+	}
+
+	visitChild = func(node *parser.Node) {
+		if definesOwnScope(node) {
+			// The suite runs elsewhere; only its header runs in this scope.
+			for _, header := range definitionTimeExpressions(node) {
+				visit(header)
+			}
+			return
+		}
+		visit(node)
+	}
+
+	if definesOwnScope(root) {
+		// Skip root's own header: the defining scope evaluated it.
+		for _, stmt := range root.Body {
+			visitChild(stmt)
+		}
+		return count
+	}
+	visit(root)
 	return count
+}
+
+// definesOwnScope reports whether the node's suite runs in a scope of its own.
+func definesOwnScope(node *parser.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Type {
+	case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef, parser.NodeClassDef, parser.NodeLambda:
+		return true
+	default:
+		return false
+	}
+}
+
+// definitionTimeExpressions returns the parts of a def/lambda/class header that
+// Python evaluates in the enclosing scope when the definition is executed.
+func definitionTimeExpressions(node *parser.Node) []*parser.Node {
+	expressions := make([]*parser.Node, 0, len(node.Decorator)+len(node.Bases)+2*len(node.Args)+1)
+	expressions = append(expressions, node.Decorator...)
+	expressions = append(expressions, node.Bases...)
+	for _, arg := range node.Args {
+		if arg == nil {
+			continue
+		}
+		if defaultValue, ok := arg.Value.(*parser.Node); ok {
+			expressions = append(expressions, defaultValue)
+		}
+		expressions = append(expressions, arg.Right) // parameter annotation
+	}
+	return append(expressions, node.Right) // return annotation
 }
 
 func toCoreSeverity(severity SeverityLevel) corecfg.DeadCodeSeverity {

--- a/internal/analyzer/dead_code.go
+++ b/internal/analyzer/dead_code.go
@@ -227,6 +227,21 @@ func (dcd *DeadCodeDetector) analyzeCoreDeadBlock(block *BasicBlock, coreReason 
 		return findings
 	}
 
+	// Skip the unreachable bare `yield` that only exists to make the enclosing
+	// function a generator:
+	//
+	//	async def run(self) -> AsyncGenerator[Event, None]:
+	//	    raise NotImplementedError()
+	//	    yield
+	//
+	// Python decides generator-ness syntactically, so removing that `yield`
+	// turns the function into a plain coroutine and breaks its contract. There
+	// is nothing for the user to act on. Only the sole `yield` of a scope earns
+	// the exemption — dead code in a function that already yields is real.
+	if isGeneratorMarkerBlock(block) && countScopeYields(cfgSourceNode(dcd.cfg)) == 1 {
+		return findings
+	}
+
 	reason, severity := dcd.determineDeadCodeReason(block)
 	switch coreReason {
 	case "after_return":
@@ -634,6 +649,45 @@ func isOnlyNoOpStatements(block *BasicBlock) bool {
 		}
 	}
 	return true
+}
+
+// isGeneratorMarkerBlock reports whether the block is nothing but a bare
+// `yield`, the statement Python requires to make a function a generator. A
+// `yield` carrying a value is excluded: it produces something no caller can
+// ever receive, so it is genuine dead code.
+func isGeneratorMarkerBlock(block *BasicBlock) bool {
+	if block == nil || len(block.Statements) != 1 {
+		return false
+	}
+	node, ok := pythonNode(block.Statements[0])
+	if !ok || node.Type != parser.NodeYield {
+		return false
+	}
+	value, ok := node.Value.(*parser.Node)
+	return !ok || value == nil
+}
+
+// countScopeYields counts the yield expressions owned by one execution scope.
+// Nested function and class suites are their own scopes, so their yields do not
+// make the enclosing function a generator and are not counted.
+func countScopeYields(root *parser.Node) int {
+	if root == nil {
+		return 0
+	}
+	count := 0
+	root.Walk(func(node *parser.Node) bool {
+		if node != root {
+			switch node.Type {
+			case parser.NodeFunctionDef, parser.NodeAsyncFunctionDef, parser.NodeClassDef, parser.NodeLambda:
+				return false
+			}
+		}
+		if node.Type == parser.NodeYield || node.Type == parser.NodeYieldFrom {
+			count++
+		}
+		return true
+	})
+	return count
 }
 
 func toCoreSeverity(severity SeverityLevel) corecfg.DeadCodeSeverity {

--- a/internal/analyzer/dead_code_test.go
+++ b/internal/analyzer/dead_code_test.go
@@ -825,6 +825,112 @@ func TestMergeContiguousFindings(t *testing.T) {
 	})
 }
 
+// TestDeadCodeSkipsGeneratorMarkerYield ensures the dead-code detector does not
+// report the unreachable bare `yield` that exists only to keep a function a
+// generator. Regression test for
+// https://github.com/ludo-technologies/pyscn/issues/772.
+func TestDeadCodeSkipsGeneratorMarkerYield(t *testing.T) {
+	code := `
+async def run_async(self):
+    raise NotImplementedError()
+    yield
+
+
+async def process(self):
+    return
+    yield
+
+
+async def other(self):
+    yield 1
+    return
+    yield 2
+
+
+def plain(self):
+    return
+    print("dead")
+`
+
+	p := parser.New()
+	parseResult, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	cfgs, err := NewCFGBuilder().BuildAll(parseResult.AST)
+	require.NoError(t, err)
+
+	for _, fnName := range []string{"run_async", "process"} {
+		cfg, ok := findCFG(cfgs, fnName)
+		require.True(t, ok, "expected CFG for %s", fnName)
+
+		result := DetectInFunction(cfg)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Findings,
+			"function %s: the sole bare yield keeps the function a generator and must not be reported", fnName)
+		assert.Zero(t, result.DeadBlocks, "function %s: suppressed block must not count as dead", fnName)
+	}
+
+	// A function with another yield still gets its trailing dead code reported.
+	cfg, ok := findCFG(cfgs, "other")
+	require.True(t, ok, "expected CFG for other")
+	result := DetectInFunction(cfg)
+	require.Len(t, result.Findings, 1, "yield after return is real dead code when the function already yields")
+	assert.Equal(t, ReasonUnreachableAfterReturn, result.Findings[0].Reason)
+
+	// Non-generator dead code is unaffected.
+	cfg, ok = findCFG(cfgs, "plain")
+	require.True(t, ok, "expected CFG for plain")
+	result = DetectInFunction(cfg)
+	require.Len(t, result.Findings, 1)
+	assert.Equal(t, ReasonUnreachableAfterReturn, result.Findings[0].Reason)
+}
+
+func TestIsGeneratorMarkerBlock(t *testing.T) {
+	bareYield := &parser.Node{Type: parser.NodeYield}
+	valueYield := &parser.Node{Type: parser.NodeYield, Value: &parser.Node{Type: parser.NodeName}}
+	pass := &parser.Node{Type: parser.NodePass}
+
+	assert.False(t, isGeneratorMarkerBlock(nil), "nil block")
+	assert.False(t, isGeneratorMarkerBlock(&BasicBlock{}), "empty block")
+	assert.True(t, isGeneratorMarkerBlock(&BasicBlock{Statements: []any{bareYield}}),
+		"block with only a bare yield")
+	assert.False(t, isGeneratorMarkerBlock(&BasicBlock{Statements: []any{valueYield}}),
+		"a yield with a value produces a value the caller never sees")
+	assert.False(t, isGeneratorMarkerBlock(&BasicBlock{Statements: []any{bareYield, pass}}),
+		"block with more than one statement")
+}
+
+func TestCountScopeYields(t *testing.T) {
+	code := `
+def outer():
+    yield 1
+    x = yield
+    def inner():
+        yield 2
+        yield 3
+
+    class C:
+        pass
+`
+
+	p := parser.New()
+	parseResult, err := p.Parse(context.Background(), []byte(code))
+	require.NoError(t, err)
+
+	cfgs, err := NewCFGBuilder().BuildAll(parseResult.AST)
+	require.NoError(t, err)
+
+	outer, ok := findCFG(cfgs, "outer")
+	require.True(t, ok)
+	assert.Equal(t, 2, countScopeYields(cfgSourceNode(outer)), "nested function yields belong to the nested scope")
+
+	inner, ok := findCFG(cfgs, "outer.inner")
+	require.True(t, ok)
+	assert.Equal(t, 2, countScopeYields(cfgSourceNode(inner)))
+
+	assert.Zero(t, countScopeYields(nil))
+}
+
 func TestIsOnlyNoOpStatements(t *testing.T) {
 	assert.False(t, isOnlyNoOpStatements(nil), "nil block")
 	assert.False(t, isOnlyNoOpStatements(&BasicBlock{}), "empty block")

--- a/internal/analyzer/dead_code_test.go
+++ b/internal/analyzer/dead_code_test.go
@@ -901,7 +901,15 @@ func TestIsGeneratorMarkerBlock(t *testing.T) {
 }
 
 func TestCountScopeYields(t *testing.T) {
-	code := `
+	tests := []struct {
+		name     string
+		code     string
+		scope    string
+		expected int
+	}{
+		{
+			name: "nested suite yields belong to the nested scope",
+			code: `
 def outer():
     yield 1
     x = yield
@@ -911,24 +919,125 @@ def outer():
 
     class C:
         pass
+`,
+			scope:    "outer",
+			expected: 2,
+		},
+		{
+			name: "nested scope counts only its own body",
+			code: `
+def outer():
+    def inner():
+        yield 2
+        yield 3
+`,
+			scope:    "outer.inner",
+			expected: 2,
+		},
+		{
+			// A nested def's header runs when the `def` executes, so its yields
+			// belong to the enclosing scope.
+			name: "nested parameter default",
+			code: `
+def outer():
+    def inner(x=(yield 1)):
+        pass
+`,
+			scope:    "outer",
+			expected: 1,
+		},
+		{
+			name: "nested decorator, annotation and class base",
+			code: `
+def outer():
+    @(yield 1)
+    def inner(x: (yield 2) = (yield 3)) -> (yield 4):
+        pass
+
+    class C((yield 5)):
+        pass
+`,
+			scope:    "outer",
+			expected: 5,
+		},
+		{
+			// The mirror case: the scope's own header was evaluated by whoever
+			// defined it, so it does not make this scope a generator.
+			name: "own header excluded",
+			code: `
+def outer():
+    def inner(x=(yield 1)):
+        yield 2
+`,
+			scope:    "outer.inner",
+			expected: 1,
+		},
+		{
+			name: "lambda body is its own scope",
+			code: `
+def outer():
+    f = lambda x=(yield 1): x
+`,
+			scope:    "outer",
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parseResult, err := parser.New().Parse(context.Background(), []byte(tt.code))
+			require.NoError(t, err)
+
+			cfgs, err := NewCFGBuilder().BuildAll(parseResult.AST)
+			require.NoError(t, err)
+
+			cfg, ok := findCFG(cfgs, tt.scope)
+			require.True(t, ok, "expected CFG for %s", tt.scope)
+			assert.Equal(t, tt.expected, countScopeYields(cfgSourceNode(cfg)))
+		})
+	}
+
+	assert.Zero(t, countScopeYields(nil))
+}
+
+// TestDeadCodeGeneratorMarkerYieldRespectsDefinitionTimeYields covers the two
+// directions in which a nested definition's header changes which scope is a
+// generator.
+func TestDeadCodeGeneratorMarkerYieldRespectsDefinitionTimeYields(t *testing.T) {
+	code := `
+def enclosing():
+    def inner(x=(yield 1)):
+        pass
+    return
+    yield
+
+
+def outer():
+    def marker(x=(yield 1)):
+        return
+        yield
 `
 
-	p := parser.New()
-	parseResult, err := p.Parse(context.Background(), []byte(code))
+	parseResult, err := parser.New().Parse(context.Background(), []byte(code))
 	require.NoError(t, err)
 
 	cfgs, err := NewCFGBuilder().BuildAll(parseResult.AST)
 	require.NoError(t, err)
 
-	outer, ok := findCFG(cfgs, "outer")
+	// `enclosing` is already a generator through inner's default, so its
+	// trailing yield is removable and must still be reported.
+	cfg, ok := findCFG(cfgs, "enclosing")
 	require.True(t, ok)
-	assert.Equal(t, 2, countScopeYields(cfgSourceNode(outer)), "nested function yields belong to the nested scope")
+	result := DetectInFunction(cfg)
+	require.Len(t, result.Findings, 1, "trailing yield is real dead code when the scope already yields")
+	assert.Equal(t, ReasonUnreachableAfterReturn, result.Findings[0].Reason)
 
-	inner, ok := findCFG(cfgs, "outer.inner")
+	// `marker`'s own default was evaluated by `outer`, so the trailing yield is
+	// the only thing making `marker` a generator.
+	cfg, ok = findCFG(cfgs, "outer.marker")
 	require.True(t, ok)
-	assert.Equal(t, 2, countScopeYields(cfgSourceNode(inner)))
-
-	assert.Zero(t, countScopeYields(nil))
+	assert.Empty(t, DetectInFunction(cfg).Findings,
+		"the sole yield of the scope keeps it a generator and must not be reported")
 }
 
 func TestIsOnlyNoOpStatements(t *testing.T) {

--- a/internal/analyzer/python_cfg.go
+++ b/internal/analyzer/python_cfg.go
@@ -27,6 +27,14 @@ func mustPythonNode(value any) *parser.Node {
 	return node
 }
 
+// cfgSourceNode returns the AST node the CFG was built from.
+func cfgSourceNode(cfg *CFG) *parser.Node {
+	if cfg == nil || cfg.FunctionNode == nil {
+		return nil
+	}
+	return mustPythonNode(cfg.FunctionNode)
+}
+
 func (pythonCFGClassifier) IsReturn(value any) bool {
 	node, ok := pythonNode(value)
 	return ok && node.Type == parser.NodeReturn


### PR DESCRIPTION
`raise NotImplementedError()` / `return` followed by a lone bare `yield` is the standard way to declare an (Async)Generator that yields nothing. Python decides generator-ness syntactically, so removing the `yield` turns the function into a plain coroutine — the critical `unreachable_after_raise` / `unreachable_after_return` finding is unactionable.

Suppress the finding when the dead block is exactly one bare `yield` and it is the only yield of its scope. A `yield` carrying a value, or one in a function that already yields elsewhere, is still reported.

Closes #772